### PR TITLE
fix(dashboard): Make Japanese and Korean selectable and complete their translations

### DIFF
--- a/packages/dashboard/lingui.config.js
+++ b/packages/dashboard/lingui.config.js
@@ -30,6 +30,7 @@ export default defineConfig({
         'sv',
         'tr',
         'ja',
+        'ko',
         'bg',
         'nl',
         'ro',

--- a/packages/dashboard/src/i18n/locales/ja.po
+++ b/packages/dashboard/src/i18n/locales/ja.po
@@ -1570,7 +1570,7 @@ msgstr "顧客"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
-msgstr "配送料計算機を選択"
+msgstr "配送料の計算方法を選択"
 
 #: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
@@ -5713,7 +5713,7 @@ msgstr "これらの変更には支払いまたは返金は必要ありません
 
 #: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
-msgstr "{cancellableCount, plural, other {{cancellableCount} 件のジョブをキャンセルしてもよろしいですか？この操作は元に戻せません。}}"
+msgstr "{cancellableCount, plural, other {{cancellableCount} 件のジョブをキャンセルしてもよろしいですか？この操作は取り消せません。}}"
 
 #: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"

--- a/packages/dashboard/src/i18n/locales/ja.po
+++ b/packages/dashboard/src/i18n/locales/ja.po
@@ -836,7 +836,7 @@ msgstr "{0}個の適格な配送方法が見つかりました"
 #: src/lib/components/shared/asset/asset-gallery.tsx
 #: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
-msgstr "サイズ"
+msgstr "寸法"
 
 #: src/lib/components/ui/password-input.tsx
 msgid "Show password"
@@ -5787,7 +5787,7 @@ msgstr "注文カスタムフィールドが更新されました"
 #: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
-msgstr "計算機"
+msgstr "計算方法"
 
 #: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"

--- a/packages/dashboard/src/i18n/locales/ja.po
+++ b/packages/dashboard/src/i18n/locales/ja.po
@@ -163,7 +163,7 @@ msgstr "タイプ"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
-msgstr ""
+msgstr "デフォルト通貨はこのリストから選択されます。"
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
@@ -175,7 +175,7 @@ msgstr "{0}を選択"
 #. placeholder {0}: selectedItems.length
 #: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
-msgstr ""
+msgstr "さらに追加（{0} 件選択中）"
 
 #: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
@@ -237,7 +237,7 @@ msgstr "{deleted}{entityName}を削除しました"
 
 #: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
-msgstr ""
+msgstr "ファイルサイズ"
 
 #: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
@@ -548,7 +548,7 @@ msgstr "注文数"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
-msgstr ""
+msgstr "デフォルト通貨を設定するには、まず利用可能な通貨を選択する必要があります"
 
 #: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
@@ -715,7 +715,7 @@ msgstr "メタデータ"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
-msgstr ""
+msgstr "注文の配送方法の設定に失敗しました: {0}"
 
 #: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 #: src/lib/components/data-table/data-table.tsx
@@ -891,7 +891,7 @@ msgstr "確認"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
-msgstr ""
+msgstr "下書き注文の完了に失敗しました: {0}"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
@@ -1048,7 +1048,7 @@ msgstr "割り当て済み"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
-msgstr ""
+msgstr "注文のクーポンコードの設定に失敗しました: {0}"
 
 #: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
@@ -1170,7 +1170,7 @@ msgstr "メールアドレス"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
-msgstr ""
+msgstr "注文からのクーポンコードの削除に失敗しました: {0}"
 
 #: src/lib/components/data-input/slug-input.tsx
 #: src/lib/components/data-input/slug-input.tsx
@@ -1235,7 +1235,7 @@ msgstr "価格はデフォルト税ゾーンの税を含みます"
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
-msgstr ""
+msgstr "このフィールドは必須です"
 
 #: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
@@ -1321,7 +1321,7 @@ msgstr "アカウントに割り当てられたロールのみ使用可能です
 
 #: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
-msgstr ""
+msgstr "{cancellableCount, plural, other {{cancellableCount} 件のジョブをキャンセル}}"
 
 #: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
@@ -1475,7 +1475,7 @@ msgstr "以前"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
-msgstr ""
+msgstr "注文の顧客の設定に失敗しました: {0}"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
@@ -1570,7 +1570,7 @@ msgstr "顧客"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
-msgstr ""
+msgstr "配送料計算機を選択"
 
 #: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
@@ -1612,7 +1612,7 @@ msgstr "{0}を移動するターゲットコレクションを選択してくだ
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
-msgstr ""
+msgstr "注文の請求先住所の解除に失敗しました: {0}"
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
@@ -1666,7 +1666,7 @@ msgstr "キャンセル"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
-msgstr ""
+msgstr "注文カスタムフィールドの更新に失敗しました: {0}"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 #: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
@@ -1711,7 +1711,7 @@ msgstr "コレクション"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
-msgstr ""
+msgstr "配送適格性チェッカーを選択"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
@@ -2059,7 +2059,7 @@ msgstr "テーマ"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
-msgstr ""
+msgstr "利用可能な通貨を少なくとも1つ選択する必要があります"
 
 #. placeholder {0}: value.totalItems
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
@@ -2433,7 +2433,7 @@ msgstr "コレクションの移動が完了しました"
 
 #: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
-msgstr ""
+msgstr "選択を変更"
 
 #: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
@@ -2442,7 +2442,7 @@ msgstr "登録済み"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
-msgstr ""
+msgstr "注文の配送先住所の設定に失敗しました: {0}"
 
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
@@ -2748,7 +2748,7 @@ msgstr "すべてのタイプ"
 #. placeholder {0}: entityIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
-msgstr ""
+msgstr "{0}件の{entityType}を割り当てるチャネルを選択"
 
 #: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
@@ -2760,7 +2760,7 @@ msgstr "商品の更新に失敗しました"
 
 #: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
-msgstr ""
+msgstr "コレクションフィルターを追加"
 
 #. placeholder {0}: adjustedLines.length
 #: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
@@ -3071,7 +3071,7 @@ msgstr "住所を更新しました"
 #. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+msgstr "{entityIdsLength} 件の{entityType}を {0} 件のチャネルに割り当てました"
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3079,7 +3079,7 @@ msgstr "返金が正常に処理されました"
 
 #: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
-msgstr ""
+msgstr "値を選択"
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
@@ -3248,7 +3248,7 @@ msgstr "表示言語を選択"
 
 #: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
-msgstr ""
+msgstr "支払いハンドラーを選択"
 
 #: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
@@ -3328,7 +3328,7 @@ msgstr "販売者を作成しました"
 #. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+msgstr "{entityIdsLength} 件の{entityType}を {1} 件中 {0} 件のチャネルに割り当てられませんでした"
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3514,7 +3514,7 @@ msgstr "と等しくない"
 
 #: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
-msgstr ""
+msgstr "チェッカーが見つかりません"
 
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
@@ -3983,7 +3983,7 @@ msgstr "国"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
-msgstr ""
+msgstr "注文明細の削除に失敗しました: {0}"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
@@ -4064,7 +4064,7 @@ msgstr "と等しい"
 
 #: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
-msgstr ""
+msgstr "ソースファイル"
 
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
@@ -4257,7 +4257,7 @@ msgstr "利用可能なアクション"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
-msgstr ""
+msgstr "注文明細の更新に失敗しました: {0}"
 
 #: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
@@ -4376,7 +4376,7 @@ msgstr "高さ"
 
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
-msgstr ""
+msgstr "{entityType}をチャネルに割り当て"
 
 #: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
@@ -4436,7 +4436,7 @@ msgstr "顧客情報を更新しました"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
-msgstr ""
+msgstr "下書き注文の削除に失敗しました: {0}"
 
 #: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
@@ -4444,15 +4444,15 @@ msgstr "ビューのグローバル化に失敗しました"
 
 #: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
-msgstr ""
+msgstr "支払い適格性チェッカーを選択"
 
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
-msgstr ""
+msgstr "1つ以上のチャネルを選択"
 
 #: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
-msgstr ""
+msgstr "演算子を選択"
 
 #. js-lingui-explicit-id
 #: src/lib/framework/defaults.ts
@@ -4583,7 +4583,7 @@ msgstr "OR"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
-msgstr ""
+msgstr "利用可能な通貨のリストからデフォルト通貨を選択する必要があります"
 
 #: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
@@ -4614,12 +4614,12 @@ msgstr "注文をフルフィルメントしました"
 
 #: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
-msgstr ""
+msgstr "選択したアイテムを読み込み中..."
 
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
-msgstr ""
+msgstr "注文の請求先住所の設定に失敗しました: {0}"
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
@@ -4820,7 +4820,7 @@ msgstr "{customerGroupName}の顧客グループメンバー"
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
-msgstr ""
+msgstr "注文の住所の設定に失敗しました: {0}"
 
 #: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
@@ -4981,7 +4981,7 @@ msgstr "識別子"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
-msgstr ""
+msgstr "フルフィルメントハンドラーを選択"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
@@ -5423,7 +5423,7 @@ msgstr "名"
 
 #: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
-msgstr ""
+msgstr "注文にアイテムを追加"
 
 #: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
@@ -5440,7 +5440,7 @@ msgstr "アイテムが見つかりません"
 #: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 #: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
-msgstr ""
+msgstr "オプショングループの削除に失敗しました"
 
 #: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
@@ -5551,7 +5551,7 @@ msgstr "国を追加"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
-msgstr ""
+msgstr "デフォルト言語が使用されます。"
 
 #: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
@@ -5713,7 +5713,7 @@ msgstr "これらの変更には支払いまたは返金は必要ありません
 
 #: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
-msgstr ""
+msgstr "{cancellableCount, plural, other {{cancellableCount} 件のジョブをキャンセルしてもよろしいですか？この操作は元に戻せません。}}"
 
 #: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
@@ -5943,7 +5943,7 @@ msgstr "{groupName}にオプション値を追加"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
-msgstr ""
+msgstr "注文の配送先住所の解除に失敗しました: {0}"
 
 #: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
@@ -5987,7 +5987,7 @@ msgstr "商品バリエーションの作成に失敗しました"
 
 #: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
-msgstr ""
+msgstr "検索..."
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
 #: src/lib/components/layout/channel-switcher.tsx

--- a/packages/dashboard/src/i18n/locales/ko.po
+++ b/packages/dashboard/src/i18n/locales/ko.po
@@ -45,7 +45,7 @@ msgstr "새 세율"
 
 #: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
-msgstr ""
+msgstr "기존 옵션 그룹을 할당하거나 새로 만드세요"
 
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx
@@ -67,7 +67,7 @@ msgstr "링크 편집"
 
 #: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
-msgstr ""
+msgstr "주문에 항목을 하나 이상 추가하세요"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
@@ -84,7 +84,7 @@ msgstr "모두 토글"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
-msgstr ""
+msgstr "JSON 값 편집"
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
@@ -92,7 +92,7 @@ msgstr "외부 인증 전략 사용: {strategy}"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
-msgstr ""
+msgstr "사유 선택..."
 
 #: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
@@ -155,15 +155,15 @@ msgstr "세율이 업데이트되었습니다"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
-msgstr ""
+msgstr "사용자 지정 사유 입력..."
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
-msgstr ""
+msgstr "유형"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
-msgstr ""
+msgstr "기본 통화는 이 목록에서 선택됩니다."
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
@@ -175,7 +175,7 @@ msgstr "{0} 선택"
 #. placeholder {0}: selectedItems.length
 #: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
-msgstr ""
+msgstr "더 추가 ({0}개 선택됨)"
 
 #: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
@@ -193,7 +193,7 @@ msgstr "조건"
 #: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
-msgstr ""
+msgstr "현재"
 
 #: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
@@ -204,7 +204,7 @@ msgstr "이행 없음"
 #. placeholder {2}: failed.length
 #: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
-msgstr ""
+msgstr "{0, plural, other {{2}개 재고 위치 삭제 실패: {messages}}}"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
@@ -233,7 +233,7 @@ msgstr "{deleted}개 {entityName}이(가) 삭제되었습니다"
 
 #: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
-msgstr ""
+msgstr "파일 크기"
 
 #: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
@@ -247,11 +247,11 @@ msgstr "판매자"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
-msgstr ""
+msgstr "옵션"
 
 #: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
-msgstr ""
+msgstr "{fulfilled, plural, other {{fulfilled}개 작업이 취소되었습니다}}"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
@@ -259,11 +259,11 @@ msgstr "판매자"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
-msgstr ""
+msgstr "SKU:"
 
 #: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
-msgstr ""
+msgstr "결제 추가"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
@@ -296,7 +296,7 @@ msgstr "주문"
 
 #: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
-msgstr ""
+msgstr "역할 선택"
 
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
@@ -312,11 +312,11 @@ msgstr "이 변형을 삭제하시겠습니까?"
 
 #: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
-msgstr ""
+msgstr "관리자 생성 실패"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
-msgstr ""
+msgstr "아니요"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
@@ -376,7 +376,7 @@ msgstr "알 수 없는 오류"
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
-msgstr ""
+msgstr "환불 합계는 음수일 수 없습니다"
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
@@ -393,7 +393,7 @@ msgstr "고객이 생성되었습니다"
 #: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
-msgstr ""
+msgstr "최근 7일"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
@@ -415,7 +415,7 @@ msgstr "에셋 삭제 실패: {message}"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
-msgstr ""
+msgstr "재고로 반환"
 
 #: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
@@ -423,7 +423,7 @@ msgstr "공개 설정"
 
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
-msgstr ""
+msgstr "상품 변형"
 
 #: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 #: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
@@ -442,11 +442,11 @@ msgstr "이름 변경"
 
 #: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
-msgstr ""
+msgstr "원하는 표시 언어와 로케일 설정을 선택하세요"
 
 #: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
-msgstr ""
+msgstr "채널에서 {successCount}개 옵션 그룹이 제거되었습니다"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
@@ -467,7 +467,7 @@ msgstr "세율"
 
 #: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
-msgstr ""
+msgstr "주문 임시 저장본은 완료할 준비가 되지 않았습니다"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx
@@ -476,7 +476,7 @@ msgstr "새 컬렉션"
 
 #: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
-msgstr ""
+msgstr "인사이트"
 
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
@@ -496,11 +496,11 @@ msgstr "비공개"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
-msgstr ""
+msgstr "상품 옵션이 생성되었습니다"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
-msgstr ""
+msgstr "상위 상품"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -519,7 +519,7 @@ msgstr "총 가격: <0/>"
 
 #: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
-msgstr ""
+msgstr "다음 페이지로 이동"
 
 #: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
@@ -527,16 +527,16 @@ msgstr "링크 제거"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
-msgstr ""
+msgstr "이 필드는 읽기 전용입니다"
 
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
-msgstr ""
+msgstr "주문 수"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
-msgstr ""
+msgstr "기본 통화를 설정하려면 먼저 사용 가능한 통화를 선택해야 합니다"
 
 #: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
@@ -561,7 +561,7 @@ msgstr "주문의 배송 주소가 해제됨"
 
 #: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
-msgstr ""
+msgstr "{enabledCount}개 변형 생성"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
@@ -593,7 +593,7 @@ msgstr "이후"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
-msgstr ""
+msgstr "상품 옵션이 업데이트되었습니다"
 
 #: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
@@ -621,7 +621,7 @@ msgstr "역할"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
-msgstr ""
+msgstr "그리드 보기"
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
@@ -645,11 +645,11 @@ msgstr "{selectionLength}개 에셋을 삭제하시겠습니까?"
 
 #: src/lib/components/login/login-form.tsx
 msgid "Sign in"
-msgstr ""
+msgstr "로그인"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
-msgstr ""
+msgstr "목록 보기"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
@@ -657,11 +657,11 @@ msgstr "테스트 주문"
 
 #: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
-msgstr ""
+msgstr "계속하려면 고객을 선택하세요"
 
 #: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
-msgstr ""
+msgstr "옵션 그룹이 할당되었습니다"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
@@ -693,7 +693,7 @@ msgstr "기본 세금 지역"
 
 #: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
-msgstr ""
+msgstr "주문 임시 저장본을 완료할 준비가 되었습니다"
 
 #: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
@@ -703,7 +703,7 @@ msgstr "메타데이터"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
-msgstr ""
+msgstr "주문의 배송 방법 설정 실패: {0}"
 
 #: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 #: src/lib/components/data-table/data-table.tsx
@@ -721,7 +721,7 @@ msgstr "채널이 업데이트되었습니다"
 
 #: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
-msgstr ""
+msgstr "간략히 보기"
 
 #: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
@@ -738,11 +738,11 @@ msgstr "{0}개 항목 선택"
 
 #: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
-msgstr ""
+msgstr "주문 일시"
 
 #: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
-msgstr ""
+msgstr "이 키를 교체하면 현재 키가 즉시 무효화됩니다. 이 키를 사용하는 모든 연동은 새 키로 업데이트할 때까지 작동이 중단됩니다."
 
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
@@ -805,7 +805,7 @@ msgstr "이 환불 정산의 거래 ID를 입력하세요"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
-msgstr ""
+msgstr "내 API 키"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
@@ -824,16 +824,16 @@ msgstr "{0}개의 적합한 배송 방법을 찾았습니다"
 #: src/lib/components/shared/asset/asset-gallery.tsx
 #: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
-msgstr ""
+msgstr "크기"
 
 #: src/lib/components/ui/password-input.tsx
 msgid "Show password"
-msgstr ""
+msgstr "비밀번호 표시"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
-msgstr ""
+msgstr "(최대: {0})"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -853,7 +853,7 @@ msgstr "작업"
 
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
-msgstr ""
+msgstr "할인"
 
 #: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
@@ -865,11 +865,11 @@ msgstr "주문 항목이 제거되었습니다"
 
 #: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
-msgstr ""
+msgstr "내용:"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
-msgstr ""
+msgstr "키"
 
 #: src/lib/components/login/login-form.tsx
 #~ msgid "Username"
@@ -883,7 +883,7 @@ msgstr "확인"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
-msgstr ""
+msgstr "임시 저장 주문 완료 실패: {0}"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
@@ -891,7 +891,7 @@ msgstr "컬렉션 생성 실패"
 
 #: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
-msgstr ""
+msgstr "첫 페이지로 이동"
 
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
@@ -920,7 +920,7 @@ msgstr "초점"
 
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
-msgstr ""
+msgstr "단일 변형, 옵션 없음"
 
 #: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
@@ -995,7 +995,7 @@ msgstr "배송지 주소가 변경되었습니다"
 
 #: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
-msgstr ""
+msgstr "상품을 찾을 수 없습니다"
 
 #: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
@@ -1008,7 +1008,7 @@ msgstr "{suggestedState}(으)로 전환"
 #: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
-msgstr ""
+msgstr "이번 달"
 
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
@@ -1016,7 +1016,7 @@ msgstr "속성 생성 실패"
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
-msgstr ""
+msgstr "주문 항목 취소 실패"
 
 #: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
@@ -1036,15 +1036,15 @@ msgstr "할당됨"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
-msgstr ""
+msgstr "주문의 쿠폰 코드 설정 실패: {0}"
 
 #: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
-msgstr ""
+msgstr "남은 재고의 처리 방법을 선택하세요"
 
 #: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
-msgstr ""
+msgstr "Platform & Cloud 살펴보기"
 
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
@@ -1071,11 +1071,11 @@ msgstr "임시 저장 주문"
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
-msgstr ""
+msgstr "범위"
 
 #: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
-msgstr ""
+msgstr "조건 추가"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
@@ -1100,7 +1100,7 @@ msgstr "결제 또는 환불 불필요"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
-msgstr ""
+msgstr ".env 파일로 다운로드"
 
 #: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
@@ -1122,12 +1122,12 @@ msgstr "프로모션 업데이트 실패"
 #: src/lib/components/shared/asset/asset-gallery.tsx
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
-msgstr ""
+msgstr "이미지"
 
 #. js-lingui-explicit-id
 #: src/lib/framework/defaults.ts
 msgid "API Keys"
-msgstr ""
+msgstr "API 키"
 
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
@@ -1158,7 +1158,7 @@ msgstr "이메일 주소"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
-msgstr ""
+msgstr "주문에서 쿠폰 코드 제거 실패: {0}"
 
 #: src/lib/components/data-input/slug-input.tsx
 #: src/lib/components/data-input/slug-input.tsx
@@ -1182,7 +1182,7 @@ msgstr "결과를 찾을 수 없습니다"
 
 #: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
-msgstr ""
+msgstr "배송지 주소를 설정하고 배송 방법을 선택하세요"
 
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
@@ -1191,7 +1191,7 @@ msgstr "끄기"
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
-msgstr ""
+msgstr "설정 저장소"
 
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
@@ -1223,7 +1223,7 @@ msgstr "가격에 기본 세금 지역의 세금이 포함됩니다"
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
-msgstr ""
+msgstr "이 필드는 필수입니다"
 
 #: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
@@ -1245,7 +1245,7 @@ msgstr "선택한 항목 없음"
 #. placeholder {0}: selected.length
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
-msgstr ""
+msgstr ", {0}개 선택됨"
 
 #: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
@@ -1253,7 +1253,7 @@ msgstr "국가를 찾을 수 없습니다"
 
 #: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
-msgstr ""
+msgstr "변형이 생성되었습니다"
 
 #: src/lib/components/data-input/slug-input.tsx
 #: src/lib/components/data-input/slug-input.tsx
@@ -1292,11 +1292,11 @@ msgstr "결제 상태가 업데이트되었습니다"
 
 #: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
-msgstr ""
+msgstr "새로 만들기"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
-msgstr ""
+msgstr "환불 합계"
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -1305,11 +1305,11 @@ msgstr "주소가 삭제되었습니다"
 
 #: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
-msgstr ""
+msgstr "계정에 할당된 역할만 사용할 수 있습니다."
 
 #: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
-msgstr ""
+msgstr "{cancellableCount, plural, other {{cancellableCount}개 작업 취소}}"
 
 #: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
@@ -1321,7 +1321,7 @@ msgstr "주문에 항목이 추가되었습니다"
 
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
-msgstr ""
+msgstr "초점 편집"
 
 #: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
@@ -1329,11 +1329,11 @@ msgstr ""
 
 #: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
-msgstr ""
+msgstr "에셋"
 
 #: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
-msgstr ""
+msgstr "{productCount, plural, one {이 옵션 그룹은 다른 상품 하나에서 사용 중입니다. 변경 사항은 해당 상품에도 영향을 줍니다.} other {이 옵션 그룹은 # 개 상품에서 공유됩니다. 변경 사항은 모든 상품에 영향을 줍니다.}}"
 
 #: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
@@ -1351,11 +1351,11 @@ msgstr "판매자 생성 실패"
 #. placeholder {0}: entityName.toLowerCase()
 #: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
-msgstr ""
+msgstr "{0} 복제 설정 구성"
 
 #: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
-msgstr ""
+msgstr "현재 필터와 일치하는 변형이 없습니다."
 
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
@@ -1364,7 +1364,7 @@ msgstr "주소"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
-msgstr ""
+msgstr "{groupName} 옵션 그룹에 새 옵션 값 추가"
 
 #. placeholder {0}: entry.data.modificationId
 #: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
@@ -1424,7 +1424,7 @@ msgstr "프로모션이 업데이트되었습니다"
 
 #: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
-msgstr ""
+msgstr "{rejected, plural, other {{rejected}개 작업 취소 실패}}"
 
 #: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
@@ -1441,11 +1441,11 @@ msgstr "이행 세부정보"
 #: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 #: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
-msgstr ""
+msgstr "남은 재고 폐기"
 
 #: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
-msgstr ""
+msgstr "지금"
 
 #. js-lingui-explicit-id
 #: src/lib/framework/defaults.ts
@@ -1463,11 +1463,11 @@ msgstr "이전"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
-msgstr ""
+msgstr "주문의 고객 설정 실패: {0}"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
-msgstr ""
+msgstr "크기"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
 #: src/lib/components/shared/translatable-form-field.tsx
@@ -1480,7 +1480,7 @@ msgstr "새 고객"
 
 #: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
-msgstr ""
+msgstr "최근 주문"
 
 #: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
@@ -1535,7 +1535,7 @@ msgstr "뷰 이름 변경 실패"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
-msgstr ""
+msgstr "사용 가능"
 
 #: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
@@ -1558,7 +1558,7 @@ msgstr "고객"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
-msgstr ""
+msgstr "배송료 계산기 선택"
 
 #: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
@@ -1600,7 +1600,7 @@ msgstr "{0}을(를) 이동할 대상 컬렉션을 선택하세요."
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
-msgstr ""
+msgstr "주문의 청구지 주소 해제 실패: {0}"
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
@@ -1620,7 +1620,7 @@ msgstr "새 상품 옵션"
 
 #: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
-msgstr ""
+msgstr "마지막 페이지로 이동"
 
 #: src/app/common/duplicate-entity-dialog.tsx
 #: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
@@ -1654,7 +1654,7 @@ msgstr "취소"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
-msgstr ""
+msgstr "주문 사용자 정의 필드 업데이트 실패: {0}"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 #: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
@@ -1685,7 +1685,7 @@ msgstr "새 세금 카테고리"
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
-msgstr ""
+msgstr "부분 환불이 완료되었습니다"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
@@ -1699,11 +1699,11 @@ msgstr "컬렉션"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
-msgstr ""
+msgstr "배송 적격성 확인 선택"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
-msgstr ""
+msgstr "변형 삭제"
 
 #: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
@@ -1715,7 +1715,7 @@ msgstr "기본 배송 지역"
 
 #: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
-msgstr ""
+msgstr "사유:"
 
 #: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
@@ -1794,7 +1794,7 @@ msgstr "채널 설정을 볼 수 있는 권한이 없습니다"
 #: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
-msgstr ""
+msgstr "최근 30일"
 
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
@@ -1802,11 +1802,11 @@ msgstr "속성 값 없음"
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
-msgstr ""
+msgstr "환불 사유가 필요합니다"
 
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
-msgstr ""
+msgstr "옵션 그룹을 제거할 수 없습니다"
 
 #: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
@@ -1912,7 +1912,7 @@ msgstr "열 설정"
 
 #: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
-msgstr ""
+msgstr "{count, plural, other {{count}개 재고 위치 삭제 실패}}"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #: src/app/routes/_authenticated/_countries/countries_.$id.tsx
@@ -1930,7 +1930,7 @@ msgstr "코드"
 
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
-msgstr ""
+msgstr "옵션 그룹 제거 실패"
 
 #: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
@@ -1938,15 +1938,15 @@ msgstr "주문이 배송되었습니다"
 
 #: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
-msgstr ""
+msgstr "{name}(으)로 이전"
 
 #: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
-msgstr ""
+msgstr "남은 재고"
 
 #: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
-msgstr ""
+msgstr "지역에서 제거"
 
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
@@ -1958,7 +1958,7 @@ msgstr "이 주소를 삭제하시겠습니까?"
 
 #: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
-msgstr ""
+msgstr "옵션 그룹 할당 실패"
 
 #: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
@@ -2006,13 +2006,13 @@ msgstr "메모 업데이트 실패"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
-msgstr ""
+msgstr "배송비 환불"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
-msgstr ""
+msgstr "읽기 전용"
 
 #: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
@@ -2020,7 +2020,7 @@ msgstr "전역 뷰 복제 실패"
 
 #: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
-msgstr ""
+msgstr "{total}개 중 {shown}개 표시 • {selected}개 선택됨"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
@@ -2041,7 +2041,7 @@ msgstr "테마"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
-msgstr ""
+msgstr "사용 가능한 통화를 하나 이상 선택해야 합니다"
 
 #. placeholder {0}: value.totalItems
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
@@ -2052,7 +2052,7 @@ msgstr "{0}명의 고객"
 #: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 #: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
-msgstr ""
+msgstr "API 키"
 
 #: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
@@ -2415,7 +2415,7 @@ msgstr "컬렉션이 성공적으로 이동되었습니다"
 
 #: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
-msgstr ""
+msgstr "선택 변경"
 
 #: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
@@ -2424,7 +2424,7 @@ msgstr "등록됨"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
-msgstr ""
+msgstr "주문의 배송지 주소 설정 실패: {0}"
 
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
@@ -2438,7 +2438,7 @@ msgstr "종료 일시"
 #. placeholder {1}: table.getPageCount() || 1
 #: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
-msgstr ""
+msgstr "{1} 페이지 중 {0} 페이지"
 
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
@@ -2446,12 +2446,12 @@ msgstr "요율"
 
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
-msgstr ""
+msgstr "크기, 색상 등"
 
 #: src/lib/components/shared/facet-value-selector.tsx
 #: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
-msgstr ""
+msgstr "속성 탐색"
 
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
@@ -2486,7 +2486,7 @@ msgstr "배송됨"
 
 #: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
-msgstr ""
+msgstr "뷰 저장"
 
 #. placeholder {0}: selection.length
 #: src/lib/components/data-table/data-table-bulk-actions.tsx
@@ -2496,7 +2496,7 @@ msgstr "{0}개 선택됨"
 
 #: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
-msgstr ""
+msgstr "옵션 그룹 검색..."
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
@@ -2548,7 +2548,7 @@ msgstr "새 지역"
 #: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 #: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
-msgstr ""
+msgstr "새 API 키"
 
 #: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
@@ -2556,7 +2556,7 @@ msgstr "열 삭제"
 
 #: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
-msgstr ""
+msgstr "기존 항목 할당"
 
 #: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 #: src/lib/components/data-table/human-readable-operator.tsx
@@ -2577,7 +2577,7 @@ msgstr "기본 채널"
 
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
-msgstr ""
+msgstr "소스, 제목, 크기를 지정하여 새 이미지 삽입"
 
 #: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
@@ -2589,7 +2589,7 @@ msgstr "="
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
-msgstr ""
+msgstr "상품 옵션 업데이트 실패"
 
 #: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
@@ -2610,7 +2610,7 @@ msgstr "일정"
 
 #: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
-msgstr ""
+msgstr "컬렉션을 자신의 하위 항목으로 이동할 수 없습니다"
 
 #: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
@@ -2646,7 +2646,7 @@ msgstr "더 많은 뷰"
 
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
-msgstr ""
+msgstr "선택한 이미지 속성 편집"
 
 #: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
@@ -2666,7 +2666,7 @@ msgstr "새 에셋"
 
 #: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
-msgstr ""
+msgstr "배송비 재계산"
 
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
@@ -2683,7 +2683,7 @@ msgstr "에셋"
 
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
-msgstr ""
+msgstr "이 상품에서 모든 옵션 그룹이 제거되고 변형 설정 선택으로 돌아갑니다."
 
 #: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
@@ -2721,16 +2721,16 @@ msgstr "할인"
 #: src/lib/components/shared/asset/asset-gallery.tsx
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
-msgstr ""
+msgstr "모든 유형"
 
 #. placeholder {0}: entityIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
-msgstr ""
+msgstr "{0}개 {entityType}을(를) 할당할 채널을 선택하세요"
 
 #: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
-msgstr ""
+msgstr "임시 저장 주문만 완료할 수 있습니다"
 
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
@@ -2738,7 +2738,7 @@ msgstr "상품 업데이트 실패"
 
 #: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
-msgstr ""
+msgstr "컬렉션 필터 추가"
 
 #. placeholder {0}: adjustedLines.length
 #: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
@@ -2784,7 +2784,7 @@ msgstr "이미지"
 
 #: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
-msgstr ""
+msgstr "관리자가 생성되었습니다"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
@@ -2805,11 +2805,11 @@ msgstr "이 전역 뷰를 삭제하시겠습니까? 이 작업은 취소할 수 
 
 #: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
-msgstr ""
+msgstr "옵션 그룹 강제 제거"
 
 #: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
-msgstr ""
+msgstr "추가됨"
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
@@ -2848,7 +2848,7 @@ msgstr "개인용으로 복사"
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
-msgstr ""
+msgstr "환불 합계가 최대 환불 가능 금액 {0}을(를) 초과합니다"
 
 #: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
@@ -2901,7 +2901,7 @@ msgstr "고객 생성 실패"
 
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
-msgstr ""
+msgstr "초점이 업데이트되었습니다"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
@@ -2918,7 +2918,7 @@ msgstr "고객 없음"
 
 #: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
-msgstr ""
+msgstr "지역에서 국가 제거 실패"
 
 #: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 #: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
@@ -2928,12 +2928,12 @@ msgstr "프로모션 생성 실패"
 #: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
-msgstr ""
+msgstr "오늘"
 
 #: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
-msgstr ""
+msgstr "어제"
 
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
@@ -2943,12 +2943,12 @@ msgstr ""
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
 #: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
-msgstr ""
+msgstr "이 지역에서 {0}개 {1}을(를) 제거하시겠습니까?"
 
 #. placeholder {0}: addedSurcharges.length
 #: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
-msgstr ""
+msgstr "{0}개 추가 요금 추가 중"
 
 #: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
@@ -2956,7 +2956,7 @@ msgstr "링크 URL"
 
 #: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
-msgstr ""
+msgstr "대체 값: {value}"
 
 #: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 #: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
@@ -2965,7 +2965,7 @@ msgstr "주문 이력"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
-msgstr ""
+msgstr "재정의"
 
 #: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
@@ -2987,7 +2987,7 @@ msgstr "선택한 태그 없음"
 #: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
-msgstr ""
+msgstr "뒤로"
 
 #: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
@@ -3045,15 +3045,15 @@ msgstr "주소가 업데이트되었습니다"
 #. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+msgstr "{entityIdsLength}개 {entityType}이(가) {0}개 채널에 할당되었습니다"
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
-msgstr ""
+msgstr "환불이 처리되었습니다"
 
 #: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
-msgstr ""
+msgstr "값 선택"
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
@@ -3077,11 +3077,11 @@ msgstr "새 지역"
 
 #: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
-msgstr ""
+msgstr "컬렉션 위치 업데이트 실패"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
-msgstr ""
+msgstr "환불"
 
 #: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 #: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
@@ -3113,7 +3113,7 @@ msgstr "{facetName}의 속성 값"
 
 #: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
-msgstr ""
+msgstr "레이아웃 저장"
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3143,7 +3143,7 @@ msgstr "옵션 값 이름"
 #: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 #: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
-msgstr ""
+msgstr "마지막 사용"
 
 #: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
@@ -3155,7 +3155,7 @@ msgstr "슬러그가 설정되었습니다"
 
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
-msgstr ""
+msgstr "초점 업데이트 실패"
 
 #: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
@@ -3167,7 +3167,7 @@ msgstr "시/도"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
-msgstr ""
+msgstr "옵션 그룹 업데이트 실패"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
@@ -3179,7 +3179,7 @@ msgstr "세금 카테고리 생성 실패"
 
 #: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
-msgstr ""
+msgstr "{columnId} 열의 필터 조건 설정"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 #: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
@@ -3189,7 +3189,7 @@ msgstr "국가"
 
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
-msgstr ""
+msgstr "단순 상품"
 
 #. js-lingui-explicit-id
 #: src/lib/framework/defaults.ts
@@ -3198,7 +3198,7 @@ msgstr "작업 큐"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
-msgstr ""
+msgstr "닫기 전에 API 키를 저장했는지 확인하세요."
 
 #: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
@@ -3210,11 +3210,11 @@ msgstr "주문 수정 실패"
 
 #: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
-msgstr ""
+msgstr "{taxRate}% 세금 포함"
 
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
-msgstr ""
+msgstr "주문 지표"
 
 #: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
@@ -3222,19 +3222,19 @@ msgstr "표시 언어 선택"
 
 #: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
-msgstr ""
+msgstr "결제 처리기 선택"
 
 #: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
-msgstr ""
+msgstr "인증 방법"
 
 #: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
-msgstr ""
+msgstr "시작"
 
 #: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
-msgstr ""
+msgstr "API 키 교체 실패"
 
 #: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
@@ -3257,16 +3257,16 @@ msgstr "전역 뷰 관리"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
-msgstr ""
+msgstr "처리 중..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
-msgstr ""
+msgstr "{totalItems}개의 {0}을(를) 찾았습니다"
 
 #: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
-msgstr ""
+msgstr "기간 선택"
 
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
@@ -3276,7 +3276,7 @@ msgstr "상품"
 
 #: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
-msgstr ""
+msgstr "API 키 교체"
 
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
@@ -3298,11 +3298,11 @@ msgstr "판매자가 생성되었습니다"
 #. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+msgstr "{entityIdsLength}개 {entityType}을(를) {1}개 채널 중 {0}개에 할당하지 못했습니다"
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
-msgstr ""
+msgstr "배송 방법이 업데이트되었습니다"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
@@ -3320,16 +3320,16 @@ msgstr "지역"
 
 #: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
-msgstr ""
+msgstr "삭제하려는 {count, plural, other {#개 재고 위치}}에 남아 있는 재고의 처리 방법을 선택하세요. 선택한 모든 위치는 남은 재고를 선택한 단일 위치로 이전하거나 폐기합니다."
 
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 #: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
-msgstr ""
+msgstr "속성 값 검색..."
 
 #: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
-msgstr ""
+msgstr "메모"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
@@ -3339,7 +3339,7 @@ msgstr "사용 가능한 언어"
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
 #: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
-msgstr ""
+msgstr "{0}개 더 불러오기 ({remaining}개 남음)"
 
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 #: src/app/routes/_authenticated/_product-variants/product-variants.tsx
@@ -3349,11 +3349,11 @@ msgstr "속성 값"
 
 #: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
-msgstr ""
+msgstr "항목 순서 변경 실패"
 
 #: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
-msgstr ""
+msgstr "총 주문 수"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
@@ -3371,11 +3371,11 @@ msgstr "배송"
 
 #: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
-msgstr ""
+msgstr "useWidgetDimensions는 DashboardBaseWidget 내에서 사용해야 합니다"
 
 #: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
-msgstr ""
+msgstr "이 옵션 그룹은 기존 변형에서 사용 중입니다. 강제로 제거하면 해당 변형에 영향을 줄 수 있습니다. 계속하시겠습니까?"
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
@@ -3407,11 +3407,11 @@ msgstr "국가 선택"
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
-msgstr ""
+msgstr "배송 방법 업데이트 실패"
 
 #: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
-msgstr ""
+msgstr "{deleted, plural, other {{deleted}개 재고 위치를 삭제했습니다}}"
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
@@ -3425,7 +3425,7 @@ msgstr "주소 선택"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
-msgstr ""
+msgstr "예"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
@@ -3438,7 +3438,7 @@ msgstr "초점 설정"
 
 #: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
-msgstr ""
+msgstr "종료"
 
 #: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
@@ -3463,7 +3463,7 @@ msgstr "배송 방법이 변경되었습니다"
 
 #: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
-msgstr ""
+msgstr "세금 설명"
 
 #: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
@@ -3484,7 +3484,7 @@ msgstr "같지 않음"
 
 #: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
-msgstr ""
+msgstr "확인 도구를 찾을 수 없습니다"
 
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
@@ -3502,11 +3502,11 @@ msgstr "채널"
 
 #: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
-msgstr ""
+msgstr "배송비 환불됨"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
-msgstr ""
+msgstr "에셋 유형"
 
 #: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
@@ -3514,7 +3514,7 @@ msgstr "새 재고 위치"
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
-msgstr ""
+msgstr "실패 전에 {successfulRefundCount}건의 결제가 환불되었습니다. 자세한 내용은 주문 내역을 확인하세요."
 
 #: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
@@ -3531,11 +3531,11 @@ msgstr "태그 관리"
 
 #: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
-msgstr ""
+msgstr "환불된 항목"
 
 #: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
-msgstr ""
+msgstr "작업 추가"
 
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
@@ -3557,7 +3557,7 @@ msgstr "이행 상태 업데이트 실패"
 
 #: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
-msgstr ""
+msgstr "옵션, 가격, 재고를 지정하여 새 상품 변형 생성"
 
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
@@ -3573,7 +3573,7 @@ msgstr "실행 중 아님"
 
 #: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
-msgstr ""
+msgstr "할당됨"
 
 #: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
@@ -3598,7 +3598,7 @@ msgstr "세금 합계"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
-msgstr ""
+msgstr "임시 저장 주문 상태"
 
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
@@ -3606,7 +3606,7 @@ msgstr ""
 
 #: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
-msgstr ""
+msgstr "위치를 불러오는 중…"
 
 #: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
@@ -3640,7 +3640,7 @@ msgstr "통화 검색..."
 
 #: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
-msgstr ""
+msgstr "채널에서 제거"
 
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
@@ -3691,7 +3691,7 @@ msgstr "청구지 주소 없음"
 #. placeholder {2}: failed.length
 #: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
-msgstr ""
+msgstr "{0, plural, other {{2}개 재고 위치 삭제 실패}}"
 
 #: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
@@ -3699,7 +3699,7 @@ msgstr "속성"
 
 #: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
-msgstr ""
+msgstr "활성 채널에서는 제거할 수 없습니다"
 
 #: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
@@ -3708,7 +3708,7 @@ msgstr "설정되지 않음"
 
 #: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
-msgstr ""
+msgstr "강제 제거"
 
 #: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
@@ -3757,7 +3757,7 @@ msgstr "주소가 생성되었습니다"
 
 #: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
-msgstr ""
+msgstr "API 키가 교체되었습니다"
 
 #: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
@@ -3766,7 +3766,7 @@ msgstr "옵션 그룹 추가"
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
-msgstr ""
+msgstr "{0} 환불"
 
 #: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
@@ -3774,7 +3774,7 @@ msgstr "슬러그 수동 입력"
 
 #: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
-msgstr ""
+msgstr "사용 가능한 위젯이 없습니다"
 
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
@@ -3792,15 +3792,15 @@ msgstr "전역 뷰가 복제되었습니다"
 #: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 #: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
-msgstr ""
+msgstr "생성자"
 
 #: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
-msgstr ""
+msgstr "변형 필터링..."
 
 #: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
-msgstr ""
+msgstr "다른 통화로 가격 추가"
 
 #: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
@@ -3847,7 +3847,7 @@ msgstr "다음 상태 선택"
 
 #: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
-msgstr ""
+msgstr "알림 없음"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
@@ -3899,7 +3899,7 @@ msgstr "항목 추가"
 
 #: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
-msgstr ""
+msgstr "API 키가 생성되었습니다"
 
 #: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
@@ -3917,7 +3917,7 @@ msgstr "뷰가 복제되었습니다"
 #: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
-msgstr ""
+msgstr "옵션 그룹 제거"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 #: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
@@ -3942,7 +3942,7 @@ msgstr "국가"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
-msgstr ""
+msgstr "주문 항목 제거 실패: {0}"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
@@ -3954,7 +3954,7 @@ msgstr "전역 뷰가 삭제되었습니다"
 
 #: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
-msgstr ""
+msgstr "레이아웃 편집"
 
 #: src/lib/components/shared/assign-to-channel-bulk-action.tsx
 #: src/lib/components/shared/assigned-channels.tsx
@@ -3964,7 +3964,7 @@ msgstr "채널에 할당"
 #: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
-msgstr ""
+msgstr "이번 주"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
 #: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
@@ -3977,11 +3977,11 @@ msgstr "포함"
 
 #: src/lib/components/login/login-form.tsx
 msgid "Email"
-msgstr ""
+msgstr "이메일"
 
 #: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
-msgstr ""
+msgstr "관리자 업데이트 실패"
 
 #: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
@@ -3993,7 +3993,7 @@ msgstr "태그로 필터"
 
 #: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
-msgstr ""
+msgstr "관리 대시보드에 접속하려면 로그인하세요"
 
 #: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
@@ -4019,7 +4019,7 @@ msgstr "같음"
 
 #: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
-msgstr ""
+msgstr "소스 파일"
 
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
@@ -4037,7 +4037,7 @@ msgstr "포함하지 않음"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
-msgstr ""
+msgstr "옵션 그룹"
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
@@ -4058,7 +4058,7 @@ msgstr "결제 상태 업데이트 실패"
 
 #: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
-msgstr ""
+msgstr "주문 요약"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
@@ -4066,7 +4066,7 @@ msgstr "업로드"
 
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
-msgstr ""
+msgstr "옵션이 있는 상품"
 
 #. placeholder {0}: filteredTags.length
 #: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
@@ -4077,7 +4077,7 @@ msgstr "{0}개 결과를 모두 표시 중"
 #: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
-msgstr ""
+msgstr "조회 ID"
 
 #. placeholder {0}: list.totalItems - 3
 #: src/app/routes/_authenticated/_facets/facets.tsx
@@ -4087,7 +4087,7 @@ msgstr "+ {0}개 더보기"
 #. js-lingui-explicit-id
 #: src/lib/framework/defaults.ts
 msgid "Option Groups"
-msgstr ""
+msgstr "옵션 그룹"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
@@ -4095,7 +4095,7 @@ msgstr "사용자 정의 필드"
 
 #: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
-msgstr ""
+msgstr "가능한 모든 주문 상태와 전환입니다. 현재 상태가 강조 표시되어 있습니다."
 
 #. js-lingui-explicit-id
 #: src/lib/framework/defaults.ts
@@ -4183,7 +4183,7 @@ msgstr "엔티티 정보"
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
-msgstr ""
+msgstr "주문 합계"
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
@@ -4191,7 +4191,7 @@ msgstr "관리자만 볼 수 있음"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
-msgstr ""
+msgstr "수량"
 
 #: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
@@ -4207,12 +4207,12 @@ msgstr "최고 관리자"
 
 #: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
-msgstr ""
+msgstr "사용 가능한 작업"
 
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
-msgstr ""
+msgstr "주문 항목 업데이트 실패: {0}"
 
 #: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
@@ -4238,7 +4238,7 @@ msgstr "결제가 정산되었습니다"
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
 #: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
-msgstr ""
+msgstr "지역에서 {0}개 {1}을(를) 제거했습니다"
 
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
@@ -4293,7 +4293,7 @@ msgstr "정산됨"
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
-msgstr ""
+msgstr "평균 주문 금액"
 
 #: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
@@ -4305,7 +4305,7 @@ msgstr "재고 수준"
 
 #: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
-msgstr ""
+msgstr "API 키 업데이트 실패"
 
 #: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
@@ -4323,7 +4323,7 @@ msgstr "전역 뷰 이름 변경 실패"
 
 #: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
-msgstr ""
+msgstr "URL과 대상 옵션을 지정하여 새 하이퍼링크 삽입"
 
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
@@ -4331,7 +4331,7 @@ msgstr "높이"
 
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
-msgstr ""
+msgstr "{entityType}을(를) 채널에 할당"
 
 #: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
@@ -4353,7 +4353,7 @@ msgstr "결제 실패"
 
 #: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
-msgstr ""
+msgstr "채널 추가"
 
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/channel-selector.tsx
@@ -4370,7 +4370,7 @@ msgstr "사용 가능한 언어"
 
 #: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
-msgstr ""
+msgstr "선택 초기화"
 
 #: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
@@ -4387,7 +4387,7 @@ msgstr "고객 정보가 업데이트되었습니다"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
-msgstr ""
+msgstr "임시 저장 주문 삭제 실패: {0}"
 
 #: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
@@ -4395,15 +4395,15 @@ msgstr "뷰를 전역으로 변환하는 데 실패했습니다"
 
 #: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
-msgstr ""
+msgstr "결제 적격성 확인 선택"
 
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
-msgstr ""
+msgstr "하나 이상의 채널을 선택하세요"
 
 #: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
-msgstr ""
+msgstr "연산자 선택"
 
 #. js-lingui-explicit-id
 #: src/lib/framework/defaults.ts
@@ -4422,7 +4422,7 @@ msgstr "프로모션"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
-msgstr ""
+msgstr "상품 옵션 생성 실패"
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
@@ -4434,7 +4434,7 @@ msgstr "모든 사용자가 사용할 수 있도록 뷰를 \"전역\"으로 저�
 
 #: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
-msgstr ""
+msgstr "변형 생성 실패"
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -4443,11 +4443,11 @@ msgstr "이 변형이 품절로 간주되는 재고 수준을 설정합니다. �
 #: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 #: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
-msgstr ""
+msgstr "키 교체"
 
 #: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
-msgstr ""
+msgstr "비밀번호 숨기기"
 
 #: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 #: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
@@ -4476,11 +4476,11 @@ msgstr "지역"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
-msgstr ""
+msgstr "업로드하려면 여기에 파일을 놓으세요"
 
 #: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
-msgstr ""
+msgstr "표시된 모든 변형 전환"
 
 #: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
@@ -4490,7 +4490,7 @@ msgstr "확인됨"
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
-msgstr ""
+msgstr "새 옵션 그룹"
 
 #: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
@@ -4506,7 +4506,7 @@ msgstr "역할 업데이트 실패"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
-msgstr ""
+msgstr "전체 API 키가 표시되는 것은 이번 한 번뿐입니다. 지금 복사하거나 다운로드하세요. 나중에는 다시 확인할 수 없습니다."
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
@@ -4530,7 +4530,7 @@ msgstr "OR"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
-msgstr ""
+msgstr "사용 가능한 통화 목록에서 기본 통화를 선택해야 합니다"
 
 #: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
@@ -4561,12 +4561,12 @@ msgstr "주문이 이행되었습니다"
 
 #: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
-msgstr ""
+msgstr "선택한 항목을 불러오는 중..."
 
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
-msgstr ""
+msgstr "주문의 청구지 주소 설정 실패: {0}"
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
@@ -4636,7 +4636,7 @@ msgstr "새 배송 방법"
 
 #: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
-msgstr ""
+msgstr "재고 위치 삭제"
 
 #: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
@@ -4646,7 +4646,7 @@ msgstr "이상"
 #: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 #: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
-msgstr ""
+msgstr "미리보기"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
@@ -4657,32 +4657,32 @@ msgstr "{1}개 중 {0}개 처리 가능"
 #: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
-msgstr ""
+msgstr "이번 달 누계"
 
 #. js-lingui-explicit-id
 #: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
-msgstr ""
+msgstr "고객 요청"
 
 #. js-lingui-explicit-id
 #: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
-msgstr ""
+msgstr "배송 중 파손"
 
 #. js-lingui-explicit-id
 #: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
-msgstr ""
+msgstr "재고 없음"
 
 #. js-lingui-explicit-id
 #: src/i18n/common-strings.ts
 msgid "refundReason.Other"
-msgstr ""
+msgstr "기타"
 
 #. js-lingui-explicit-id
 #: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
-msgstr ""
+msgstr "잘못된 상품"
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
@@ -4767,7 +4767,7 @@ msgstr "{customerGroupName}의 고객 그룹 멤버"
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
-msgstr ""
+msgstr "주문의 주소 설정 실패: {0}"
 
 #: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
@@ -4789,7 +4789,7 @@ msgstr "이행 #{0}이(가) 생성되었습니다"
 #. js-lingui-explicit-id
 #: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
-msgstr ""
+msgstr "대기 중인 검색 색인 업데이트 실행 중"
 
 #: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
@@ -4826,7 +4826,7 @@ msgstr "활성화됨"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
-msgstr ""
+msgstr "페이지당 항목 수"
 
 #: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
@@ -4846,7 +4846,7 @@ msgstr "ID"
 
 #: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
-msgstr ""
+msgstr "알림"
 
 #: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
@@ -4858,7 +4858,7 @@ msgstr "변경사항 미리보기"
 
 #: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
-msgstr ""
+msgstr "채널에서 {entityType} 제거 실패"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
@@ -4866,7 +4866,7 @@ msgstr "변형이 삭제되었습니다"
 
 #: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
-msgstr ""
+msgstr "선택한 링크 속성 편집"
 
 #. js-lingui-explicit-id
 #: src/lib/framework/defaults.ts
@@ -4879,7 +4879,7 @@ msgstr "대상 컬렉션 선택"
 
 #: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
-msgstr ""
+msgstr "최근 주문"
 
 #. js-lingui-explicit-id
 #: src/lib/framework/defaults.ts
@@ -4907,7 +4907,7 @@ msgstr "설정"
 #. js-lingui-explicit-id
 #: src/lib/framework/defaults.ts
 msgid "Settings Store"
-msgstr ""
+msgstr "설정 저장소"
 
 #: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
@@ -4915,7 +4915,7 @@ msgstr "제목 3"
 
 #: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
-msgstr ""
+msgstr "Vendure에 오신 것을 환영합니다"
 
 #. js-lingui-explicit-id
 #: src/lib/framework/defaults.ts
@@ -4924,7 +4924,7 @@ msgstr "배송 방법"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
-msgstr ""
+msgstr "({maxRefundable} 환불 가능)"
 
 #: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
@@ -4932,7 +4932,7 @@ msgstr "식별자"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
-msgstr ""
+msgstr "이행 처리기 선택"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
@@ -4965,7 +4965,7 @@ msgstr "비밀번호 재설정이 요청되었습니다"
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
-msgstr ""
+msgstr "할당된 결제 금액은 환불 합계와 같아야 합니다"
 
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
@@ -4996,7 +4996,7 @@ msgstr "재고 위치"
 
 #: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
-msgstr ""
+msgstr "이전 페이지로 이동"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 #: src/app/routes/_authenticated/_collections/collections.tsx
@@ -5025,7 +5025,7 @@ msgstr "시스템"
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 #: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
-msgstr ""
+msgstr "변형 이름"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
@@ -5038,11 +5038,11 @@ msgstr "고객 업데이트 실패"
 
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
-msgstr ""
+msgstr "옵션 그룹을 제거하시겠습니까?"
 
 #: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
-msgstr ""
+msgstr "현재 필터 설정을 기준으로 한 컬렉션 내용 미리보기입니다. 컬렉션을 저장하면 새 필터 설정이 반영되도록 내용이 업데이트됩니다."
 
 #: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
@@ -5068,7 +5068,7 @@ msgstr "전역 설정 로딩 실패"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
-msgstr ""
+msgstr "환불할 항목을 선택하고 필요하면 재고로 반환하세요"
 
 #: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 #: src/app/routes/_authenticated/_system/settings-store.tsx
@@ -5094,7 +5094,7 @@ msgstr "도로명 주소"
 
 #: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
-msgstr ""
+msgstr "더 이상 속성이 없습니다"
 
 #: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
@@ -5102,7 +5102,7 @@ msgstr "검색 인덱스 재구성이 시작되었습니다"
 
 #: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
-msgstr ""
+msgstr "컬렉션 위치가 업데이트되었습니다"
 
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
@@ -5143,7 +5143,7 @@ msgstr "상품에 옵션 그룹 추가"
 #. placeholder {0}: asset.name
 #: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
-msgstr ""
+msgstr "{0} 미리보기"
 
 #: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
@@ -5156,7 +5156,7 @@ msgstr "주문 상태 전환 실패"
 #. placeholder {0}: group.entries.length - 2
 #: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
-msgstr ""
+msgstr "모두 표시 ({0})"
 
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
@@ -5164,7 +5164,7 @@ msgstr "세율 생성 실패"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
-msgstr ""
+msgstr "이 API 키를 저장했습니다"
 
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
@@ -5181,7 +5181,7 @@ msgstr "상품 변형 추가"
 #. js-lingui-explicit-id
 #: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
-msgstr ""
+msgstr "입력한 후 Enter 또는 쉼표를 눌러 추가..."
 
 #: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
@@ -5189,7 +5189,7 @@ msgstr "메모 편집"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
-msgstr ""
+msgstr "에셋을 찾을 수 없습니다. 필터를 조정해 보세요."
 
 #: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
@@ -5209,7 +5209,7 @@ msgstr "\"테스트 실행\"을 클릭하여 이 배송 방법을 테스트하�
 
 #: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
-msgstr ""
+msgstr "관리자가 업데이트되었습니다"
 
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 #: src/lib/components/data-table/data-table-faceted-filter.tsx
@@ -5240,16 +5240,16 @@ msgstr "상태"
 #: src/lib/components/shared/configurable-operation-multi-selector.tsx
 #: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
-msgstr ""
+msgstr "옵션을 찾을 수 없습니다"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
-msgstr ""
+msgstr "바이너리"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
-msgstr ""
+msgstr "옵션 그룹이 업데이트되었습니다"
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
@@ -5274,7 +5274,7 @@ msgstr "옵션 값이 추가되었습니다"
 
 #: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
-msgstr ""
+msgstr "컬렉션이 새 상위 항목으로 이동되었습니다"
 
 #: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 #: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
@@ -5295,11 +5295,11 @@ msgstr "기본적으로 재고 추적"
 
 #: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
-msgstr ""
+msgstr "{total}개 중 {selected}개 선택됨"
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
-msgstr ""
+msgstr "배송 방법이 생성되었습니다"
 
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
@@ -5340,7 +5340,7 @@ msgstr "추가할 새 속성 값:"
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
-msgstr ""
+msgstr "환불 처리 실패"
 
 #: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
@@ -5350,7 +5350,7 @@ msgstr "이름"
 
 #: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
-msgstr ""
+msgstr "주문에 항목 추가"
 
 #: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
@@ -5358,7 +5358,7 @@ msgstr "포함"
 
 #: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
-msgstr ""
+msgstr "옵션 그룹을 찾을 수 없습니다"
 
 #: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
@@ -5367,7 +5367,7 @@ msgstr "항목을 찾을 수 없습니다"
 #: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 #: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
-msgstr ""
+msgstr "옵션 그룹 제거 실패"
 
 #: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
@@ -5380,7 +5380,7 @@ msgstr "이행된 항목({0})"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
-msgstr ""
+msgstr "값이 업데이트되었습니다"
 
 #: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
@@ -5425,7 +5425,7 @@ msgstr "새 결제 방법"
 
 #: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
-msgstr ""
+msgstr "중복 값 \"{trimmed}\"이(가) 이미 존재합니다"
 
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5438,7 +5438,7 @@ msgstr "고객 그룹"
 
 #: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
-msgstr ""
+msgstr "채널에서 {entityType}이(가) 제거되었습니다"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
@@ -5453,7 +5453,7 @@ msgstr "옵션 그룹"
 #: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
-msgstr ""
+msgstr "추가 요금 추가"
 
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
@@ -5461,12 +5461,12 @@ msgstr "현재 속성 값"
 
 #: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
-msgstr ""
+msgstr "{totalPages} 페이지 중 {page} 페이지"
 
 #: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
-msgstr ""
+msgstr "지난달"
 
 #: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
@@ -5474,7 +5474,7 @@ msgstr "국가 추가"
 
 #: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
-msgstr ""
+msgstr "기본 언어가 사용됩니다."
 
 #: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
@@ -5483,7 +5483,7 @@ msgstr "항목 제거"
 #: src/lib/components/shared/asset/asset-gallery.tsx
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
-msgstr ""
+msgstr "비디오"
 
 #: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
@@ -5491,11 +5491,11 @@ msgstr "보다 작음"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
-msgstr ""
+msgstr "변형을 추가할 수 없습니다. 상위 상품이 활성화되어 있는지 확인하세요."
 
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
-msgstr ""
+msgstr "지표"
 
 #: src/lib/components/layout/nav-user.tsx
 msgid "Language"
@@ -5507,7 +5507,7 @@ msgstr "새 컬렉션"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
-msgstr ""
+msgstr "환불 및 주문 취소"
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
@@ -5519,7 +5519,7 @@ msgstr "사이"
 
 #: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
-msgstr ""
+msgstr "환불 및 취소"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
@@ -5532,7 +5532,7 @@ msgstr "{label}"
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
-msgstr ""
+msgstr "배송 방법 생성 실패"
 
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
@@ -5584,7 +5584,7 @@ msgstr "지역이 생성되었습니다"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
-msgstr ""
+msgstr "값"
 
 #: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
@@ -5606,7 +5606,7 @@ msgstr "새 속성"
 #: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
-msgstr ""
+msgstr "이 상품에서 옵션 그룹을 제거하시겠습니까?"
 
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
@@ -5628,11 +5628,11 @@ msgstr "이 변경사항에는 결제 또는 환불이 필요하지 않습니다
 
 #: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
-msgstr ""
+msgstr "{cancellableCount, plural, other {{cancellableCount}개 작업을 취소하시겠습니까? 이 작업은 되돌릴 수 없습니다.}}"
 
 #: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
-msgstr ""
+msgstr "총 매출"
 
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
@@ -5648,7 +5648,7 @@ msgstr "중간 날짜"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
-msgstr ""
+msgstr "유효하지 않은 숫자"
 
 #: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
@@ -5660,7 +5660,7 @@ msgstr "이 뷰를 삭제하시겠습니까? 이 작업은 취소할 수 없습�
 
 #: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
-msgstr ""
+msgstr "주문 프로세스 보기"
 
 #: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
@@ -5677,7 +5677,7 @@ msgstr "슬러그 수동 편집"
 
 #: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
-msgstr ""
+msgstr "컬렉션 내용을 미리 보려면 필터를 추가하세요."
 
 #: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
@@ -5697,7 +5697,7 @@ msgstr "환불 ID"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
-msgstr ""
+msgstr "주문 사용자 정의 필드가 업데이트되었습니다"
 
 #: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
@@ -5706,7 +5706,7 @@ msgstr "계산기"
 
 #: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
-msgstr ""
+msgstr "채널에서 옵션 그룹 제거 실패: {message}"
 
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
@@ -5722,11 +5722,11 @@ msgstr "지우기"
 
 #: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
-msgstr ""
+msgstr "주문 요약"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
-msgstr ""
+msgstr "에셋 검색..."
 
 #: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
@@ -5753,7 +5753,7 @@ msgstr "오류 메시지"
 
 #: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
-msgstr ""
+msgstr "다른 위치의 재고 수량 추가"
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
@@ -5765,7 +5765,7 @@ msgstr "속성 업데이트 실패"
 
 #: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
-msgstr ""
+msgstr "useWidgetFilters는 WidgetFiltersProvider 내에서 사용해야 합니다"
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
@@ -5820,7 +5820,7 @@ msgstr "결과 보기"
 
 #: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
-msgstr ""
+msgstr "페이지당 행 수"
 
 #: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
@@ -5858,7 +5858,7 @@ msgstr "{groupName}에 옵션 값 추가"
 #. placeholder {0}: error.message
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
-msgstr ""
+msgstr "주문의 배송지 주소 해제 실패: {0}"
 
 #: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
@@ -5872,7 +5872,7 @@ msgstr "SKU"
 
 #: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
-msgstr ""
+msgstr "{totalQuantity}개 항목이 환불되었습니다"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
@@ -5902,12 +5902,12 @@ msgstr "상품 변형 생성 실패"
 
 #: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
-msgstr ""
+msgstr "검색..."
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
 #: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
-msgstr ""
+msgstr "언어: {0}"
 
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
@@ -5928,7 +5928,7 @@ msgstr "쿠폰 코드가 추가되었습니다"
 #: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
-msgstr ""
+msgstr "활성"
 
 #: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
@@ -5945,7 +5945,7 @@ msgstr "환불이 정산되었습니다"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
-msgstr ""
+msgstr "API 키"
 
 #: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
@@ -5953,7 +5953,7 @@ msgstr "{count}개 {entityName}이(가) 복제되었습니다"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
-msgstr ""
+msgstr "새 옵션 그룹"
 
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
@@ -5966,11 +5966,11 @@ msgstr "결제가 완료되었습니다"
 
 #: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
-msgstr ""
+msgstr "사용 가능한 조건"
 
 #: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
-msgstr ""
+msgstr "활성 필터"
 
 #: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 #: src/lib/components/data-table/data-table-active-filters-popover.tsx
@@ -5984,7 +5984,7 @@ msgstr "보다 큼"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
-msgstr ""
+msgstr "닫기"
 
 #: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
@@ -6016,7 +6016,7 @@ msgstr "이행 ID"
 
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
-msgstr ""
+msgstr "환불할 결제를 선택하세요"
 
 #: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
@@ -6028,11 +6028,11 @@ msgstr "품절 임계값"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
-msgstr ""
+msgstr "값 업데이트 실패"
 
 #: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
-msgstr ""
+msgstr "API 키 생성 실패"
 
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 #: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
@@ -6069,7 +6069,7 @@ msgstr "지역"
 
 #: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
-msgstr ""
+msgstr "판매자 검색..."
 
 #: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
@@ -6081,7 +6081,7 @@ msgstr "옵션"
 
 #: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
-msgstr ""
+msgstr "주문 프로세스"
 
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
@@ -6102,7 +6102,7 @@ msgstr "전역 설정이 업데이트되었습니다"
 
 #: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
-msgstr ""
+msgstr "API 키가 업데이트되었습니다"
 
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"

--- a/packages/dashboard/src/i18n/locales/ko.po
+++ b/packages/dashboard/src/i18n/locales/ko.po
@@ -5702,7 +5702,7 @@ msgstr "주문 사용자 정의 필드가 업데이트되었습니다"
 #: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
-msgstr "계산기"
+msgstr "계산 방식"
 
 #: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"

--- a/packages/dashboard/src/i18n/locales/ko.po
+++ b/packages/dashboard/src/i18n/locales/ko.po
@@ -233,7 +233,7 @@ msgstr "{deleted}개 {entityName}이(가) 삭제되었습니다"
 
 #: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
-msgstr "파일 크기"
+msgstr "파일 용량"
 
 #: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
@@ -467,7 +467,7 @@ msgstr "세율"
 
 #: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
-msgstr "주문 임시 저장본은 완료할 준비가 되지 않았습니다"
+msgstr "임시 저장 주문은 완료할 준비가 되지 않았습니다"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx
@@ -693,7 +693,7 @@ msgstr "기본 세금 지역"
 
 #: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
-msgstr "주문 임시 저장본을 완료할 준비가 되었습니다"
+msgstr "임시 저장 주문은 완료할 준비가 되었습니다"
 
 #: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
@@ -1467,7 +1467,7 @@ msgstr "주문의 고객 설정 실패: {0}"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
-msgstr "크기"
+msgstr "용량"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
 #: src/lib/components/shared/translatable-form-field.tsx
@@ -1558,7 +1558,7 @@ msgstr "고객"
 
 #: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
-msgstr "배송료 계산기 선택"
+msgstr "배송비 계산 방식 선택"
 
 #: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
@@ -3298,7 +3298,7 @@ msgstr "판매자가 생성되었습니다"
 #. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr "{entityIdsLength}개 {entityType}을(를) {1}개 채널 중 {0}개에 할당하지 못했습니다"
+msgstr "{entityIdsLength}개 {entityType}을(를) {1}개 채널 중 {0}개에 할당 실패"
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -5628,7 +5628,7 @@ msgstr "이 변경사항에는 결제 또는 환불이 필요하지 않습니다
 
 #: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
-msgstr "{cancellableCount, plural, other {{cancellableCount}개 작업을 취소하시겠습니까? 이 작업은 되돌릴 수 없습니다.}}"
+msgstr "{cancellableCount, plural, other {{cancellableCount}개 작업을 취소하시겠습니까? 취소하면 되돌릴 수 없습니다.}}"
 
 #: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"

--- a/packages/dashboard/src/i18n/locales/ko.po
+++ b/packages/dashboard/src/i18n/locales/ko.po
@@ -13,4632 +13,6097 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
-msgid "Query extension error"
-msgstr "쿼리 확장 오류"
-
-#. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
-msgid "The page will continue with the default query."
-msgstr "페이지는 기본 쿼리로 계속됩니다."
-
-#. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
-msgid "Failed to extend query document"
-msgstr "쿼리 문서 확장 실패"
-
-#. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
-msgid "Query extension is invalid: must have at least one top-level field"
-msgstr "쿼리 확장이 유효하지 않습니다: 최소 하나의 최상위 필드가 필요합니다"
-
-#. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
-msgid "Query extension mismatch: "
-msgstr "쿼리 확장 불일치:"
-
-#. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
-msgid "Query extension contains invalid GraphQL syntax"
-msgstr "쿼리 확장에 유효하지 않은 GraphQL 구문이 포함되어 있습니다"
-
-#. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
-msgid "Query extension error: "
-msgstr "쿼리 확장 오류:"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:22
-msgid "Insights"
-msgstr "인사이트"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:30
-msgid "Catalog"
-msgstr "카탈로그"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:37
-msgid "Products"
-msgstr "상품"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:44
-msgid "Product Variants"
-msgstr "상품 변형"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:51
-msgid "Facets"
-msgstr "속성"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:58
-msgid "Collections"
-msgstr "컬렉션"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:65
-msgid "Assets"
-msgstr "에셋"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:74
-msgid "Sales"
-msgstr "판매"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:81
-msgid "Orders"
-msgstr "주문"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:90
-#: src/lib/framework/defaults.ts:97
-msgid "Customers"
-msgstr "고객"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:104
-msgid "Customer Groups"
-msgstr "고객 그룹"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:113
-msgid "Marketing"
-msgstr "마케팅"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:120
-msgid "Promotions"
-msgstr "프로모션"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:129
-msgid "System"
-msgstr "시스템"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:136
-msgid "Job Queue"
-msgstr "작업 큐"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:143
-msgid "Healthchecks"
-msgstr "헬스체크"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:150
-msgid "Scheduled Tasks"
-msgstr "예약된 작업"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:159
-msgid "Settings"
-msgstr "설정"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:166
-msgid "Sellers"
-msgstr "판매자"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:173
-msgid "Channels"
-msgstr "채널"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:180
-msgid "Stock Locations"
-msgstr "재고 위치"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:187
-msgid "Administrators"
-msgstr "관리자"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:194
-msgid "Roles"
-msgstr "역할"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:201
-msgid "Shipping Methods"
-msgstr "배송 방법"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:208
-msgid "Payment Methods"
-msgstr "결제 방법"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:215
-msgid "Tax Categories"
-msgstr "세금 카테고리"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:222
-msgid "Tax Rates"
-msgstr "세율"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:229
-msgid "Countries"
-msgstr "국가"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:236
-msgid "Zones"
-msgstr "지역"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:243
-msgid "Global Settings"
-msgstr "전역 설정"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:255
-msgid "Metrics Widget"
-msgstr "지표 위젯"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
-msgid "Latest Orders Widget"
-msgstr "최근 주문 위젯"
-
-#. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:270
-msgid "Orders Summary Widget"
-msgstr "주문 요약 위젯"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-msgid "fulfillmentState.Created"
-msgstr "생성됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
-msgid "fulfillmentState.Pending"
-msgstr "대기 중"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
-msgid "fulfillmentState.Cancelled"
-msgstr "취소됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
-msgid "fulfillmentState.Shipped"
-msgstr "배송됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
-msgid "fulfillmentState.Delivered"
-msgstr "배달됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
-msgid "paymentState.Created"
-msgstr "생성됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
-msgid "paymentState.Authorized"
-msgstr "승인됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
-msgid "paymentState.Settled"
-msgstr "정산됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
-msgid "paymentState.Declined"
-msgstr "거절됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
-msgid "paymentState.Error"
-msgstr "오류"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
-msgid "paymentState.Cancelled"
-msgstr "취소됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
-msgid "paymentState.Pending"
-msgstr "대기 중"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
-msgid "paymentState.Failed"
-msgstr "실패"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
-msgid "orderState.Created"
-msgstr "생성됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
-msgid "orderState.Draft"
-msgstr "임시 저장"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
-msgid "orderState.AddingItems"
-msgstr "상품 추가 중"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
-msgid "orderState.Cancelled"
-msgstr "취소됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
-msgid "orderState.ArrangingPayment"
-msgstr "결제 준비 중"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
-msgid "orderState.PaymentAuthorized"
-msgstr "결제 승인됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
-msgid "orderState.PaymentSettled"
-msgstr "결제 완료"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
-msgid "orderState.PartiallyShipped"
-msgstr "부분 배송됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
-msgid "orderState.Shipped"
-msgstr "배송됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
-msgid "orderState.PartiallyDelivered"
-msgstr "부분 배달됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
-msgid "orderState.Delivered"
-msgstr "배달됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
-msgid "orderState.Modifying"
-msgstr "수정 중"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
-msgid "orderState.ArrangingAdditionalPayment"
-msgstr "추가 결제 준비 중"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
-msgid "fieldName.attempts"
-msgstr "시도 횟수"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
-msgid "fieldName.availableCurrencyCodes"
-msgstr "사용 가능한 통화 코드"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
-msgid "fieldName.availableLanguageCodes"
-msgstr "사용 가능한 언어 코드"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
-msgid "fieldName.breadcrumbs"
-msgstr "경로"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
-msgid "fieldName.category"
-msgstr "카테고리"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:48
-msgid "fieldName.channels"
-msgstr "채널"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:49
-msgid "fieldName.children"
-msgstr "하위 항목"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
-msgid "fieldName.code"
-msgstr "코드"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
-msgid "fieldName.couponCode"
-msgstr "쿠폰 코드"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
-msgid "fieldName.createdAt"
-msgstr "생성일"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
-msgid "fieldName.currencyCode"
-msgstr "통화 코드"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
-msgid "fieldName.customer"
-msgstr "고객"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
-msgid "fieldName.customerGroup"
-msgstr "고객 그룹"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
-msgid "fieldName.customers"
-msgstr "고객"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
-msgid "fieldName.customFields"
-msgstr "사용자 정의 필드"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
-msgid "fieldName.data"
-msgstr "데이터"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
-msgid "fieldName.defaultCurrencyCode"
-msgstr "기본 통화 코드"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
-msgid "fieldName.defaultLanguageCode"
-msgstr "기본 언어 코드"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
-msgid "fieldName.defaultShippingZone"
-msgstr "기본 배송 지역"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
-msgid "fieldName.defaultTaxZone"
-msgstr "기본 세금 지역"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
-msgid "fieldName.description"
-msgstr "설명"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
-msgid "fieldName.duration"
-msgstr "기간"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
-msgid "fieldName.emailAddress"
-msgstr "이메일 주소"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
-msgid "fieldName.enabled"
-msgstr "활성화됨"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
-msgid "fieldName.endsAt"
-msgstr "종료 일시"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
-msgid "fieldName.error"
-msgstr "오류"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
-msgid "fieldName.featuredAsset"
-msgstr "주요 에셋"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
-msgid "fieldName.firstName"
-msgstr "이름"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
-msgid "fieldName.fulfillmentHandlerCode"
-msgstr "배송 처리 코드"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
-msgid "fieldName.id"
-msgstr "ID"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
-msgid "fieldName.isDefault"
-msgstr "기본값"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
-msgid "fieldName.isPrivate"
-msgstr "비공개"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
-msgid "fieldName.isSettled"
-msgstr "정산 완료"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
-msgid "fieldName.lastName"
-msgstr "성"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
-msgid "fieldName.name"
-msgstr "이름"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
-msgid "fieldName.orderPlacedAt"
-msgstr "주문 일시"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
-msgid "fieldName.parentId"
-msgstr "상위 ID"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
-msgid "fieldName.perCustomerUsageLimit"
-msgstr "고객당 사용 제한"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
-msgid "fieldName.permissions"
-msgstr "권한"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
-msgid "fieldName.position"
-msgstr "위치"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
-msgid "fieldName.price"
-msgstr "가격"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
-msgid "fieldName.priceWithTax"
-msgstr "세금 포함 가격"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
-msgid "fieldName.pricesIncludeTax"
-msgstr "가격에 세금 포함"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
-msgid "fieldName.productVariants"
-msgstr "상품 변형"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
-msgid "fieldName.progress"
-msgstr "진행률"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
-msgid "fieldName.queueName"
-msgstr "큐 이름"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
-msgid "fieldName.result"
-msgstr "결과"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
-msgid "fieldName.retries"
-msgstr "재시도"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
-msgid "fieldName.seller"
-msgstr "판매자"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
-msgid "fieldName.settledAt"
-msgstr "정산일"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
-msgid "fieldName.shippingLines"
-msgstr "배송 항목"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
-msgid "fieldName.sku"
-msgstr "SKU"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
-msgid "fieldName.slug"
-msgstr "슬러그"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
-msgid "fieldName.startedAt"
-msgstr "시작일"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
-msgid "fieldName.startsAt"
-msgstr "시작 일시"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
-msgid "fieldName.state"
-msgstr "상태"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
-msgid "fieldName.stockLevels"
-msgstr "재고 수준"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
-msgid "fieldName.token"
-msgstr "토큰"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
-msgid "fieldName.total"
-msgstr "합계"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
-msgid "fieldName.totalWithTax"
-msgstr "세금 포함 합계"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
-msgid "fieldName.type"
-msgstr "유형"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
-msgid "fieldName.updatedAt"
-msgstr "수정일"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
-msgid "fieldName.usageLimit"
-msgstr "사용 제한"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
-msgid "fieldName.user"
-msgstr "사용자"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
-msgid "fieldName.value"
-msgstr "값"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
-msgid "fieldName.valueList"
-msgstr "값 목록"
-
-#. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
-msgid "fieldName.zone"
-msgstr "지역"
-
-#. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:99
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
-msgid "Note added successfully"
-msgstr "메모가 추가되었습니다"
-
-#. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
-msgid "Failed to add note"
-msgstr "메모 추가 실패"
-
-#. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:120
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
-msgid "Note updated successfully"
-msgstr "메모가 업데이트되었습니다"
-
-#. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
-msgid "Failed to update note"
-msgstr "메모 업데이트 실패"
-
-#. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:140
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
-msgid "Note deleted successfully"
-msgstr "메모가 삭제되었습니다"
-
-#. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
-msgid "Failed to delete note"
-msgstr "메모 삭제 실패"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:26
-msgid "!="
-msgstr "!="
-
-#. placeholder {0}: action.label
-#. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
-#. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:102
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:93
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:189
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:45
-#: src/lib/components/data-input/product-multi-selector-input.tsx:278
-#: src/lib/components/data-input/relation-selector.tsx:403
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:421
-msgid "{0}"
-msgstr "{0}"
-
-#. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:41
-msgid "{0} customers"
-msgstr "{0}명의 고객"
-
-#. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:401
-msgid "{0} items selected"
-msgstr "{0}개 항목 선택됨"
-
-#. placeholder {0}: quantity.max
-#. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:258
-msgid "{0} of {1} available to fulfill"
-msgstr "{1}개 중 {0}개 처리 가능"
-
-#. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:72
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:82
-msgid "{0} selected"
-msgstr "{0}개 선택됨"
-
-#. placeholder {0}: row.original.productVariants?.totalItems
-#: src/app/routes/_authenticated/_collections/collections.tsx:150
-msgid "{0} variants"
-msgstr "{0}개 변형"
-
-#: src/lib/components/data-input/product-multi-selector-input.tsx:396
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:225
-#: src/lib/components/shared/configurable-operation-selector.tsx:135
-msgid "{buttonText}"
-msgstr "{buttonText}"
-
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:106
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:134
-msgid "{label}"
-msgstr "{label}"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:63
-msgid "{operator}"
-msgstr "{operator}"
-
-#: src/lib/framework/dashboard-widget/base-widget.tsx:78
-msgid "{title}"
-msgstr "{title}"
-
-#. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
-msgid "+ {0} more"
-msgstr "+ {0}개 더보기"
-
-#: src/app/routes/_authenticated/_collections/collections.tsx:168
-msgid "+ {leftOver} more"
-msgstr "+ {leftOver}개 더보기"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:24
-msgid "="
-msgstr "="
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:173
-msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
-msgstr "{formattedDiff}의 환불이 필요합니다. 결제 금액을 선택하고 메모를 입력하여 계속하세요."
-
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:238
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:191
-#: src/lib/components/data-table/use-generated-columns.tsx:231
-msgid "Actions"
-msgstr "작업"
-
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:81
-msgid "Add \"{newOptionInput}\""
-msgstr "「{newOptionInput}」추가"
-
-#. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
-msgid "Add a manual payment of {0}"
-msgstr "{0}의 수동 결제 추가"
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:230
-msgid "Add a new address to the customer."
-msgstr "고객에게 새 주소를 추가합니다."
-
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
-msgid "Add another option group"
-msgstr "다른 옵션 그룹 추가"
-
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:132
-msgid "Add asset"
-msgstr "에셋 추가"
-
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:151
-msgid "Add column after"
-msgstr "뒤에 열 추가"
-
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:145
-msgid "Add column before"
-msgstr "앞에 열 추가"
-
-#: src/app/routes/_authenticated/_countries/countries.tsx:65
-msgid "Add Country"
-msgstr "국가 추가"
-
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:247
-msgid "Add coupon code"
-msgstr "쿠폰 코드 추가"
-
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:129
-msgid "Add customer"
-msgstr "고객 추가"
-
-#: src/lib/components/shared/customer-group-selector.tsx:46
-msgid "Add customer groups"
-msgstr "고객 그룹 추가"
-
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:102
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:169
-msgid "Add facet value"
-msgstr "속성 값 추가"
-
-#: src/lib/components/shared/facet-value-selector.tsx:256
-msgid "Add facet values"
-msgstr "속성 값 추가"
-
-#: src/lib/components/data-table/add-filter-menu.tsx:39
-msgid "Add filter"
-msgstr "필터 추가"
-
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
-msgid "Add item"
-msgstr "항목 추가"
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:221
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-msgid "Add new address"
-msgstr "새 주소 추가"
-
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
-msgid "Add option"
-msgstr "옵션 추가"
-
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:175
-msgid "Add Option"
-msgstr "옵션 추가"
-
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:97
-msgid "Add option group"
-msgstr "옵션 그룹 추가"
-
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:103
-msgid "Add option group to product"
-msgstr "상품에 옵션 그룹 추가"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:149
-msgid "Add option value"
-msgstr "옵션 값 추가"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:134
-msgid "Add option value to {groupName}"
-msgstr "{groupName}에 옵션 값 추가"
-
-#. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-msgid "Add or remove facet values for {0} {entityType}"
-msgstr "{0}개 {entityType}의 속성 값 추가 또는 제거"
-
-#. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
-msgid "Add payment ({0})"
-msgstr "결제 추가({0})"
-
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
-msgid "Add payment to order"
-msgstr "주문에 결제 추가"
-
-#. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
-msgid "Add payment to order ({0})"
-msgstr "주문에 결제 추가({0})"
-
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:105
-msgid "Add product option"
-msgstr "상품 옵션 추가"
-
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
-msgid "Add product options first"
-msgstr "먼저 상품 옵션을 추가하세요"
-
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:276
-msgid "Add product variant"
-msgstr "상품 변형 추가"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:231
-msgid "Add products to create a test order"
-msgstr "테스트 주문을 생성하려면 상품을 추가하세요"
-
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:203
-msgid "Add row after"
-msgstr "뒤에 행 추가"
-
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:197
-msgid "Add row before"
-msgstr "앞에 행 추가"
-
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:179
-msgid "Add Stock to Location"
-msgstr "위치에 재고 추가"
-
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:141
-msgid "Add tags..."
-msgstr "태그 추가..."
-
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:243
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:270
-msgid "Add variant"
-msgstr "변형 추가"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:187
-msgid "Added coupon codes"
-msgstr "쿠폰 코드가 추가되었습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
-msgid "Added to group"
-msgstr "그룹에 추가되었습니다"
-
-#. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:161
-msgid "Adding {0} item(s)"
-msgstr "{0}개 항목 추가 중"
-
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
-msgid "Adding..."
-msgstr "추가 중..."
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:321
-msgid "Additional payment required"
-msgstr "추가 결제가 필요합니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
-msgid "Address created"
-msgstr "주소가 생성되었습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
-msgid "Address deleted"
-msgstr "주소가 삭제되었습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
-msgid "Address deleted successfully"
-msgstr "주소가 삭제되었습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
-msgid "Address updated"
-msgstr "주소가 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
-msgid "Address updated successfully"
-msgstr "주소가 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:200
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:464
-msgid "Addresses"
-msgstr "주소"
-
-#. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:130
-msgid "Adjusting {0} lines"
-msgstr "{0}개 항목 조정 중"
-
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:16
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:23
-msgid "Administrators"
-msgstr "관리자"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:30
-msgid "after"
-msgstr "이후"
-
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
-msgid "All resources are up and running"
-msgstr "모든 리소스가 정상 작동 중입니다"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:222
-msgid "Allocated"
-msgstr "할당됨"
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-msgid "Amount"
-msgstr "금액"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:324
-msgid "An additional payment of {formattedDiff} will be required."
-msgstr "{formattedDiff}의 추가 결제가 필요합니다."
-
-#: src/lib/components/data-input/combination-mode-input.tsx:44
-msgid "AND"
-msgstr "AND"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:163
-#: src/lib/components/shared/customer-address-form.tsx:154
-msgid "Apartment, suite, etc."
-msgstr "아파트, 스위트 등"
-
-#: src/lib/components/data-table/views-sheet.tsx:49
-msgid "Applied global view \"{viewName}\""
-msgstr "전역 뷰 \"{viewName}\"가 적용되었습니다"
-
-#: src/lib/components/data-table/views-sheet.tsx:49
-msgid "Applied view \"{viewName}\""
-msgstr "뷰 \"{viewName}\"가 적용되었습니다"
-
-#: src/lib/components/data-table/views-sheet.tsx:227
-msgid "Apply"
-msgstr "적용"
-
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:66
-msgid "Apply filter"
-msgstr "필터 적용"
-
-#: src/lib/components/data-table/views-sheet.tsx:155
-msgid "Apply filters to the table and click \"Save View\" to get started."
-msgstr "테이블에 필터를 적용하고 \"뷰 저장\"을 클릭하여 시작하세요."
-
-#. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
-msgid "Are you sure you want to delete {0} {entityName}?"
-msgstr "{0}개 {entityName}을(를) 삭제하시겠습니까?"
-
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
-msgid "Are you sure you want to delete {selectionLength} assets?"
-msgstr "{selectionLength}개 에셋을 삭제하시겠습니까?"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
-msgid "Are you sure you want to delete this address?"
-msgstr "이 주소를 삭제하시겠습니까?"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:287
-msgid "Are you sure you want to delete this draft order?"
-msgstr "이 임시 저장 주문을 삭제하시겠습니까?"
-
-#: src/lib/components/data-table/views-sheet.tsx:168
-msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
-msgstr "이 전역 뷰를 삭제하시겠습니까? 이 작업은 취소할 수 없으며 모든 사용자에게 영향을 미칩니다."
-
-#: src/lib/components/data-table/use-generated-columns.tsx:322
-msgid "Are you sure you want to delete this item? This action cannot be undone."
-msgstr "이 항목을 삭제하시겠습니까? 이 작업은 취소할 수 없습니다."
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:236
-msgid "Are you sure you want to delete this variant?"
-msgstr "이 변형을 삭제하시겠습니까?"
-
-#: src/lib/components/data-table/views-sheet.tsx:173
-msgid "Are you sure you want to delete this view? This action cannot be undone."
-msgstr "이 뷰를 삭제하시겠습니까? 이 작업은 취소할 수 없습니다."
-
-#: src/lib/components/shared/navigation-confirmation.tsx:47
-msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
-msgstr "이 페이지에서 나가시겠습니까? 저장하지 않은 변경사항은 손실됩니다."
-
-#. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:83
-msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
-msgstr "현재 채널에서 {0}개 {entityType}을(를) 제거하시겠습니까?"
-
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:38
-#: src/app/routes/_authenticated/_assets/assets.tsx:9
-#: src/app/routes/_authenticated/_assets/assets.tsx:16
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:198
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:310
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:208
-msgid "Assets"
-msgstr "에셋"
-
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:125
-msgid "Assign"
-msgstr "할당"
-
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
-msgid "Assign {entityType} to channel"
-msgstr "채널에 {entityType} 할당"
-
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
-msgid "Assign options to existing variant"
-msgstr "기존 변형에 옵션 할당"
-
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-msgid "Assign to channel"
-msgstr "채널에 할당"
-
-#. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:236
-msgid "Auto refresh: {0}"
-msgstr "자동 새로고침: {0}"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:176
-msgid "Available currencies"
-msgstr "사용 가능한 통화"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:164
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:111
-msgid "Available languages"
-msgstr "사용 가능한 언어"
-
-#: src/lib/components/layout/manage-languages-dialog.tsx:340
-msgid "Available Languages"
-msgstr "사용 가능한 언어"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:235
-msgid "Available:"
-msgstr "사용 가능:"
-
-#: src/lib/components/shared/facet-value-selector.tsx:288
-msgid "Back to search"
-msgstr "검색으로 돌아가기"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:28
-msgid "before"
-msgstr "이전"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:32
-msgid "between"
-msgstr "사이"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:267
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:493
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:433
-msgid "Billing address"
-msgstr "청구지 주소"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:116
-msgid "Billing address changed"
-msgstr "청구지 주소가 변경되었습니다"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:174
-msgid "Billing address set for order"
-msgstr "주문에 청구 주소가 설정되었습니다"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:190
-msgid "Billing address unset for order"
-msgstr "주문에서 청구 주소가 제거되었습니다"
-
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:185
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:185
-msgid "Calculator"
-msgstr "계산기"
-
-#: src/app/common/duplicate-entity-dialog.tsx:108
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:414
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:334
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:304
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:350
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:270
-#: src/lib/components/data-input/product-multi-selector-input.tsx:364
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:119
-#: src/lib/components/data-table/use-generated-columns.tsx:329
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:295
-#: src/lib/components/layout/manage-languages-dialog.tsx:396
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:122
-#: src/lib/components/shared/confirmation-dialog.tsx:43
-#: src/lib/components/shared/customer-address-form.tsx:325
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:205
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
-msgid "Cancel"
-msgstr "취소"
-
-#: src/app/routes/_authenticated/_system/job-queue.tsx:184
-msgid "Cancel Job"
-msgstr "작업 취소"
-
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:397
-msgid "Cancel modification"
-msgstr "수정 취소"
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
-msgid "Cancel payment"
-msgstr "결제 취소"
-
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:54
-msgid "Category"
-msgstr "카테고리"
-
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:103
-msgid "Channel"
-msgstr "채널"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:187
-msgid "Channel defaults"
-msgstr "채널 기본값"
-
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
-msgid "Channel Languages"
-msgstr "채널 언어"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:40
-#: src/app/routes/_authenticated/_channels/channels.tsx:16
-#: src/app/routes/_authenticated/_channels/channels.tsx:24
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:115
-#: src/lib/components/layout/channel-switcher.tsx:121
-msgid "Channels"
-msgstr "채널"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:184
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:195
-#: src/lib/components/shared/customer-address-form.tsx:175
-msgid "City"
-msgstr "도시"
-
-#: src/lib/components/data-input/product-multi-selector-input.tsx:323
-msgid "Clear"
-msgstr "지우기"
-
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:180
-#: src/lib/components/data-table/data-table.tsx:277
-msgid "Clear all"
-msgstr "모두 지우기"
-
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:54
-msgid "Clear filter"
-msgstr "필터 지우기"
-
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:163
-msgid "Clear filters"
-msgstr "필터 지우기"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
-msgid "Click \"Run Test\" to test this shipping method."
-msgstr "\"테스트 실행\"을 클릭하여 이 배송 방법을 테스트하세요."
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:136
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:114
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:113
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:140
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:130
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:157
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:159
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:191
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:104
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:149
-msgid "Code"
-msgstr "코드"
-
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:36
-msgid "Collection contents for {collectionName}"
-msgstr "{collectionName}의 컬렉션 내용"
-
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:45
-#: src/app/routes/_authenticated/_collections/collections.tsx:29
-#: src/app/routes/_authenticated/_collections/collections.tsx:85
-msgid "Collections"
-msgstr "컬렉션"
-
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:283
-msgid "Collections moved successfully"
-msgstr "컬렉션이 성공적으로 이동되었습니다"
-
-#: src/lib/components/data-table/data-table-view-options.tsx:93
-msgid "Column settings"
-msgstr "열 설정"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:125
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:164
-#: src/lib/components/shared/customer-address-form.tsx:116
-msgid "Company"
-msgstr "회사"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:308
-msgid "Complete draft"
-msgstr "임시 저장 완료"
-
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:226
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:173
-msgid "Conditions"
-msgstr "조건"
-
-#: src/lib/components/layout/manage-languages-dialog.tsx:261
-msgid "Configure available languages for your store and channels"
-msgstr "스토어 및 채널에 사용 가능한 언어 구성"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:359
-#: src/lib/components/shared/navigation-confirmation.tsx:58
-msgid "Confirm"
-msgstr "확인"
-
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:113
-msgid "Confirm Action"
-msgstr "작업 확인"
-
-#: src/lib/components/data-table/use-generated-columns.tsx:319
-msgid "Confirm deletion"
-msgstr "삭제 확인"
-
-#: src/lib/components/shared/navigation-confirmation.tsx:44
-msgid "Confirm navigation"
-msgstr "이동 확인"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:56
-msgid "contains"
-msgstr "포함"
-
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:222
-#: src/app/routes/_authenticated/_collections/collections.tsx:143
-msgid "Contents"
-msgstr "내용"
-
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/shared/confirmation-dialog.tsx:52
-msgid "Continue"
-msgstr "계속"
-
-#: src/lib/components/data-table/views-sheet.tsx:253
-msgid "Copy to Personal"
-msgstr "개인용으로 복사"
-
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:34
-#: src/app/routes/_authenticated/_countries/countries.tsx:14
-#: src/app/routes/_authenticated/_countries/countries.tsx:23
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:103
-msgid "Countries"
-msgstr "국가"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:239
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:216
-#: src/lib/components/shared/customer-address-form.tsx:230
-msgid "Country"
-msgstr "국가"
-
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:196
-msgid "Coupon code"
-msgstr "쿠폰 코드"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:230
-msgid "Coupon code removed from order"
-msgstr "주문에서 쿠폰 코드가 제거되었습니다"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
-msgid "Coupon code set for order"
-msgstr "주문에 쿠폰 코드가 설정되었습니다"
-
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:125
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:124
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:87
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:96
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:155
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:112
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:102
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:130
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:134
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:197
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:142
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:163
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:135
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:87
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:81
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:132
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:99
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:98
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:95
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:85
-msgid "Create"
-msgstr "생성"
-
-#. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:161
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:178
-msgid "Create \"{0}\""
-msgstr "\"{0}\" 생성"
-
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:181
-msgid "Create {createCount} variants"
-msgstr "{createCount}개 변형 생성"
-
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
-msgid "Create options"
-msgstr "옵션 생성"
-
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
-msgid "Create product options"
-msgstr "상품 옵션 생성"
-
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:364
-msgid "Create variant"
-msgstr "변형 생성"
-
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:152
-msgid "Create Variants"
-msgstr "변형 생성"
-
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:155
-msgid "Create variants for your product"
-msgstr "상품 변형 생성"
-
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:114
-#: src/lib/framework/layout-engine/page-layout.tsx:394
-msgid "Created"
-msgstr "생성일"
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
-msgid "Created at"
-msgstr "생성 일시"
-
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:179
-msgid "Creating..."
-msgstr "생성 중..."
-
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:199
-msgid "Current facet values"
-msgstr "현재 속성 값"
-
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
-msgid "Current status"
-msgstr "현재 상태"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:362
-msgid "Custom fields"
-msgstr "사용자 정의 필드"
-
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:42
-msgid "Custom Fields"
-msgstr "사용자 정의 필드"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:150
-msgid "Custom fields changed"
-msgstr "사용자 정의 필드가 변경되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:242
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:450
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
-#: src/lib/components/shared/role-code-label.tsx:8
-msgid "Customer"
-msgstr "고객"
-
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:55
-msgid "Customer added to group"
-msgstr "고객이 그룹에 추가되었습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
-msgid "Customer details updated"
-msgstr "고객 정보가 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:36
-msgid "Customer group members for {customerGroupName}"
-msgstr "{customerGroupName}의 고객 그룹 멤버"
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:255
-msgid "Customer groups"
-msgstr "고객 그룹"
-
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:37
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:15
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:22
-msgid "Customer Groups"
-msgstr "고객 그룹"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:249
-msgid "Customer history"
-msgstr "고객 이력"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:84
-msgid "Customer information updated"
-msgstr "고객 정보가 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
-msgid "Customer not found"
-msgstr "고객을 찾을 수 없습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
-msgid "Customer registered"
-msgstr "고객이 등록되었습니다"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
-msgid "Customer set for order"
-msgstr "주문에 고객이 설정되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:98
-msgid "Customer updated"
-msgstr "고객이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
-msgid "Customer verified"
-msgstr "고객이 인증되었습니다"
-
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:114
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:58
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
-msgid "Customers"
-msgstr "고객"
-
-#: src/lib/components/layout/nav-user.tsx:131
-msgctxt "theme"
-msgid "Dark"
-msgstr "다크"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:319
-#: src/lib/components/shared/customer-address-form.tsx:310
-msgid "Default Billing Address"
-msgstr "기본 청구지 주소"
-
-#: src/lib/components/shared/channel-code-label.tsx:5
-msgid "Default channel"
-msgstr "기본 채널"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:205
-msgid "Default currency"
-msgstr "기본 통화"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:192
-msgid "Default language"
-msgstr "기본 언어"
-
-#: src/lib/components/layout/manage-languages-dialog.tsx:368
-msgid "Default Language"
-msgstr "기본 언어"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:299
-#: src/lib/components/shared/customer-address-form.tsx:290
-msgid "Default Shipping Address"
-msgstr "기본 배송지 주소"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:226
-msgid "Default shipping zone"
-msgstr "기본 배송 지역"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:218
-msgid "Default tax zone"
-msgstr "기본 세금 지역"
-
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:312
-#: src/lib/components/data-table/use-generated-columns.tsx:312
-#: src/lib/components/data-table/use-generated-columns.tsx:343
-#: src/lib/components/data-table/views-sheet.tsx:272
-#: src/lib/components/data-table/views-sheet.tsx:298
-msgid "Delete"
-msgstr "삭제"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
-msgid "Delete Address"
-msgstr "주소 삭제"
-
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:166
-msgid "Delete column"
-msgstr "열 삭제"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:293
-msgid "Delete draft"
-msgstr "임시 저장 삭제"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:286
-msgid "Delete draft order"
-msgstr "임시 저장 주문 삭제"
-
-#: src/lib/components/data-table/views-sheet.tsx:163
-msgid "Delete Global View"
-msgstr "전역 뷰 삭제"
-
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:218
-msgid "Delete row"
-msgstr "행 삭제"
-
-#: src/lib/components/data-table/views-sheet.tsx:163
-msgid "Delete View"
-msgstr "뷰 삭제"
-
-#: src/app/common/delete-bulk-action.tsx:108
-msgid "Deleted {deleted} {entityName}"
-msgstr "{deleted}개 {entityName}이(가) 삭제되었습니다"
-
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
-msgid "Deleted {selectionLength} assets"
-msgstr "{selectionLength}개 에셋이 삭제되었습니다"
-
-#: src/lib/components/data-table/use-generated-columns.tsx:293
-msgid "Deleted successfully"
-msgstr "삭제되었습니다"
-
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:167
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:155
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:166
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:98
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:157
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:118
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:110
-msgid "Description"
-msgstr "설명"
-
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:166
-msgid "Description (alt)"
-msgstr "설명(대체 텍스트)"
-
-#: src/lib/components/layout/dev-mode-indicator.tsx:12
-#: src/lib/components/layout/nav-user.tsx:144
-msgid "Dev Mode"
-msgstr "개발 모드"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
-msgid "Disable"
-msgstr "비활성화"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:121
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:50
-#: src/lib/components/layout/nav-user.tsx:155
-msgid "Disabled"
-msgstr "비활성화됨"
-
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:36
-msgid "Discount"
-msgstr "할인"
-
-#: src/lib/components/layout/language-dialog.tsx:42
-msgid "Display language"
-msgstr "표시 언어"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:256
-msgid "Do not track"
-msgstr "추적 안 함"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:58
-msgid "does not contain"
-msgstr "포함하지 않음"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:280
-#: src/app/routes/_authenticated/_orders/orders.tsx:113
-msgid "Draft order"
-msgstr "임시 저장 주문"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:241
-msgid "Draft order completed"
-msgstr "임시 저장 주문이 완료되었습니다"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:258
-msgid "Draft order deleted"
-msgstr "임시 저장 주문이 삭제되었습니다"
-
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
-msgid "Drag to reorder"
-msgstr "드래그하여 순서 변경"
-
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:111
-#: src/lib/components/data-table/views-sheet.tsx:246
-msgid "Duplicate"
-msgstr "복제"
-
-#. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:83
-msgid "Duplicate {0}s"
-msgstr "{0} 복제"
-
-#. placeholder {0}: progress.completed
-#. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
-msgid "Duplicating... ({0}/{1})"
-msgstr "복제 중...({0}/{1})"
-
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
-msgid "e.g. Size"
-msgstr "예: 사이즈"
-
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
-msgid "e.g. Small"
-msgstr "예: 스몰"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
-msgid "e.g., Red, Large, Cotton"
-msgstr "예: 레드, 라지, 코튼"
-
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:474
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:500
-#: src/lib/components/shared/asset/asset-gallery.tsx:457
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:48
-msgid "Edit"
-msgstr "편집"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
-msgid "Edit Address"
-msgstr "주소 편집"
-
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:95
-msgid "Edit asset"
-msgstr "에셋 편집"
-
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:156
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
-msgid "Edit facet values"
-msgstr "속성 값 편집"
-
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-msgid "Edit image"
-msgstr "이미지 편집"
-
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
-msgid "Edit link"
-msgstr "링크 편집"
-
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
-msgid "Edit members"
-msgstr "멤버 편집"
-
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
-msgid "Edit Note"
-msgstr "메모 편집"
-
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
-msgid "Edit or delete existing tags"
-msgstr "기존 태그 편집 또는 삭제"
-
-#: src/lib/components/data-input/slug-input.tsx:279
-#: src/lib/components/data-input/slug-input.tsx:281
-msgid "Edit slug manually"
-msgstr "슬러그 수동 편집"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
-msgid "Edit the address details below."
-msgstr "아래 주소 정보를 편집하세요."
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:185
-msgid "Email address"
-msgstr "이메일 주소"
-
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:138
-#: src/app/routes/_authenticated/_profile/profile.tsx:104
-msgid "Email Address or identifier"
-msgstr "이메일 주소 또는 식별자"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
-msgid "Email update requested"
-msgstr "이메일 업데이트가 요청되었습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
-msgid "Email update verified"
-msgstr "이메일 업데이트가 확인되었습니다"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
-msgid "Enable"
-msgstr "활성화"
-
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:96
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:140
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:144
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:121
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:145
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:113
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:117
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:47
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:49
-#: src/lib/components/layout/nav-user.tsx:152
-msgid "Enabled"
-msgstr "활성화됨"
-
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:185
-msgid "Ends at"
-msgstr "종료 일시"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:306
-msgid "Enter refund note"
-msgstr "환불 메모 입력"
-
-#: src/lib/components/data-input/slug-input.tsx:239
-msgid "Enter slug manually"
-msgstr "슬러그 수동 입력"
-
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
-msgid "Enter the transaction ID for this refund settlement"
-msgstr "이 환불 정산의 거래 ID를 입력하세요"
-
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
-msgid "Enter transaction ID"
-msgstr "거래 ID 입력"
-
-#: src/lib/framework/layout-engine/page-layout.tsx:367
-msgid "Entity Information"
-msgstr "엔티티 정보"
-
-#: src/lib/components/shared/error-page.tsx:18
-msgid "Error"
-msgstr "오류"
-
-#. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
-msgid "Error loading customer history: {0}"
-msgstr "고객 이력 로딩 오류: {0}"
-
-#. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
-msgid "Error loading order history: {0}"
-msgstr "주문 이력 로딩 오류: {0}"
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
-msgid "Error message"
-msgstr "오류 메시지"
-
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:125
-msgid "Error transitioning to state"
-msgstr "상태 전환 오류"
-
-#: src/app/routes/_authenticated/_system/job-queue.tsx:72
-msgid "Every 10 seconds"
-msgstr "10초마다"
-
-#: src/app/routes/_authenticated/_system/job-queue.tsx:73
-msgid "Every 30 seconds"
-msgstr "30초마다"
-
-#: src/app/routes/_authenticated/_system/job-queue.tsx:71
-msgid "Every 5 seconds"
-msgstr "5초마다"
-
-#: src/app/routes/_authenticated/_system/job-queue.tsx:74
-msgid "Every 60 seconds"
-msgstr "60초마다"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
-msgid "ex. tax:"
-msgstr "세금 제외:"
-
-#: src/lib/components/layout/nav-user.tsx:98
-msgid "Explore Enterprise Edition"
-msgstr "Enterprise Edition 살펴보기"
-
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:122
-msgid "Facet"
-msgstr "속성"
-
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:145
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:301
-msgid "Facet values"
-msgstr "속성 값"
-
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:199
-msgid "Facet Values"
-msgstr "속성 값"
-
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:32
-msgid "Facet values for {facetName}"
-msgstr "{facetName}의 속성 값"
-
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:39
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:37
-#: src/app/routes/_authenticated/_facets/facets.tsx:24
-#: src/app/routes/_authenticated/_facets/facets.tsx:64
-#: src/lib/components/shared/facet-value-selector.tsx:321
-msgid "Facets"
-msgstr "속성"
-
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:129
-msgid "Failed to add customer to group"
-msgstr "고객을 그룹에 추가하는 데 실패했습니다"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:103
-msgid "Failed to add option value"
-msgstr "옵션 값 추가 실패"
-
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
-msgid "Failed to add payment"
-msgstr "결제 추가 실패"
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
-msgid "Failed to cancel payment"
-msgstr "결제 취소 실패"
-
-#: src/lib/components/data-table/views-sheet.tsx:110
-msgid "Failed to convert global view to personal view"
-msgstr "전역 뷰를 개인 뷰로 변환하는 데 실패했습니다"
-
-#: src/lib/components/data-table/views-sheet.tsx:120
-msgid "Failed to convert view to global"
-msgstr "뷰를 전역으로 변환하는 데 실패했습니다"
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:119
-msgid "Failed to create address"
-msgstr "주소 생성 실패"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:92
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:98
-msgid "Failed to create channel"
-msgstr "채널 생성 실패"
-
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:102
-msgid "Failed to create collection"
-msgstr "컬렉션 생성 실패"
-
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:71
-msgid "Failed to create country"
-msgstr "국가 생성 실패"
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:106
-msgid "Failed to create customer"
-msgstr "고객 생성 실패"
-
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:76
-msgid "Failed to create customer group"
-msgstr "고객 그룹 생성 실패"
-
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:86
-msgid "Failed to create facet"
-msgstr "속성 생성 실패"
-
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:94
-msgid "Failed to create facet value"
-msgstr "속성 값 생성 실패"
-
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:86
-msgid "Failed to create option group"
-msgstr "옵션 그룹 생성 실패"
-
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
-msgid "Failed to create payment method"
-msgstr "결제 방법 생성 실패"
-
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:95
-msgid "Failed to create product"
-msgstr "상품 생성 실패"
-
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
-msgid "Failed to create product options"
-msgstr "상품 옵션 생성 실패"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:112
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:174
-msgid "Failed to create product variant"
-msgstr "상품 변형 생성 실패"
-
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:111
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:119
-msgid "Failed to create promotion"
-msgstr "프로모션 생성 실패"
-
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:71
-msgid "Failed to create role"
-msgstr "역할 생성 실패"
-
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:65
-msgid "Failed to create seller"
-msgstr "판매자 생성 실패"
-
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:79
-msgid "Failed to create stock location"
-msgstr "재고 위치 생성 실패"
-
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:78
-msgid "Failed to create tax category"
-msgstr "세금 카테고리 생성 실패"
-
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:79
-msgid "Failed to create tax rate"
-msgstr "세율 생성 실패"
-
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:69
-msgid "Failed to create zone"
-msgstr "지역 생성 실패"
-
-#: src/lib/components/data-table/use-generated-columns.tsx:295
-#: src/lib/components/data-table/use-generated-columns.tsx:301
-msgid "Failed to delete"
-msgstr "삭제 실패"
-
-#: src/app/common/delete-bulk-action.tsx:115
-msgid "Failed to delete {failed} {entityName}"
-msgstr "{failed}개 {entityName} 삭제 실패"
-
-#: src/app/common/delete-bulk-action.tsx:114
-msgid "Failed to delete {failed} {entityName}: {allErrors}"
-msgstr "{failed}개 {entityName} 삭제 실패: {allErrors}"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
-msgid "Failed to delete address"
-msgstr "주소 삭제 실패"
-
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
-msgid "Failed to delete assets: {message}"
-msgstr "에셋 삭제 실패: {message}"
-
-#: src/lib/components/data-table/views-sheet.tsx:87
-msgid "Failed to delete global view"
-msgstr "전역 뷰 삭제 실패"
-
-#: src/lib/components/data-table/views-sheet.tsx:87
-msgid "Failed to delete view"
-msgstr "뷰 삭제 실패"
-
-#: src/lib/components/data-table/views-sheet.tsx:100
-msgid "Failed to duplicate global view"
-msgstr "전역 뷰 복제 실패"
-
-#: src/lib/components/data-table/views-sheet.tsx:100
-msgid "Failed to duplicate view"
-msgstr "뷰 복제 실패"
-
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:79
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:85
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:187
-msgid "Failed to fulfill order"
-msgstr "주문 이행 실패"
-
-#: src/lib/components/layout/manage-languages-dialog.tsx:290
-msgid "Failed to load global settings"
-msgstr "전역 설정 로딩 실패"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:136
-msgid "Failed to modify order"
-msgstr "주문 수정 실패"
-
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:290
-msgid "Failed to move collections"
-msgstr "컬렉션 이동 실패"
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:139
-msgid "Failed to remove customer from group"
-msgstr "그룹에서 고객 제거 실패"
-
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
-msgid "Failed to remove facet from channel: {message}"
-msgstr "채널에서 속성 제거 실패: {message}"
-
-#: src/lib/components/data-table/views-sheet.tsx:68
-msgid "Failed to rename global view"
-msgstr "전역 뷰 이름 변경 실패"
-
-#: src/lib/components/data-table/views-sheet.tsx:68
-msgid "Failed to rename view"
-msgstr "뷰 이름 변경 실패"
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
-msgid "Failed to settle payment"
-msgstr "결제 정산 실패"
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
-msgid "Failed to settle refund"
-msgstr "환불 정산 실패"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:112
-msgid "Failed to transition order to state"
-msgstr "주문 상태 전환 실패"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
-msgid "Failed to update address"
-msgstr "주소 업데이트 실패"
-
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:74
-msgid "Failed to update asset"
-msgstr "에셋 업데이트 실패"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:92
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:98
-msgid "Failed to update channel"
-msgstr "채널 업데이트 실패"
-
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:102
-msgid "Failed to update collection"
-msgstr "컬렉션 업데이트 실패"
-
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:71
-msgid "Failed to update country"
-msgstr "국가 업데이트 실패"
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:106
-msgid "Failed to update customer"
-msgstr "고객 업데이트 실패"
-
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:76
-msgid "Failed to update customer group"
-msgstr "고객 그룹 업데이트 실패"
-
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:86
-msgid "Failed to update facet"
-msgstr "속성 업데이트 실패"
-
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:94
-msgid "Failed to update facet value"
-msgstr "속성 값 업데이트 실패"
-
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:42
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:46
-msgid "Failed to update fulfillment state"
-msgstr "이행 상태 업데이트 실패"
-
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:76
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:82
-msgid "Failed to update global settings"
-msgstr "전역 설정 업데이트 실패"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:89
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:91
-msgid "Failed to update order"
-msgstr "주문 업데이트 실패"
-
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
-msgid "Failed to update payment method"
-msgstr "결제 방법 업데이트 실패"
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
-msgid "Failed to update payment state"
-msgstr "결제 상태 업데이트 실패"
-
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:95
-msgid "Failed to update product"
-msgstr "상품 업데이트 실패"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:112
-msgid "Failed to update product variant"
-msgstr "상품 변형 업데이트 실패"
-
-#: src/app/routes/_authenticated/_profile/profile.tsx:65
-msgid "Failed to update profile"
-msgstr "프로필 업데이트 실패"
-
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:111
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:119
-msgid "Failed to update promotion"
-msgstr "프로모션 업데이트 실패"
-
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:71
-msgid "Failed to update role"
-msgstr "역할 업데이트 실패"
-
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:65
-msgid "Failed to update seller"
-msgstr "판매자 업데이트 실패"
-
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:79
-msgid "Failed to update stock location"
-msgstr "재고 위치 업데이트 실패"
-
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:78
-msgid "Failed to update tax category"
-msgstr "세금 카테고리 업데이트 실패"
-
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:79
-msgid "Failed to update tax rate"
-msgstr "세율 업데이트 실패"
-
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:69
-msgid "Failed to update zone"
-msgstr "지역 업데이트 실패"
-
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:53
-msgid "False"
-msgstr "거짓"
-
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:34
-msgid "Filter by {columnId}"
-msgstr "{columnId}로 필터"
-
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:366
-msgid "Filter by collection name"
-msgstr "컬렉션 이름으로 필터"
-
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:104
-msgid "Filter by tags"
-msgstr "태그로 필터"
-
-#: src/lib/components/data-table/data-table.tsx:217
-msgid "Filter..."
-msgstr "필터..."
-
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:172
-msgid "Filters"
-msgstr "필터"
-
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:126
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/app/routes/_authenticated/_profile/profile.tsx:92
-msgid "First name"
-msgstr "이름"
-
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-msgid "Focal Point"
-msgstr "초점"
-
-#. placeholder {0}: testResult.length
-#. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
-msgid "Found {0} eligible shipping method{1}"
-msgstr "{0}개의 적합한 배송 방법을 찾았습니다"
-
-#. placeholder {0}: entry.data.from
-#. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:11
-msgid "From {0} to {1}"
-msgstr "{0}에서 {1}까지"
-
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:219
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:225
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:310
-msgid "Fulfill order"
-msgstr "주문 이행"
-
-#. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:121
-msgid "Fulfilled items ({0})"
-msgstr "이행된 항목({0})"
-
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:308
-msgid "Fulfilling..."
-msgstr "이행 중..."
-
-#. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:63
-msgid "Fulfillment #{0} created"
-msgstr "이행 #{0}이(가) 생성되었습니다"
-
-#. placeholder {0}: entry.data.fulfillmentId
-#. placeholder {1}: entry.data.from
-#. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:50
-msgid "Fulfillment #{0} from {1} to {2}"
-msgstr "{1}에서 {2}로의 이행 #{0}"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
-msgid "Fulfillment created"
-msgstr "이행이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:277
-msgid "Fulfillment details"
-msgstr "이행 세부정보"
-
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:289
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:165
-msgid "Fulfillment handler"
-msgstr "이행 처리기"
-
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:105
-msgid "Fulfillment ID"
-msgstr "이행 ID"
-
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:39
-msgid "Fulfillment state updated successfully"
-msgstr "이행 상태가 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:92
-msgid "Fulfillment transitioned"
-msgstr "이행이 전환되었습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:108
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:158
-#: src/lib/components/shared/customer-address-form.tsx:99
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "전체 이름"
 
-#: src/lib/components/shared/custom-fields-form.tsx:100
-msgid "General"
-msgstr "일반"
-
-#: src/lib/components/data-input/slug-input.tsx:279
-#: src/lib/components/data-input/slug-input.tsx:281
-msgid "Generate slug automatically"
-msgstr "슬러그 자동 생성"
-
-#: src/lib/components/layout/manage-languages-dialog.tsx:270
-msgid "Global Languages"
-msgstr "전역 언어"
-
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:129
-msgid "Global out of stock threshold"
-msgstr "전역 품절 임계값"
-
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:91
-msgid "Global Settings"
-msgstr "전역 설정"
-
-#: src/lib/components/data-table/views-sheet.tsx:108
-msgid "Global view converted to personal view successfully"
-msgstr "전역 뷰가 개인 뷰로 변환되었습니다"
-
-#: src/lib/components/data-table/views-sheet.tsx:83
-msgid "Global view deleted successfully"
-msgstr "전역 뷰가 삭제되었습니다"
-
-#: src/lib/components/data-table/views-sheet.tsx:96
-msgid "Global view duplicated successfully"
-msgstr "전역 뷰가 복제되었습니다"
-
-#: src/lib/components/data-table/views-sheet.tsx:63
-msgid "Global view renamed successfully"
-msgstr "전역 뷰 이름이 변경되었습니다"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:40
-msgid "greater than"
-msgstr "보다 큼"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:43
-msgid "greater than or equal"
-msgstr "이상"
-
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:82
-msgid "Gross price: <0/>"
-msgstr "총 가격: <0/>"
-
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:76
-msgid "Heading 1"
-msgstr "제목 1"
-
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:77
-msgid "Heading 2"
-msgstr "제목 2"
-
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:78
-msgid "Heading 3"
-msgstr "제목 3"
-
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:79
-msgid "Heading 4"
-msgstr "제목 4"
-
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:80
-msgid "Heading 5"
-msgstr "제목 5"
-
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:81
-msgid "Heading 6"
-msgstr "제목 6"
-
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
-msgid "Health checks"
-msgstr "헬스체크"
-
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
-msgid "Healthchecks"
-msgstr "헬스체크"
-
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:191
-msgid "Height"
-msgstr "높이"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:107
-msgid "ID"
-msgstr "ID"
-
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:65
-msgid "Identifier"
-msgstr "식별자"
-
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:178
-msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
-msgstr "활성화하면 필터가 상위 컬렉션에서 상속되어 이 컬렉션에 설정된 필터와 결합됩니다."
-
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-msgid "Image"
-msgstr "이미지"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:36
-msgid "in"
-msgstr "포함"
-
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:176
-msgid "Inherit filters"
-msgstr "필터 상속"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:250
-msgid "Inherit from global settings"
-msgstr "전역 설정에서 상속"
-
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-msgid "Insert image"
-msgstr "이미지 삽입"
-
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
-msgid "Insert link"
-msgstr "링크 삽입"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:30
-msgid "is after"
-msgstr "이후"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:28
-msgid "is before"
-msgstr "이전"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:32
-msgid "is between"
-msgstr "사이"
-
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:115
-msgid "Is default tax category"
-msgstr "기본 세금 카테고리"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:24
-msgid "is equal to"
-msgstr "같음"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:40
-msgid "is greater than"
-msgstr "보다 큼"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:45
-msgid "is greater than or equal to"
-msgstr "이상"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:36
-msgid "is in"
-msgstr "포함"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:48
-msgid "is less than"
-msgstr "보다 작음"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:53
-msgid "is less than or equal to"
-msgstr "이하"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:26
-msgid "is not equal to"
-msgstr "같지 않음"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:38
-msgid "is not in"
-msgstr "포함하지 않음"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:34
-msgid "is null"
-msgstr "NULL임"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:105
-msgid "Item added to order"
-msgstr "주문에 항목이 추가되었습니다"
-
-#: src/app/routes/_authenticated/_system/job-queue.tsx:33
-#: src/app/routes/_authenticated/_system/job-queue.tsx:97
-msgid "Job Queue"
-msgstr "작업 큐"
-
-#: src/lib/components/layout/nav-user.tsx:112
-msgid "Language"
-msgstr "언어"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:133
-msgid "Last Executed"
-msgstr "마지막 실행"
-
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:132
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:179
-#: src/app/routes/_authenticated/_profile/profile.tsx:98
-msgid "Last name"
-msgstr "성"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:169
-msgid "Last Result"
-msgstr "마지막 결과"
-
-#. placeholder {0}: formatRelative(dataUpdatedAt, new Date())
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
-msgid "Last updated {0}"
-msgstr "마지막 업데이트 {0}"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:48
-msgid "less than"
-msgstr "보다 작음"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:51
-msgid "less than or equal"
-msgstr "이하"
-
-#: src/lib/components/layout/nav-user.tsx:127
-msgctxt "theme"
-msgid "Light"
-msgstr "라이트"
-
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:90
-msgid "Link href"
-msgstr "링크 URL"
-
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:115
-msgid "Link target"
-msgstr "링크 대상"
-
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:103
-msgid "Link title"
-msgstr "링크 제목"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
-msgid "Load more"
-msgstr "더 보기"
-
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
-msgid "Loading addresses..."
-msgstr "주소 로딩 중..."
-
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:376
-msgid "Loading collections..."
-msgstr "컬렉션 로딩 중..."
-
-#: src/lib/components/layout/manage-languages-dialog.tsx:284
-msgid "Loading global settings..."
-msgstr "전역 설정 로딩 중..."
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:158
-msgid "Loading preview…"
-msgstr "미리보기 로딩 중..."
-
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
-msgid "Loading tags..."
-msgstr "태그 로딩 중..."
-
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:124
-#: src/lib/components/data-input/product-multi-selector-input.tsx:82
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:88
-#: src/lib/components/shared/customer-selector.tsx:90
-#: src/lib/components/shared/facet-value-selector.tsx:275
-#: src/lib/components/shared/seller-selector.tsx:92
-msgid "Loading..."
-msgstr "로딩 중..."
-
-#: src/lib/components/layout/language-dialog.tsx:60
-msgid "Locale"
-msgstr "로케일"
-
-#: src/lib/components/layout/nav-user.tsx:165
-msgid "Log out"
-msgstr "로그아웃"
-
-#: src/lib/components/data-table/views-sheet.tsx:263
-msgid "Make Global"
-msgstr "전역으로 만들기"
-
-#: src/lib/components/data-table/views-sheet.tsx:130
-msgid "Manage global saved views that are visible to all users"
-msgstr "모든 사용자에게 표시되는 전역 저장 뷰 관리"
-
-#: src/lib/components/data-table/manage-global-views-button.tsx:20
-msgid "Manage global views"
-msgstr "전역 뷰 관리"
-
-#: src/lib/components/data-table/views-sheet.tsx:125
-msgid "Manage Global Views"
-msgstr "전역 뷰 관리"
-
-#: src/lib/components/layout/channel-switcher.tsx:184
-#: src/lib/components/layout/manage-languages-dialog.tsx:258
-msgid "Manage Languages"
-msgstr "언어 관리"
-
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:215
-msgid "Manage tags"
-msgstr "태그 관리"
-
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
-msgid "Manage Tags"
-msgstr "태그 관리"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:173
-msgid "Manage variants"
-msgstr "변형 관리"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:56
-msgid "Manage Variants"
-msgstr "변형 관리"
-
-#: src/lib/components/data-table/views-sheet.tsx:132
-msgid "Manage your personal saved views for this table"
-msgstr "이 테이블의 개인 저장 뷰 관리"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:60
-msgid "matches regex"
-msgstr "정규식 일치"
-
-#: src/lib/components/layout/language-dialog.tsx:96
-msgid "Medium date"
-msgstr "중간 날짜"
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
-msgid "Metadata"
-msgstr "메타데이터"
-
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:106
-msgid "Method"
-msgstr "메서드"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:166
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:75
-msgid "Modify"
-msgstr "수정"
-
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:392
-msgid "Modify order"
-msgstr "주문 수정"
-
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
-msgid "Monitored Resources"
-msgstr "모니터링 중인 리소스"
-
-#: src/lib/components/data-table/global-views-bar.tsx:76
-msgid "More views"
-msgstr "더 많은 뷰"
-
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:112
-msgid "Move"
-msgstr "이동"
-
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:336
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:423
-msgid "Move Collections"
-msgstr "컬렉션 이동"
-
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
-msgid "Move to the top level"
-msgstr "최상위 레벨로 이동"
-
-#. placeholder {0}: collectionsToMove.length
-#. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
-#. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
-msgid "Moving {0} collection{1} into {2}"
-msgstr "{0}개 컬렉션을 {2}로 이동 중"
-
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:421
-msgid "Moving..."
-msgstr "이동 중..."
-
-#: src/lib/components/data-table/my-views-button.tsx:35
-msgid "My saved views"
-msgstr "저장한 뷰"
-
-#: src/lib/components/data-table/views-sheet.tsx:125
-msgid "My Saved Views"
-msgstr "저장한 뷰"
-
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:36
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:146
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:108
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:107
-#: src/app/routes/_authenticated/_customers/customers.tsx:55
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:104
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:134
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:124
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:151
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:328
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:303
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:153
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:185
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:157
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:96
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:143
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:109
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:109
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:116
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:96
-msgid "Name"
-msgstr "이름"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:140
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:150
-msgid "Never"
-msgstr "없음"
-
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:40
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-msgid "New administrator"
-msgstr "새 관리자"
-
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-msgid "New asset"
-msgstr "새 에셋"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:41
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:113
-msgid "New channel"
-msgstr "새 채널"
-
-#: src/app/routes/_authenticated/_channels/channels.tsx:74
-msgid "New Channel"
-msgstr "새 채널"
-
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:116
-msgid "New collection"
-msgstr "새 컬렉션"
-
-#: src/app/routes/_authenticated/_collections/collections.tsx:242
-msgid "New Collection"
-msgstr "새 컬렉션"
-
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:35
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:79
-msgid "New country"
-msgstr "새 국가"
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:59
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:147
-msgid "New customer"
-msgstr "새 고객"
-
-#: src/app/routes/_authenticated/_customers/customers.tsx:82
-msgid "New Customer"
-msgstr "새 고객"
-
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:38
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:87
-msgid "New customer group"
-msgstr "새 고객 그룹"
-
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:65
-msgid "New Customer Group"
-msgstr "새 고객 그룹"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:166
-msgid "New email:"
-msgstr "새 이메일:"
-
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:94
-msgid "New facet"
-msgstr "새 속성"
-
-#: src/app/routes/_authenticated/_facets/facets.tsx:130
-msgid "New Facet"
-msgstr "새 속성"
-
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:41
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:103
-msgid "New facet value"
-msgstr "새 속성 값"
-
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:253
-msgid "New facet values to add:"
-msgstr "추가할 새 속성 값:"
-
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:86
-msgid "New option"
-msgstr "새 옵션"
-
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:121
-msgid "New payment method"
-msgstr "새 결제 방법"
-
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:77
-msgid "New Payment Method"
-msgstr "새 결제 방법"
-
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:46
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:103
-msgid "New product"
-msgstr "새 상품"
-
-#: src/app/routes/_authenticated/_products/products.tsx:92
-msgid "New Product"
-msgstr "새 상품"
-
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:154
-msgid "New product option"
-msgstr "새 상품 옵션"
-
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:133
-msgid "New product option group"
-msgstr "새 상품 옵션 그룹"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:125
-msgid "New product variant"
-msgstr "새 상품 변형"
-
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:127
-msgid "New promotion"
-msgstr "새 프로모션"
-
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:75
-msgid "New Promotion"
-msgstr "새 프로모션"
-
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:35
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:79
-msgid "New role"
-msgstr "새 역할"
-
-#: src/app/routes/_authenticated/_roles/roles.tsx:92
-msgid "New Role"
-msgstr "새 역할"
-
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:32
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:73
-msgid "New seller"
-msgstr "새 판매자"
-
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:49
-msgid "New Seller"
-msgstr "새 판매자"
-
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:44
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:120
-msgid "New shipping method"
-msgstr "새 배송 방법"
-
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:65
-msgid "New Shipping Method"
-msgstr "새 배송 방법"
-
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:39
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:90
-msgid "New stock location"
-msgstr "새 재고 위치"
-
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
-msgid "New Stock Location"
-msgstr "새 재고 위치"
-
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:39
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:89
-msgid "New tax category"
-msgstr "새 세금 카테고리"
-
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:62
-msgid "New Tax Category"
-msgstr "새 세금 카테고리"
-
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:38
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:87
-msgid "New tax rate"
-msgstr "새 세율"
-
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:103
-msgid "New Tax Rate"
-msgstr "새 세율"
-
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:129
-msgid "New window"
-msgstr "새 창"
-
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:35
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:77
-msgid "New zone"
-msgstr "새 지역"
-
-#: src/app/routes/_authenticated/_zones/zones.tsx:56
-msgid "New Zone"
-msgstr "새 지역"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:145
-msgid "Next Execution"
-msgstr "다음 실행"
-
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:92
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:102
-msgid "No actions available"
-msgstr "사용 가능한 작업이 없습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
-msgid "No address"
-msgstr "주소 없음"
-
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
-msgid "No addresses found"
-msgstr "주소를 찾을 수 없습니다"
-
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:513
-msgid "No billing address"
-msgstr "청구지 주소 없음"
-
-#: src/lib/components/shared/country-selector.tsx:88
-msgid "No countries found"
-msgstr "국가를 찾을 수 없습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:252
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:460
-msgid "No customer"
-msgstr "고객 없음"
-
-#: src/lib/components/shared/customer-selector.tsx:90
-msgid "No customers found"
-msgstr "고객을 찾을 수 없습니다"
-
-#: src/app/common/duplicate-entity-dialog.tsx:99
-msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
-msgstr "{entityName}에 대한 코드 \"{duplicatorCode}\"의 복제 도구를 찾을 수 없습니다"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
-msgid "No eligible shipping methods found for this order."
-msgstr "이 주문에 적합한 배송 방법을 찾을 수 없습니다."
-
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:235
-msgid "No facet values"
-msgstr "속성 값 없음"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:297
-msgid "No fulfillments"
-msgstr "이행 없음"
-
-#: src/lib/components/layout/manage-languages-dialog.tsx:354
-msgid "No global languages configured"
-msgstr "전역 언어가 구성되지 않았습니다"
-
-#: src/lib/components/data-table/views-sheet.tsx:141
-msgid "No global views have been created yet."
-msgstr "아직 전역 뷰가 생성되지 않았습니다."
-
-#: src/lib/components/data-input/product-multi-selector-input.tsx:90
-msgid "No items found"
-msgstr "항목을 찾을 수 없습니다"
-
-#: src/lib/components/data-input/product-multi-selector-input.tsx:331
-msgid "No items selected"
-msgstr "선택한 항목 없음"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:217
-msgid "No modifications made"
-msgstr "수정 없음"
-
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:314
-msgid "No more items"
-msgstr "더 이상 항목 없음"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
-msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
-msgstr "아직 옵션 그룹이 정의되지 않았습니다. 상품의 다양한 변형을 만들려면 옵션 그룹을 추가하세요(예: 사이즈, 색상, 소재)"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:336
-msgid "No payment or refund is required for these changes."
-msgstr "이 변경사항에는 결제 또는 환불이 필요하지 않습니다."
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:333
-msgid "No payment or refund required"
-msgstr "결제 또는 환불 불필요"
-
-#: src/app/routes/_authenticated/_system/job-queue.tsx:141
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:184
-msgid "No result yet"
-msgstr "아직 결과 없음"
-
-#: src/lib/components/data-table/data-table.tsx:338
-msgid "No results"
-msgstr "결과 없음"
-
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/shared/facet-value-selector.tsx:277
-msgid "No results found"
-msgstr "결과를 찾을 수 없습니다"
-
-#: src/lib/components/shared/seller-selector.tsx:92
-msgid "No sellers found"
-msgstr "판매자를 찾을 수 없습니다"
-
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:487
-msgid "No shipping address"
-msgstr "배송지 주소 없음"
-
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
-msgid "No shipping methods available"
-msgstr "사용 가능한 배송 방법 없음"
-
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:171
-msgid "No stock locations available on current channel"
-msgstr "현재 채널에 사용 가능한 재고 위치가 없습니다"
-
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:128
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:166
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
-msgid "No tags found"
-msgstr "태그를 찾을 수 없습니다"
-
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
-msgid "No tags selected"
-msgstr "선택한 태그 없음"
-
-#. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:62
-msgid "No translation found for {0}"
-msgstr "{0}의 번역을 찾을 수 없습니다"
-
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:75
-msgid "Normal"
-msgstr "일반"
-
-#: src/lib/components/data-table/human-readable-operator.tsx:38
-msgid "not in"
-msgstr "포함하지 않음"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:163
-msgid "Not Running"
-msgstr "실행 중 아님"
-
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:158
-msgid "Not set"
-msgstr "설정되지 않음"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
-msgid "Note added"
-msgstr "메모가 추가되었습니다"
-
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
-msgid "Note is private"
-msgstr "메모는 비공개입니다"
-
-#: src/app/routes/_authenticated/_system/job-queue.tsx:70
-msgid "Off"
-msgstr "끄기"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:158
-msgid "Old email:"
-msgstr "기존 이메일:"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:269
-msgid "Option"
-msgstr "옵션"
-
-#. placeholder {0}: groupIndex + 1
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
-msgid "Option group {0}"
-msgstr "옵션 그룹 {0}"
-
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
-msgid "Option group name"
-msgstr "옵션 그룹 이름"
-
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:81
-msgid "Option Group Name"
-msgstr "옵션 그룹 이름"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:190
-msgid "Option group removed"
-msgstr "옵션 그룹이 제거되었습니다"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:255
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:63
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:81
-msgid "Option Groups"
-msgstr "옵션 그룹"
-
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
-msgid "Option name"
-msgstr "옵션 이름"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:142
-msgid "Option value name"
-msgstr "옵션 값 이름"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:275
-msgid "Option values"
-msgstr "옵션 값"
-
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:90
-msgid "Option Values"
-msgstr "옵션 값"
-
-#: src/lib/components/data-input/combination-mode-input.tsx:56
-msgid "OR"
-msgstr "OR"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:94
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:78
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:100
-msgid "Order cancelled"
-msgstr "주문이 취소되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
-msgid "Order delivered"
-msgstr "주문이 배송되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:75
-msgid "Order fulfilled"
-msgstr "주문이 이행되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:230
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
-msgid "Order history"
-msgstr "주문 이력"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:137
-msgid "Order line removed"
-msgstr "주문 항목이 제거되었습니다"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:121
-msgid "Order line updated"
-msgstr "주문 항목이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:241
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:402
-msgid "Order lines"
-msgstr "주문 항목"
-
-#. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:74
-msgid "Order modification #{0}"
-msgstr "주문 수정 #{0}"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:96
-msgid "Order modified"
-msgstr "주문이 수정되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
-msgid "Order not found"
-msgstr "주문을 찾을 수 없습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
-msgid "Order placed"
-msgstr "주문이 확정되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:81
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:87
-msgid "Order shipped"
-msgstr "주문이 발송되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:83
-msgid "Order transitioned"
-msgstr "주문이 전환되었습니다"
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:246
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:45
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:59
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:73
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:122
-msgid "Orders"
-msgstr "주문"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:265
-msgid "Out-of-stock threshold"
-msgstr "품절 임계값"
-
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:144
-#: src/app/routes/_authenticated/_profile/profile.tsx:110
-#: src/lib/components/login/login-form.tsx:128
-msgid "Password"
-msgstr "비밀번호"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
-msgid "Password reset requested"
-msgstr "비밀번호 재설정이 요청되었습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
-msgid "Password reset verified"
-msgstr "비밀번호 재설정이 확인되었습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
-msgid "Password updated"
-msgstr "비밀번호가 업데이트되었습니다"
-
-#. placeholder {0}: entry.data.paymentId
-#. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:24
-msgid "Payment #{0} transitioned to {1}"
-msgstr "결제 #{0}이(가) {1}(으)로 전환되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:57
-msgid "Payment authorized"
-msgstr "결제가 승인되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
-msgid "Payment cancelled successfully"
-msgstr "결제가 취소되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:218
-msgid "Payment details"
-msgstr "결제 세부정보"
-
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:172
-msgid "Payment eligibility checker"
-msgstr "결제 적격성 확인"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:60
-msgid "Payment failed"
-msgstr "결제 실패"
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
-msgid "Payment metadata"
-msgstr "결제 메타데이터"
-
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
-msgid "Payment method"
-msgstr "결제 방법"
-
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
-msgid "Payment method is required"
-msgstr "결제 방법은 필수입니다"
-
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
-msgid "Payment Methods"
-msgstr "결제 방법"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:54
-msgid "Payment settled"
-msgstr "결제가 완료되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
-msgid "Payment settled successfully"
-msgstr "결제가 정산되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
-msgid "Payment state updated successfully"
-msgstr "결제 상태가 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:62
-msgid "Payment transitioned"
-msgstr "결제가 전환되었습니다"
-
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:202
-msgid "Per customer usage limit"
-msgstr "고객당 사용 제한"
-
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:133
-msgid "Permissions"
-msgstr "권한"
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:191
-msgid "Phone number"
-msgstr "전화번호"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:272
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:240
-#: src/lib/components/shared/customer-address-form.tsx:263
-msgid "Phone Number"
-msgstr "전화번호"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
-msgid "Please add products and complete the shipping address to run the test."
-msgstr "테스트를 실행하려면 상품을 추가하고 배송지 주소를 완성하세요."
-
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:308
-msgid "Please select a target collection"
-msgstr "대상 컬렉션을 선택하세요"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:222
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:207
-#: src/lib/components/shared/customer-address-form.tsx:213
-msgid "Postal Code"
-msgstr "우편번호"
-
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:439
-msgid "Preview changes"
-msgstr "변경사항 미리보기"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:149
-msgid "Preview order modifications"
-msgstr "주문 수정사항 미리보기"
-
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:185
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:340
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:209
-#: src/lib/components/layout/language-dialog.tsx:108
-msgid "Price"
-msgstr "가격"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:170
-msgid "Price and tax"
-msgstr "가격 및 세금"
-
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:142
-msgid "Price conversion factor"
-msgstr "가격 변환 계수"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:234
-msgid "Prices include tax for default tax zone"
-msgstr "가격에 기본 세금 지역의 세금이 포함됩니다"
-
-#: src/app/routes/_authenticated/_facets/facets.tsx:82
-msgid "private"
-msgstr "비공개"
-
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:134
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:112
-msgid "Private"
-msgstr "비공개"
-
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:135
-msgid "Private collections are not visible in the shop"
-msgstr "비공개 컬렉션은 상점에 표시되지 않습니다"
-
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:113
-msgid "Private facets are not visible in the shop"
-msgstr "비공개 속성은 상점에 표시되지 않습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:41
-msgid "Product"
-msgstr "상품"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:133
-msgid "Product name"
-msgstr "상품명"
-
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:173
-msgid "Product Option Group"
-msgstr "상품 옵션 그룹"
-
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:291
+#: src/lib/components/data-input/relation-selector.tsx
+msgid "Select items"
+msgstr "항목 선택"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+msgid "View changes"
+msgstr "변경사항 보기"
+
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+msgid "Tracking code"
+msgstr "추적 코드"
+
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+msgid "The selected permissions will be applied to the these channels."
+msgstr "선택한 권한이 이 채널에 적용됩니다."
+
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "상품 옵션"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:191
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:174
-msgid "Product Options"
-msgstr "상품 옵션"
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+msgid "New Tax Rate"
+msgstr "새 세율"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:54
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:18
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:26
-msgid "Product Variants"
-msgstr "상품 변형"
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+msgid "Assign an existing option group or create a new one"
+msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:49
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:54
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:45
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:61
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_products/products.tsx:23
-#: src/app/routes/_authenticated/_products/products.tsx:46
-msgid "Products"
-msgstr "상품"
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+msgid "New role"
+msgstr "새 역할"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:30
-#: src/app/routes/_authenticated/_profile/profile.tsx:74
-#: src/lib/components/layout/nav-user.tsx:106
-msgid "Profile"
-msgstr "프로필"
+#: src/lib/components/shared/customer-address-form.tsx
+msgid "Apartment, suite, etc."
+msgstr "아파트, 스위트 등"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
-msgid "Promotions"
-msgstr "프로모션"
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
+msgid "No more items"
+msgstr "더 이상 항목 없음"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:82
-msgid "public"
-msgstr "공개"
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
+msgid "Edit link"
+msgstr "링크 편집"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:265
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:77
-msgid "Quantity"
-msgstr "수량"
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
+msgid "Add at least one item to the order"
+msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:211
-msgid "Queue"
-msgstr "큐"
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
+msgid "Add products to create a test order"
+msgstr "테스트 주문을 생성하려면 상품을 추가하세요"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:122
-msgid "Rate"
-msgstr "요율"
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+msgid "Failed to create address"
+msgstr "주소 생성 실패"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-msgid "Reason"
-msgstr "사유"
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+msgid "Toggle all"
+msgstr "모두 토글"
 
-#: src/app/routes/_authenticated/_products/products.tsx:85
-msgid "Rebuild search index"
-msgstr "검색 인덱스 재구성"
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+msgid "Edit JSON value"
+msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
-msgid "Refresh"
-msgstr "새로고침"
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+msgid "Using external authentication strategy: {strategy}"
+msgstr "외부 인증 전략 사용: {strategy}"
 
-#: src/lib/components/data-table/refresh-button.tsx:45
-msgid "Refresh data"
-msgstr "데이터 새로고침"
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Select a reason..."
+msgstr ""
 
-#. placeholder {0}: entry.data.refundId
-#. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:37
-msgid "Refund #{0} transitioned to {1}"
-msgstr "환불 #{0}이(가) {1}(으)로 전환되었습니다"
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
+msgid "Heading 5"
+msgstr "제목 5"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:229
-msgid "Refund from this method"
-msgstr "이 방법에서 환불"
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+msgid "Failed to add payment"
+msgstr "결제 추가 실패"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
-msgid "Refund ID"
-msgstr "환불 ID"
+#: src/lib/framework/layout-engine/page-layout.tsx
+msgid "Updated"
+msgstr "업데이트 일시"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:170
-msgid "Refund required"
-msgstr "환불 필요"
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+msgid "Failed to update global settings"
+msgstr "전역 설정 업데이트 실패"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:65
-msgid "Refund settled"
-msgstr "환불이 정산되었습니다"
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+msgid "Successfully fulfilled order"
+msgstr "주문이 이행되었습니다"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
-msgid "Refund settled successfully"
-msgstr "환불이 정산되었습니다"
+#. placeholder {0}: selection.length
+#: src/app/common/delete-bulk-action.tsx
+msgid "Are you sure you want to delete {0} {entityName}?"
+msgstr "{0}개 {entityName}을(를) 삭제하시겠습니까?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
-msgid "Refund transitioned"
-msgstr "환불이 전환되었습니다"
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+msgid "Global out of stock threshold"
+msgstr "전역 품절 임계값"
 
-#. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
-msgid "Refunds ({0})"
-msgstr "환불({0})"
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "Manage Languages"
+msgstr "언어 관리"
 
-#: src/lib/components/data-input/slug-input.tsx:265
-#: src/lib/components/data-input/slug-input.tsx:266
-msgid "Regenerate slug from source field"
-msgstr "원본 필드에서 슬러그 재생성"
+#. placeholder {0}: progress.completed
+#. placeholder {1}: progress.total
+#: src/app/common/duplicate-bulk-action.tsx
+msgid "Duplicating... ({0}/{1})"
+msgstr "복제 중...({0}/{1})"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
-msgid "Regions"
-msgstr "지역"
+#: src/lib/components/data-table/use-generated-columns.tsx
+msgid "Deleted successfully"
+msgstr "삭제되었습니다"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
-msgid "Registered"
-msgstr "등록됨"
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
+#~ msgid "Remove from current channel"
+#~ msgstr "현재 채널에서 제거"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:289
-msgid "Remaining:"
-msgstr "남은:"
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+msgid "Deleted {selectionLength} assets"
+msgstr "{selectionLength}개 에셋이 삭제되었습니다"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:472
-msgid "Remove"
-msgstr "제거"
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+msgid "Successfully updated tax rate"
+msgstr "세율이 업데이트되었습니다"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:81
-msgid "Remove from current channel"
-msgstr "현재 채널에서 제거"
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Enter custom reason..."
+msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
-msgid "Remove group"
-msgstr "그룹 제거"
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "Type"
+msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
-msgid "Remove item"
-msgstr "항목 제거"
-
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:138
-msgid "Remove link"
-msgstr "링크 제거"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:199
-msgid "Removed coupon codes"
-msgstr "쿠폰 코드가 제거되었습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
-msgid "Removed from group"
-msgstr "그룹에서 제거되었습니다"
-
-#. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:175
-msgid "Removing {0} item(s)"
-msgstr "{0}개 항목 제거 중"
-
-#: src/lib/components/data-table/views-sheet.tsx:240
-msgid "Rename"
-msgstr "이름 변경"
-
-#: src/lib/components/data-table/data-table-view-options.tsx:123
-msgid "Reset"
-msgstr "재설정"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:152
-msgid "Review the changes before applying them to the order."
-msgstr "주문에 적용하기 전에 변경사항을 검토하세요."
-
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:150
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:46
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:34
-#: src/app/routes/_authenticated/_roles/roles.tsx:19
-#: src/app/routes/_authenticated/_roles/roles.tsx:28
-msgid "Roles"
-msgstr "역할"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
-msgid "Run"
-msgstr "실행"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
-msgid "Run Test"
-msgstr "테스트 실행"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:155
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:159
-msgid "Running"
-msgstr "실행 중"
-
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:126
-msgid "Same window"
-msgstr "같은 창"
-
-#: src/lib/components/layout/language-dialog.tsx:79
-msgid "Sample Formatting"
-msgstr "샘플 서식"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:213
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
-msgid "Save"
-msgstr "저장"
-
-#: src/lib/components/data-table/views-sheet.tsx:144
-msgid "Save a view as \"Global\" to make it available to all users."
-msgstr "모든 사용자가 사용할 수 있도록 뷰를 \"전역\"으로 저장하세요."
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:338
-#: src/lib/components/shared/customer-address-form.tsx:329
-msgid "Save Address"
-msgstr "주소 저장"
-
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
-msgid "Save changes"
-msgstr "변경사항 저장"
-
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:399
-msgid "Save Changes"
-msgstr "변경사항 저장"
-
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:121
-msgid "Save option group"
-msgstr "옵션 그룹 저장"
-
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:399
-msgid "Saving..."
-msgstr "저장 중..."
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:130
-msgid "Schedule"
-msgstr "일정"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:127
-msgid "Schedule Pattern"
-msgstr "일정 패턴"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:90
-msgid "Scheduled task could not be executed"
-msgstr "예약된 작업을 실행할 수 없습니다"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:87
-msgid "Scheduled task will be executed"
-msgstr "예약된 작업이 실행됩니다"
-
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:29
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
-msgid "Scheduled Tasks"
-msgstr "예약된 작업"
-
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:66
-msgid "Search {name}..."
-msgstr "{name} 검색..."
-
-#: src/lib/components/shared/channel-selector.tsx:48
-msgid "Search channels..."
-msgstr "채널 검색..."
-
-#: src/lib/components/shared/currency-selector.tsx:30
-msgid "Search currencies..."
-msgstr "통화 검색..."
-
-#: src/app/routes/_authenticated/_products/products.tsx:34
-msgid "Search index rebuild could not be started"
-msgstr "검색 인덱스 재구성을 시작할 수 없습니다"
-
-#: src/app/routes/_authenticated/_products/products.tsx:31
-msgid "Search index rebuild started"
-msgstr "검색 인덱스 재구성이 시작되었습니다"
-
-#: src/lib/components/shared/language-selector.tsx:45
-msgid "Search languages..."
-msgstr "언어 검색..."
-
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
-msgid "Search payment methods..."
-msgstr "결제 방법 검색..."
-
-#: src/lib/components/shared/role-selector.tsx:53
-msgid "Search roles..."
-msgstr "역할 검색..."
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "The default currency is chosen from this list."
+msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:58
-#: src/lib/components/data-input/default-relation-input.tsx:616
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "{0} 선택"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:367
-msgid "Select {0} Items"
-msgstr "{0}개 항목 선택"
+#: src/lib/components/data-input/relation-selector.tsx
+msgid "Add more ({0} selected)"
+msgstr ""
 
-#. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:603
-msgid "Select {0}s"
-msgstr "{0} 선택"
+#: src/app/routes/_authenticated/_facets/facets.tsx
+msgid "View values"
+msgstr "값 보기"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:107
-#: src/lib/components/shared/channel-selector.tsx:47
-msgid "Select a channel"
-msgstr "채널 선택"
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
+msgid "Delete row"
+msgstr "행 삭제"
 
-#. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
-msgid "Select a channel to assign {0} {entityType} to"
-msgstr "{0}개 {entityType}을(를) 할당할 채널 선택"
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+msgid "Conditions"
+msgstr "조건"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:249
-#: src/lib/components/shared/customer-address-form.tsx:240
-msgid "Select a country"
-msgstr "국가 선택"
+#: src/lib/components/layout/channel-switcher.tsx
+msgctxt "current channel"
+msgid "Current"
+msgstr ""
 
-#: src/lib/components/shared/currency-selector.tsx:29
-msgid "Select a currency"
-msgstr "통화 선택"
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+msgid "No fulfillments"
+msgstr "이행 없음"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
-msgid "Select a destination collection"
-msgstr "대상 컬렉션 선택"
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
+msgstr ""
 
-#: src/lib/components/shared/language-selector.tsx:44
-msgid "Select a language"
-msgstr "언어 선택"
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
+msgstr "이 옵션을 활성화하면 상품 카탈로그에 입력된 가격에 기본 세금 지역의 세금이 포함됩니다."
 
-#: src/lib/components/shared/role-selector.tsx:52
-msgid "Select a role"
-msgstr "역할 선택"
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
+#~ msgid "Create variants for your product"
+#~ msgstr "상품 변형 생성"
 
-#. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:339
-msgid "Select a target collection to move {0} to."
-msgstr "{0}을(를) 이동할 대상 컬렉션을 선택하세요."
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Draft order completed"
+msgstr "임시 저장 주문이 완료되었습니다"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
-msgid "Select a tax category"
-msgstr "세금 카테고리 선택"
+#. placeholder {0}: currentInterval?.label
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+msgid "Auto refresh: {0}"
+msgstr "자동 새로고침: {0}"
 
-#: src/lib/components/shared/zone-selector.tsx:50
-msgid "Select a zone"
-msgstr "지역 선택"
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
+#~ msgid "Health checks"
+#~ msgstr "헬스체크"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:51
-msgid "Select address"
-msgstr "주소 선택"
+#: src/app/common/delete-bulk-action.tsx
+msgid "Deleted {deleted} {entityName}"
+msgstr "{deleted}개 {entityName}이(가) 삭제되었습니다"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
-msgid "Select an address"
-msgstr "주소 선택"
+#: src/lib/components/shared/asset/asset-properties.tsx
+msgid "File Size"
+msgstr ""
 
-#: src/lib/components/data-input/select-with-options.tsx:81
-msgid "Select an option"
-msgstr "옵션 선택"
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
+#~ msgid "Healthchecks"
+#~ msgstr "헬스체크"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:296
-msgid "Select Available Languages"
-msgstr "사용 가능한 언어 선택"
-
-#: src/lib/components/shared/country-selector.tsx:73
-msgid "Select country"
-msgstr "국가 선택"
-
-#: src/lib/components/shared/customer-selector.tsx:78
-msgid "Select customer"
-msgstr "고객 선택"
-
-#: src/lib/components/layout/language-dialog.tsx:36
-msgid "Select display language"
-msgstr "표시 언어 선택"
-
-#: src/lib/components/layout/manage-languages-dialog.tsx:358
-msgid "Select from globally available languages for this channel"
-msgstr "이 채널에서 전역적으로 사용 가능한 언어 중 선택"
-
-#: src/lib/components/data-input/relation-selector.tsx:410
-msgid "Select item"
-msgstr "항목 선택"
-
-#: src/lib/components/data-input/relation-selector.tsx:407
-msgid "Select items"
-msgstr "항목 선택"
-
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:104
-msgid "Select next state"
-msgstr "다음 상태 선택"
-
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-msgid "Select quantities to fulfill and configure the fulfillment handler"
-msgstr "이행할 수량을 선택하고 이행 처리기를 구성하세요"
-
-#: src/lib/components/shared/seller-selector.tsx:76
-msgid "Select seller"
-msgstr "판매자 선택"
-
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:108
-msgid "Select the next state for the order"
-msgstr "주문의 다음 상태 선택"
-
-#. placeholder {0}: productData.product.variants[0].name
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
-msgid "Select which options should apply to the existing variant \"{0}\""
-msgstr "기존 변형 \"{0}\"에 적용할 옵션 선택"
-
-#: src/lib/components/data-input/product-multi-selector-input.tsx:316
-msgid "Selected Items"
-msgstr "선택한 항목"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
-msgid "Seller"
-msgstr "판매자"
-
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:36
-msgid "Seller order"
-msgstr "판매자 주문"
-
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
-msgid "Seller orders"
-msgstr "판매자 주문"
-
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:31
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:14
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:23
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "판매자"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-msgid "Set custom fields"
-msgstr "사용자 정의 필드 설정"
-
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:97
-msgid "Set Focal Point"
-msgstr "초점 설정"
-
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:145
-msgid "Set link"
-msgstr "링크 설정"
-
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:113
-msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
-msgstr "모든 채널에서 사용 가능한 언어를 설정합니다. 개별 채널은 이러한 언어의 하위 집합을 지원할 수 있습니다."
-
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
-msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
-msgstr "이 변형이 품절로 간주되는 재고 수준을 설정합니다. 음수 값을 사용하면 예약 주문이 지원됩니다. 상품 변형으로 재정의할 수 있습니다."
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:267
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:285
-msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
-msgstr "이 변형이 품절로 간주되는 재고 수준을 설정합니다. 음수 값을 사용하면 예약 주문이 지원됩니다."
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
-msgid "Settle payment"
-msgstr "결제 정산"
-
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
-msgid "Settle refund"
-msgstr "환불 정산"
-
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:62
-#: src/app/routes/_authenticated/_orders/orders.tsx:83
-msgid "Shipping"
-msgstr "배송"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:259
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:467
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:403
-msgid "Shipping address"
-msgstr "배송지 주소"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:142
-msgid "Shipping Address"
-msgstr "배송지 주소"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:109
-msgid "Shipping address changed"
-msgstr "배송지 주소가 변경되었습니다"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:166
-msgid "Shipping address set for order"
-msgstr "주문의 배송 주소가 설정됨"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:182
-msgid "Shipping address unset for order"
-msgstr "주문의 배송 주소가 해제됨"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:123
-msgid "Shipping method changed"
-msgstr "배송 방법이 변경되었습니다"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
-msgid "Shipping method is eligible for this order"
-msgstr "이 배송 방법은 이 주문에 적합합니다"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
-msgid "Shipping method is not eligible for this order"
-msgstr "이 배송 방법은 이 주문에 적합하지 않습니다"
-
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:201
-msgid "Shipping method set for order"
-msgstr "주문의 배송 방법이 설정됨"
-
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
-msgid "Shipping Methods"
-msgstr "배송 방법"
-
-#: src/lib/components/layout/language-dialog.tsx:102
-msgid "Short date"
-msgstr "짧은 날짜"
-
-#. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:167
-msgid "Showing all {0} results"
-msgstr "{0}개 결과를 모두 표시 중"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:163
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:334
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:195
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:206
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:306
-msgid "SKU"
-msgstr "SKU"
-
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:152
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:139
-msgid "Slug"
-msgstr "슬러그"
-
-#: src/lib/components/data-input/slug-input.tsx:237
-msgid "Slug is set"
-msgstr "슬러그가 설정되었습니다"
-
-#: src/lib/components/data-input/slug-input.tsx:238
-msgid "Slug will be generated automatically..."
-msgstr "슬러그가 자동으로 생성됩니다..."
-
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
-msgid "Some resources are down"
-msgstr "일부 리소스가 다운되었습니다"
-
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:138
-msgid "Source"
-msgstr "소스"
-
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-msgid "Starts at"
-msgstr "시작 일시"
-
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:108
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:99
-#: src/app/routes/_authenticated/_system/job-queue.tsx:222
-msgid "State"
-msgstr "상태"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:201
-msgid "State / Province"
-msgstr "시/도"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:201
-#: src/lib/components/shared/customer-address-form.tsx:192
-msgid "State/Province"
-msgstr "시/도"
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:252
-#: src/app/routes/_authenticated/_customers/customers.tsx:45
-msgid "Status"
-msgstr "상태"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:201
-msgid "Stock"
-msgstr "재고"
-
-#: src/lib/components/shared/stock-level-label.tsx:18
-msgid "Stock allocated"
-msgstr "재고 할당됨"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:208
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:353
-msgid "Stock level"
-msgstr "재고 수준"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:233
-msgid "Stock levels"
-msgstr "재고 수준"
-
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:38
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:18
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:25
-msgid "Stock Locations"
-msgstr "재고 위치"
-
-#: src/lib/components/shared/stock-level-label.tsx:18
-msgid "Stock on hand"
-msgstr "보유 재고"
-
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:212
-msgid "Stock on Hand"
-msgstr "보유 재고"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:146
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:174
-#: src/lib/components/shared/customer-address-form.tsx:137
-msgid "Street Address"
-msgstr "도로명 주소"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:181
-msgid "Street Address 2"
-msgstr "도로명 주소 2"
-
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:50
-msgid "Sub total"
-msgstr "소계"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:219
-msgid "Subtotal"
-msgstr "소계"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:97
-msgid "Successfully added option value"
-msgstr "옵션 값이 추가되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
-msgid "Successfully added payment to order"
-msgstr "주문에 결제가 추가되었습니다"
-
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
-msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
-msgstr "{entityIdsLength}개 {entityType}이(가) 채널에 할당되었습니다"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:85
-msgid "Successfully created channel"
-msgstr "채널이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:94
-msgid "Successfully created collection"
-msgstr "컬렉션이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:64
-msgid "Successfully created country"
-msgstr "국가가 생성되었습니다"
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:93
-msgid "Successfully created customer"
-msgstr "고객이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:66
-msgid "Successfully created customer group"
-msgstr "고객 그룹이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:79
-msgid "Successfully created facet"
-msgstr "속성이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:85
-msgid "Successfully created facet value"
-msgstr "속성 값이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:82
-msgid "Successfully created option group"
-msgstr "옵션 그룹이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
-msgid "Successfully created payment method"
-msgstr "결제 방법이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:87
-msgid "Successfully created product"
-msgstr "상품이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
-msgid "Successfully created product options"
-msgstr "상품 옵션이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:102
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:169
-msgid "Successfully created product variant"
-msgstr "상품 변형이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:103
-msgid "Successfully created promotion"
-msgstr "프로모션이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:64
-msgid "Successfully created role"
-msgstr "역할이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:58
-msgid "Successfully created seller"
-msgstr "판매자가 생성되었습니다"
-
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:69
-msgid "Successfully created stock location"
-msgstr "재고 위치가 생성되었습니다"
-
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
-msgid "Successfully created tax category"
-msgstr "세금 카테고리가 생성되었습니다"
-
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:71
-msgid "Successfully created tax rate"
-msgstr "세율이 생성되었습니다"
-
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:62
-msgid "Successfully created zone"
-msgstr "지역이 생성되었습니다"
-
-#: src/app/common/duplicate-bulk-action.tsx:97
-msgid "Successfully duplicated {count} {entityName}"
-msgstr "{count}개 {entityName}이(가) 복제되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:76
-msgid "Successfully fulfilled order"
-msgstr "주문이 이행되었습니다"
-
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:52
-msgid "Successfully removed {selectionLength} {entityType} from channel"
-msgstr "채널에서 {selectionLength}개 {entityType}이(가) 제거되었습니다"
-
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
-msgid "Successfully removed {successCount} facets from channel"
-msgstr "채널에서 {successCount}개 속성이 제거되었습니다"
-
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:70
-msgid "Successfully updated asset"
-msgstr "에셋이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:85
-msgid "Successfully updated channel"
-msgstr "채널이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:94
-msgid "Successfully updated collection"
-msgstr "컬렉션이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:64
-msgid "Successfully updated country"
-msgstr "국가가 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:93
-msgid "Successfully updated customer"
-msgstr "고객이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:67
-msgid "Successfully updated customer group"
-msgstr "고객 그룹이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:79
-msgid "Successfully updated facet"
-msgstr "속성이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:85
-msgid "Successfully updated facet value"
-msgstr "속성 값이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
-msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
-msgstr "{entityIdsLength}개 {entityType}의 속성 값이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:70
-msgid "Successfully updated global settings"
-msgstr "전역 설정이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:85
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:87
-msgid "Successfully updated order"
-msgstr "주문이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
-msgid "Successfully updated payment method"
-msgstr "결제 방법이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:87
-msgid "Successfully updated product"
-msgstr "상품이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:103
-msgid "Successfully updated product variant"
-msgstr "상품 변형이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_profile/profile.tsx:61
-msgid "Successfully updated profile"
-msgstr "프로필이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:103
-msgid "Successfully updated promotion"
-msgstr "프로모션이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:64
-msgid "Successfully updated role"
-msgstr "역할이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:58
-msgid "Successfully updated seller"
-msgstr "판매자가 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:70
-msgid "Successfully updated stock location"
-msgstr "재고 위치가 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:69
-msgid "Successfully updated tax category"
-msgstr "세금 카테고리가 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:71
-msgid "Successfully updated tax rate"
-msgstr "세율이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:62
-msgid "Successfully updated zone"
-msgstr "지역이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:420
-msgid "Summary of modifications"
-msgstr "수정 요약"
-
-#: src/lib/components/shared/role-code-label.tsx:6
-msgid "Super Admin"
-msgstr "최고 관리자"
-
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:20
-msgid "Surcharge"
-msgstr "추가 요금"
-
-#: src/lib/components/layout/nav-user.tsx:135
-msgctxt "theme"
-msgid "System"
-msgstr "시스템"
-
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
-msgid "Tags"
-msgstr "태그"
-
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
-msgid "Tax base"
-msgstr "과세 기준"
-
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:38
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:15
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:24
-msgid "Tax Categories"
-msgstr "세금 카테고리"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:175
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:136
-msgid "Tax category"
-msgstr "세금 카테고리"
-
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
-msgid "Tax rate"
-msgstr "세율"
-
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:79
-msgid "Tax rate: {taxRate}%"
-msgstr "세율: {taxRate}%"
-
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
-msgid "Tax Rates"
-msgstr "세율"
-
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:202
-msgid "Tax summary"
-msgstr "세금 요약"
-
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
-msgid "Tax total"
-msgstr "세금 합계"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:23
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:33
-msgid "Test"
-msgstr "테스트"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
-msgid "Test data has been updated. Click \"Run Test\" to see updated results."
-msgstr "테스트 데이터가 업데이트되었습니다. \"테스트 실행\"을 클릭하여 업데이트된 결과를 확인하세요."
-
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:163
-msgid "Test Order"
-msgstr "테스트 주문"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
-msgid "Test Results"
-msgstr "테스트 결과"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:39
-msgid "Test Shipping Method"
-msgstr "배송 방법 테스트"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:29
-msgid "Test shipping methods"
-msgstr "배송 방법 테스트"
-
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:42
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "Options"
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
+msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "Seller"
+msgstr "판매자"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "SKU:"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+msgid "Add payment"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "주문을 시뮬레이션하여 이 배송 방법이 적합한지, 배송 비용이 얼마인지 테스트하세요."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:32
-msgid "Test your shipping methods by simulating a new order."
-msgstr "새 주문을 시뮬레이션하여 배송 방법을 테스트하세요."
+#: src/lib/components/layout/nav-user.tsx
+#~ msgid "Explore Enterprise Edition"
+#~ msgstr "Enterprise Edition 살펴보기"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
-msgid "Testing shipping method..."
-msgstr "배송 방법 테스트 중..."
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+msgid "Stock Locations"
+msgstr "재고 위치"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
-msgid "Testing shipping methods..."
-msgstr "배송 방법 테스트 중..."
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+msgid "Fulfillment handler"
+msgstr "이행 처리기"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
-msgid "The data that has been passed to the job"
-msgstr "작업에 전달된 데이터"
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+msgid "Orders"
+msgstr "주문"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:132
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:175
-msgid "The result of the job"
-msgstr "작업 결과"
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+msgid "Select roles"
+msgstr ""
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:117
-msgid "The selected permissions will be applied to the these channels."
-msgstr "선택한 권한이 이 채널에 적용됩니다."
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+msgid "Successfully created role"
+msgstr "역할이 생성되었습니다"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:147
-msgid "The token is used to specify the channel when making API requests."
-msgstr "토큰은 API 요청 시 채널을 지정하는 데 사용됩니다."
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Are you sure you want to delete this variant?"
+msgstr "이 변형을 삭제하시겠습니까?"
 
-#: src/lib/components/layout/nav-user.tsx:118
-msgid "Theme"
-msgstr "테마"
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
+#~ msgid "All resources are up and running"
+#~ msgstr "모든 리소스가 정상 작동 중입니다"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:39
-msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
-msgstr "<0>{customerGroupName}</0> 고객 그룹의 고객입니다."
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+msgid "Failed to create administrator"
+msgstr ""
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:35
-msgid "These are the facet values for the <0>{facetName}</0> facet."
-msgstr "<0>{facetName}</0> 속성의 속성 값입니다."
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+msgid "No"
+msgstr ""
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:311
-msgid "These languages will be available for all channels to use"
-msgstr "이 언어는 모든 채널에서 사용할 수 있습니다"
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "Successfully updated product variant"
+msgstr "상품 변형이 업데이트되었습니다"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:54
-msgid "This is a default Role and cannot be modified"
-msgstr "이것은 기본 역할이며 수정할 수 없습니다"
+#: src/app/common/delete-bulk-action.tsx
+msgid "Failed to delete {failed} {entityName}: {allErrors}"
+msgstr "{failed}개 {entityName} 삭제 실패: {allErrors}"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:39
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Successfully updated product"
+msgstr "상품이 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+msgid "Failed to update country"
+msgstr "국가 업데이트 실패"
+
+#: src/lib/components/shared/facet-value-selector.tsx
+msgid "Type at least 2 characters to search..."
+msgstr "검색하려면 최소 2자를 입력하세요..."
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+msgid "Last name"
+msgstr "성"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
+msgid "Link title"
+msgstr "링크 제목"
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+msgid "Successfully updated customer group"
+msgstr "고객 그룹이 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
+msgid "Custom fields changed"
+msgstr "사용자 정의 필드가 변경되었습니다"
+
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+msgid "Successfully created stock location"
+msgstr "재고 위치가 생성되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
+msgid "Unknown error"
+msgstr "알 수 없는 오류"
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+msgid "Refund total cannot be negative"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+msgid "View details"
+msgstr "세부정보 보기"
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#~ msgid "Select a channel to assign {0} {entityType} to"
+#~ msgstr "{0}개 {entityType}을(를) 할당할 채널 선택"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+msgid "Successfully created customer"
+msgstr "고객이 생성되었습니다"
+
+#: src/lib/components/date-range-picker.tsx
+msgctxt "date-range"
+msgid "Last 7 days"
+msgstr ""
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "Failed to create channel"
+msgstr "채널 생성 실패"
+
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
+msgid "Dev Mode"
+msgstr "개발 모드"
+
+#: src/app/routes/_authenticated/_roles/roles.tsx
+msgid "New Role"
+msgstr "새 역할"
+
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+msgid "Failed to delete assets: {message}"
+msgstr "에셋 삭제 실패: {message}"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Return to stock"
+msgstr ""
+
+#: src/app/routes/_authenticated/_facets/facets.tsx
+msgid "Visibility"
+msgstr "공개 설정"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Product variants"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+msgid "New customer group"
+msgstr "새 고객 그룹"
+
+#. placeholder {0}: searchValue.trim()
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+msgid "Create \"{0}\""
+msgstr "\"{0}\" 생성"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Rename"
+msgstr "이름 변경"
+
+#: src/lib/components/layout/language-dialog.tsx
+msgid "Choose your preferred display language and locale settings"
+msgstr ""
+
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
+msgid "Successfully removed {successCount} option groups from channel"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
+msgid "Shipping method is not eligible for this order"
+msgstr "이 배송 방법은 이 주문에 적합하지 않습니다"
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
+msgid "Failed to update address"
+msgstr "주소 업데이트 실패"
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
+msgid "Address deleted successfully"
+msgstr "주소가 삭제되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+msgid "Tax rate"
+msgstr "세율"
+
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
+msgid "Order draft isn't ready to be completed"
+msgstr ""
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+msgid "New collection"
+msgstr "새 컬렉션"
+
+#: src/app/routes/_authenticated/index.tsx
+msgid "Insights"
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Run"
+msgstr "실행"
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+msgid "Failed to update tax rate"
+msgstr "세율 업데이트 실패"
+
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "<0>{collectionName}</0> 컬렉션의 내용입니다."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
-msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
-msgstr "이 상품에는 기존 변형이 있지만 옵션 그룹이 정의되어 있지 않습니다. 새 변형을 생성하기 전에 옵션 그룹을 추가해야 합니다."
+#: src/app/routes/_authenticated/_facets/facets.tsx
+msgid "private"
+msgstr "비공개"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
-msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
-msgstr "이 배송 방법의 적격성 확인 조건이 현재 주문 및 배송지 주소에 충족되지 않습니다."
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+msgid "Successfully created product option"
+msgstr ""
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:166
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:154
-msgid "Title"
-msgstr "제목"
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "Parent product"
+msgstr ""
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:95
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:180
-msgid "Toggle all"
-msgstr "모두 토글"
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+msgid "City"
+msgstr "도시"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:158
-msgid "Toggle header column"
-msgstr "헤더 열 토글"
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+msgid "Administrators"
+msgstr "관리자"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:210
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
+msgid "Gross price: <0/>"
+msgstr "총 가격: <0/>"
+
+#: src/lib/components/data-table/data-table-pagination.tsx
+msgid "Go to next page"
+msgstr ""
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
+msgid "Remove link"
+msgstr "링크 제거"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+msgid "This field is readonly"
+msgstr ""
+
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+msgid "Order Count"
+msgstr ""
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "You must first select an available currency to set a default currency"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+msgid "Successfully updated order"
+msgstr "주문이 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+msgid "Inherit filters"
+msgstr "필터 상속"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Manage global saved views that are visible to all users"
+msgstr "모든 사용자에게 표시되는 전역 저장 뷰 관리"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+msgid "Search payment methods..."
+msgstr "결제 방법 검색..."
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Shipping address unset for order"
+msgstr "주문의 배송 주소가 해제됨"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+msgid "Create {enabledCount} variants"
+msgstr ""
+
+#. placeholder {0}: entry.data.paymentId
+#. placeholder {1}: entry.data.to
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+msgid "Payment #{0} transitioned to {1}"
+msgstr "결제 #{0}이(가) {1}(으)로 전환되었습니다"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+msgid "Error loading customer history: {0}"
+msgstr "고객 이력 로딩 오류: {0}"
+
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
+msgid "Successfully removed {selectionLength} {entityType} from channel"
+msgstr "채널에서 {selectionLength}개 {entityType}이(가) 제거되었습니다"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Add option value"
+msgstr "옵션 값 추가"
+
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+msgid "Global Settings"
+msgstr "전역 설정"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "is after"
+msgstr "이후"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+msgid "Successfully updated product option"
+msgstr ""
+
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
+msgid "Edit facet values"
+msgstr "속성 값 편집"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+msgid "Adding..."
+msgstr "추가 중..."
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+msgid "Move Collections"
+msgstr "컬렉션 이동"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+msgid "Roles"
+msgstr "역할"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "Grid view"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
+msgid "Failed to delete address"
+msgstr "주소 삭제 실패"
+
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+msgid "No shipping methods available"
+msgstr "사용 가능한 배송 방법 없음"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Global view converted to personal view successfully"
+msgstr "전역 뷰가 개인 뷰로 변환되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Fulfillment transitioned"
+msgstr "이행이 전환되었습니다"
+
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+msgid "Are you sure you want to delete {selectionLength} assets?"
+msgstr "{selectionLength}개 에셋을 삭제하시겠습니까?"
+
+#: src/lib/components/login/login-form.tsx
+msgid "Sign in"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "List view"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
+msgid "Test Order"
+msgstr "테스트 주문"
+
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
+msgid "Select a customer to continue"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+msgid "Successfully assigned option group"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+msgid "Run Test"
+msgstr "테스트 실행"
+
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
+msgid "Tax rate: {taxRate}%"
+msgstr "세율: {taxRate}%"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+msgid "Please add products and complete the shipping address to run the test."
+msgstr "테스트를 실행하려면 상품을 추가하고 배송지 주소를 완성하세요."
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "헤더 행 토글"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:145
-msgid "Token"
-msgstr "토큰"
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
+msgid "Select address"
+msgstr "주소 선택"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:74
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:111
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+msgid "Payment eligibility checker"
+msgstr "결제 적격성 확인"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "Default tax zone"
+msgstr "기본 세금 지역"
+
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
+msgid "Order draft is ready to be completed"
+msgstr ""
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Metadata"
+msgstr "메타데이터"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Failed to set shipping method for order: {0}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
+msgid "Filter..."
+msgstr "필터..."
+
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+msgid "New facet value"
+msgstr "새 속성 값"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "Successfully updated channel"
+msgstr "채널이 업데이트되었습니다"
+
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
+msgid "Show less"
+msgstr ""
+
+#: src/lib/components/layout/language-dialog.tsx
+msgid "Short date"
+msgstr "짧은 날짜"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "Available currencies"
+msgstr "사용 가능한 통화"
+
+#. placeholder {0}: selectedIds.size
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+msgid "Select {0} Items"
+msgstr "{0}개 항목 선택"
+
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
+msgid "Placed At"
+msgstr ""
+
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+msgid "The data that has been passed to the job"
+msgstr "작업에 전달된 데이터"
+
+#: src/lib/components/shared/navigation-confirmation.tsx
+msgid "Confirm navigation"
+msgstr "이동 확인"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
+msgid "Link target"
+msgstr "링크 대상"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Complete draft"
+msgstr "임시 저장 완료"
+
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "Name"
+msgstr "이름"
+
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+msgid "Failed to fulfill order"
+msgstr "주문 이행 실패"
+
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "합계"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:275
-msgid "Total refund:"
-msgstr "총 환불:"
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+msgid "Enter the transaction ID for this refund settlement"
+msgstr "이 환불 정산의 거래 ID를 입력하세요"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:253
-msgid "Track"
-msgstr "추적"
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+msgid "Your API Key"
+msgstr ""
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:148
-msgid "Track inventory by default"
-msgstr "기본적으로 재고 추적"
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Are you sure you want to delete this draft order?"
+msgstr "이 임시 저장 주문을 삭제하시겠습니까?"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:112
-msgid "Tracking code"
-msgstr "추적 코드"
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Fulfillment created"
+msgstr "이행이 생성되었습니다"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#. placeholder {0}: testResult.length
+#. placeholder {1}: testResult.length !== 1 ? 's' : ''
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
+msgid "Found {0} eligible shipping method{1}"
+msgstr "{0}개의 적합한 배송 방법을 찾았습니다"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
+msgid "Dimensions"
+msgstr ""
+
+#: src/lib/components/ui/password-input.tsx
+msgid "Show password"
+msgstr ""
+
+#. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "(max: {0})"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+msgid "Company"
+msgstr "회사"
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
+msgid "Add column after"
+msgstr "뒤에 열 추가"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+msgid "Actions"
+msgstr "작업"
+
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+msgid "Discounts"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+msgid "Enter refund note"
+msgstr "환불 메모 입력"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Order line removed"
+msgstr "주문 항목이 제거되었습니다"
+
+#: src/lib/components/layout/channel-switcher.tsx
+msgid "Content:"
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+msgid "Key"
+msgstr ""
+
+#: src/lib/components/login/login-form.tsx
+#~ msgid "Username"
+#~ msgstr "사용자명"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+msgid "Confirm"
+msgstr "확인"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Failed to complete draft order: {0}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+msgid "Failed to create collection"
+msgstr "컬렉션 생성 실패"
+
+#: src/lib/components/data-table/data-table-pagination.tsx
+msgid "Go to first page"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Failed to create product"
+msgstr "상품 생성 실패"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
+msgid "Customer"
+msgstr "고객"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
+msgid "Error loading order history: {0}"
+msgstr "주문 이력 로딩 오류: {0}"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Shipping address set for order"
+msgstr "주문의 배송 주소가 설정됨"
+
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
+msgid "Focal Point"
+msgstr "초점"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Single variant, no options"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
+msgid "Select the next state for the order"
+msgstr "주문의 다음 상태 선택"
+
+#: src/lib/components/layout/language-dialog.tsx
+msgid "Locale"
+msgstr "로케일"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Scheduled Tasks"
+msgstr "예약된 작업"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+msgid "Enter transaction ID"
+msgstr "거래 ID 입력"
+
+#: src/lib/components/data-table/refresh-button.tsx
+msgid "Refresh data"
+msgstr "데이터 새로고침"
+
+#. placeholder {0}: entityIds.length
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+msgid "Add or remove facet values for {0} {entityType}"
+msgstr "{0}개 {entityType}의 속성 값 추가 또는 제거"
+
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
+msgid "These are the facet values for the <0>{facetName}</0> facet."
+msgstr "<0>{facetName}</0> 속성의 속성 값입니다."
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+msgid "Successfully added payment to order"
+msgstr "주문에 결제가 추가되었습니다"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Billing address set for order"
+msgstr "주문에 청구 주소가 설정되었습니다"
+
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+msgid "Failed to update zone"
+msgstr "지역 업데이트 실패"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
+msgid "Password"
+msgstr "비밀번호"
+
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+msgid "Failed to delete"
+msgstr "삭제 실패"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Scheduled task will be executed"
+msgstr "예약된 작업이 실행됩니다"
+
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+msgid "New stock location"
+msgstr "새 재고 위치"
+
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+msgid "Permissions"
+msgstr "권한"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
+msgid "Shipping address changed"
+msgstr "배송지 주소가 변경되었습니다"
+
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+msgid "No products found"
+msgstr ""
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
+msgid "Add row before"
+msgstr "앞에 행 추가"
+
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+msgid "Transition to {suggestedState}"
+msgstr "{suggestedState}(으)로 전환"
+
+#: src/lib/components/date-range-picker.tsx
+msgctxt "date-range"
+msgid "This month"
+msgstr ""
+
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+msgid "Failed to create facet"
+msgstr "속성 생성 실패"
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+msgid "Failed to cancel order items"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "거래 ID"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
-msgid "Transaction ID is required"
-msgstr "거래 ID는 필수입니다"
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "Allocated"
+msgstr "할당됨"
+
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#~ msgid "Add another option group"
+#~ msgstr "다른 옵션 그룹 추가"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Failed to set coupon code for order: {0}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+msgid "Select what to do with remaining stock"
+msgstr ""
+
+#: src/lib/components/layout/nav-user.tsx
+msgid "Explore Platform & Cloud"
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+msgid "Every 5 seconds"
+msgstr "5초마다"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+msgid "Successfully created collection"
+msgstr "컬렉션이 생성되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
+msgid "Price"
+msgstr "가격"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+msgid "Draft order"
+msgstr "임시 저장 주문"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+msgid "Scope"
+msgstr ""
+
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
+msgid "Add condition"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
+msgid "Shipping method is eligible for this order"
+msgstr "이 배송 방법은 이 주문에 적합합니다"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Administrators"
+msgstr "관리자"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+msgid "Removed from group"
+msgstr "그룹에서 제거되었습니다"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+msgid "Width"
+msgstr "너비"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+msgid "No payment or refund required"
+msgstr "결제 또는 환불 불필요"
+
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+msgid "Download as .env file"
+msgstr ""
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+msgid "When enabled, a promotion is available in the shop"
+msgstr "활성화하면 프로모션이 상점에서 사용 가능합니다"
+
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
+msgstr "추적 시 상품 변형 재고 수준이 판매 시 자동으로 조정됩니다. 이 설정은 개별 상품 변형으로 재정의할 수 있습니다."
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Shipping method set for order"
+msgstr "주문의 배송 방법이 설정됨"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+msgid "Failed to update promotion"
+msgstr "프로모션 업데이트 실패"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "Images"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "API Keys"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+msgid "Search {name}..."
+msgstr "{name} 검색..."
+
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+msgid "Edit asset"
+msgstr "에셋 편집"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Cancel payment"
+msgstr "결제 취소"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+msgid "Job Queue"
+msgstr "작업 큐"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Assets"
+msgstr "에셋"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+msgid "Email address"
+msgstr "이메일 주소"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Failed to remove coupon code from order: {0}"
+msgstr ""
+
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
+msgid "Regenerate slug from source field"
+msgstr "원본 필드에서 슬러그 재생성"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "Inherit from global settings"
+msgstr "전역 설정에서 상속"
+
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
+msgid "No results found"
+msgstr "결과를 찾을 수 없습니다"
+
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
+#~ msgid "Current status"
+#~ msgstr "현재 상태"
+
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
+msgid "Set a shipping address and select a shipping method"
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+msgid "Off"
+msgstr "끄기"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+msgid "Settings Store"
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+msgid "Queue"
+msgstr "큐"
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+msgid "New tax rate"
+msgstr "새 세율"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Payment transitioned"
+msgstr "결제가 전환되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+msgid "Remaining:"
+msgstr "남은:"
+
+#: src/app/common/duplicate-entity-dialog.tsx
+msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
+msgstr "{entityName}에 대한 코드 \"{duplicatorCode}\"의 복제 도구를 찾을 수 없습니다"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "Prices include tax for default tax zone"
+msgstr "가격에 기본 세금 지역의 세금이 포함됩니다"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "This field is required"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+msgid "Total refund:"
+msgstr "총 환불:"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "View job result"
+msgstr "작업 결과 보기"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+msgid "Test your shipping methods by simulating a new order."
+msgstr "새 주문을 시뮬레이션하여 배송 방법을 테스트하세요."
+
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+msgid "No items selected"
+msgstr "선택한 항목 없음"
+
+#. placeholder {0}: selected.length
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid ", {0} selected"
+msgstr ""
+
+#: src/lib/components/shared/country-selector.tsx
+msgid "No countries found"
+msgstr "국가를 찾을 수 없습니다"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+msgid "Successfully created variants"
+msgstr ""
+
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
+msgid "Generate slug automatically"
+msgstr "슬러그 자동 생성"
+
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+msgid "Surcharge"
+msgstr "추가 요금"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+msgid "Payment Methods"
+msgstr "결제 방법"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "Stock"
+msgstr "재고"
+
+#: src/lib/components/shared/customer-selector.tsx
+msgid "No customers found"
+msgstr "고객을 찾을 수 없습니다"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "Use global out-of-stock threshold"
+msgstr "전역 품절 임계값 사용"
+
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
+#~ msgid "New product option group"
+#~ msgstr "새 상품 옵션 그룹"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Payment state updated successfully"
+msgstr "결제 상태가 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+msgid "Create new"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Refund total"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+msgid "Address deleted"
+msgstr "주소가 삭제되었습니다"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+msgid "Only roles assigned to your account are available."
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
+msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
+msgstr ""
+
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+msgid "{buttonText}"
+msgstr "{buttonText}"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Item added to order"
+msgstr "주문에 항목이 추가되었습니다"
+
+#: src/lib/components/shared/asset/asset-preview.tsx
+msgid "Edit focal point"
+msgstr ""
+
+#: src/lib/components/shared/seller-selector.tsx
+#~ msgid "No sellers found"
+#~ msgstr "판매자를 찾을 수 없습니다"
+
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
+msgid "Asset"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
+msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
+msgstr ""
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "My Saved Views"
+msgstr "저장한 뷰"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "New channel"
+msgstr "새 채널"
+
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+msgid "Failed to create seller"
+msgstr "판매자 생성 실패"
+
+#. placeholder {0}: entityName.toLowerCase()
+#: src/app/common/duplicate-entity-dialog.tsx
+msgid "Configure duplication settings for {0}s"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+msgid "No variants match the current filter."
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+msgid "Addresses"
+msgstr "주소"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Add a new option value to the {groupName} option group"
+msgstr ""
+
+#. placeholder {0}: entry.data.modificationId
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+msgid "Order modification #{0}"
+msgstr "주문 수정 #{0}"
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
+msgid "Add column before"
+msgstr "앞에 열 추가"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "Channel Languages"
+msgstr "채널 언어"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+msgid "Failed to create option group"
+msgstr "옵션 그룹 생성 실패"
+
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
+msgid "True"
+msgstr "참"
+
+#: src/lib/components/shared/customer-selector.tsx
+msgid "Select customer"
+msgstr "고객 선택"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Order transitioned"
+msgstr "주문이 전환되었습니다"
+
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
+#~ msgstr "이 상품에는 기존 변형이 있지만 옵션 그룹이 정의되어 있지 않습니다. 새 변형을 생성하기 전에 옵션 그룹을 추가해야 합니다."
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "is before"
+msgstr "이전"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Delete draft order"
+msgstr "임시 저장 주문 삭제"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Catalog"
+msgstr "카탈로그"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+msgid "New payment method"
+msgstr "새 결제 방법"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+msgid "Successfully updated promotion"
+msgstr "프로모션이 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
+msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
+msgstr ""
+
+#: src/lib/components/shared/channel-selector.tsx
+msgid "Select a channel"
+msgstr "채널 선택"
+
+#: src/lib/components/layout/language-dialog.tsx
+msgid "Display language"
+msgstr "표시 언어"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+msgid "Fulfillment details"
+msgstr "이행 세부정보"
+
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+msgid "Discard remaining stock"
+msgstr ""
+
+#: src/lib/components/data-input/datetime-input.tsx
+msgid "Now"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Channels"
+msgstr "채널"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "View converted to global successfully"
+msgstr "뷰가 전역으로 변환되었습니다"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "before"
+msgstr "이전"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Failed to set customer for order: {0}"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "Size"
+msgstr ""
+
+#. placeholder {0}: formatLanguageName(contentLanguage)
+#: src/lib/components/shared/translatable-form-field.tsx
+msgid "No translation found for {0}"
+msgstr "{0}의 번역을 찾을 수 없습니다"
+
+#: src/app/routes/_authenticated/_customers/customers.tsx
+msgid "New Customer"
+msgstr "새 고객"
+
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
+msgid "Latest Orders"
+msgstr ""
+
+#: src/app/routes/_authenticated/_collections/collections.tsx
+msgid "+ {leftOver} more"
+msgstr "+ {leftOver}개 더보기"
+
+#: src/lib/components/shared/customer-address-form.tsx
+msgid "Use as the default billing address"
+msgstr "기본 청구지 주소로 사용"
+
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Delete"
+msgstr "삭제"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Disable"
+msgstr "비활성화"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Collections"
+msgstr "컬렉션"
+
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+msgid "Add variant"
+msgstr "변형 추가"
+
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+msgid "Failed to create country"
+msgstr "국가 생성 실패"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Countries"
+msgstr "국가"
+
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#~ msgid "Failed to create product options"
+#~ msgstr "상품 옵션 생성 실패"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Failed to rename view"
+msgstr "뷰 이름 변경 실패"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Available"
+msgstr ""
+
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
+msgid "Normal"
+msgstr "일반"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+msgid "Filters"
+msgstr "필터"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Customer Groups"
+msgstr "고객 그룹"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
+msgid "Customers"
+msgstr "고객"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
+msgid "Select Shipping Calculator"
+msgstr ""
+
+#: src/lib/components/layout/language-dialog.tsx
+msgid "Sample Formatting"
+msgstr "샘플 서식"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+msgid "New option"
+msgstr "새 옵션"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+msgid "Usage limit"
+msgstr "사용 제한"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "Loading global settings..."
+msgstr "전역 설정 로딩 중..."
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
+msgid "Address updated successfully"
+msgstr "주소가 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
+msgid "Created"
+msgstr "생성일"
+
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
+msgid "Loading addresses..."
+msgstr "주소 로딩 중..."
+
+#. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+msgid "Select a target collection to move {0} to."
+msgstr "{0}을(를) 이동할 대상 컬렉션을 선택하세요."
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Failed to unset billing address for order: {0}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+msgid "Customer details updated"
+msgstr "고객 정보가 업데이트되었습니다"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "not in"
+msgstr "포함하지 않음"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Apply"
+msgstr "적용"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+msgid "New product option"
+msgstr "새 상품 옵션"
+
+#: src/lib/components/data-table/data-table-pagination.tsx
+msgid "Go to last page"
+msgstr ""
+
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
+msgid "Cancel"
+msgstr "취소"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Failed to update order custom fields: {0}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+msgid "Successfully created product variant"
+msgstr "상품 변형이 생성되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+msgid "Refund from this method"
+msgstr "이 방법에서 환불"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+msgid "Postal Code"
+msgstr "우편번호"
+
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#~ msgid "Add product options first"
+#~ msgstr "먼저 상품 옵션을 추가하세요"
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+msgid "New tax category"
+msgstr "새 세금 카테고리"
+
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#~ msgid "Add option"
+#~ msgstr "옵션 추가"
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+msgid "Partial refund completed"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Set custom fields"
+msgstr "사용자 정의 필드 설정"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+msgid "Collections"
+msgstr "컬렉션"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
+msgid "Select Shipping Eligibility Checker"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Delete variant"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
+msgid "No modifications made"
+msgstr "수정 없음"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "Default shipping zone"
+msgstr "기본 배송 지역"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+msgid "Reason:"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Shipping address"
+msgstr "배송지 주소"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:92
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:107
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "{0}(으)로 전환"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:84
-msgid "Transition to {suggestedState}"
-msgstr "{suggestedState}(으)로 전환"
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+msgid "Tax Categories"
+msgstr "세금 카테고리"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:131
-msgid "Transition to selected state"
-msgstr "선택한 상태로 전환"
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+msgid "Private collections are not visible in the shop"
+msgstr "비공개 컬렉션은 상점에 표시되지 않습니다"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:50
-msgid "True"
-msgstr "참"
-
-#: src/lib/components/shared/facet-value-selector.tsx:273
-msgid "Type at least 2 characters to search..."
-msgstr "검색하려면 최소 2자를 입력하세요..."
-
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:54
-msgid "Unit price"
-msgstr "단가"
-
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:102
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:87
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:175
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:125
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
-msgid "Unknown error"
-msgstr "알 수 없는 오류"
-
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
-msgid "Unverified"
-msgstr "미확인"
-
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:115
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:101
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:125
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:124
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:87
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:96
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:155
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:112
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:102
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:100
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:46
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:130
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:134
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:276
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:142
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:163
-#: src/app/routes/_authenticated/_profile/profile.tsx:82
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:135
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:87
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:81
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:132
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:99
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:98
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:95
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:85
-#: src/lib/framework/page/detail-page.tsx:205
-msgid "Update"
-msgstr "업데이트"
-
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
-msgid "Update the note content or visibility"
-msgstr "메모 내용 또는 공개 설정 업데이트"
-
-#: src/lib/framework/layout-engine/page-layout.tsx:407
-msgid "Updated"
-msgstr "업데이트 일시"
-
-#: src/lib/components/shared/asset/asset-gallery.tsx:355
-msgid "Upload"
-msgstr "업로드"
-
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:214
-msgid "Usage limit"
-msgstr "사용 제한"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:322
-#: src/lib/components/shared/customer-address-form.tsx:313
-msgid "Use as the default billing address"
-msgstr "기본 청구지 주소로 사용"
-
-#: src/app/routes/_authenticated/_customers/components/customer-address-form.tsx:302
-#: src/lib/components/shared/customer-address-form.tsx:293
-msgid "Use as the default shipping address"
-msgstr "기본 배송지 주소로 사용"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:283
-msgid "Use global out-of-stock threshold"
-msgstr "전역 품절 임계값 사용"
-
-#: src/lib/components/login/login-form.tsx:112
-msgid "Username"
-msgstr "사용자명"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
-msgid "Using external authentication strategy: {strategy}"
-msgstr "외부 인증 전략 사용: {strategy}"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
-msgid "Using native authentication strategy"
-msgstr "기본 인증 전략 사용"
-
-#: src/app/routes/_authenticated/_facets/facets.tsx:88
-msgid "Values"
-msgstr "값"
-
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:202
-msgid "Variant"
-msgstr "변형"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:182
-msgid "Variant deleted successfully"
-msgstr "변형이 삭제되었습니다"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:174
-msgid "Variant updated successfully"
-msgstr "변형이 업데이트되었습니다"
-
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
-msgid "Variants"
-msgstr "변형"
-
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
-msgid "Verified"
-msgstr "확인됨"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
-msgid "View changes"
-msgstr "변경사항 보기"
-
-#: src/lib/components/data-table/views-sheet.tsx:118
-msgid "View converted to global successfully"
-msgstr "뷰가 전역으로 변환되었습니다"
-
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
-msgid "View data"
-msgstr "데이터 보기"
-
-#: src/lib/components/data-table/views-sheet.tsx:83
-msgid "View deleted successfully"
-msgstr "뷰가 삭제되었습니다"
-
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:152
-msgid "View details"
-msgstr "세부정보 보기"
-
-#: src/lib/components/data-table/views-sheet.tsx:97
-msgid "View duplicated successfully"
-msgstr "뷰가 복제되었습니다"
-
-#: src/app/routes/_authenticated/_system/job-queue.tsx:113
-msgid "View job data"
-msgstr "작업 데이터 보기"
-
-#: src/app/routes/_authenticated/_system/job-queue.tsx:131
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:174
-msgid "View job result"
-msgstr "작업 결과 보기"
-
-#: src/lib/components/data-table/views-sheet.tsx:63
-msgid "View renamed successfully"
-msgstr "뷰 이름이 변경되었습니다"
-
-#: src/app/routes/_authenticated/_system/job-queue.tsx:135
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:178
-msgid "View result"
-msgstr "결과 보기"
-
-#: src/app/routes/_authenticated/_facets/facets.tsx:53
-msgid "View values"
-msgstr "값 보기"
-
-#: src/app/routes/_authenticated/_facets/facets.tsx:77
-msgid "Visibility"
-msgstr "공개 설정"
-
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
-msgid "Visible to admins only"
-msgstr "관리자만 볼 수 있음"
-
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
-msgid "Visible to customer"
-msgstr "고객에게 표시"
-
-#: src/lib/components/login/login-form.tsx:89
-msgid "Welcome back!"
-msgstr "환영합니다"
-
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:145
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:122
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "활성화하면 상품이 상점에서 사용 가능합니다"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:146
-msgid "When enabled, a promotion is available in the shop"
-msgstr "활성화하면 프로모션이 상점에서 사용 가능합니다"
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Scheduled task could not be executed"
+msgstr "예약된 작업을 실행할 수 없습니다"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:236
-msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
-msgstr "이 옵션을 활성화하면 상품 카탈로그에 입력된 가격에 기본 세금 지역의 세금이 포함됩니다."
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+msgid "Customer Groups"
+msgstr "고객 그룹"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:150
-msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
-msgstr "추적 시 상품 변형 재고 수준이 판매 시 자동으로 조정됩니다. 이 설정은 개별 상품 변형으로 재정의할 수 있습니다."
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
+msgid "Disabled"
+msgstr "비활성화됨"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:179
-msgid "Width"
-msgstr "너비"
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+msgid "New promotion"
+msgstr "새 프로모션"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:77
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:87
-msgid "With selected..."
-msgstr "선택한 항목으로..."
+#: src/lib/components/shared/customer-address-form.tsx
+msgid "Default Shipping Address"
+msgstr "기본 배송지 주소"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:333
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "{operator}"
+msgstr "{operator}"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+msgid "Refund required"
+msgstr "환불 필요"
+
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+msgid "Fulfill order"
+msgstr "주문 이행"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "채널 설정을 볼 수 있는 권한이 없습니다"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
-msgid "You don't have permission to view global language settings"
-msgstr "전역 언어 설정을 볼 수 있는 권한이 없습니다"
+#: src/lib/components/date-range-picker.tsx
+msgctxt "date-range"
+msgid "Last 30 days"
+msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:152
-msgid "You haven't saved any views yet."
-msgstr "아직 저장한 뷰가 없습니다."
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+msgid "No facet values"
+msgstr "속성 값 없음"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:144
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:64
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+msgid "A reason for the refund is required"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Could not remove option group"
+msgstr ""
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+msgid "Failed to update tax category"
+msgstr "세금 카테고리 업데이트 실패"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Refund settled successfully"
+msgstr "환불이 정산되었습니다"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
+msgid "Update"
+msgstr "업데이트"
+
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
+msgid "Heading 2"
+msgstr "제목 2"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Order placed"
+msgstr "주문이 확정되었습니다"
+
+#: src/app/routes/_authenticated/_profile/profile.tsx
+msgid "Successfully updated profile"
+msgstr "프로필이 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Payment method"
+msgstr "결제 방법"
+
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
+msgid "Edit"
+msgstr "편집"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Variant updated successfully"
+msgstr "변형이 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+msgid "Filter by collection name"
+msgstr "컬렉션 이름으로 필터"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Note added"
+msgstr "메모가 추가되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+msgid "Select quantities to fulfill and configure the fulfillment handler"
+msgstr "이행할 수량을 선택하고 이행 처리기를 구성하세요"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Billing address unset for order"
+msgstr "주문에서 청구 주소가 제거되었습니다"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+msgid "Starts at"
+msgstr "시작 일시"
+
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Duplicate"
+msgstr "복제"
+
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+msgid "No results"
+msgstr "결과 없음"
+
+#: src/lib/components/data-table/data-table-view-options.tsx
+msgid "Column settings"
+msgstr "열 설정"
+
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
+msgid "Code"
+msgstr "코드"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Failed to remove option groups"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Order delivered"
+msgstr "주문이 배송되었습니다"
+
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+msgid "Transfer to {name}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+msgid "Remaining stock"
+msgstr ""
+
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
+msgid "Remove from zone"
+msgstr ""
+
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "Select from globally available languages for this channel"
+msgstr "이 채널에서 전역적으로 사용 가능한 언어 중 선택"
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
+msgid "Are you sure you want to delete this address?"
+msgstr "이 주소를 삭제하시겠습니까?"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+msgid "Failed to assign option group"
+msgstr ""
+
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+msgid "Failed to update asset"
+msgstr "에셋 업데이트 실패"
+
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+msgid "Successfully updated stock location"
+msgstr "재고 위치가 업데이트되었습니다"
+
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+msgid "Confirm Action"
+msgstr "작업 확인"
+
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+msgid "Successfully updated country"
+msgstr "국가가 업데이트되었습니다"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Facets"
+msgstr "속성"
+
+#. js-lingui-explicit-id
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
+msgid "Failed to add note"
+msgstr "메모 추가 실패"
+
+#. js-lingui-explicit-id
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
+msgid "Failed to delete note"
+msgstr "메모 삭제 실패"
+
+#. js-lingui-explicit-id
+#: src/lib/hooks/use-extended-list-query.ts
+msgid "Failed to extend query document"
+msgstr "쿼리 문서 확장 실패"
+
+#. js-lingui-explicit-id
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
+msgid "Failed to update note"
+msgstr "메모 업데이트 실패"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Refund shipping"
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+msgid "Readonly"
+msgstr ""
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Failed to duplicate global view"
+msgstr "전역 뷰 복제 실패"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+msgid "Showing {shown} of {total} • {selected} selected"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
+msgid "Test Shipping Method"
+msgstr "배송 방법 테스트"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Facet Values"
+msgstr "속성 값"
+
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+msgid "Successfully updated asset"
+msgstr "에셋이 업데이트되었습니다"
+
+#: src/lib/components/layout/nav-user.tsx
+msgid "Theme"
+msgstr "테마"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "You must select at least one available currency"
+msgstr ""
+
+#. placeholder {0}: value.totalItems
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+msgid "{0} customers"
+msgstr "{0}명의 고객"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+msgid "API Keys"
+msgstr ""
+
+#: src/lib/components/shared/language-selector.tsx
+msgid "Select a language"
+msgstr "언어 선택"
+
+#: src/lib/components/layout/nav-user.tsx
+msgid "Log out"
+msgstr "로그아웃"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.attempts"
+msgstr "시도 횟수"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.availableCurrencyCodes"
+msgstr "사용 가능한 통화 코드"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.availableLanguageCodes"
+msgstr "사용 가능한 언어 코드"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.breadcrumbs"
+msgstr "경로"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.category"
+msgstr "카테고리"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.channels"
+msgstr "채널"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.children"
+msgstr "하위 항목"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.code"
+msgstr "코드"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.couponCode"
+msgstr "쿠폰 코드"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.createdAt"
+msgstr "생성일"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.currencyCode"
+msgstr "통화 코드"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.customer"
+msgstr "고객"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.customerGroup"
+msgstr "고객 그룹"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.customers"
+msgstr "고객"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.customFields"
+msgstr "사용자 정의 필드"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.data"
+msgstr "데이터"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.defaultCurrencyCode"
+msgstr "기본 통화 코드"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.defaultLanguageCode"
+msgstr "기본 언어 코드"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.defaultShippingZone"
+msgstr "기본 배송 지역"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.defaultTaxZone"
+msgstr "기본 세금 지역"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.description"
+msgstr "설명"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.duration"
+msgstr "기간"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.emailAddress"
+msgstr "이메일 주소"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.enabled"
+msgstr "활성화됨"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.endsAt"
+msgstr "종료 일시"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.error"
+msgstr "오류"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.featuredAsset"
+msgstr "주요 에셋"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.firstName"
+msgstr "이름"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.fulfillmentHandlerCode"
+msgstr "배송 처리 코드"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.id"
+msgstr "ID"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.isDefault"
+msgstr "기본값"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.isPrivate"
+msgstr "비공개"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.isSettled"
+msgstr "정산 완료"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.lastName"
+msgstr "성"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.name"
+msgstr "이름"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.orderPlacedAt"
+msgstr "주문 일시"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.parentId"
+msgstr "상위 ID"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.perCustomerUsageLimit"
+msgstr "고객당 사용 제한"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.permissions"
+msgstr "권한"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.position"
+msgstr "위치"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.price"
+msgstr "가격"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.pricesIncludeTax"
+msgstr "가격에 세금 포함"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.priceWithTax"
+msgstr "세금 포함 가격"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.productVariants"
+msgstr "상품 변형"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.progress"
+msgstr "진행률"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.queueName"
+msgstr "큐 이름"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.result"
+msgstr "결과"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.retries"
+msgstr "재시도"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.seller"
+msgstr "판매자"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.settledAt"
+msgstr "정산일"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.shippingLines"
+msgstr "배송 항목"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.sku"
+msgstr "SKU"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.slug"
+msgstr "슬러그"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.startedAt"
+msgstr "시작일"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.startsAt"
+msgstr "시작 일시"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.state"
+msgstr "상태"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.stockLevels"
+msgstr "재고 수준"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.token"
+msgstr "토큰"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.total"
+msgstr "합계"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.totalWithTax"
+msgstr "세금 포함 합계"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.type"
+msgstr "유형"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.updatedAt"
+msgstr "수정일"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.usageLimit"
+msgstr "사용 제한"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.user"
+msgstr "사용자"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.value"
+msgstr "값"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.valueList"
+msgstr "값 목록"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fieldName.zone"
+msgstr "지역"
+
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+msgid "Method"
+msgstr "메서드"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+msgid "Tax summary"
+msgstr "세금 요약"
+
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
+msgstr "모든 채널에서 사용 가능한 언어를 설정합니다. 개별 채널은 이러한 언어의 하위 집합을 지원할 수 있습니다."
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+msgid "Collections moved successfully"
+msgstr "컬렉션이 성공적으로 이동되었습니다"
+
+#: src/lib/components/data-input/relation-selector.tsx
+msgid "Change selection"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
+msgid "Registered"
+msgstr "등록됨"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Failed to set shipping address for order: {0}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+msgid "Cancel Job"
+msgstr "작업 취소"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+msgid "Ends at"
+msgstr "종료 일시"
+
+#. placeholder {0}: table.getState().pagination.pageIndex + 1
+#. placeholder {1}: table.getPageCount() || 1
+#: src/lib/components/data-table/data-table-pagination.tsx
+msgid "Page {0} of {1}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+msgid "Rate"
+msgstr "요율"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Size, colour, etc."
+msgstr ""
+
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
+msgid "Browse facets"
+msgstr ""
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "지역"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones.tsx:15
-#: src/app/routes/_authenticated/_zones/zones.tsx:25
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
+msgid "fulfillmentState.Cancelled"
+msgstr "취소됨"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fulfillmentState.Created"
+msgstr "생성됨"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fulfillmentState.Delivered"
+msgstr "배달됨"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fulfillmentState.Pending"
+msgstr "대기 중"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "fulfillmentState.Shipped"
+msgstr "배송됨"
+
+#: src/lib/components/data-table/save-view-button.tsx
+msgid "Save View"
+msgstr ""
+
+#. placeholder {0}: selection.length
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
+msgid "{0} selected"
+msgstr "{0}개 선택됨"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+msgid "Search option groups..."
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+msgid "Modify order"
+msgstr "주문 수정"
+
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+msgid "Selected Items"
+msgstr "선택한 항목"
+
+#: src/app/routes/_authenticated/_facets/facets.tsx
+msgid "Values"
+msgstr "값"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Customer set for order"
+msgstr "주문에 고객이 설정되었습니다"
+
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
+msgid "Facets"
+msgstr "속성"
+
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
+msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
+msgstr "{count, plural, other {이 그룹에서 {count}명의 고객을 제거하시겠습니까?}}"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+msgid "Stock on Hand"
+msgstr "보유 재고"
+
+#: src/app/routes/_authenticated/_products/products.tsx
+msgid "Search index rebuild could not be started"
+msgstr "검색 인덱스 재구성을 시작할 수 없습니다"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+msgid "Shipping Address"
+msgstr "배송지 주소"
+
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+msgid "New zone"
+msgstr "새 지역"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+msgid "New API Key"
+msgstr ""
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
+msgid "Delete column"
+msgstr "열 삭제"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+msgid "Assign existing"
+msgstr ""
+
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "is null"
+msgstr "NULL임"
+
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
+msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
+msgstr "<0>{customerGroupName}</0> 고객 그룹의 고객입니다."
+
+#: src/lib/components/data-table/manage-global-views-button.tsx
+msgid "Manage global views"
+msgstr "전역 뷰 관리"
+
+#: src/lib/components/shared/channel-code-label.tsx
+msgid "Default channel"
+msgstr "기본 채널"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+msgid "Insert a new image with source, title, and dimensions"
+msgstr ""
+
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+msgid "Failed to create facet value"
+msgstr "속성 값 생성 실패"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "="
+msgstr "="
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+msgid "Failed to update product option"
+msgstr ""
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+msgid "Coupon code"
+msgstr "쿠폰 코드"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+msgid "Customer verified"
+msgstr "고객이 인증되었습니다"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Global Settings"
+msgstr "전역 설정"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Schedule"
+msgstr "일정"
+
+#: src/app/routes/_authenticated/_collections/collections.tsx
+msgid "Cannot move a collection into its own descendant"
+msgstr ""
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+msgid "New Tax Category"
+msgstr "새 세금 카테고리"
+
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
+#~ msgid "No stock locations available on current channel"
+#~ msgstr "현재 채널에 사용 가능한 재고 위치가 없습니다"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "Successfully created channel"
+msgstr "채널이 생성되었습니다"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+msgid "Successfully updated customer"
+msgstr "고객이 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+msgid "View data"
+msgstr "데이터 보기"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Delete View"
+msgstr "뷰 삭제"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+msgid "Add a new address to the customer."
+msgstr "고객에게 새 주소를 추가합니다."
+
+#: src/lib/components/data-table/global-views-bar.tsx
+msgid "More views"
+msgstr "더 많은 뷰"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+msgid "Edit the selected image properties"
+msgstr ""
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Applied view \"{viewName}\""
+msgstr "뷰 \"{viewName}\"가 적용되었습니다"
+
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
+msgid "Successfully removed {successCount} facets from channel"
+msgstr "채널에서 {successCount}개 속성이 제거되었습니다"
+
+#: src/app/routes/_authenticated/_products/products.tsx
+msgid "New Product"
+msgstr "새 상품"
+
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+msgid "New asset"
+msgstr "새 에셋"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
+msgid "Recalculate shipping"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#~ msgid "Select which options should apply to the existing variant \"{0}\""
+#~ msgstr "기존 변형 \"{0}\"에 적용할 옵션 선택"
+
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Assets"
+msgstr "에셋"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "This will remove all option groups from this product and return to the variant setup choice."
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Billing address"
+msgstr "청구지 주소"
+
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+msgid "Add facet value"
+msgstr "속성 값 추가"
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+msgid "Please select a target collection"
+msgstr "대상 컬렉션을 선택하세요"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+msgid "Review the changes before applying them to the order."
+msgstr "주문에 적용하기 전에 변경사항을 검토하세요."
+
+#: src/lib/components/shared/role-selector.tsx
+msgid "Select a role"
+msgstr "역할 선택"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Order cancelled"
+msgstr "주문이 취소되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+msgid "Discount"
+msgstr "할인"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "All types"
+msgstr ""
+
+#. placeholder {0}: entityIds.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Select channels to assign {0} {entityType} to"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
+msgid "Only draft orders can be completed"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Failed to update product"
+msgstr "상품 업데이트 실패"
+
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
+msgid "Add collection filter"
+msgstr ""
+
+#. placeholder {0}: adjustedLines.length
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
+msgid "Adjusting {0} lines"
+msgstr "{0}개 항목 조정 중"
+
+#: src/lib/components/shared/facet-value-selector.tsx
+msgid "Add facet values"
+msgstr "속성 값 추가"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "after"
+msgstr "이후"
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Channel"
+msgstr "채널"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+#~ msgid "Healthchecks"
+#~ msgstr "헬스체크"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Amount"
+msgstr "금액"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+msgid "Phone Number"
+msgstr "전화번호"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+msgid "New customer"
+msgstr "새 고객"
+
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Image"
+msgstr "이미지"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+msgid "Successfully created administrator"
+msgstr ""
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Product Options"
+msgstr "상품 옵션"
+
+#: src/lib/components/shared/country-selector.tsx
+msgid "Select country"
+msgstr "국가 선택"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+msgid "Creating..."
+msgstr "생성 중..."
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
+msgstr "이 전역 뷰를 삭제하시겠습니까? 이 작업은 취소할 수 없으며 모든 사용자에게 영향을 미칩니다."
+
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+msgid "Force remove option group"
+msgstr ""
+
+#: src/app/routes/_authenticated/_profile/profile.tsx
+msgid "Added"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+msgid "Customer history"
+msgstr "고객 이력"
+
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
+msgstr "{entityIdsLength}개 {entityType}의 속성 값이 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+msgid "Failed to remove customer from group"
+msgstr "그룹에서 고객 제거 실패"
+
+#: src/lib/components/layout/nav-user.tsx
+msgctxt "theme"
+msgid "System"
+msgstr "시스템"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+msgid "Per customer usage limit"
+msgstr "고객당 사용 제한"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
+msgid "Billing address changed"
+msgstr "청구지 주소가 변경되었습니다"
+
+#: src/lib/components/data-input/select-with-options.tsx
+msgid "Select an option"
+msgstr "옵션 선택"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Copy to Personal"
+msgstr "개인용으로 복사"
+
+#. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+msgid "Refund total exceeds maximum refundable amount of {0}"
+msgstr ""
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Delete Global View"
+msgstr "전역 뷰 삭제"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+msgid "Create"
+msgstr "생성"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+msgid "Every 30 seconds"
+msgstr "30초마다"
+
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+msgid "New country"
+msgstr "새 국가"
+
+#. placeholder {0}: entry.data.from
+#. placeholder {1}: entry.data.to
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+msgid "From {0} to {1}"
+msgstr "{0}에서 {1}까지"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+msgid "Failed to create customer"
+msgstr "고객 생성 실패"
+
+#: src/lib/components/shared/asset/asset-preview.tsx
+msgid "Focal point updated"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Option values"
+msgstr "옵션 값"
+
+#: src/lib/components/shared/customer-address-form.tsx
+msgid "Default Billing Address"
+msgstr "기본 청구지 주소"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+msgid "No customer"
+msgstr "고객 없음"
+
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
+msgid "Failed to remove countries from zone"
+msgstr ""
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+msgid "Failed to create promotion"
+msgstr "프로모션 생성 실패"
+
+#: src/lib/components/date-range-picker.tsx
+msgctxt "date-range"
+msgid "Today"
+msgstr ""
+
+#: src/lib/components/date-range-picker.tsx
+msgctxt "date-range"
+msgid "Yesterday"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#~ msgid "Option name"
+#~ msgstr "옵션 이름"
+
+#. placeholder {0}: selection.length
+#. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
+msgid "Are you sure you want to remove {0} {1} from this zone?"
+msgstr ""
+
+#. placeholder {0}: addedSurcharges.length
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
+msgid "Adding {0} surcharge(s)"
+msgstr ""
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
+msgid "Link href"
+msgstr "링크 URL"
+
+#: src/lib/utils/get-locale-fallback-placeholder.ts
+msgid "Fallback: {value}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
+msgid "Order history"
+msgstr "주문 이력"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Override"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+msgid "Transaction ID is required"
+msgstr "거래 ID는 필수입니다"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "matches regex"
+msgstr "정규식 일치"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Global view renamed successfully"
+msgstr "전역 뷰 이름이 변경되었습니다"
+
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+msgid "No tags selected"
+msgstr "선택한 태그 없음"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+msgid "Back"
+msgstr ""
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "View renamed successfully"
+msgstr "뷰 이름이 변경되었습니다"
+
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
+msgid "Apply filter"
+msgstr "필터 적용"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Last Result"
+msgstr "마지막 결과"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+msgid "Added to group"
+msgstr "그룹에 추가되었습니다"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Insights"
+msgstr "인사이트"
+
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
+#~ msgid "Create Variants"
+#~ msgstr "변형 생성"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
+msgid "Testing shipping method..."
+msgstr "배송 방법 테스트 중..."
+
+#: src/lib/components/layout/nav-user.tsx
+msgctxt "theme"
+msgid "Dark"
+msgstr "다크"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+msgid "Test Results"
+msgstr "테스트 결과"
+
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+msgid "Add customer"
+msgstr "고객 추가"
+
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "Save Changes"
+msgstr "변경사항 저장"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+msgid "Address updated"
+msgstr "주소가 업데이트되었습니다"
+
+#. placeholder {0}: selectedChannelIds.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+msgid "Refund processed successfully"
+msgstr ""
+
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+msgid "Select value"
+msgstr ""
+
+#. placeholder {0}: action.label
+#. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
+#. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
+msgid "{0}"
+msgstr "{0}"
+
+#: src/app/routes/_authenticated/_zones/zones.tsx
+msgid "New Zone"
+msgstr "새 지역"
+
+#: src/app/routes/_authenticated/_collections/collections.tsx
+msgid "Failed to update collection position"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Refund"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+msgid "Modify"
+msgstr "수정"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "No global languages configured"
+msgstr "전역 언어가 구성되지 않았습니다"
+
+#. placeholder {0}: removedLines.length
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
+msgid "Removing {0} item(s)"
+msgstr "{0}개 항목 제거 중"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "Track"
+msgstr "추적"
+
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+msgid "Create variant"
+msgstr "변형 생성"
+
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
+msgid "Facet values for {facetName}"
+msgstr "{facetName}의 속성 값"
+
+#: src/app/routes/_authenticated/index.tsx
+msgid "Save Layout"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+msgid "Password reset verified"
+msgstr "비밀번호 재설정이 확인되었습니다"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Failed to delete view"
+msgstr "뷰 삭제 실패"
+
+#: src/lib/components/shared/navigation-confirmation.tsx
+msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
+msgstr "이 페이지에서 나가시겠습니까? 저장하지 않은 변경사항은 손실됩니다."
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
+msgid "Toggle header column"
+msgstr "헤더 열 토글"
+
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+msgid "New Promotion"
+msgstr "새 프로모션"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Option value name"
+msgstr "옵션 값 이름"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+msgid "Last used"
+msgstr ""
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+msgid "Is default tax category"
+msgstr "기본 세금 카테고리"
+
+#: src/lib/components/data-input/slug-input.tsx
+msgid "Slug is set"
+msgstr "슬러그가 설정되었습니다"
+
+#: src/lib/components/shared/asset/asset-preview.tsx
+msgid "Failed to update focal point"
+msgstr ""
+
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+msgid "Successfully updated zone"
+msgstr "지역이 업데이트되었습니다"
+
+#: src/lib/components/shared/customer-address-form.tsx
+msgid "State/Province"
+msgstr "시/도"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+msgid "Failed to update option group"
+msgstr ""
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "Channel defaults"
+msgstr "채널 기본값"
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+msgid "Failed to create tax category"
+msgstr "세금 카테고리 생성 실패"
+
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
+msgid "Set filter criteria for the {columnId} column"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+msgid "Country"
+msgstr "국가"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Simple product"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Job Queue"
+msgstr "작업 큐"
+
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+msgid "Please confirm you have saved the API key before closing."
+msgstr ""
+
+#: src/lib/components/data-table/use-generated-columns.tsx
+msgid "Confirm deletion"
+msgstr "삭제 확인"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+msgid "Failed to modify order"
+msgstr "주문 수정 실패"
+
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+msgid "Includes tax at {taxRate}%"
+msgstr ""
+
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+msgid "Order metrics"
+msgstr ""
+
+#: src/lib/components/layout/language-dialog.tsx
+msgid "Select display language"
+msgstr "표시 언어 선택"
+
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
+msgid "Select Payment Handler"
+msgstr ""
+
+#: src/app/routes/_authenticated/_profile/profile.tsx
+msgid "Authentication methods"
+msgstr ""
+
+#: src/lib/components/data-table/data-table-filter-badge.tsx
+msgid "start"
+msgstr ""
+
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+msgid "Failed to rotate API key"
+msgstr ""
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "in"
+msgstr "포함"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
+msgid "Search roles..."
+msgstr "역할 검색..."
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+msgid "Product Variants"
+msgstr "상품 변형"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Manage Global Views"
+msgstr "전역 뷰 관리"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Processing..."
+msgstr ""
+
+#. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "{totalItems} {0} found"
+msgstr ""
+
+#: src/lib/components/date-range-picker.tsx
+msgid "Select date range"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Product"
+msgstr "상품"
+
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+msgid "Rotate API Key"
+msgstr ""
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+msgid "Category"
+msgstr "카테고리"
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+msgid "Moving..."
+msgstr "이동 중..."
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Assign"
+msgstr "할당"
+
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+msgid "Successfully created seller"
+msgstr "판매자가 생성되었습니다"
+
+#. placeholder {0}: failedChannelIds.length
+#. placeholder {1}: selectedChannelIds.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+msgid "Successfully updated shipping method"
+msgstr ""
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "Failed to update product variant"
+msgstr "상품 변형 업데이트 실패"
+
+#: src/lib/components/data-input/custom-field-list-input.tsx
+msgid "Drag to reorder"
+msgstr "드래그하여 순서 변경"
+
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "지역"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
+msgstr ""
+
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
+msgid "Search facet values..."
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
+msgid "Note"
+msgstr ""
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+msgid "Available languages"
+msgstr "사용 가능한 언어"
+
+#. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
+#: src/app/routes/_authenticated/_collections/collections.tsx
+msgid "Load {0} more ({remaining} remaining)"
+msgstr ""
+
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+msgid "Facet values"
+msgstr "속성 값"
+
+#: src/lib/components/data-table/data-table.tsx
+msgid "Failed to reorder items"
+msgstr ""
+
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
+msgid "Total Orders"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
+msgid "No eligible shipping methods found for this order."
+msgstr "이 주문에 적합한 배송 방법을 찾을 수 없습니다."
+
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
+msgid "Add product option"
+msgstr "상품 옵션 추가"
+
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+msgid "Shipping"
+msgstr "배송"
+
+#: src/lib/hooks/use-widget-dimensions.ts
+msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+msgid "Email update requested"
+msgstr "이메일 업데이트가 요청되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
+msgid "Error transitioning to state"
+msgstr "상태 전환 오류"
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+msgid "Successfully created customer group"
+msgstr "고객 그룹이 생성되었습니다"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
+msgid "New window"
+msgstr "새 창"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Payment authorized"
+msgstr "결제가 승인되었습니다"
+
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+msgid "Successfully updated role"
+msgstr "역할이 업데이트되었습니다"
+
+#: src/lib/components/shared/customer-address-form.tsx
+msgid "Select a country"
+msgstr "국가 선택"
+
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+msgid "Failed to update shipping method"
+msgstr ""
+
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+msgid "Shipping Methods"
+msgstr "배송 방법"
+
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
+msgid "Select an address"
+msgstr "주소 선택"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+msgid "Yes"
+msgstr ""
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Slug"
+msgstr "슬러그"
+
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+msgid "Set Focal Point"
+msgstr "초점 설정"
+
+#: src/lib/components/data-table/data-table-filter-badge.tsx
+msgid "end"
+msgstr ""
+
+#: src/lib/components/shared/currency-selector.tsx
+msgid "Select a currency"
+msgstr "통화 선택"
+
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
+msgid "Update the note content or visibility"
+msgstr "메모 내용 또는 공개 설정 업데이트"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Latest Orders Widget"
+msgstr "최근 주문 위젯"
+
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
+msgid "Collection contents for {collectionName}"
+msgstr "{collectionName}의 컬렉션 내용"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
+msgid "Shipping method changed"
+msgstr "배송 방법이 변경되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+msgid "Tax description"
+msgstr ""
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "is less than or equal to"
+msgstr "이하"
+
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "is not equal to"
+msgstr "같지 않음"
+
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
+#~ msgid "Refresh"
+#~ msgstr "새로고침"
+
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#~ msgid "e.g. Size"
+#~ msgstr "예: 사이즈"
+
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
+msgid "No checkers found"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Settle payment"
+msgstr "결제 정산"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
+msgid "Channels"
+msgstr "채널"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+msgid "Shipping refunded"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "Asset type"
+msgstr ""
+
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+msgid "New Stock Location"
+msgstr "새 재고 위치"
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
+msgstr ""
+
+#: src/lib/components/data-input/relation-selector.tsx
+msgid "Select item"
+msgstr "항목 선택"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "New product"
+msgstr "새 상품"
+
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+msgid "Manage Tags"
+msgstr "태그 관리"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Items refunded"
+msgstr ""
+
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
+msgid "Add action"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#~ msgid "Assign options to existing variant"
+#~ msgstr "기존 변형에 옵션 할당"
+
+#. placeholder {0}: entityName.toLowerCase()
+#: src/app/common/duplicate-entity-dialog.tsx
+msgid "Duplicate {0}s"
+msgstr "{0} 복제"
+
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "그룹에서 제거"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
-msgid "Failed to remove customers from group"
-msgstr "그룹에서 고객을 제거하지 못했습니다"
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+msgid "Failed to update fulfillment state"
+msgstr "이행 상태 업데이트 실패"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+msgid "Create a new product variant with options, pricing, and stock"
+msgstr ""
+
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+msgid "Private facets are not visible in the shop"
+msgstr "비공개 속성은 상점에 표시되지 않습니다"
+
+#: src/lib/components/shared/tax-category-selector.tsx
+msgid "Select a tax category"
+msgstr "세금 카테고리 선택"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Not Running"
+msgstr "실행 중 아님"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+msgid "Assigned"
+msgstr ""
+
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
+msgid "Heading 1"
+msgstr "제목 1"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "Select Available Languages"
+msgstr "사용 가능한 언어 선택"
+
+#. placeholder {0}: addedLines.length
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
+msgid "Adding {0} item(s)"
+msgstr "{0}개 항목 추가 중"
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
+msgid "Add row after"
+msgstr "뒤에 행 추가"
+
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+msgid "Tax total"
+msgstr "세금 합계"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Draft order status"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#~ msgid "Successfully created product options"
+#~ msgstr "상품 옵션이 생성되었습니다"
+
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+msgid "Loading locations…"
+msgstr ""
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+msgid "Failed to create payment method"
+msgstr "결제 방법 생성 실패"
+
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+msgid "Successfully created facet value"
+msgstr "속성 값이 생성되었습니다"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Marketing"
+msgstr "마케팅"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Draft order deleted"
+msgstr "임시 저장 주문이 삭제되었습니다"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "greater than"
+msgstr "보다 큼"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Metrics Widget"
+msgstr "지표 위젯"
+
+#: src/lib/components/shared/currency-selector.tsx
+msgid "Search currencies..."
+msgstr "통화 검색..."
+
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
+msgid "Remove from channel"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+msgid "Title"
+msgstr "제목"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+msgid "Insert image"
+msgstr "이미지 삽입"
+
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+msgid "Failed to update seller"
+msgstr "판매자 업데이트 실패"
+
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+msgid "Successfully created country"
+msgstr "국가가 생성되었습니다"
+
+#: src/lib/components/shared/seller-selector.tsx
+msgid "Select seller"
+msgstr "판매자 선택"
+
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+msgid "Loading tags..."
+msgstr "태그 로딩 중..."
+
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+msgid "Successfully created facet"
+msgstr "속성이 생성되었습니다"
+
+#. placeholder {0}: row.original.productVariantCount
+#: src/app/routes/_authenticated/_collections/collections.tsx
+msgid "{0} variants"
+msgstr "{0}개 변형"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Failed to settle payment"
+msgstr "결제 정산 실패"
+
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+msgid "No billing address"
+msgstr "청구지 주소 없음"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+msgid "Facet"
+msgstr "속성"
+
+#: src/lib/components/shared/assigned-channels.tsx
+msgid "Cannot remove from active channel"
+msgstr ""
+
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
+msgid "Not set"
+msgstr "설정되지 않음"
+
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+msgid "Force remove"
+msgstr ""
+
+#: src/app/routes/_authenticated/_channels/channels.tsx
+msgid "New Channel"
+msgstr "새 채널"
+
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
+msgid "Option Group Name"
+msgstr "옵션 그룹 이름"
+
+#: src/lib/components/data-input/combination-mode-input.tsx
+msgid "AND"
+msgstr "AND"
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+msgid "Failed to create customer group"
+msgstr "고객 그룹 생성 실패"
+
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+msgid "Failed to create role"
+msgstr "역할 생성 실패"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Product name"
+msgstr "상품명"
+
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+msgid "Fulfillment state updated successfully"
+msgstr "이행 상태가 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+msgid "Products"
+msgstr "상품"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+msgid "Address created"
+msgstr "주소가 생성되었습니다"
+
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+msgid "API key rotated successfully"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+msgid "Add option group"
+msgstr "옵션 그룹 추가"
+
+#. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Refund {0}"
+msgstr ""
+
+#: src/lib/components/data-input/slug-input.tsx
+msgid "Enter slug manually"
+msgstr "슬러그 수동 입력"
+
+#: src/app/routes/_authenticated/index.tsx
+msgid "No widgets available"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Failed to cancel payment"
+msgstr "결제 취소 실패"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Payment cancelled successfully"
+msgstr "결제가 취소되었습니다"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Global view duplicated successfully"
+msgstr "전역 뷰가 복제되었습니다"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+msgid "Created by"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+msgid "Filter variants..."
+msgstr ""
+
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
+msgid "Add a price in another currency"
+msgstr ""
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+msgid "Email Address or identifier"
+msgstr "이메일 주소 또는 식별자"
+
+#. placeholder {0}: entry.data.refundId
+#. placeholder {1}: entry.data.to
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+msgid "Refund #{0} transitioned to {1}"
+msgstr "환불 #{0}이(가) {1}(으)로 전환되었습니다"
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+msgid "Customers"
+msgstr "고객"
+
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
+msgid "Heading 4"
+msgstr "제목 4"
+
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+msgid "Failed to update stock location"
+msgstr "재고 위치 업데이트 실패"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Order shipped"
+msgstr "주문이 발송되었습니다"
+
+#: src/lib/components/shared/customer-address-form.tsx
+msgid "Save Address"
+msgstr "주소 저장"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Make Global"
+msgstr "전역으로 만들기"
+
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
+msgid "Select next state"
+msgstr "다음 상태 선택"
+
+#: src/lib/components/shared/alerts.tsx
+msgid "No alerts"
+msgstr ""
+
+#. placeholder {0}: collectionsToMove.length
+#. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
+#. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+msgid "Moving {0} collection{1} into {2}"
+msgstr "{0}개 컬렉션을 {2}로 이동 중"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
+msgid "Test"
+msgstr "테스트"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "between"
+msgstr "사이"
+
+#. js-lingui-explicit-id
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
+msgid "Note added successfully"
+msgstr "메모가 추가되었습니다"
+
+#. js-lingui-explicit-id
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
+msgid "Note deleted successfully"
+msgstr "메모가 삭제되었습니다"
+
+#. js-lingui-explicit-id
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
+msgid "Note updated successfully"
+msgstr "메모가 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Failed to settle refund"
+msgstr "환불 정산 실패"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+msgid "Stock level"
+msgstr "재고 수준"
+
+#: src/lib/components/data-input/custom-field-list-input.tsx
+msgid "Add item"
+msgstr "항목 추가"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+msgid "Successfully created API key"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+msgid "Loading preview…"
+msgstr "미리보기 로딩 중..."
+
+#: src/lib/components/shared/facet-value-selector.tsx
+msgid "Back to search"
+msgstr "검색으로 돌아가기"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "View duplicated successfully"
+msgstr "뷰가 복제되었습니다"
+
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Remove option group"
+msgstr ""
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Description"
+msgstr "설명"
+
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+msgid "Countries"
+msgstr "국가"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Failed to remove order line: {0}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+msgid "Street Address 2"
+msgstr "도로명 주소 2"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Global view deleted successfully"
+msgstr "전역 뷰가 삭제되었습니다"
+
+#: src/app/routes/_authenticated/index.tsx
+msgid "Edit Layout"
+msgstr ""
+
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
+msgid "Assign to channel"
+msgstr "채널에 할당"
+
+#: src/lib/components/date-range-picker.tsx
+msgctxt "date-range"
+msgid "This week"
+msgstr ""
+
+#. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+msgid "Add a manual payment of {0}"
+msgstr "{0}의 수동 결제 추가"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "is in"
+msgstr "포함"
+
+#: src/lib/components/login/login-form.tsx
+msgid "Email"
+msgstr ""
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+msgid "Failed to update administrator"
+msgstr ""
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Manage your personal saved views for this table"
+msgstr "이 테이블의 개인 저장 뷰 관리"
+
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+msgid "Filter by tags"
+msgstr "태그로 필터"
+
+#: src/lib/components/login/login-form.tsx
+msgid "Sign in to access the admin dashboard"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#~ msgid "Add payment to order ({0})"
+#~ msgstr "주문에 결제 추가({0})"
+
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
+msgid "False"
+msgstr "거짓"
+
+#: src/lib/components/layout/nav-user.tsx
+msgctxt "theme"
+msgid "Light"
+msgstr "라이트"
+
+#: src/lib/components/data-table/data-table-view-options.tsx
+msgid "Reset"
+msgstr "재설정"
+
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "is equal to"
+msgstr "같음"
+
+#: src/lib/components/shared/asset/asset-properties.tsx
+msgid "Source File"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#~ msgid "Create options"
+#~ msgstr "옵션 생성"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+msgid "Password updated"
+msgstr "비밀번호가 업데이트되었습니다"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "does not contain"
+msgstr "포함하지 않음"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+msgid "Option Group"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
+msgid "Edit the address details below."
+msgstr "아래 주소 정보를 편집하세요."
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+msgid "Successfully created tax category"
+msgstr "세금 카테고리가 생성되었습니다"
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+msgid "Failed to move collections"
+msgstr "컬렉션 이동 실패"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Failed to update payment state"
+msgstr "결제 상태 업데이트 실패"
+
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
+msgid "Your orders summary"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "Upload"
+msgstr "업로드"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Product with options"
+msgstr ""
+
+#. placeholder {0}: filteredTags.length
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+msgid "Showing all {0} results"
+msgstr "{0}개 결과를 모두 표시 중"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+msgid "Lookup ID"
+msgstr ""
+
+#. placeholder {0}: list.totalItems - 3
+#: src/app/routes/_authenticated/_facets/facets.tsx
+msgid "+ {0} more"
+msgstr "+ {0}개 더보기"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Option Groups"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Custom fields"
+msgstr "사용자 정의 필드"
+
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
+msgid "All possible order states and their transitions. The current state is highlighted."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Orders"
+msgstr "주문"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Orders Summary Widget"
+msgstr "주문 요약 위젯"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "orderState.AddingItems"
+msgstr "상품 추가 중"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "orderState.ArrangingAdditionalPayment"
+msgstr "추가 결제 준비 중"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "orderState.ArrangingPayment"
+msgstr "결제 준비 중"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "orderState.Cancelled"
+msgstr "취소됨"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "orderState.Created"
+msgstr "생성됨"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "orderState.Delivered"
+msgstr "배달됨"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "orderState.Draft"
+msgstr "임시 저장"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "orderState.Modifying"
+msgstr "수정 중"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "orderState.PartiallyDelivered"
+msgstr "부분 배달됨"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "orderState.PartiallyShipped"
+msgstr "부분 배송됨"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "orderState.PaymentAuthorized"
+msgstr "결제 승인됨"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "orderState.PaymentSettled"
+msgstr "결제 완료"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "orderState.Shipped"
+msgstr "배송됨"
+
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
+#~ msgid "Monitored Resources"
+#~ msgstr "모니터링 중인 리소스"
+
+#: src/lib/framework/layout-engine/page-layout.tsx
+msgid "Entity Information"
+msgstr "엔티티 정보"
+
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+msgid "Order Total"
+msgstr ""
+
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
+msgid "Visible to admins only"
+msgstr "관리자만 볼 수 있음"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Qty"
+msgstr ""
+
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+msgid "Tags"
+msgstr "태그"
+
+#: src/lib/components/shared/role-code-label.tsx
+msgid "Super Admin"
+msgstr "최고 관리자"
+
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
+#~ msgid "Some resources are down"
+#~ msgstr "일부 리소스가 다운되었습니다"
+
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
+msgid "Available Actions"
+msgstr ""
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Failed to update order line: {0}"
+msgstr ""
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
+msgid "Insert link"
+msgstr "링크 삽입"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
+msgstr "활성화하면 필터가 상위 컬렉션에서 상속되어 이 컬렉션에 설정된 필터와 결합됩니다."
+
+#: src/lib/components/shared/zone-selector.tsx
+msgid "Select a zone"
+msgstr "지역 선택"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+msgid "Test shipping methods"
+msgstr "배송 방법 테스트"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Payment settled successfully"
+msgstr "결제가 정산되었습니다"
+
+#. placeholder {0}: selection.length
+#. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
+msgid "Removed {0} {1} from zone"
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Enable"
+msgstr "활성화"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Payment Methods"
+msgstr "결제 방법"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "paymentState.Authorized"
+msgstr "승인됨"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "paymentState.Cancelled"
+msgstr "취소됨"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "paymentState.Created"
+msgstr "생성됨"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "paymentState.Declined"
+msgstr "거절됨"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "paymentState.Error"
+msgstr "오류"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "paymentState.Failed"
+msgstr "실패"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "paymentState.Pending"
+msgstr "대기 중"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
+msgid "paymentState.Settled"
+msgstr "정산됨"
+
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+msgid "Average Order Value"
+msgstr ""
+
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+msgid "Failed to create zone"
+msgstr "지역 생성 실패"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "Stock levels"
+msgstr "재고 수준"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+msgid "Failed to update API key"
+msgstr ""
+
+#: src/lib/framework/dashboard-widget/base-widget.tsx
+msgid "{title}"
+msgstr "{title}"
+
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+msgid "Order lines"
+msgstr "주문 항목"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Failed to rename global view"
+msgstr "전역 뷰 이름 변경 실패"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
+msgid "Insert a new hyperlink with URL and target options"
+msgstr ""
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+msgid "Height"
+msgstr "높이"
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Assign {entityType} to channels"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
+msgstr "{formattedDiff}의 환불이 필요합니다. 결제 금액을 선택하고 메모를 입력하여 계속하세요."
+
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Unit price"
+msgstr "단가"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Schedule Pattern"
+msgstr "일정 패턴"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Payment failed"
+msgstr "결제 실패"
+
+#: src/lib/components/layout/channel-switcher.tsx
+msgid "Add channel"
+msgstr ""
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
+msgid "Search channels..."
+msgstr "채널 검색..."
+
+#: src/lib/components/shared/customer-group-selector.tsx
+msgid "Add customer groups"
+msgstr "고객 그룹 추가"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "Available Languages"
+msgstr "사용 가능한 언어"
+
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+msgid "Reset selection"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
+msgid "No address"
+msgstr "주소 없음"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+msgid "Successfully created payment method"
+msgstr "결제 방법이 생성되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+msgid "Customer information updated"
+msgstr "고객 정보가 업데이트되었습니다"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Failed to delete draft order: {0}"
+msgstr ""
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Failed to convert view to global"
+msgstr "뷰를 전역으로 변환하는 데 실패했습니다"
+
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
+msgid "Select Payment Eligibility Checker"
+msgstr ""
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Select one or more channels"
+msgstr ""
+
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+msgid "Select operator"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Product Variants"
+msgstr "상품 변형"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Products"
+msgstr "상품"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Promotions"
+msgstr "프로모션"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+msgid "Failed to create product option"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+msgid "Old email:"
+msgstr "기존 이메일:"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Save a view as \"Global\" to make it available to all users."
+msgstr "모든 사용자가 사용할 수 있도록 뷰를 \"전역\"으로 저장하세요."
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+msgid "Failed to create variants"
+msgstr ""
+
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
+msgstr "이 변형이 품절로 간주되는 재고 수준을 설정합니다. 음수 값을 사용하면 예약 주문이 지원됩니다. 상품 변형으로 재정의할 수 있습니다."
+
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+msgid "Rotate Key"
+msgstr ""
+
+#: src/lib/components/ui/password-input.tsx
+msgid "Hide password"
+msgstr ""
+
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+msgid "New seller"
+msgstr "새 판매자"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "e.g., Red, Large, Cotton"
+msgstr "예: 레드, 라지, 코튼"
+
+#: src/app/routes/_authenticated/_profile/profile.tsx
+msgid "Failed to update profile"
+msgstr "프로필 업데이트 실패"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
+msgid "Removed coupon codes"
+msgstr "쿠폰 코드가 제거되었습니다"
+
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
+msgid "Clear filter"
+msgstr "필터 지우기"
+
+#: src/app/routes/_authenticated/_zones/zones.tsx
+msgid "Regions"
+msgstr "지역"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "Drop files here to upload"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+msgid "Toggle all visible variants"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
+msgid "Verified"
+msgstr "확인됨"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+msgid "New option group"
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
+#~ msgid "Last updated {0}"
+#~ msgstr "마지막 업데이트 {0}"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "No global views have been created yet."
+msgstr "아직 전역 뷰가 생성되지 않았습니다."
+
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+msgid "Failed to update role"
+msgstr "역할 업데이트 실패"
+
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
+msgstr ""
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+msgid "Successfully updated collection"
+msgstr "컬렉션이 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+msgid "Successfully updated payment method"
+msgstr "결제 방법이 업데이트되었습니다"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "View deleted successfully"
+msgstr "뷰가 삭제되었습니다"
+
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#~ msgid "Option group {0}"
+#~ msgstr "옵션 그룹 {0}"
+
+#: src/lib/components/data-input/combination-mode-input.tsx
+msgid "OR"
+msgstr "OR"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "You must select a default currency from the list of available currencies"
+msgstr ""
+
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+msgid "Manage tags"
+msgstr "태그 관리"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Coupon code removed from order"
+msgstr "주문에서 쿠폰 코드가 제거되었습니다"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Never"
+msgstr "없음"
+
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+msgid "Failed to update facet value"
+msgstr "속성 값 업데이트 실패"
+
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#~ msgid "Remove group"
+#~ msgstr "그룹 제거"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Order fulfilled"
+msgstr "주문이 이행되었습니다"
+
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+msgid "Loading selected items..."
+msgstr ""
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Failed to set billing address for order: {0}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+msgid "No shipping address"
+msgstr "배송지 주소 없음"
+
+#. js-lingui-explicit-id
+#: src/lib/hooks/use-extended-list-query.ts
+msgid "Query extension contains invalid GraphQL syntax"
+msgstr "쿼리 확장에 유효하지 않은 GraphQL 구문이 포함되어 있습니다"
+
+#. js-lingui-explicit-id
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
+msgid "Query extension error"
+msgstr "쿼리 확장 오류"
+
+#. js-lingui-explicit-id
+#: src/lib/hooks/use-extended-list-query.ts
+msgid "Query extension error: "
+msgstr "쿼리 확장 오류:"
+
+#. js-lingui-explicit-id
+#: src/lib/hooks/use-extended-list-query.ts
+msgid "Query extension is invalid: must have at least one top-level field"
+msgstr "쿼리 확장이 유효하지 않습니다: 최소 하나의 최상위 필드가 필요합니다"
+
+#. js-lingui-explicit-id
+#: src/lib/hooks/use-extended-list-query.ts
+msgid "Query extension mismatch: "
+msgstr "쿼리 확장 불일치:"
+
+#: src/app/routes/_authenticated/_facets/facets.tsx
+msgid "public"
+msgstr "공개"
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+msgid "Successfully updated tax category"
+msgstr "세금 카테고리가 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
+msgid "Move"
+msgstr "이동"
+
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+msgid "Edit or delete existing tags"
+msgstr "기존 태그 편집 또는 삭제"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
+msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
+msgstr "이 배송 방법의 적격성 확인 조건이 현재 주문 및 배송지 주소에 충족되지 않습니다."
+
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+msgid "Add coupon code"
+msgstr "쿠폰 코드 추가"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Coupon code set for order"
+msgstr "주문에 쿠폰 코드가 설정되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+msgid "Custom Fields"
+msgstr "사용자 정의 필드"
+
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+msgid "New Shipping Method"
+msgstr "새 배송 방법"
+
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+msgid "Delete stock locations"
+msgstr ""
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "is greater than or equal to"
+msgstr "이상"
+
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
+msgid "Preview"
+msgstr ""
+
+#. placeholder {0}: quantity.max
+#. placeholder {1}: line.quantity
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+msgid "{0} of {1} available to fulfill"
+msgstr "{1}개 중 {0}개 처리 가능"
+
+#: src/lib/components/date-range-picker.tsx
+msgctxt "date-range"
+msgid "Month to date"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "refundReason.CustomerRequest"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "refundReason.DamagedInShipping"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "refundReason.NotAvailable"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "refundReason.Other"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts
+msgid "refundReason.WrongItem"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+msgid "Summary of modifications"
+msgstr "수정 요약"
+
+#. placeholder {0}: payment.refunds.length
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Refunds ({0})"
+msgstr "환불({0})"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Last Executed"
+msgstr "마지막 실행"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+msgid "Payment details"
+msgstr "결제 세부정보"
+
+#: src/app/routes/_authenticated/_products/products.tsx
+msgid "Rebuild search index"
+msgstr "검색 인덱스 재구성"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Running"
+msgstr "실행 중"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+msgid "Every 60 seconds"
+msgstr "60초마다"
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+msgid "Failed to update customer group"
+msgstr "고객 그룹 업데이트 실패"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Payment metadata"
+msgstr "결제 메타데이터"
+
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+msgid "Cancel modification"
+msgstr "수정 취소"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
+msgid "Same window"
+msgstr "같은 창"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Apply filters to the table and click \"Save View\" to get started."
+msgstr "테이블에 필터를 적용하고 \"뷰 저장\"을 클릭하여 시작하세요."
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Roles"
+msgstr "역할"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+msgid "Additional payment required"
+msgstr "추가 결제가 필요합니다"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+msgid "Failed to update order"
+msgstr "주문 업데이트 실패"
+
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
+msgid "With selected..."
+msgstr "선택한 항목으로..."
+
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+msgid "Failed to create stock location"
+msgstr "재고 위치 생성 실패"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "less than or equal"
+msgstr "이하"
+
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
+msgid "Customer group members for {customerGroupName}"
+msgstr "{customerGroupName}의 고객 그룹 멤버"
+
+#. placeholder {0}: e instanceof Error ? e.message : String(e)
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Failed to set address for order: {0}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+msgid "State"
+msgstr "상태"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "Do not track"
+msgstr "추적 안 함"
+
+#. placeholder {0}: entry.data.fulfillmentId
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+msgid "Fulfillment #{0} created"
+msgstr "이행 #{0}이(가) 생성되었습니다"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
+msgid "Running pending search index updates"
+msgstr ""
+
+#: src/app/routes/_authenticated/_roles/roles.tsx
+msgid "This is a default Role and cannot be modified"
+msgstr "이것은 기본 역할이며 수정할 수 없습니다"
+
+#: src/lib/components/data-table/my-views-button.tsx
+msgid "My saved views"
+msgstr "저장한 뷰"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+msgid "State / Province"
+msgstr "시/도"
+
+#: src/lib/components/login/login-form.tsx
+#~ msgid "Welcome back!"
+#~ msgstr "환영합니다"
+
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
+msgid "Enabled"
+msgstr "활성화됨"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "Items per page"
+msgstr ""
+
+#: src/app/routes/_authenticated/_zones/zones.tsx
+msgid "Edit members"
+msgstr "멤버 편집"
+
+#: src/lib/components/shared/stock-level-label.tsx
+msgid "Stock on hand"
+msgstr "보유 재고"
+
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
+msgid "Filter by {columnId}"
+msgstr "{columnId}로 필터"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "ID"
+msgstr "ID"
+
+#: src/lib/components/shared/alerts.tsx
+msgid "Alerts"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
+msgid "Option Values"
+msgstr "옵션 값"
+
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+msgid "Preview changes"
+msgstr "변경사항 미리보기"
+
+#: src/lib/components/shared/assigned-channels.tsx
+msgid "Failed to remove {entityType} from channel"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Variant deleted successfully"
+msgstr "변형이 삭제되었습니다"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
+msgid "Edit the selected link properties"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Sales"
+msgstr "판매"
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+msgid "Select a destination collection"
+msgstr "대상 컬렉션 선택"
+
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
+msgid "Your latest orders"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Scheduled Tasks"
+msgstr "예약된 작업"
+
+#: src/lib/components/data-table/use-generated-columns.tsx
+msgid "Are you sure you want to delete this item? This action cannot be undone."
+msgstr "이 항목을 삭제하시겠습니까? 이 작업은 취소할 수 없습니다."
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Variants"
+msgstr "변형"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Sellers"
+msgstr "판매자"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Settings"
+msgstr "설정"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Settings Store"
+msgstr ""
+
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
+msgid "Heading 3"
+msgstr "제목 3"
+
+#: src/lib/components/login/login-form.tsx
+msgid "Welcome to Vendure"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Shipping Methods"
+msgstr "배송 방법"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "({maxRefundable} refundable)"
+msgstr ""
+
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+msgid "Identifier"
+msgstr "식별자"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
+msgid "Select a fulfillment handler"
+msgstr ""
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+msgid "Failed to update collection"
+msgstr "컬렉션 업데이트 실패"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "Price and tax"
+msgstr "가격 및 세금"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
+msgid "Order not found"
+msgstr "주문을 찾을 수 없습니다"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "!="
+msgstr "!="
+
+#: src/lib/components/shared/error-page.tsx
+msgid "Error"
+msgstr "오류"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Order modified"
+msgstr "주문이 수정되었습니다"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+msgid "Password reset requested"
+msgstr "비밀번호 재설정이 요청되었습니다"
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+msgid "Allocated payment amount must equal refund total"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#~ msgid "e.g. Small"
+#~ msgstr "예: 스몰"
+
+#. placeholder {0}: selection.length
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
+msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
+msgstr "현재 채널에서 {0}개 {entityType}을(를) 제거하시겠습니까?"
+
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+msgid "Add tags..."
+msgstr "태그 추가..."
+
+#. placeholder {0}: selectedIds.length
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+msgid "{0} items selected"
+msgstr "{0}개 항목 선택됨"
+
+#: src/lib/components/shared/language-selector.tsx
+msgid "Search languages..."
+msgstr "언어 검색..."
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Stock Locations"
+msgstr "재고 위치"
+
+#: src/lib/components/data-table/data-table-pagination.tsx
+msgid "Go to previous page"
+msgstr ""
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+msgid "Contents"
+msgstr "내용"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Failed to convert global view to personal view"
+msgstr "전역 뷰를 개인 뷰로 변환하는 데 실패했습니다"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "The result of the job"
+msgstr "작업 결과"
+
+#. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+msgid "Add payment ({0})"
+msgstr "결제 추가({0})"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "System"
+msgstr "시스템"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
+msgid "Variant name"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Remove"
+msgstr "제거"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+msgid "Failed to update customer"
+msgstr "고객 업데이트 실패"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Remove option groups?"
+msgstr ""
+
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
+msgstr ""
+
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, other {{count}명의 고객을 그룹에서 제거했습니다}}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
-msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
-msgstr "{count, plural, other {이 그룹에서 {count}명의 고객을 제거하시겠습니까?}}"
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Tax Categories"
+msgstr "세금 카테고리"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Tax Rates"
+msgstr "세율"
+
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
+msgid "Failed to remove customers from group"
+msgstr "그룹에서 고객을 제거하지 못했습니다"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "Failed to load global settings"
+msgstr "전역 설정 로딩 실패"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Select items to refund and optionally return to stock"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
+msgid "Save"
+msgstr "저장"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+msgid "Preview order modifications"
+msgstr "주문 수정사항 미리보기"
+
+#. js-lingui-explicit-id
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
+msgid "The page will continue with the default query."
+msgstr "페이지는 기본 쿼리로 계속됩니다."
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+msgid "Street Address"
+msgstr "도로명 주소"
+
+#: src/lib/components/shared/facet-value-selector.tsx
+msgid "No more facets"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/products.tsx
+msgid "Search index rebuild started"
+msgstr "검색 인덱스 재구성이 시작되었습니다"
+
+#: src/app/routes/_authenticated/_collections/collections.tsx
+msgid "Collection position updated"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#~ msgid "Option group name"
+#~ msgstr "옵션 그룹 이름"
+
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+msgid "Add \"{newOptionInput}\""
+msgstr "「{newOptionInput}」추가"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "New product variant"
+msgstr "새 상품 변형"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Refund transitioned"
+msgstr "환불이 전환되었습니다"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+msgid "Using native authentication strategy"
+msgstr "기본 인증 전략 사용"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "Default Language"
+msgstr "기본 언어"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "Token"
+msgstr "토큰"
+
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+msgid "Fulfilling..."
+msgstr "이행 중..."
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+msgid "Add option group to product"
+msgstr "상품에 옵션 그룹 추가"
+
+#. placeholder {0}: asset.name
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
+msgid "Preview of {0}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+msgid "Successfully updated seller"
+msgstr "판매자가 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+msgid "Failed to transition order to state"
+msgstr "주문 상태 전환 실패"
+
+#. placeholder {0}: group.entries.length - 2
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
+msgid "Show all ({0})"
+msgstr ""
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+msgid "Failed to create tax rate"
+msgstr "세율 생성 실패"
+
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+msgid "I have saved this API key"
+msgstr ""
+
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "Configure available languages for your store and channels"
+msgstr "스토어 및 채널에 사용 가능한 언어 구성"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Successfully created product"
+msgstr "상품이 생성되었습니다"
+
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+msgid "Add product variant"
+msgstr "상품 변형 추가"
+
+#. js-lingui-explicit-id
+#: src/lib/components/data-input/string-list-input.tsx
+msgid "Type and press Enter or comma to add..."
+msgstr ""
+
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
+msgid "Edit Note"
+msgstr "메모 편집"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "No assets found. Try adjusting your filters."
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
+msgid "Add Option"
+msgstr "옵션 추가"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+msgid "Save option group"
+msgstr "옵션 그룹 저장"
+
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
+#~ msgid "Create {createCount} variants"
+#~ msgstr "{createCount}개 변형 생성"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
+msgid "Click \"Run Test\" to test this shipping method."
+msgstr "\"테스트 실행\"을 클릭하여 이 배송 방법을 테스트하세요."
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+msgid "Successfully updated administrator"
+msgstr ""
+
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "Clear filters"
+msgstr "필터 지우기"
+
+#. placeholder {0}: entry.data.fulfillmentId
+#. placeholder {1}: entry.data.from
+#. placeholder {2}: entry.data.to
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+msgid "Fulfillment #{0} from {1} to {2}"
+msgstr "{1}에서 {2}로의 이행 #{0}"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Failed to delete global view"
+msgstr "전역 뷰 삭제 실패"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "Default language"
+msgstr "기본 언어"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+msgid "Status"
+msgstr "상태"
+
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
+msgid "No options found"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "Binary"
+msgstr ""
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+msgid "Successfully updated option group"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+msgid "New shipping method"
+msgstr "새 배송 방법"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+msgid "Every 10 seconds"
+msgstr "10초마다"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
+msgid "ex. tax:"
+msgstr "세금 제외:"
+
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
+#~ msgid "Add Stock to Location"
+#~ msgstr "위치에 재고 추가"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Successfully added option value"
+msgstr "옵션 값이 추가되었습니다"
+
+#: src/app/routes/_authenticated/_collections/collections.tsx
+msgid "Collection moved to new parent"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+msgid "Option group removed"
+msgstr "옵션 그룹이 제거되었습니다"
+
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
+msgid "Transition to selected state"
+msgstr "선택한 상태로 전환"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+msgid "An additional payment of {formattedDiff} will be required."
+msgstr "{formattedDiff}의 추가 결제가 필요합니다."
+
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+msgid "Track inventory by default"
+msgstr "기본적으로 재고 추적"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+msgid "{selected} of {total} selected"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+msgid "Successfully created shipping method"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+msgid "New Customer Group"
+msgstr "새 고객 그룹"
+
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
+msgid "Visible to customer"
+msgstr "고객에게 표시"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+msgid "Successfully created option group"
+msgstr "옵션 그룹이 생성되었습니다"
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+msgid "Tax Rates"
+msgstr "세율"
+
+#: src/lib/components/data-input/slug-input.tsx
+msgid "Slug will be generated automatically..."
+msgstr "슬러그가 자동으로 생성됩니다..."
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+msgid "Customer not found"
+msgstr "고객을 찾을 수 없습니다"
+
+#. placeholder {0}: entityName.toLowerCase()
+#: src/lib/components/data-input/default-relation-input.tsx
+msgid "Select {0}s"
+msgstr "{0} 선택"
+
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+msgid "New facet values to add:"
+msgstr "추가할 새 속성 값:"
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+msgid "Failed to process refund"
+msgstr ""
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+msgid "First name"
+msgstr "이름"
+
+#: src/lib/components/shared/product-variant-selector.tsx
+msgid "Add item to order"
+msgstr ""
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "contains"
+msgstr "포함"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+msgid "No option groups found"
+msgstr ""
+
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+msgid "No items found"
+msgstr "항목을 찾을 수 없습니다"
+
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+msgid "Failed to remove option group"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+msgid "Sub total"
+msgstr "소계"
+
+#. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+msgid "Fulfilled items ({0})"
+msgstr "이행된 항목({0})"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+msgid "Value updated"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
+msgid "Unverified"
+msgstr "미확인"
+
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+msgid "Quantity"
+msgstr "수량"
+
+#: src/lib/components/data-table/add-filter-menu.tsx
+msgid "Add filter"
+msgstr "필터 추가"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+msgid "Tax category"
+msgstr "세금 카테고리"
+
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
+msgid "Profile"
+msgstr "프로필"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+msgid "Test data has been updated. Click \"Run Test\" to see updated results."
+msgstr "테스트 데이터가 업데이트되었습니다. \"테스트 실행\"을 클릭하여 업데이트된 결과를 확인하세요."
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "is not in"
+msgstr "포함하지 않음"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Order line updated"
+msgstr "주문 항목이 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+msgid "New Payment Method"
+msgstr "새 결제 방법"
+
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
+msgid "Duplicate value \"{trimmed}\" already exists"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Reason"
+msgstr "사유"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+msgid "Customer groups"
+msgstr "고객 그룹"
+
+#: src/lib/components/shared/assigned-channels.tsx
+msgid "Successfully removed {entityType} from channel"
+msgstr ""
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Option Groups"
+msgstr "옵션 그룹"
+
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+msgid "Add surcharge"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+msgid "Current facet values"
+msgstr "현재 속성 값"
+
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+msgid "Page {page} of {totalPages}"
+msgstr ""
+
+#: src/lib/components/date-range-picker.tsx
+msgctxt "date-range"
+msgid "Last month"
+msgstr ""
+
+#: src/app/routes/_authenticated/_countries/countries.tsx
+msgid "Add Country"
+msgstr "국가 추가"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "Defaults to the default language."
+msgstr ""
+
+#: src/lib/components/data-input/custom-field-list-input.tsx
+msgid "Remove item"
+msgstr "항목 제거"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "Video"
+msgstr ""
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "less than"
+msgstr "보다 작음"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "The variant could not be added. Ensure the parent product is enabled."
+msgstr ""
+
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+msgid "Metrics"
+msgstr ""
+
+#: src/lib/components/layout/nav-user.tsx
+msgid "Language"
+msgstr "언어"
+
+#: src/app/routes/_authenticated/_collections/collections.tsx
+msgid "New Collection"
+msgstr "새 컬렉션"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Refund and cancel order"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+msgid "Email update verified"
+msgstr "이메일 업데이트가 확인되었습니다"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "is between"
+msgstr "사이"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+msgid "Refund & Cancel"
+msgstr ""
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
+msgid "Testing shipping methods..."
+msgstr "배송 방법 테스트 중..."
+
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+msgid "{label}"
+msgstr "{label}"
+
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+msgid "Failed to create shipping method"
+msgstr ""
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
+#~ msgstr "{entityIdsLength}개 {entityType}이(가) 채널에 할당되었습니다"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "Global Languages"
+msgstr "전역 언어"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+msgid "New administrator"
+msgstr "새 관리자"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Delete draft"
+msgstr "임시 저장 삭제"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+msgid "Source"
+msgstr "소스"
+
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
+msgid "No actions available"
+msgstr "사용 가능한 작업이 없습니다"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "Failed to update channel"
+msgstr "채널 업데이트 실패"
+
+#: src/lib/components/shared/custom-fields-form.tsx
+msgid "General"
+msgstr "일반"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+msgid "Add new address"
+msgstr "새 주소 추가"
+
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+msgid "Successfully updated facet"
+msgstr "속성이 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+msgid "Successfully created zone"
+msgstr "지역이 생성되었습니다"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+msgid "Value"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Customer updated"
+msgstr "고객이 업데이트되었습니다"
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Price conversion factor"
+msgstr "가격 변환 계수"
+
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
+msgid "Seller order"
+msgstr "판매자 주문"
+
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+msgid "New facet"
+msgstr "새 속성"
+
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Are you sure you want to remove this option group from the product?"
+msgstr ""
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+msgid "Description (alt)"
+msgstr "설명(대체 텍스트)"
+
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+msgid "No tags found"
+msgstr "태그를 찾을 수 없습니다"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "Default currency"
+msgstr "기본 통화"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+msgid "No payment or refund is required for these changes."
+msgstr "이 변경사항에는 결제 또는 환불이 필요하지 않습니다."
+
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
+msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
+msgstr ""
+
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
+msgid "Total Revenue"
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "Next Execution"
+msgstr "다음 실행"
+
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
+msgid "Note is private"
+msgstr "메모는 비공개입니다"
+
+#: src/lib/components/layout/language-dialog.tsx
+msgid "Medium date"
+msgstr "중간 날짜"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+msgid "Invalid number"
+msgstr ""
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "You haven't saved any views yet."
+msgstr "아직 저장한 뷰가 없습니다."
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Are you sure you want to delete this view? This action cannot be undone."
+msgstr "이 뷰를 삭제하시겠습니까? 이 작업은 취소할 수 없습니다."
+
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
+msgid "View order process"
+msgstr ""
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Failed to duplicate view"
+msgstr "뷰 복제 실패"
+
+#: src/lib/components/shared/customer-address-form.tsx
+msgid "Use as the default shipping address"
+msgstr "기본 배송지 주소로 사용"
+
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
+msgid "Edit slug manually"
+msgstr "슬러그 수동 편집"
+
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+msgid "Add filters to preview the collection contents."
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
+#~ msgid "Product Option Group"
+#~ msgstr "상품 옵션 그룹"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
+msgid "Subtotal"
+msgstr "소계"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "is less than"
+msgstr "보다 작음"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Refund ID"
+msgstr "환불 ID"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Order custom fields updated"
+msgstr ""
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+msgid "Calculator"
+msgstr "계산기"
+
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
+msgid "Failed to remove option group from channel: {message}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+msgid "View job data"
+msgstr "작업 데이터 보기"
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+msgid "Move to the top level"
+msgstr "최상위 레벨로 이동"
+
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+msgid "Clear"
+msgstr "지우기"
+
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
+msgid "Orders Summary"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-gallery.tsx
+msgid "Search assets..."
+msgstr ""
+
+#: src/app/routes/_authenticated/_facets/facets.tsx
+msgid "New Facet"
+msgstr "새 속성"
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#~ msgid "Assign {entityType} to channel"
+#~ msgstr "채널에 {entityType} 할당"
+
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+msgid "Continue"
+msgstr "계속"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+msgid "Promotions"
+msgstr "프로모션"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Error message"
+msgstr "오류 메시지"
+
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
+msgid "Add stock level for another location"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
+msgid "Delete Address"
+msgstr "주소 삭제"
+
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+msgid "Failed to update facet"
+msgstr "속성 업데이트 실패"
+
+#: src/lib/hooks/use-widget-filters.ts
+msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
+msgid "Edit Address"
+msgstr "주소 편집"
+
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
+msgid "Failed to remove facet from channel: {message}"
+msgstr "채널에서 속성 제거 실패: {message}"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
+msgid "Set link"
+msgstr "링크 설정"
+
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+msgid "New Seller"
+msgstr "새 판매자"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+msgid "Edit image"
+msgstr "이미지 편집"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Manage Variants"
+msgstr "변형 관리"
+
+#: src/lib/components/shared/stock-level-label.tsx
+msgid "Stock allocated"
+msgstr "재고 할당됨"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "greater than or equal"
+msgstr "이상"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
+msgstr "이 변형이 품절로 간주되는 재고 수준을 설정합니다. 음수 값을 사용하면 예약 주문이 지원됩니다."
+
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#~ msgid "Create product options"
+#~ msgstr "상품 옵션 생성"
+
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "Saving..."
+msgstr "저장 중..."
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "View result"
+msgstr "결과 보기"
+
+#: src/lib/components/data-table/data-table-pagination.tsx
+msgid "Rows per page"
+msgstr ""
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+msgid "Loading collections..."
+msgstr "컬렉션 로딩 중..."
+
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+msgid "Successfully updated facet value"
+msgstr "속성 값이 업데이트되었습니다"
+
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+msgid "Add asset"
+msgstr "에셋 추가"
+
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
+#~ msgid "Save changes"
+#~ msgstr "변경사항 저장"
+
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+msgid "Customer added to group"
+msgstr "고객이 그룹에 추가되었습니다"
+
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
+msgid "Seller orders"
+msgstr "판매자 주문"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Failed to add option value"
+msgstr "옵션 값 추가 실패"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Add option value to {groupName}"
+msgstr "{groupName}에 옵션 값 추가"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+msgid "Failed to unset shipping address for order: {0}"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "SKU"
+msgstr "SKU"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+msgid "{totalQuantity} item(s) refunded"
+msgstr ""
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
+msgstr "아직 옵션 그룹이 정의되지 않았습니다. 상품의 다양한 변형을 만들려면 옵션 그룹을 추가하세요(예: 사이즈, 색상, 소재)"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+msgid "New email:"
+msgstr "새 이메일:"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+msgid "Failed to update payment method"
+msgstr "결제 방법 업데이트 실패"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+msgid "Available:"
+msgstr "사용 가능:"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+msgid "Created at"
+msgstr "생성 일시"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+msgid "Failed to create product variant"
+msgstr "상품 변형 생성 실패"
+
+#: src/lib/components/data-input/relation-selector.tsx
+msgid "Search..."
+msgstr ""
+
+#. placeholder {0}: formatLanguageName(contentLanguage)
+#: src/lib/components/layout/channel-switcher.tsx
+msgid "Language: {0}"
+msgstr ""
+
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "You don't have permission to view global language settings"
+msgstr "전역 언어 설정을 볼 수 있는 권한이 없습니다"
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+msgid "Successfully created tax rate"
+msgstr "세율이 생성되었습니다"
+
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
+msgid "Heading 6"
+msgstr "제목 6"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
+msgid "Added coupon codes"
+msgstr "쿠폰 코드가 추가되었습니다"
+
+#: src/lib/components/layout/channel-switcher.tsx
+msgctxt "active language"
+msgid "Active"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+msgid "Tax base"
+msgstr "과세 기준"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
+msgid "Load more"
+msgstr "더 보기"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Refund settled"
+msgstr "환불이 정산되었습니다"
+
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+msgid "API Key"
+msgstr ""
+
+#: src/app/common/duplicate-bulk-action.tsx
+msgid "Successfully duplicated {count} {entityName}"
+msgstr "{count}개 {entityName}이(가) 복제되었습니다"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+msgid "New Option Group"
+msgstr ""
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+msgid "No result yet"
+msgstr "아직 결과 없음"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+msgid "Payment settled"
+msgstr "결제가 완료되었습니다"
+
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
+msgid "Available Conditions"
+msgstr ""
+
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+msgid "Active filters"
+msgstr ""
+
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
+msgid "Clear all"
+msgstr "모두 지우기"
+
+#: src/lib/components/data-table/human-readable-operator.tsx
+msgid "is greater than"
+msgstr "보다 큼"
+
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+msgid "Close"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+msgid "Add payment to order"
+msgstr "주문에 결제 추가"
+
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
+msgid "Loading..."
+msgstr "로딩 중..."
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+msgid "The token is used to specify the channel when making API requests."
+msgstr "토큰은 API 요청 시 채널을 지정하는 데 사용됩니다."
+
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
+msgid "No addresses found"
+msgstr "주소를 찾을 수 없습니다"
+
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+msgid "Fulfillment ID"
+msgstr "이행 ID"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+msgid "Select payments to refund"
+msgstr ""
+
+#: src/app/common/delete-bulk-action.tsx
+msgid "Failed to delete {failed} {entityName}"
+msgstr "{failed}개 {entityName} 삭제 실패"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+msgid "Out-of-stock threshold"
+msgstr "품절 임계값"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+msgid "Failed to update value"
+msgstr ""
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+msgid "Failed to create API key"
+msgstr ""
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+msgid "Settle refund"
+msgstr "환불 정산"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+msgid "Payment method is required"
+msgstr "결제 방법은 필수입니다"
+
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+msgid "Failed to add customer to group"
+msgstr "고객을 그룹에 추가하는 데 실패했습니다"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+msgid "Manage variants"
+msgstr "변형 관리"
+
+#: src/lib/components/data-table/views-sheet.tsx
+msgid "Applied global view \"{viewName}\""
+msgstr "전역 뷰 \"{viewName}\"가 적용되었습니다"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+msgid "Customer registered"
+msgstr "고객이 등록되었습니다"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts
+msgid "Zones"
+msgstr "지역"
+
+#: src/lib/components/shared/seller-selector.tsx
+msgid "Search sellers..."
+msgstr ""
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+msgid "Successfully created promotion"
+msgstr "프로모션이 생성되었습니다"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+msgid "Option"
+msgstr "옵션"
+
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
+msgid "Order process"
+msgstr ""
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+msgid "Phone number"
+msgstr "전화번호"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+msgid "Private"
+msgstr "비공개"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+msgid "Variant"
+msgstr "변형"
+
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+msgid "Successfully updated global settings"
+msgstr "전역 설정이 업데이트되었습니다"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+msgid "Successfully updated API key"
+msgstr ""
+
+#: src/lib/components/layout/manage-languages-dialog.tsx
+msgid "These languages will be available for all channels to use"
+msgstr "이 언어는 모든 채널에서 사용할 수 있습니다"

--- a/packages/dashboard/vite/constants.ts
+++ b/packages/dashboard/vite/constants.ts
@@ -26,6 +26,8 @@ export const defaultAvailableLanguages = [
     LanguageCode.sv,
     LanguageCode.nb,
     LanguageCode.tr,
+    LanguageCode.ja,
+    LanguageCode.ko,
     LanguageCode.bg,
     LanguageCode.nl,
     LanguageCode.ro,


### PR DESCRIPTION
Makes Japanese and Korean selectable in the Dashboard, and fills in every missing translation for both.

## The problem

`packages/dashboard/src/i18n/locales/ko.po` is tracked and holds around 1,005 Korean translations, but `ko` appears in neither the `locales` array in `lingui.config.js` nor `defaultAvailableLanguages` in `vite/constants.ts`. So `lingui extract` never updated it, and the Display language selector could never offer it. The catalog was still being compiled into every build, because the Vite plugin reads the locales directory with `readdirSync` and compiles whatever `.po` files it finds — Korean has been shipping in the bundle all along with no way to select it.

Japanese had half the same problem. It is in `lingui.config.js`, so `ja.po` stayed current, but it was missing from `defaultAvailableLanguages`, so it could not be selected either.

## What changed

**Enablement.** `LanguageCode.ja` and `LanguageCode.ko` added to `defaultAvailableLanguages`, and `'ko'` added to the `locales` array so extraction maintains the catalog from now on. `ko.po` is regenerated, picking up the 327 messages that accumulated while it was frozen. No language-name mapping was needed — `language-dialog.tsx` resolves labels through `Intl.DisplayNames`, so both appear with their native names automatically.

**Translations.** 327 Korean and 44 Japanese strings. The translation commit is exactly 371 removed `msgstr ""` lines and 371 added ones, with no msgid, reference comment, or header line touched, so it can be reviewed as pure translation content rather than catalog churn.

Both languages are now the best-covered locales in the repo: Korean has no untranslated strings at all and Japanese has 11, all of them obsolete `#~` entries for messages that no longer exist in the source. Every other locale sits between 34 and 104.

## Native-speaker review

Both catalogs were reviewed against the source code and the existing translations. That review found one genuine UI bug:

`Size` and `Dimensions` are consecutive `<TableHead>` elements in `asset-gallery.tsx`, and `File Size` / `Dimensions` are adjacent labels in `asset-properties.tsx`. Both rendered identically — 크기 in Korean and サイズ in Japanese — so the asset list showed two adjacent columns with the same header over different data (`formatFileSize(asset.fileSize)` versus `{asset.width} x {asset.height}`). Every other locale already distinguished the two. Japanese now uses サイズ / 寸法; Korean uses 용량 / 크기, with `File Size` moving to 파일 용량.

The review also produced a few consistency corrections, and two back-corrections to translations that pre-date this PR, kept in their own commit:

- `Calculator` was rendered as 計算機 / 계산기, which reads as a physical calculating device. In Vendure it names a pluggable shipping- or payment-cost strategy selected from a dropdown, so it is now 計算方法 / 계산 방식. The label is shared between the shipping-method and payment-method screens, so the replacement had to work for both.
- Japanese `Dimensions`, as described above.

## Verification

- `scripts/check-i18n-sync.sh`, the `dashboard i18n sync` CI job, reports "i18n catalogs are in sync" and exits 0.
- `lingui compile` succeeds, so every ICU message in both catalogs parses. This matters because the Vite plugin parses these catalogs at build time.
- Extraction is idempotent: a second `lingui extract` produces an identical diffstat.
- `audit-translations.js` reports 0 suspicious entries for both languages. Most other locales report between 1 and 34.
- No empty translations remain in either catalog, confirmed with the repo's shared PO parser, a raw grep, and Lingui's own `@lingui/format-po` parser.

## Two tooling gaps worth a follow-up

Both are in `scripts/translate/i18n-tool.js` and affect every locale, so they are not fixed here. Two entries had to be written into `ko.po` by hand as a result.

1. `isLatinOnlyTechTerm` exempts short verbatim Latin technical terms from the native-script guard, but its regex `^[A-Za-z0-9 _\-./]+$` has no colon. So `SKU:` is rejected for Korean even though leaving it verbatim is correct, which `zh_Hans` and `ja` both already do. Adding `:` to the character class would make the guard behave as its own comment describes.
2. `escapeRegex` escapes the msgid for PO format, turning `"` into `\"`, and then for regex, but never escapes the backslash itself. The resulting pattern matches the unescaped text and never finds the entry. `Duplicate value \"{trimmed}\" already exists` was silently reported as "not found" rather than failing loudly.

Separately, `packages/dashboard/plugin/constants.ts` exports its own `defaultAvailableLanguages` and `defaultAvailableLocales` which nothing imports, and whose language list has drifted to 10 entries against the 28 in `vite/constants.ts`.

Follows on from https://github.com/vendurehq/vendure/pull/5075, which is where this work was originally split out from.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788085888&installation_model_id=20193&pr_number=5077&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5077&signature=715252048b195945cc3f00c1194015a6a3d65e4e5a3bd677e88529fdd275b71e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
