### PR TITLE
fix(core): Invalidate stock location channel id cache correctly

### DIFF
--- a/packages/core/e2e/stock-location.e2e-spec.ts
+++ b/packages/core/e2e/stock-location.e2e-spec.ts
@@ -32,7 +32,11 @@ import {
     createProductDocument,
     createProductVariantsDocument,
 } from './graphql/shared-definitions';
-import { localUpdatedOrderFragment, testOrderFragment } from './graphql/shop-definitions';
+import {
+    getProductWithStockLevelDocument,
+    localUpdatedOrderFragment,
+    testOrderFragment,
+} from './graphql/shop-definitions';
 
 describe('Stock location', () => {
     const defaultStockLocationId = 'T_1';
@@ -390,15 +394,12 @@ describe('Stock location', () => {
                 }
                 // Create a StockLocation in Channel A
                 adminClient.setChannelToken(CHANNEL_A_TOKEN);
-                const { createStockLocation } = await adminClient.query(
-                    testCreateStockLocationDocument,
-                    {
-                        input: {
-                            name: 'Channel-A Location',
-                            description: 'Belongs to Channel A only',
-                        },
+                const { createStockLocation } = await adminClient.query(testCreateStockLocationDocument, {
+                    input: {
+                        name: 'Channel-A Location',
+                        description: 'Belongs to Channel A only',
                     },
-                );
+                });
                 targetLocationId = createStockLocation.id;
             });
 
@@ -421,14 +422,86 @@ describe('Stock location', () => {
 
                 // Verify the original entity in Channel A is completely unchanged.
                 adminClient.setChannelToken(CHANNEL_A_TOKEN);
-                const { stockLocations } = await adminClient.query(
-                    testGetStockLocationsListDocument,
-                );
-                const target = stockLocations.items.find(
-                    (sl: any) => sl.id === targetLocationId,
-                );
+                const { stockLocations } = await adminClient.query(testGetStockLocationsListDocument);
+                const target = stockLocations.items.find((sl: any) => sl.id === targetLocationId);
                 expect(target?.name).toBe('Channel-A Location');
                 expect(target?.description).toBe('Belongs to Channel A only');
+            });
+        });
+
+        // Repro for #3324: the MultiChannelStockLocationStrategy caches each StockLocation's
+        // channel ids for 7 days. Assigning a StockLocation to a Channel must invalidate that
+        // cache entry, otherwise the new channel sees no saleable stock until the entry expires
+        // or the server restarts.
+        describe('channelId cache invalidation (#3324)', () => {
+            const CACHE_TEST_CHANNEL_TOKEN = 'stock-loc-cache-test';
+            let cacheTestChannelId: string;
+            let cacheTestLocationId: string;
+
+            beforeAll(async () => {
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                const { createStockLocation } = await adminClient.query(testCreateStockLocationDocument, {
+                    input: {
+                        name: 'Cache test location',
+                    },
+                });
+                cacheTestLocationId = createStockLocation.id;
+                await adminClient.query(testSetStockLevelInLocationDocument, {
+                    input: {
+                        id: 'T_1',
+                        stockLevels: [
+                            {
+                                stockLocationId: cacheTestLocationId,
+                                stockOnHand: 10,
+                            },
+                        ],
+                    },
+                });
+                const { createChannel } = await adminClient.query(createChannelDocument, {
+                    input: {
+                        code: 'cache-test-channel',
+                        token: CACHE_TEST_CHANNEL_TOKEN,
+                        defaultLanguageCode: LanguageCode.en,
+                        currencyCode: CurrencyCode.GBP,
+                        pricesIncludeTax: true,
+                        defaultShippingZoneId: 'T_1',
+                        defaultTaxZoneId: 'T_1',
+                    },
+                });
+                channelGuard.assertSuccess(createChannel);
+                cacheTestChannelId = createChannel.id;
+                await adminClient.query(assignProductToChannelDocument, {
+                    input: {
+                        channelId: cacheTestChannelId,
+                        productIds: ['T_1'],
+                    },
+                });
+            });
+
+            afterAll(() => {
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                shopClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            });
+
+            it('saleable stock becomes visible once the StockLocation is assigned to the channel', async () => {
+                // Populate the strategy's channelId cache for the location while it is
+                // not yet assigned to the new channel
+                shopClient.setChannelToken(CACHE_TEST_CHANNEL_TOKEN);
+                const before = await shopClient.query(getProductWithStockLevelDocument, { id: 'T_1' });
+                expect(before.product?.variants[0].stockLevel).toBe('OUT_OF_STOCK');
+
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                await adminClient.query(testAssignStockLocationToChannelDocument, {
+                    input: {
+                        stockLocationIds: [cacheTestLocationId],
+                        channelId: cacheTestChannelId,
+                    },
+                });
+                // Wait a bit for the ChangeChannelEvent subscriber to invalidate the cache
+                await new Promise(resolve => setTimeout(resolve, 100));
+
+                const after = await shopClient.query(getProductWithStockLevelDocument, { id: 'T_1' });
+                expect(after.product?.variants[0].stockLevel).toBe('IN_STOCK');
             });
         });
     });

--- a/packages/core/e2e/stock-location.e2e-spec.ts
+++ b/packages/core/e2e/stock-location.e2e-spec.ts
@@ -435,8 +435,27 @@ describe('Stock location', () => {
         // or the server restarts.
         describe('channelId cache invalidation (#3324)', () => {
             const CACHE_TEST_CHANNEL_TOKEN = 'stock-loc-cache-test';
+            const CACHE_REMOVAL_CHANNEL_TOKEN = 'stock-loc-cache-removal';
             let cacheTestChannelId: string;
             let cacheTestLocationId: string;
+
+            // The cache delete runs in an async event subscriber, so the shop query is
+            // polled with a deadline rather than assuming a fixed delay. Returns the
+            // last observed value so a timeout produces a clear assertion failure.
+            async function pollShopStockLevel(expected: string, timeoutMs = 10_000): Promise<string> {
+                const deadline = Date.now() + timeoutMs;
+                let lastSeen = '';
+                for (;;) {
+                    const { product } = await shopClient.query(getProductWithStockLevelDocument, {
+                        id: 'T_1',
+                    });
+                    lastSeen = product?.variants[0].stockLevel ?? '';
+                    if (lastSeen === expected || Date.now() > deadline) {
+                        return lastSeen;
+                    }
+                    await new Promise(resolve => setTimeout(resolve, 50));
+                }
+            }
 
             beforeAll(async () => {
                 adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
@@ -497,11 +516,85 @@ describe('Stock location', () => {
                         channelId: cacheTestChannelId,
                     },
                 });
-                // Wait a bit for the ChangeChannelEvent subscriber to invalidate the cache
-                await new Promise(resolve => setTimeout(resolve, 100));
 
-                const after = await shopClient.query(getProductWithStockLevelDocument, { id: 'T_1' });
-                expect(after.product?.variants[0].stockLevel).toBe('IN_STOCK');
+                expect(await pollShopStockLevel('IN_STOCK')).toBe('IN_STOCK');
+            });
+
+            it('saleable stock disappears once the StockLocation is removed from the channel', async () => {
+                // Fresh location + channel: this direction needs a cache entry that is
+                // first populated after assignment (warm and including the channel),
+                // which the fixtures of the assignment test above cannot provide.
+                // Ordering constraint: the location's StockLevel row is created only
+                // after the channel assignment, because any admin response that
+                // resolves variant stock in between (e.g. assignProductsToChannel)
+                // runs the strategy and would seed the cache with the pre-assignment
+                // channel list.
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                const { createStockLocation } = await adminClient.query(testCreateStockLocationDocument, {
+                    input: {
+                        name: 'Cache removal test location',
+                    },
+                });
+                const removalLocationId = createStockLocation.id;
+                const { createChannel } = await adminClient.query(createChannelDocument, {
+                    input: {
+                        code: 'cache-removal-test-channel',
+                        token: CACHE_REMOVAL_CHANNEL_TOKEN,
+                        defaultLanguageCode: LanguageCode.en,
+                        currencyCode: CurrencyCode.GBP,
+                        pricesIncludeTax: true,
+                        defaultShippingZoneId: 'T_1',
+                        defaultTaxZoneId: 'T_1',
+                    },
+                });
+                channelGuard.assertSuccess(createChannel);
+                await adminClient.query(assignProductToChannelDocument, {
+                    input: {
+                        channelId: createChannel.id,
+                        productIds: ['T_1'],
+                    },
+                });
+                await adminClient.query(testAssignStockLocationToChannelDocument, {
+                    input: {
+                        stockLocationIds: [removalLocationId],
+                        channelId: createChannel.id,
+                    },
+                });
+                await adminClient.query(testSetStockLevelInLocationDocument, {
+                    input: {
+                        id: 'T_1',
+                        stockLevels: [
+                            {
+                                stockLocationId: removalLocationId,
+                                stockOnHand: 7,
+                            },
+                        ],
+                    },
+                });
+
+                // Warm the cache with the post-assignment channel list
+                shopClient.setChannelToken(CACHE_REMOVAL_CHANNEL_TOKEN);
+                expect(await pollShopStockLevel('IN_STOCK')).toBe('IN_STOCK');
+
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                await adminClient.query(testRemoveStockLocationsFromChannelDocument, {
+                    input: {
+                        stockLocationIds: [removalLocationId],
+                        channelId: createChannel.id,
+                    },
+                });
+
+                // The removal does not touch the location's stock, so a lingering
+                // IN_STOCK below could only come from the stale cached membership
+                const { productVariant } = await adminClient.query(testGetStockLevelsForVariantDocument, {
+                    id: 'T_1',
+                });
+                expect(
+                    productVariant?.stockLevels.find(sl => sl.stockLocationId === removalLocationId)
+                        ?.stockOnHand,
+                ).toBe(7);
+
+                expect(await pollShopStockLevel('OUT_OF_STOCK')).toBe('OUT_OF_STOCK');
             });
         });
     });

--- a/packages/core/src/config/catalog/multi-channel-stock-location-strategy.spec.ts
+++ b/packages/core/src/config/catalog/multi-channel-stock-location-strategy.spec.ts
@@ -11,6 +11,7 @@ import { StockLocation } from '../../entity/stock-location/stock-location.entity
 import { ChangeChannelEvent } from '../../event-bus/events/change-channel-event';
 import { StockLocationEvent } from '../../event-bus/events/stock-location-event';
 import { ensureConfigLoaded } from '../config-helpers';
+import { Logger } from '../logger/vendure-logger';
 
 /**
  * Unit tests for the MultiChannelStockLocationStrategy channelId cache invalidation.
@@ -21,6 +22,8 @@ import { ensureConfigLoaded } from '../config-helpers';
  */
 
 const cacheStore = new Map<string, any>();
+/** When set, the backing store rejects deletes, simulating an unavailable cache backend. */
+let deleteRejection: Error | undefined;
 const mockCacheService = {
     createCache: (config: any) =>
         new Cache(config, {
@@ -30,13 +33,18 @@ const mockCacheService = {
                 return Promise.resolve();
             },
             delete: (key: string) => {
+                if (deleteRejection) {
+                    return Promise.reject(deleteRejection);
+                }
                 cacheStore.delete(key);
                 return Promise.resolve();
             },
         } as any),
 } as any;
 
-const eventStream = new Subject<any>();
+// Replaced before each test: `init()` subscribes and nothing tears the subscription down,
+// so a shared stream would deliver one event to every strategy built so far.
+let eventStream = new Subject<any>();
 const mockEventBus = {
     ofType: (type: any) => eventStream.asObservable().pipe(filter((e: any) => e.constructor === type)),
 } as any;
@@ -93,6 +101,8 @@ describe('MultiChannelStockLocationStrategy', () => {
 
     beforeEach(async () => {
         cacheStore.clear();
+        deleteRejection = undefined;
+        eventStream = new Subject<any>();
         channelsInDb = [channel1];
         getEntityOrThrow.mockClear();
         // Dynamic import to avoid vitest circular dependency issue
@@ -158,6 +168,18 @@ describe('MultiChannelStockLocationStrategy', () => {
 
         const fresh = await strategy.getAvailableStock(ctxChannel2, 1, [stockLevel]);
         expect(fresh.stockOnHand).toBe(0);
+    });
+
+    it('logs rather than throws when the cache backend rejects the invalidation', async () => {
+        const logError = vi.spyOn(Logger, 'error').mockImplementation(() => undefined);
+        deleteRejection = new Error('cache backend unavailable');
+
+        eventStream.next(new ChangeChannelEvent(ctxChannel1, stockLocation, [2], 'assigned', StockLocation));
+        await flushEventHandlers();
+
+        expect(logError).toHaveBeenCalledTimes(1);
+        expect(logError.mock.calls[0][0]).toContain('cache backend unavailable');
+        logError.mockRestore();
     });
 
     it('does not invalidate the cache on ChangeChannelEvents for other entity types', async () => {

--- a/packages/core/src/config/catalog/multi-channel-stock-location-strategy.spec.ts
+++ b/packages/core/src/config/catalog/multi-channel-stock-location-strategy.spec.ts
@@ -1,0 +1,174 @@
+import { Subject } from 'rxjs';
+import { filter } from 'rxjs/operators';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RequestContext } from '../../api/common/request-context';
+import { Cache } from '../../cache/cache';
+import { Channel } from '../../entity/channel/channel.entity';
+import { Product } from '../../entity/product/product.entity';
+import { StockLevel } from '../../entity/stock-level/stock-level.entity';
+import { StockLocation } from '../../entity/stock-location/stock-location.entity';
+import { ChangeChannelEvent } from '../../event-bus/events/change-channel-event';
+import { StockLocationEvent } from '../../event-bus/events/stock-location-event';
+import { ensureConfigLoaded } from '../config-helpers';
+
+/**
+ * Unit tests for the MultiChannelStockLocationStrategy channelId cache invalidation.
+ *
+ * The real `Cache` wrapper is used (backed by an in-memory Map) so that the
+ * key-prefixing behaviour of `Cache.get()`/`Cache.delete()` matches production —
+ * the invalidation bugs under test live exactly in that interaction.
+ */
+
+const cacheStore = new Map<string, any>();
+const mockCacheService = {
+    createCache: (config: any) =>
+        new Cache(config, {
+            get: (key: string) => Promise.resolve(cacheStore.get(key)),
+            set: (key: string, value: any) => {
+                cacheStore.set(key, value);
+                return Promise.resolve();
+            },
+            delete: (key: string) => {
+                cacheStore.delete(key);
+                return Promise.resolve();
+            },
+        } as any),
+} as any;
+
+const eventStream = new Subject<any>();
+const mockEventBus = {
+    ofType: (type: any) => eventStream.asObservable().pipe(filter((e: any) => e.constructor === type)),
+} as any;
+
+let channelsInDb: Channel[];
+const getEntityOrThrow = vi.fn(() => Promise.resolve(new StockLocation({ id: 1, channels: channelsInDb })));
+
+const mockInjector = {
+    get: (token: unknown) => {
+        const name = (token as { name?: string })?.name;
+        if (name === 'EventBus') return mockEventBus;
+        if (name === 'CacheService') return mockCacheService;
+        if (name === 'TransactionalConnection') return { getEntityOrThrow };
+        return {};
+    },
+} as any;
+
+const channel1 = new Channel({ id: 1 });
+const channel2 = new Channel({ id: 2 });
+
+function contextForChannel(channel: Channel): RequestContext {
+    return new RequestContext({
+        apiType: 'shop',
+        channel,
+        authorizedAsOwnerOnly: false,
+        isAuthorized: true,
+        session: {} as any,
+    } as any);
+}
+
+const ctxChannel1 = contextForChannel(channel1);
+const ctxChannel2 = contextForChannel(channel2);
+
+const stockLevel = new StockLevel({
+    stockLocationId: 1,
+    stockOnHand: 100,
+    stockAllocated: 0,
+    productVariantId: 1,
+});
+
+const stockLocation = new StockLocation({ id: 1 });
+
+/** Lets the async `subscribe` handlers (cache deletes) settle. */
+function flushEventHandlers() {
+    return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('MultiChannelStockLocationStrategy', () => {
+    let strategy: import('./multi-channel-stock-location-strategy').MultiChannelStockLocationStrategy;
+
+    beforeAll(async () => {
+        await ensureConfigLoaded();
+    });
+
+    beforeEach(async () => {
+        cacheStore.clear();
+        channelsInDb = [channel1];
+        getEntityOrThrow.mockClear();
+        // Dynamic import to avoid vitest circular dependency issue
+        const { MultiChannelStockLocationStrategy } =
+            await import('./multi-channel-stock-location-strategy.js');
+        strategy = new MultiChannelStockLocationStrategy();
+        await strategy.init(mockInjector);
+    });
+
+    it('caches the channel ids of a StockLocation after the first lookup', async () => {
+        const first = await strategy.getAvailableStock(ctxChannel1, 1, [stockLevel]);
+        const second = await strategy.getAvailableStock(ctxChannel1, 1, [stockLevel]);
+
+        expect(first.stockOnHand).toBe(100);
+        expect(second.stockOnHand).toBe(100);
+        expect(getEntityOrThrow).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidates the cache when a StockLocation is updated', async () => {
+        // Cache the channel ids while the location belongs to channel1 only
+        const stale = await strategy.getAvailableStock(ctxChannel2, 1, [stockLevel]);
+        expect(stale.stockOnHand).toBe(0);
+
+        channelsInDb = [channel1, channel2];
+        eventStream.next(new StockLocationEvent(ctxChannel1, stockLocation, 'updated'));
+        await flushEventHandlers();
+
+        const fresh = await strategy.getAvailableStock(ctxChannel2, 1, [stockLevel]);
+        expect(fresh.stockOnHand).toBe(100);
+    });
+
+    it('does not invalidate the cache when a StockLocation is created', async () => {
+        await strategy.getAvailableStock(ctxChannel1, 1, [stockLevel]);
+
+        eventStream.next(new StockLocationEvent(ctxChannel1, stockLocation, 'created'));
+        await flushEventHandlers();
+
+        await strategy.getAvailableStock(ctxChannel1, 1, [stockLevel]);
+        expect(getEntityOrThrow).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidates the cache when a StockLocation is assigned to a Channel', async () => {
+        // Cache the channel ids before the location is assigned to channel2
+        const stale = await strategy.getAvailableStock(ctxChannel2, 1, [stockLevel]);
+        expect(stale.stockOnHand).toBe(0);
+
+        channelsInDb = [channel1, channel2];
+        eventStream.next(new ChangeChannelEvent(ctxChannel1, stockLocation, [2], 'assigned', StockLocation));
+        await flushEventHandlers();
+
+        const fresh = await strategy.getAvailableStock(ctxChannel2, 1, [stockLevel]);
+        expect(fresh.stockOnHand).toBe(100);
+    });
+
+    it('invalidates the cache when a StockLocation is removed from a Channel', async () => {
+        channelsInDb = [channel1, channel2];
+        const beforeRemoval = await strategy.getAvailableStock(ctxChannel2, 1, [stockLevel]);
+        expect(beforeRemoval.stockOnHand).toBe(100);
+
+        channelsInDb = [channel1];
+        eventStream.next(new ChangeChannelEvent(ctxChannel1, stockLocation, [2], 'removed', StockLocation));
+        await flushEventHandlers();
+
+        const fresh = await strategy.getAvailableStock(ctxChannel2, 1, [stockLevel]);
+        expect(fresh.stockOnHand).toBe(0);
+    });
+
+    it('does not invalidate the cache on ChangeChannelEvents for other entity types', async () => {
+        await strategy.getAvailableStock(ctxChannel1, 1, [stockLevel]);
+
+        eventStream.next(
+            new ChangeChannelEvent(ctxChannel1, new Product({ id: 1 }) as any, [2], 'assigned', Product),
+        );
+        await flushEventHandlers();
+
+        await strategy.getAvailableStock(ctxChannel1, 1, [stockLevel]);
+        expect(getEntityOrThrow).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/core/src/config/catalog/multi-channel-stock-location-strategy.ts
+++ b/packages/core/src/config/catalog/multi-channel-stock-location-strategy.ts
@@ -1,8 +1,8 @@
-import type { GlobalSettingsService } from '../../service/index';
 import { GlobalFlag } from '@vendure/common/lib/generated-types';
 import { ID } from '@vendure/common/lib/shared-types';
 import ms from 'ms';
 import { filter } from 'rxjs/operators';
+import type { GlobalSettingsService } from '../../service/index';
 
 import { RequestContext } from '../../api/common/request-context';
 import { Cache, CacheService, RequestContextCacheService } from '../../cache/index';
@@ -11,7 +11,7 @@ import { ProductVariant } from '../../entity/index';
 import { OrderLine } from '../../entity/order-line/order-line.entity';
 import { StockLevel } from '../../entity/stock-level/stock-level.entity';
 import { StockLocation } from '../../entity/stock-location/stock-location.entity';
-import { EventBus, StockLocationEvent } from '../../event-bus/index';
+import { ChangeChannelEvent, EventBus, StockLocationEvent } from '../../event-bus/index';
 
 import { BaseStockLocationStrategy } from './default-stock-location-strategy';
 import { AvailableStock, LocationWithQuantity, StockLocationStrategy } from './stock-location-strategy';
@@ -59,11 +59,21 @@ export class MultiChannelStockLocationStrategy extends BaseStockLocationStrategy
             getKey: id => this.getCacheKey(id),
         });
 
-        // When a StockLocation is updated, we need to invalidate the cache
+        // When a StockLocation is updated, we need to invalidate the cache.
+        // Note: `Cache.delete()` applies the configured `getKey` function itself,
+        // so it must be passed the raw id, not the result of `getCacheKey()`.
         this.eventBus
             .ofType(StockLocationEvent)
             .pipe(filter(event => event.type !== 'created'))
-            .subscribe(({ entity }) => this.channelIdCache.delete(this.getCacheKey(entity.id)));
+            .subscribe(({ entity }) => this.channelIdCache.delete(entity.id));
+
+        // Assigning a StockLocation to a Channel (or removing it) does not emit a
+        // StockLocationEvent, so we also need to invalidate the cache on ChangeChannelEvents
+        // which relate to StockLocations.
+        this.eventBus
+            .ofType(ChangeChannelEvent)
+            .pipe(filter(event => event.entityType === StockLocation))
+            .subscribe(({ entity }) => this.channelIdCache.delete(entity.id));
     }
 
     /**

--- a/packages/core/src/config/catalog/multi-channel-stock-location-strategy.ts
+++ b/packages/core/src/config/catalog/multi-channel-stock-location-strategy.ts
@@ -12,9 +12,12 @@ import { OrderLine } from '../../entity/order-line/order-line.entity';
 import { StockLevel } from '../../entity/stock-level/stock-level.entity';
 import { StockLocation } from '../../entity/stock-location/stock-location.entity';
 import { ChangeChannelEvent, EventBus, StockLocationEvent } from '../../event-bus/index';
+import { Logger } from '../logger/vendure-logger';
 
 import { BaseStockLocationStrategy } from './default-stock-location-strategy';
 import { AvailableStock, LocationWithQuantity, StockLocationStrategy } from './stock-location-strategy';
+
+const loggerCtx = 'MultiChannelStockLocationStrategy';
 
 /**
  * @description
@@ -65,7 +68,7 @@ export class MultiChannelStockLocationStrategy extends BaseStockLocationStrategy
         this.eventBus
             .ofType(StockLocationEvent)
             .pipe(filter(event => event.type !== 'created'))
-            .subscribe(({ entity }) => this.channelIdCache.delete(entity.id));
+            .subscribe(({ entity }) => this.invalidateChannelIdCache(entity.id));
 
         // Assigning a StockLocation to a Channel (or removing it) does not emit a
         // StockLocationEvent, so we also need to invalidate the cache on ChangeChannelEvents
@@ -73,7 +76,7 @@ export class MultiChannelStockLocationStrategy extends BaseStockLocationStrategy
         this.eventBus
             .ofType(ChangeChannelEvent)
             .pipe(filter(event => event.entityType === StockLocation))
-            .subscribe(({ entity }) => this.channelIdCache.delete(entity.id));
+            .subscribe(({ entity }) => this.invalidateChannelIdCache(entity.id));
     }
 
     /**
@@ -172,6 +175,24 @@ export class MultiChannelStockLocationStrategy extends BaseStockLocationStrategy
 
     private getCacheKey(stockLocationId: ID) {
         return `MultiChannelStockLocationStrategy:StockLocationChannelIds:${stockLocationId}`;
+    }
+
+    /**
+     * Invalidation runs in an event subscriber, so there is nothing to await the returned
+     * promise. A rejection here would otherwise be silent, leaving the stale channel id list
+     * to live out its full TTL.
+     */
+    private invalidateChannelIdCache(stockLocationId: ID) {
+        void this.channelIdCache
+            .delete(stockLocationId)
+            .catch(err =>
+                Logger.error(
+                    `Failed to invalidate StockLocation channel id cache for id ${stockLocationId}: ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                    loggerCtx,
+                ),
+            );
     }
 
     private getStockLevelsForVariant(ctx: RequestContext, productVariantId: ID): Promise<StockLevel[]> {


### PR DESCRIPTION
# Description

Fixes #3324.

`MultiChannelStockLocationStrategy` caches each StockLocation's channel ids for 7 days, but the cache was never actually invalidated, for two independent reasons:

**1. The delete used a double-prefixed key** (the defect reported in the issue). The `StockLocationEvent` subscription passed `this.getCacheKey(entity.id)` into `Cache.delete()`, but `Cache.delete()` applies the configured `getKey` function itself — the same way `Cache.get()` does — so the delete targeted `MultiChannelStockLocationStrategy:StockLocationChannelIds:MultiChannelStockLocationStrategy:StockLocationChannelIds:<id>`, which never exists, and the real entry lived out its full TTL. The fix is the one-liner proposed in the issue: pass the raw id. (I checked the rest of core for the same pattern — the other `Cache` consumers, e.g. `customer-group-condition.ts` and `facet-value-checker.ts`, already pass raw ids; this was the only occurrence.)

**2. The operation that changes channel membership never emitted an invalidating event at all** — surfaced by the follow-up investigation in [this comment](https://github.com/vendurehq/vendure/issues/3324#issuecomment-5134242455). `assignStockLocationsToChannel()` / `removeStockLocationsFromChannel()` delegate to `ChannelService.assignToChannels()` / `removeFromChannels()`, which emit `ChangeChannelEvent`, not `StockLocationEvent`. So even with the key fix, assigning a StockLocation to a new Channel leaves that channel reading the stale pre-assignment channel list: in a multi-channel setup, every newly added channel can show all products as `OUT_OF_STOCK` for up to 7 days (or until a server restart clears the in-memory cache).

The fix adds a second subscription in the strategy's `init()`, on `ChangeChannelEvent` filtered to `entityType === StockLocation`. Subscribing to the event — rather than patching the two service methods — keeps the invalidation inside the strategy that owns the cache, and covers every path that changes a StockLocation's channels, including plugins calling `ChannelService` directly.

Both changes live in the same `init()` block and are only meaningful together (the first makes deletes actually work, the second makes the right operation trigger them), so they ship as one PR.

Both subscribers now route the delete through a small helper that catches and logs a rejecting cache backend. Previously the returned promise was dropped, so a failed invalidation would have been an unhandled rejection with no log line, leaving the stale list in place for its full TTL.

# Breaking changes

None. The only behavioural change is that saleable-stock reads now see channel-membership changes immediately, instead of after cache expiry or a server restart.

# Testing

**Unit** (`multi-channel-stock-location-strategy.spec.ts`, new file, 7 cases, no DB): uses the real `Cache` wrapper over an in-memory Map — so the key-prefixing interaction under test behaves exactly as in production — plus a Subject-backed EventBus stub. On master, four cases fail: the three invalidation cases (update / assign / remove: the first because the delete misses its key, the other two because no subscription exists) plus the failure-logging case below. With the fix all 7 pass. The other three pin behaviour that should not change: channel ids are cached after the first lookup, `created` events don't invalidate, and `ChangeChannelEvent`s for other entity types don't invalidate.

**E2E** (`stock-location.e2e-spec.ts`, new describe, 2 cases): both reproduce the sequence from the issue thread. The first queries a variant's saleable stock via the Shop API in a new channel's context, which caches the location's pre-assignment channel list, then calls `assignStockLocationsToChannel` and queries again; on master's dist it reports `OUT_OF_STOCK` where `IN_STOCK` is expected. The second covers the removal direction, where a stale positive list lets a location that was removed from the channel keep contributing saleable stock: it warms a positive read, removes the location, then polls until the Shop query reports `OUT_OF_STOCK`, which on master's dist never happens. Both pass with the fix, and the 16 existing tests in the file are unaffected in both runs.

What I ran:

| | Result |
|---|---|
| New unit spec against master code | 4 failed / 3 passed |
| New unit spec after the fix | 7 passed |
| Full core unit suite | 76 files, 1144 passed |
| `stock-location.e2e-spec.ts` against master dist | 2 failed (both new cases) / 16 passed |
| `stock-location.e2e-spec.ts` against rebuilt dist | 18 passed |
| `stock-control.e2e-spec.ts` + `stock-control-multi-location.e2e-spec.ts` | 46 passed |

The pre-existing type error in `order.service.ts:1460` that stops `npm run build` locally is unrelated (file untouched, reproduces on clean master).

### 🤖 AI assistance

I used Claude Code while working on this. I have reviewed every line of the change myself, and the testing table above reflects test runs I actually performed and observed — including verifying that each new regression test fails without its fix and passes with it.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788392762&installation_model_id=20193&pr_number=5087&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5087&signature=8aab0d08de8c48f97493929d84145e809cc744c92f4ffccb67d77c52263d2b2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
