### PR TITLE
fix(dashboard): keep compiled files inside outputPath for upward imports

### DIFF
--- a/docs/docs/reference/dashboard/vite-plugin/vendure-dashboard-plugin.mdx
+++ b/docs/docs/reference/dashboard/vite-plugin/vendure-dashboard-plugin.mdx
@@ -294,8 +294,11 @@ the base `tsconfig.json` lives), so that a config file at
 `apps/server/src/vendure-config.ts` outputs to
 `{outputPath}/apps/server/src/vendure-config.js`.
 
-Defaults to the directory containing the `vendureConfigPath` file,
-which places the compiled config at the output root.
+Defaults to the deepest directory containing the `vendureConfigPath`
+file and every local file it imports. When every import sits at or
+below the config, that is the config's own directory and the compiled
+config lands at the output root; an import from above widens the root
+so nothing is emitted outside `outputPath`.
 
 
 </div>

--- a/packages/dashboard/vite/tests/source-root.spec.ts
+++ b/packages/dashboard/vite/tests/source-root.spec.ts
@@ -192,6 +192,12 @@ describe('#5086 compiler source root', () => {
             }),
         ).rejects.toThrow(/outside the output directory/);
 
+        // Rejecting is only half of it: the file that would have escaped must
+        // not have been written on the way to the error.
+        expect(listFiles(path.dirname(outputPath))).toEqual(
+            listFiles(outputPath).map(file => `${path.basename(outputPath)}/${file}`),
+        );
+
         await fs.remove(outputRoot);
         await fs.remove(root);
     }, 120_000);

--- a/packages/dashboard/vite/tests/source-root.spec.ts
+++ b/packages/dashboard/vite/tests/source-root.spec.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-import { compile } from '../utils/compiler.js';
+import { commonAncestorDir, compile } from '../utils/compiler.js';
 
 // #5086 — the source root defaulted to the config's own directory, so a config
 // importing from above it produced a relative path with a leading `..` and the
@@ -72,6 +72,28 @@ async function compileProject(configPath: string, sourceRoot?: string) {
 
     return { outputRoot, outputPath, result };
 }
+
+describe('commonAncestorDir', () => {
+    it('returns the deepest shared directory', () => {
+        const base = path.resolve(path.sep, 'projects', 'shop');
+        expect(commonAncestorDir([path.join(base, 'src'), path.join(base, 'shared')])).toBe(base);
+    });
+
+    it('returns an absolute root when the paths only share the filesystem root', () => {
+        // Joining a prefix that stops at the root yields "" on POSIX and a
+        // drive-relative "C:" on Windows; neither may be returned as-is, or the
+        // emitted paths stop resolving under outputPath.
+        const root = path.parse(path.resolve(path.sep)).root;
+        const ancestor = commonAncestorDir([path.resolve(path.sep, 'alpha'), path.resolve(path.sep, 'beta')]);
+
+        expect(ancestor).toBe(root);
+        expect(path.isAbsolute(ancestor as string)).toBe(true);
+    });
+
+    it('returns undefined for an empty list', () => {
+        expect(commonAncestorDir([])).toBeUndefined();
+    });
+});
 
 describe('#5086 compiler source root', () => {
     it('keeps a config importing from above its directory inside outputPath', async () => {

--- a/packages/dashboard/vite/tests/source-root.spec.ts
+++ b/packages/dashboard/vite/tests/source-root.spec.ts
@@ -2,21 +2,31 @@ import fs from 'fs-extra';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import path, { posix, win32 } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { commonAncestorDir, compile } from '../utils/compiler.js';
+import type { Logger } from '../types.js';
+import { commonAncestorDir, compile, resolveDefaultSourceRoot } from '../utils/compiler.js';
 
 // #5086 — the source root defaulted to the config's own directory, so a config
 // importing from above it produced a relative path with a leading `..` and the
 // compiled file was written outside outputPath, past the package.json the
 // compiler writes there to declare the module type.
 
-const silentLogger = {
-    info: () => undefined,
-    warn: () => undefined,
-    debug: () => undefined,
-    error: () => undefined,
-};
+interface RecordingLogger extends Logger {
+    errors: string[];
+    warns: string[];
+}
+
+function createRecordingLogger(): RecordingLogger {
+    const logger = { errors: [], warns: [] };
+    return {
+        ...logger,
+        info: () => undefined,
+        debug: () => undefined,
+        warn: (message: string) => logger.warns.push(message),
+        error: (message: string) => logger.errors.push(message),
+    };
+}
 
 function listFiles(dir: string): string[] {
     if (!fs.existsSync(dir)) {
@@ -35,6 +45,18 @@ function listFiles(dir: string): string[] {
     };
     walk(dir);
     return files.sort();
+}
+
+// Plugin discovery can log unrelated resolution notes on some setups; what
+// must stay silent is the #5086 load-time symptom an escaped emit produces.
+function expectNoEscapeSymptom(logger: RecordingLogger): void {
+    expect(logger.errors.join('\n')).not.toMatch(/exports is not defined|Error loading config/);
+}
+
+async function removeDirs(...dirs: string[]): Promise<void> {
+    for (const dir of dirs) {
+        await fs.remove(dir);
+    }
 }
 
 async function createProject(imported: 'above' | 'below') {
@@ -58,19 +80,29 @@ async function createProject(imported: 'above' | 'below') {
     return { root, configPath: path.join(root, 'src', 'vendure-config.ts') };
 }
 
-async function compileProject(configPath: string, sourceRoot?: string) {
+async function compileProject(configPath: string, options?: { sourceRoot?: string; id?: string }) {
+    const id = options?.id ?? randomUUID();
     const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'vendure-source-root-out-'));
     // Nested, as in production: <tempCompilationDir>/compiler/<id>
-    const outputPath = path.join(outputRoot, 'compiler', randomUUID());
+    const outputPath = path.join(outputRoot, 'compiler', id);
+    // An ESM scope above outputPath is what makes an escaped emit fail to
+    // load in production (#5086). Without it, an escaped file resolves as
+    // CommonJS and only the layout assertions would catch the escape.
+    await fs.outputFile(path.join(outputRoot, 'compiler', 'package.json'), '{"type":"module"}');
 
-    const result = await compile({
-        vendureConfigPath: configPath,
-        outputPath,
-        logger: silentLogger,
-        ...(sourceRoot ? { pathAdapter: { sourceRoot } } : {}),
-    });
-
-    return { outputRoot, outputPath, result };
+    const logger = createRecordingLogger();
+    try {
+        const result = await compile({
+            vendureConfigPath: configPath,
+            outputPath,
+            logger,
+            ...(options?.sourceRoot ? { pathAdapter: { sourceRoot: options.sourceRoot } } : {}),
+        });
+        return { outputRoot, outputPath, result, logger };
+    } catch (error) {
+        await removeDirs(outputRoot);
+        throw error;
+    }
 }
 
 describe('commonAncestorDir', () => {
@@ -111,94 +143,221 @@ describe('commonAncestorDir', () => {
     });
 });
 
+describe('resolveDefaultSourceRoot', () => {
+    it('fails with a dedicated error when the files span multiple roots', () => {
+        // Cross-drive layouts cannot be constructed portably on a POSIX CI,
+        // so the win32 implementation is injected instead.
+        expect(() => resolveDefaultSourceRoot('C:\\repo\\app\\src', ['D:\\shared'], win32)).toThrow(
+            /multiple filesystem roots/,
+        );
+    });
+});
+
 describe('#5086 compiler source root', () => {
-    it('keeps a config importing from above its directory inside outputPath', async () => {
-        const { root, configPath } = await createProject('above');
-        const { outputRoot, outputPath, result } = await compileProject(configPath);
+    it(
+        'keeps a config importing from above its directory inside outputPath',
+        async () => {
+            const { root, configPath } = await createProject('above');
+            let outputRoot: string | undefined;
+            try {
+                const { outputRoot: outRoot, outputPath, result, logger } = await compileProject(configPath);
+                outputRoot = outRoot;
 
-        // The emitted files sit under outputPath, and the config nests to match
-        // the layout, so nothing lands beside the package.json guard.
-        expect(listFiles(outputPath)).toEqual(['package.json', 'shared/util.js', 'src/vendure-config.js']);
-        expect(listFiles(path.dirname(outputPath))).toEqual(
-            listFiles(outputPath).map(file => `${path.basename(outputPath)}/${file}`),
-        );
-        // Reaching a loaded config proves the compiled path followed the emit
-        // layout rather than assuming the output root.
-        expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+                expect(listFiles(outputPath)).toEqual([
+                    'package.json',
+                    'shared/util.js',
+                    'src/vendure-config.js',
+                ]);
+                // Reaching a loaded config proves the compiled config was imported
+                // from its nested emit location rather than the output root.
+                expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+                expectNoEscapeSymptom(logger);
+            } finally {
+                await removeDirs(outputRoot ?? '', root);
+            }
+        },
+        { timeout: 60_000 },
+    );
 
-        await fs.remove(outputRoot);
-        await fs.remove(root);
-    }, 120_000);
+    it(
+        'leaves the layout unchanged when every import is at or below the config',
+        async () => {
+            const { root, configPath } = await createProject('below');
+            let outputRoot: string | undefined;
+            try {
+                const { outputRoot: outRoot, outputPath, result, logger } = await compileProject(configPath);
+                outputRoot = outRoot;
 
-    it('leaves the layout unchanged when every import is at or below the config', async () => {
-        const { root, configPath } = await createProject('below');
-        const { outputRoot, outputPath, result } = await compileProject(configPath);
+                expect(listFiles(outputPath)).toEqual(['lib/util.js', 'package.json', 'vendure-config.js']);
+                expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+                expectNoEscapeSymptom(logger);
+                expect(logger.warns.filter(w => w.includes('widened'))).toEqual([]);
+            } finally {
+                await removeDirs(outputRoot ?? '', root);
+            }
+        },
+        { timeout: 60_000 },
+    );
 
-        expect(listFiles(outputPath)).toEqual(['lib/util.js', 'package.json', 'vendure-config.js']);
-        expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+    it(
+        'logs a warning when the default root widens above the config directory',
+        async () => {
+            const { root, configPath } = await createProject('above');
+            let outputRoot: string | undefined;
+            try {
+                const { outputRoot: outRoot, logger } = await compileProject(configPath);
+                outputRoot = outRoot;
 
-        await fs.remove(outputRoot);
-        await fs.remove(root);
-    }, 120_000);
+                expect(logger.warns.filter(w => w.includes('widened'))).toHaveLength(1);
+                expect(logger.warns.find(w => w.includes('widened'))).toContain('Source root widened');
+            } finally {
+                await removeDirs(outputRoot ?? '', root);
+            }
+        },
+        { timeout: 60_000 },
+    );
 
-    it('still honours an explicit pathAdapter.sourceRoot', async () => {
-        const { root, configPath } = await createProject('above');
-        const { outputRoot, outputPath, result } = await compileProject(configPath, root);
+    it(
+        'still honours an explicit pathAdapter.sourceRoot',
+        async () => {
+            const { root, configPath } = await createProject('above');
+            let outputRoot: string | undefined;
+            try {
+                const {
+                    outputRoot: outRoot,
+                    outputPath,
+                    result,
+                } = await compileProject(configPath, {
+                    sourceRoot: root,
+                });
+                outputRoot = outRoot;
 
-        expect(listFiles(outputPath)).toEqual(['package.json', 'shared/util.js', 'src/vendure-config.js']);
-        expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+                expect(listFiles(outputPath)).toEqual([
+                    'package.json',
+                    'shared/util.js',
+                    'src/vendure-config.js',
+                ]);
+                expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+            } finally {
+                await removeDirs(outputRoot ?? '', root);
+            }
+        },
+        { timeout: 60_000 },
+    );
 
-        await fs.remove(outputRoot);
-        await fs.remove(root);
-    }, 120_000);
+    it(
+        "honours a custom adapter's compiled-config path alongside an explicit widened root",
+        async () => {
+            const { root, configPath } = await createProject('above');
+            let outputRoot: string | undefined;
+            try {
+                const {
+                    outputRoot: outRoot,
+                    outputPath,
+                    result,
+                } = await compileProject(configPath, {
+                    sourceRoot: root,
+                });
+                outputRoot = outRoot;
 
-    it('does not mistake a leading-dot filename for an escape', async () => {
-        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vendure-source-root-'));
-        await fs.outputFile(
-            path.join(root, 'src', '..util.ts'),
-            'export const hostname = "shop.example.com";\n',
-        );
-        await fs.outputFile(
-            path.join(root, 'src', 'vendure-config.ts'),
-            [
-                `import type { VendureConfig } from '@vendure/core';`,
-                `import { hostname } from './..util.js';`,
-                `export const config: VendureConfig = { apiOptions: { port: 3000, hostname } } as any;`,
-            ].join('\n'),
-        );
+                // A custom adapter owns where the config is imported from; the
+                // compiler must call it instead of deriving the nested default.
+                const getCompiledConfigPath = vi.fn(
+                    ({ outputPath: out, configFileName }: { outputPath: string; configFileName: string }) =>
+                        path.join(out, 'src', configFileName),
+                );
+                const adapted = await compile({
+                    vendureConfigPath: configPath,
+                    outputPath,
+                    logger: createRecordingLogger(),
+                    pathAdapter: { sourceRoot: root, getCompiledConfigPath },
+                });
 
-        const { outputRoot, outputPath, result } = await compileProject(
-            path.join(root, 'src', 'vendure-config.ts'),
-        );
+                expect(getCompiledConfigPath).toHaveBeenCalledTimes(1);
+                expect(getCompiledConfigPath.mock.calls[0][0]).toEqual({
+                    inputRootDir: path.dirname(configPath),
+                    outputPath,
+                    configFileName: 'vendure-config.ts',
+                });
+                // The adapter's return value is what gets imported: pointing it
+                // at the emitted file loads the real config through the branch.
+                expect(adapted.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+                expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+            } finally {
+                await removeDirs(outputRoot ?? '', root);
+            }
+        },
+        { timeout: 60_000 },
+    );
 
-        expect(listFiles(outputPath)).toContain('..util.js');
-        expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+    it(
+        'does not mistake a leading-dot filename for an escape',
+        async () => {
+            const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vendure-source-root-'));
+            let outputRoot: string | undefined;
+            try {
+                await fs.outputFile(
+                    path.join(root, 'src', '..util.ts'),
+                    'export const hostname = "shop.example.com";\n',
+                );
+                await fs.outputFile(
+                    path.join(root, 'src', 'vendure-config.ts'),
+                    [
+                        `import type { VendureConfig } from '@vendure/core';`,
+                        `import { hostname } from './..util.js';`,
+                        `export const config: VendureConfig = { apiOptions: { port: 3000, hostname } } as any;`,
+                    ].join('\n'),
+                );
 
-        await fs.remove(outputRoot);
-        await fs.remove(root);
-    }, 120_000);
+                const {
+                    outputRoot: outRoot,
+                    outputPath,
+                    result,
+                } = await compileProject(path.join(root, 'src', 'vendure-config.ts'));
+                outputRoot = outRoot;
 
-    it('fails with a clear error when an explicit sourceRoot excludes an imported file', async () => {
-        const { root, configPath } = await createProject('above');
-        const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'vendure-source-root-out-'));
-        const outputPath = path.join(outputRoot, 'compiler', randomUUID());
+                expect(listFiles(outputPath)).toEqual(['..util.js', 'package.json', 'vendure-config.js']);
+                expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+            } finally {
+                await removeDirs(outputRoot ?? '', root);
+            }
+        },
+        { timeout: 60_000 },
+    );
 
-        await expect(
-            compile({
-                vendureConfigPath: configPath,
-                outputPath,
-                logger: silentLogger,
-                pathAdapter: { sourceRoot: path.join(root, 'src') },
-            }),
-        ).rejects.toThrow(/outside the output directory/);
+    it(
+        'rejects an explicit sourceRoot excluding an imported file and writes nothing outside outputPath',
+        async () => {
+            const { root, configPath } = await createProject('above');
+            let outputRoot: string | undefined;
+            try {
+                const id = 'rejected-case';
+                const outputRootTmp = await fs.mkdtemp(path.join(os.tmpdir(), 'vendure-source-root-out-'));
+                outputRoot = outputRootTmp;
+                const outputPath = path.join(outputRootTmp, 'compiler', id);
+                await fs.outputFile(
+                    path.join(outputRootTmp, 'compiler', 'package.json'),
+                    '{"type":"module"}',
+                );
+                const logger = createRecordingLogger();
 
-        // Rejecting is only half of it: the file that would have escaped must
-        // not have been written on the way to the error.
-        expect(listFiles(path.dirname(outputPath))).toEqual(
-            listFiles(outputPath).map(file => `${path.basename(outputPath)}/${file}`),
-        );
+                await expect(
+                    compile({
+                        vendureConfigPath: configPath,
+                        outputPath,
+                        logger,
+                        pathAdapter: { sourceRoot: path.join(root, 'src') },
+                    }),
+                ).rejects.toThrow(/outside the output directory/);
 
-        await fs.remove(outputRoot);
-        await fs.remove(root);
-    }, 120_000);
+                // Rejecting is only half of it: nothing may be written on the way
+                // to the error. Only the ESM guard fixture remains beside outputPath.
+                expect(listFiles(path.dirname(outputPath))).toEqual(['package.json']);
+                expect(listFiles(outputPath)).toEqual([]);
+            } finally {
+                await removeDirs(outputRoot ?? '', root);
+            }
+        },
+        { timeout: 60_000 },
+    );
 });

--- a/packages/dashboard/vite/tests/source-root.spec.ts
+++ b/packages/dashboard/vite/tests/source-root.spec.ts
@@ -59,7 +59,7 @@ async function removeDirs(...dirs: string[]): Promise<void> {
     }
 }
 
-async function createProject(imported: 'above' | 'below') {
+async function createProject(imported: 'above' | 'below', options?: { alias?: boolean }) {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vendure-source-root-'));
     const importPath = imported === 'above' ? '../shared/util.js' : './lib/util.js';
     const utilPath =
@@ -67,13 +67,29 @@ async function createProject(imported: 'above' | 'below') {
             ? path.join(root, 'shared', 'util.ts')
             : path.join(root, 'src', 'lib', 'util.ts');
 
+    // Alias fixture: the tsconfig lives next to the config and maps an alias
+    // into a sibling directory of itself, the standard setup whose resolution
+    // depends on where baseUrl lands in the emitted layout.
+    if (options?.alias) {
+        await fs.outputFile(
+            path.join(root, 'src', 'plugins', 'foo.ts'),
+            'export const pluginName = "foo-plugin";\n',
+        );
+        await fs.outputJson(path.join(root, 'src', 'tsconfig.json'), {
+            compilerOptions: { baseUrl: '.', paths: { '@plugins/*': ['plugins/*'] } },
+        });
+    }
+
     await fs.outputFile(utilPath, 'export const hostname = "shop.example.com";\n');
     await fs.outputFile(
         path.join(root, 'src', 'vendure-config.ts'),
         [
             `import type { VendureConfig } from '@vendure/core';`,
+            ...(options?.alias ? [`import { pluginName } from '@plugins/foo';`] : []),
             `import { hostname } from '${importPath}';`,
-            `export const config: VendureConfig = { apiOptions: { port: 3000, hostname } } as any;`,
+            options?.alias
+                ? `export const config: VendureConfig = { apiOptions: { port: 3000, hostname }, pluginName } as any;`
+                : `export const config: VendureConfig = { apiOptions: { port: 3000, hostname } } as any;`,
         ].join('\n'),
     );
 
@@ -156,6 +172,7 @@ describe('resolveDefaultSourceRoot', () => {
 describe('#5086 compiler source root', () => {
     it(
         'keeps a config importing from above its directory inside outputPath',
+        { timeout: 60_000 },
         async () => {
             const { root, configPath } = await createProject('above');
             let outputRoot: string | undefined;
@@ -176,11 +193,41 @@ describe('#5086 compiler source root', () => {
                 await removeDirs(outputRoot ?? '', root);
             }
         },
+    );
+
+    // tsconfig path patterns resolve relative to the tsconfig's own baseUrl.
+    // Once the root widens, that directory sits deeper inside the emit, so the
+    // runtime registration must re-express baseUrl in emitted coordinates or
+    // every alias import fails to load ("Cannot find module '@plugins/foo'").
+    it(
+        'resolves tsconfig path aliases against the emitted layout when the root widens',
         { timeout: 60_000 },
+        async () => {
+            const { root, configPath } = await createProject('above', { alias: true });
+            let outputRoot: string | undefined;
+            try {
+                const { outputRoot: outRoot, outputPath, result, logger } = await compileProject(configPath);
+                outputRoot = outRoot;
+
+                expect(listFiles(outputPath)).toEqual([
+                    'package.json',
+                    'shared/util.js',
+                    'src/plugins/foo.js',
+                    'src/vendure-config.js',
+                ]);
+                // Loading through the alias proves the remapped baseUrl resolved
+                // '@plugins/foo' to its nested emit location.
+                expect(result.vendureConfig.pluginName).toBe('foo-plugin');
+                expectNoEscapeSymptom(logger);
+            } finally {
+                await removeDirs(outputRoot ?? '', root);
+            }
+        },
     );
 
     it(
         'leaves the layout unchanged when every import is at or below the config',
+        { timeout: 60_000 },
         async () => {
             const { root, configPath } = await createProject('below');
             let outputRoot: string | undefined;
@@ -196,11 +243,11 @@ describe('#5086 compiler source root', () => {
                 await removeDirs(outputRoot ?? '', root);
             }
         },
-        { timeout: 60_000 },
     );
 
     it(
         'logs a warning when the default root widens above the config directory',
+        { timeout: 60_000 },
         async () => {
             const { root, configPath } = await createProject('above');
             let outputRoot: string | undefined;
@@ -214,123 +261,111 @@ describe('#5086 compiler source root', () => {
                 await removeDirs(outputRoot ?? '', root);
             }
         },
-        { timeout: 60_000 },
     );
 
-    it(
-        'still honours an explicit pathAdapter.sourceRoot',
-        async () => {
-            const { root, configPath } = await createProject('above');
-            let outputRoot: string | undefined;
-            try {
-                const {
-                    outputRoot: outRoot,
-                    outputPath,
-                    result,
-                    logger,
-                } = await compileProject(configPath, {
-                    sourceRoot: root,
-                });
-                outputRoot = outRoot;
+    it('still honours an explicit pathAdapter.sourceRoot', { timeout: 60_000 }, async () => {
+        const { root, configPath } = await createProject('above');
+        let outputRoot: string | undefined;
+        try {
+            const {
+                outputRoot: outRoot,
+                outputPath,
+                result,
+                logger,
+            } = await compileProject(configPath, {
+                sourceRoot: root,
+            });
+            outputRoot = outRoot;
 
-                expect(listFiles(outputPath)).toEqual([
-                    'package.json',
-                    'shared/util.js',
-                    'src/vendure-config.js',
-                ]);
-                expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
-                // An explicit root is the adapter author's deliberate layout
-                // choice, so it must not be reported as an implicit widening.
-                expect(logger.warns.filter(w => w.includes('widened'))).toEqual([]);
-            } finally {
-                await removeDirs(outputRoot ?? '', root);
-            }
-        },
-        { timeout: 60_000 },
-    );
+            expect(listFiles(outputPath)).toEqual([
+                'package.json',
+                'shared/util.js',
+                'src/vendure-config.js',
+            ]);
+            expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+            // An explicit root is the adapter author's deliberate layout
+            // choice, so it must not be reported as an implicit widening.
+            expect(logger.warns.filter(w => w.includes('widened'))).toEqual([]);
+        } finally {
+            await removeDirs(outputRoot ?? '', root);
+        }
+    });
 
-    it(
-        "honours a custom adapter's compiled-config path alongside an explicit widened root",
-        async () => {
-            const { root, configPath } = await createProject('above');
-            let outputRoot: string | undefined;
-            try {
-                const {
-                    outputRoot: outRoot,
-                    outputPath,
-                    result,
-                } = await compileProject(configPath, {
-                    sourceRoot: root,
-                });
-                outputRoot = outRoot;
+    it("honours a custom adapter's compiled-config path alongside an explicit widened root", async () => {
+        const { root, configPath } = await createProject('above');
+        let outputRoot: string | undefined;
+        try {
+            const {
+                outputRoot: outRoot,
+                outputPath,
+                result,
+            } = await compileProject(configPath, {
+                sourceRoot: root,
+            });
+            outputRoot = outRoot;
 
-                // A custom adapter owns where the config is imported from; the
-                // compiler must call it instead of deriving the nested default.
-                const getCompiledConfigPath = vi.fn(
-                    ({ outputPath: out, configFileName }: { outputPath: string; configFileName: string }) =>
-                        path.join(out, 'src', configFileName),
-                );
-                const adapted = await compile({
-                    vendureConfigPath: configPath,
-                    outputPath,
-                    logger: createRecordingLogger(),
-                    pathAdapter: { sourceRoot: root, getCompiledConfigPath },
-                });
+            // A custom adapter owns where the config is imported from; the
+            // compiler must call it instead of deriving the nested default.
+            const getCompiledConfigPath = vi.fn(
+                ({ outputPath: out, configFileName }: { outputPath: string; configFileName: string }) =>
+                    path.join(out, 'src', configFileName),
+            );
+            const adapted = await compile({
+                vendureConfigPath: configPath,
+                outputPath,
+                logger: createRecordingLogger(),
+                pathAdapter: { sourceRoot: root, getCompiledConfigPath },
+            });
 
-                expect(getCompiledConfigPath).toHaveBeenCalledTimes(1);
-                expect(getCompiledConfigPath.mock.calls[0][0]).toEqual({
-                    inputRootDir: path.dirname(configPath),
-                    outputPath,
-                    configFileName: 'vendure-config.ts',
-                });
-                // The adapter's return value is what gets imported: pointing it
-                // at the emitted file loads the real config through the branch.
-                expect(adapted.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
-                expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
-            } finally {
-                await removeDirs(outputRoot ?? '', root);
-            }
-        },
-        { timeout: 60_000 },
-    );
+            expect(getCompiledConfigPath).toHaveBeenCalledTimes(1);
+            expect(getCompiledConfigPath.mock.calls[0][0]).toEqual({
+                inputRootDir: path.dirname(configPath),
+                outputPath,
+                configFileName: 'vendure-config.ts',
+            });
+            // The adapter's return value is what gets imported: pointing it
+            // at the emitted file loads the real config through the branch.
+            expect(adapted.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+            expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+        } finally {
+            await removeDirs(outputRoot ?? '', root);
+        }
+    });
 
-    it(
-        'does not mistake a leading-dot filename for an escape',
-        async () => {
-            const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vendure-source-root-'));
-            let outputRoot: string | undefined;
-            try {
-                await fs.outputFile(
-                    path.join(root, 'src', '..util.ts'),
-                    'export const hostname = "shop.example.com";\n',
-                );
-                await fs.outputFile(
-                    path.join(root, 'src', 'vendure-config.ts'),
-                    [
-                        `import type { VendureConfig } from '@vendure/core';`,
-                        `import { hostname } from './..util.js';`,
-                        `export const config: VendureConfig = { apiOptions: { port: 3000, hostname } } as any;`,
-                    ].join('\n'),
-                );
+    it('does not mistake a leading-dot filename for an escape', { timeout: 60_000 }, async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vendure-source-root-'));
+        let outputRoot: string | undefined;
+        try {
+            await fs.outputFile(
+                path.join(root, 'src', '..util.ts'),
+                'export const hostname = "shop.example.com";\n',
+            );
+            await fs.outputFile(
+                path.join(root, 'src', 'vendure-config.ts'),
+                [
+                    `import type { VendureConfig } from '@vendure/core';`,
+                    `import { hostname } from './..util.js';`,
+                    `export const config: VendureConfig = { apiOptions: { port: 3000, hostname } } as any;`,
+                ].join('\n'),
+            );
 
-                const {
-                    outputRoot: outRoot,
-                    outputPath,
-                    result,
-                } = await compileProject(path.join(root, 'src', 'vendure-config.ts'));
-                outputRoot = outRoot;
+            const {
+                outputRoot: outRoot,
+                outputPath,
+                result,
+            } = await compileProject(path.join(root, 'src', 'vendure-config.ts'));
+            outputRoot = outRoot;
 
-                expect(listFiles(outputPath)).toEqual(['..util.js', 'package.json', 'vendure-config.js']);
-                expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
-            } finally {
-                await removeDirs(outputRoot ?? '', root);
-            }
-        },
-        { timeout: 60_000 },
-    );
+            expect(listFiles(outputPath)).toEqual(['..util.js', 'package.json', 'vendure-config.js']);
+            expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+        } finally {
+            await removeDirs(outputRoot ?? '', root);
+        }
+    });
 
     it(
         'rejects an explicit sourceRoot excluding an imported file and writes nothing outside outputPath',
+        { timeout: 60_000 },
         async () => {
             const { root, configPath } = await createProject('above');
             let outputRoot: string | undefined;
@@ -362,6 +397,5 @@ describe('#5086 compiler source root', () => {
                 await removeDirs(outputRoot ?? '', root);
             }
         },
-        { timeout: 60_000 },
     );
 });

--- a/packages/dashboard/vite/tests/source-root.spec.ts
+++ b/packages/dashboard/vite/tests/source-root.spec.ts
@@ -1,0 +1,157 @@
+import fs from 'fs-extra';
+import { randomUUID } from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { compile } from '../utils/compiler.js';
+
+// #5086 — the source root defaulted to the config's own directory, so a config
+// importing from above it produced a relative path with a leading `..` and the
+// compiled file was written outside outputPath, past the package.json the
+// compiler writes there to declare the module type.
+
+const silentLogger = {
+    info: () => undefined,
+    warn: () => undefined,
+    debug: () => undefined,
+    error: () => undefined,
+};
+
+function listFiles(dir: string): string[] {
+    if (!fs.existsSync(dir)) {
+        return [];
+    }
+    const files: string[] = [];
+    const walk = (current: string) => {
+        for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+            const entryPath = path.join(current, entry.name);
+            if (entry.isDirectory()) {
+                walk(entryPath);
+            } else {
+                files.push(path.relative(dir, entryPath).split(path.sep).join('/'));
+            }
+        }
+    };
+    walk(dir);
+    return files.sort();
+}
+
+async function createProject(imported: 'above' | 'below') {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vendure-source-root-'));
+    const importPath = imported === 'above' ? '../shared/util.js' : './lib/util.js';
+    const utilPath =
+        imported === 'above'
+            ? path.join(root, 'shared', 'util.ts')
+            : path.join(root, 'src', 'lib', 'util.ts');
+
+    await fs.outputFile(utilPath, 'export const appName = "shop";\n');
+    await fs.outputFile(
+        path.join(root, 'src', 'vendure-config.ts'),
+        [
+            `import type { VendureConfig } from '@vendure/core';`,
+            `import { appName } from '${importPath}';`,
+            `export const config: VendureConfig = { apiOptions: { port: 3000 }, __n: appName } as any;`,
+        ].join('\n'),
+    );
+
+    return { root, configPath: path.join(root, 'src', 'vendure-config.ts') };
+}
+
+async function compileProject(configPath: string, sourceRoot?: string) {
+    const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'vendure-source-root-out-'));
+    // Nested, as in production: <tempCompilationDir>/compiler/<id>
+    const outputPath = path.join(outputRoot, 'compiler', randomUUID());
+
+    const result = await compile({
+        vendureConfigPath: configPath,
+        outputPath,
+        logger: silentLogger,
+        ...(sourceRoot ? { pathAdapter: { sourceRoot } } : {}),
+    });
+
+    return { outputRoot, outputPath, result };
+}
+
+describe('#5086 compiler source root', () => {
+    it('keeps a config importing from above its directory inside outputPath', async () => {
+        const { root, configPath } = await createProject('above');
+        const { outputRoot, outputPath, result } = await compileProject(configPath);
+
+        // The emitted files sit under outputPath, and the config nests to match
+        // the layout, so nothing lands beside the package.json guard.
+        expect(listFiles(outputPath)).toEqual(['package.json', 'shared/util.js', 'src/vendure-config.js']);
+        expect(listFiles(path.dirname(outputPath))).toEqual(
+            listFiles(outputPath).map(file => `${path.basename(outputPath)}/${file}`),
+        );
+        // Reaching a loaded config proves getCompiledConfigPath followed the
+        // emit layout rather than assuming the output root.
+        expect(result.vendureConfig.apiOptions?.port).toBe(3000);
+
+        await fs.remove(outputRoot);
+        await fs.remove(root);
+    }, 120_000);
+
+    it('leaves the layout unchanged when every import is at or below the config', async () => {
+        const { root, configPath } = await createProject('below');
+        const { outputRoot, outputPath, result } = await compileProject(configPath);
+
+        expect(listFiles(outputPath)).toEqual(['lib/util.js', 'package.json', 'vendure-config.js']);
+        expect(result.vendureConfig.apiOptions?.port).toBe(3000);
+
+        await fs.remove(outputRoot);
+        await fs.remove(root);
+    }, 120_000);
+
+    it('still honours an explicit pathAdapter.sourceRoot', async () => {
+        const { root, configPath } = await createProject('above');
+        const { outputRoot, outputPath, result } = await compileProject(configPath, root);
+
+        expect(listFiles(outputPath)).toEqual(['package.json', 'shared/util.js', 'src/vendure-config.js']);
+        expect(result.vendureConfig.apiOptions?.port).toBe(3000);
+
+        await fs.remove(outputRoot);
+        await fs.remove(root);
+    }, 120_000);
+
+    it('does not mistake a leading-dot filename for an escape', async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vendure-source-root-'));
+        await fs.outputFile(path.join(root, 'src', '..util.ts'), 'export const appName = "shop";\n');
+        await fs.outputFile(
+            path.join(root, 'src', 'vendure-config.ts'),
+            [
+                `import type { VendureConfig } from '@vendure/core';`,
+                `import { appName } from './..util.js';`,
+                `export const config: VendureConfig = { apiOptions: { port: 3000 }, __n: appName } as any;`,
+            ].join('\n'),
+        );
+
+        const { outputRoot, outputPath, result } = await compileProject(
+            path.join(root, 'src', 'vendure-config.ts'),
+        );
+
+        expect(listFiles(outputPath)).toContain('..util.js');
+        expect(result.vendureConfig.apiOptions?.port).toBe(3000);
+
+        await fs.remove(outputRoot);
+        await fs.remove(root);
+    }, 120_000);
+
+    it('fails with a clear error when an explicit sourceRoot excludes an imported file', async () => {
+        const { root, configPath } = await createProject('above');
+        const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'vendure-source-root-out-'));
+        const outputPath = path.join(outputRoot, 'compiler', randomUUID());
+
+        await expect(
+            compile({
+                vendureConfigPath: configPath,
+                outputPath,
+                logger: silentLogger,
+                pathAdapter: { sourceRoot: path.join(root, 'src') },
+            }),
+        ).rejects.toThrow(/outside the output directory/);
+
+        await fs.remove(outputRoot);
+        await fs.remove(root);
+    }, 120_000);
+});

--- a/packages/dashboard/vite/tests/source-root.spec.ts
+++ b/packages/dashboard/vite/tests/source-root.spec.ts
@@ -227,6 +227,7 @@ describe('#5086 compiler source root', () => {
                     outputRoot: outRoot,
                     outputPath,
                     result,
+                    logger,
                 } = await compileProject(configPath, {
                     sourceRoot: root,
                 });
@@ -238,6 +239,9 @@ describe('#5086 compiler source root', () => {
                     'src/vendure-config.js',
                 ]);
                 expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
+                // An explicit root is the adapter author's deliberate layout
+                // choice, so it must not be reported as an implicit widening.
+                expect(logger.warns.filter(w => w.includes('widened'))).toEqual([]);
             } finally {
                 await removeDirs(outputRoot ?? '', root);
             }

--- a/packages/dashboard/vite/tests/source-root.spec.ts
+++ b/packages/dashboard/vite/tests/source-root.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
-import path from 'node:path';
+import path, { posix, win32 } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { commonAncestorDir, compile } from '../utils/compiler.js';
@@ -45,13 +45,13 @@ async function createProject(imported: 'above' | 'below') {
             ? path.join(root, 'shared', 'util.ts')
             : path.join(root, 'src', 'lib', 'util.ts');
 
-    await fs.outputFile(utilPath, 'export const appName = "shop";\n');
+    await fs.outputFile(utilPath, 'export const hostname = "shop.example.com";\n');
     await fs.outputFile(
         path.join(root, 'src', 'vendure-config.ts'),
         [
             `import type { VendureConfig } from '@vendure/core';`,
-            `import { appName } from '${importPath}';`,
-            `export const config: VendureConfig = { apiOptions: { port: 3000 }, __n: appName } as any;`,
+            `import { hostname } from '${importPath}';`,
+            `export const config: VendureConfig = { apiOptions: { port: 3000, hostname } } as any;`,
         ].join('\n'),
     );
 
@@ -75,23 +75,39 @@ async function compileProject(configPath: string, sourceRoot?: string) {
 
 describe('commonAncestorDir', () => {
     it('returns the deepest shared directory', () => {
-        const base = path.resolve(path.sep, 'projects', 'shop');
-        expect(commonAncestorDir([path.join(base, 'src'), path.join(base, 'shared')])).toBe(base);
+        expect(commonAncestorDir(['/projects/shop/src', '/projects/shop/shared'], posix)).toBe(
+            '/projects/shop',
+        );
     });
 
-    it('returns an absolute root when the paths only share the filesystem root', () => {
-        // Joining a prefix that stops at the root yields "" on POSIX and a
-        // drive-relative "C:" on Windows; neither may be returned as-is, or the
-        // emitted paths stop resolving under outputPath.
-        const root = path.parse(path.resolve(path.sep)).root;
-        const ancestor = commonAncestorDir([path.resolve(path.sep, 'alpha'), path.resolve(path.sep, 'beta')]);
-
-        expect(ancestor).toBe(root);
-        expect(path.isAbsolute(ancestor as string)).toBe(true);
+    it('returns the filesystem root when that is all the paths share', () => {
+        expect(commonAncestorDir(['/alpha', '/beta'], posix)).toBe('/');
     });
 
     it('returns undefined for an empty list', () => {
         expect(commonAncestorDir([])).toBeUndefined();
+    });
+
+    // Windows path casing is not stable in practice: process.cwd(), a resolved
+    // relative import and a tsconfig path alias can each report a different
+    // drive letter or segment casing for the same directory. Passing win32
+    // explicitly keeps these covered when the suite runs on Linux.
+    describe('with Windows paths', () => {
+        it('ignores drive letter casing', () => {
+            expect(commonAncestorDir(['C:\\repo\\app\\src', 'c:\\repo\\shared'], win32)).toBe('C:\\repo');
+        });
+
+        it('ignores segment casing rather than widening to the drive root', () => {
+            expect(commonAncestorDir(['C:\\Repo\\app\\src', 'C:\\repo\\shared'], win32)).toBe('C:\\Repo');
+        });
+
+        it('returns the drive root when that is all the paths share', () => {
+            expect(commonAncestorDir(['C:\\alpha', 'C:\\beta'], win32)).toBe('C:\\');
+        });
+
+        it('returns undefined across different drives', () => {
+            expect(commonAncestorDir(['C:\\a', 'D:\\b'], win32)).toBeUndefined();
+        });
     });
 });
 
@@ -106,9 +122,9 @@ describe('#5086 compiler source root', () => {
         expect(listFiles(path.dirname(outputPath))).toEqual(
             listFiles(outputPath).map(file => `${path.basename(outputPath)}/${file}`),
         );
-        // Reaching a loaded config proves getCompiledConfigPath followed the
-        // emit layout rather than assuming the output root.
-        expect(result.vendureConfig.apiOptions?.port).toBe(3000);
+        // Reaching a loaded config proves the compiled path followed the emit
+        // layout rather than assuming the output root.
+        expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
 
         await fs.remove(outputRoot);
         await fs.remove(root);
@@ -119,7 +135,7 @@ describe('#5086 compiler source root', () => {
         const { outputRoot, outputPath, result } = await compileProject(configPath);
 
         expect(listFiles(outputPath)).toEqual(['lib/util.js', 'package.json', 'vendure-config.js']);
-        expect(result.vendureConfig.apiOptions?.port).toBe(3000);
+        expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
 
         await fs.remove(outputRoot);
         await fs.remove(root);
@@ -130,7 +146,7 @@ describe('#5086 compiler source root', () => {
         const { outputRoot, outputPath, result } = await compileProject(configPath, root);
 
         expect(listFiles(outputPath)).toEqual(['package.json', 'shared/util.js', 'src/vendure-config.js']);
-        expect(result.vendureConfig.apiOptions?.port).toBe(3000);
+        expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
 
         await fs.remove(outputRoot);
         await fs.remove(root);
@@ -138,13 +154,16 @@ describe('#5086 compiler source root', () => {
 
     it('does not mistake a leading-dot filename for an escape', async () => {
         const root = await fs.mkdtemp(path.join(os.tmpdir(), 'vendure-source-root-'));
-        await fs.outputFile(path.join(root, 'src', '..util.ts'), 'export const appName = "shop";\n');
+        await fs.outputFile(
+            path.join(root, 'src', '..util.ts'),
+            'export const hostname = "shop.example.com";\n',
+        );
         await fs.outputFile(
             path.join(root, 'src', 'vendure-config.ts'),
             [
                 `import type { VendureConfig } from '@vendure/core';`,
-                `import { appName } from './..util.js';`,
-                `export const config: VendureConfig = { apiOptions: { port: 3000 }, __n: appName } as any;`,
+                `import { hostname } from './..util.js';`,
+                `export const config: VendureConfig = { apiOptions: { port: 3000, hostname } } as any;`,
             ].join('\n'),
         );
 
@@ -153,7 +172,7 @@ describe('#5086 compiler source root', () => {
         );
 
         expect(listFiles(outputPath)).toContain('..util.js');
-        expect(result.vendureConfig.apiOptions?.port).toBe(3000);
+        expect(result.vendureConfig.apiOptions?.hostname).toBe('shop.example.com');
 
         await fs.remove(outputRoot);
         await fs.remove(root);

--- a/packages/dashboard/vite/types.ts
+++ b/packages/dashboard/vite/types.ts
@@ -91,8 +91,11 @@ export interface PathAdapter {
      * `apps/server/src/vendure-config.ts` outputs to
      * `{outputPath}/apps/server/src/vendure-config.js`.
      *
-     * Defaults to the directory containing the `vendureConfigPath` file,
-     * which places the compiled config at the output root.
+     * Defaults to the deepest directory containing the `vendureConfigPath`
+     * file and every local file it imports. When every import sits at or
+     * below the config, that is the config's own directory and the compiled
+     * config lands at the output root; an import from above widens the root
+     * so nothing is emitted outside `outputPath`.
      *
      * @since 3.6.0
      */

--- a/packages/dashboard/vite/types.ts
+++ b/packages/dashboard/vite/types.ts
@@ -17,17 +17,6 @@ export type GetCompiledConfigPathFn = (params: {
     inputRootDir: string;
     outputPath: string;
     configFileName: string;
-    /**
-     * @description
-     * The config's path relative to `outputPath`, reflecting where the compiler
-     * actually emitted it. This equals `configFileName` unless the source root
-     * was widened because the config imports a file from above its own
-     * directory, in which case the config is nested to keep that file inside
-     * `outputPath`.
-     *
-     * @since 3.8.0
-     */
-    configOutputRelativePath?: string;
 }) => string;
 
 export type TransformTsConfigPathMappingsFn = (params: {

--- a/packages/dashboard/vite/types.ts
+++ b/packages/dashboard/vite/types.ts
@@ -17,6 +17,17 @@ export type GetCompiledConfigPathFn = (params: {
     inputRootDir: string;
     outputPath: string;
     configFileName: string;
+    /**
+     * @description
+     * The config's path relative to `outputPath`, reflecting where the compiler
+     * actually emitted it. This equals `configFileName` unless the source root
+     * was widened because the config imports a file from above its own
+     * directory, in which case the config is nested to keep that file inside
+     * `outputPath`.
+     *
+     * @since 3.8.0
+     */
+    configOutputRelativePath?: string;
 }) => string;
 
 export type TransformTsConfigPathMappingsFn = (params: {

--- a/packages/dashboard/vite/utils/compiler.ts
+++ b/packages/dashboard/vite/utils/compiler.ts
@@ -18,40 +18,55 @@ import { findTsConfigPaths } from './tsconfig-utils.js';
 const defaultPathAdapter: Required<
     Pick<PathAdapter, 'getCompiledConfigPath' | 'transformTsConfigPathMappings'>
 > = {
-    // `configOutputRelativePath` is the config's location within `outputPath`, which
-    // only differs from the bare filename when the source root had to be widened to
-    // keep an upward import inside the output directory.
-    getCompiledConfigPath: ({ outputPath, configFileName, configOutputRelativePath }) =>
-        path.join(outputPath, configOutputRelativePath ?? configFileName),
+    getCompiledConfigPath: ({ outputPath, configFileName }) => path.join(outputPath, configFileName),
     transformTsConfigPathMappings: ({ patterns }) => patterns,
 };
 
+/** Minimal surface of `node:path` used by the path helpers, so tests can pass `path.win32`. */
+type PathImpl = Pick<typeof path, 'relative' | 'resolve' | 'dirname' | 'isAbsolute' | 'sep'>;
+
+/**
+ * Whether `child` is `parent` itself or sits below it.
+ *
+ * Uses `path.relative` rather than comparing strings, so the platform's own
+ * rules apply: on Windows that means case-insensitive matching and correct
+ * handling of drive and UNC roots.
+ */
+function isWithin(parent: string, child: string, pathImpl: PathImpl = path): boolean {
+    const relative = pathImpl.relative(parent, child);
+    return (
+        relative === '' ||
+        (relative !== '..' && !relative.startsWith(`..${pathImpl.sep}`) && !pathImpl.isAbsolute(relative))
+    );
+}
+
 /**
  * Deepest directory containing all of the given paths, or `undefined` when they
- * share no common root (e.g. different Windows drives).
+ * share no common root, as with different Windows drives.
  *
- * Exported for testing.
+ * Walks up from the first path until it contains the rest, which keeps the
+ * platform's path semantics in `path.relative` instead of restating them here.
+ *
+ * `pathImpl` is injectable so the Windows behaviour can be covered from any
+ * platform; production callers use the default.
  */
-export function commonAncestorDir(dirs: string[]): string | undefined {
+export function commonAncestorDir(dirs: string[], pathImpl: PathImpl = path): string | undefined {
     if (dirs.length === 0) {
         return undefined;
     }
-    const resolved = dirs.map(dir => path.resolve(dir));
-    const segments = resolved.map(dir => dir.split(path.sep));
-    const [first] = segments;
-    let shared = 0;
-    while (shared < first.length && segments.every(parts => parts[shared] === first[shared])) {
-        shared++;
+    let ancestor = pathImpl.resolve(dirs[0]);
+    for (const dir of dirs.slice(1)) {
+        const target = pathImpl.resolve(dir);
+        while (!isWithin(ancestor, target, pathImpl)) {
+            const parent = pathImpl.dirname(ancestor);
+            if (parent === ancestor) {
+                // Reached the root without containing `target`.
+                return undefined;
+            }
+            ancestor = parent;
+        }
     }
-    if (shared === 0) {
-        return undefined;
-    }
-    const joined = first.slice(0, shared).join(path.sep);
-    // A prefix that stops at the filesystem root does not join back into an
-    // absolute path: it yields "" on POSIX and a drive-relative "C:" on Windows.
-    // Both have to become the parsed root, otherwise path.relative() below emits
-    // paths that no longer sit under outputPath.
-    return path.isAbsolute(joined) ? joined : path.parse(resolved[0]).root;
+    return ancestor;
 }
 
 export interface PackageScannerConfig {
@@ -146,17 +161,18 @@ async function compileInternal(options: CompilerOptions): Promise<CompileResult>
     // Custom pathAdapter implementations (e.g. in monorepos) rely on this being just
     // the filename, not a relative path — they hardcode the directory structure themselves.
     const configFileName = path.basename(vendureConfigPath);
-    const compiledConfigFilePath = pathToFileURL(
-        getCompiledConfigPath({
-            inputRootDir: path.dirname(vendureConfigPath),
-            outputPath,
-            configFileName,
-            // Where the config actually landed under outputPath. Equal to
-            // configFileName unless the source root was widened to keep an
-            // upward import inside the output directory.
-            configOutputRelativePath: path.relative(sourceRoot, vendureConfigPath),
-        }),
-    ).href.replace(/\.ts$/, '.js');
+    // A custom adapter owns its own layout, so it keeps deciding where the config
+    // is. The default follows the emit: that is the config's path relative to the
+    // resolved source root, which is the bare filename unless the root widened to
+    // keep an upward import inside outputPath.
+    const compiledConfigPath = pathAdapter?.getCompiledConfigPath
+        ? pathAdapter.getCompiledConfigPath({
+              inputRootDir: path.dirname(vendureConfigPath),
+              outputPath,
+              configFileName,
+          })
+        : path.join(outputPath, path.relative(sourceRoot, vendureConfigPath));
+    const compiledConfigFilePath = pathToFileURL(compiledConfigPath).href.replace(/\.ts$/, '.js');
 
     await writePackageJson(outputPath, options.module);
 
@@ -283,10 +299,21 @@ async function compileTypeScript({
     // below would produce a leading `..` and emit that file outside outputPath,
     // past the package.json written to mark the output's module type.
     const configDir = path.dirname(inputPath);
-    const sourceRoot =
-        customSourceRoot ??
-        commonAncestorDir([configDir, ...sourceFiles.map(file => path.dirname(file))]) ??
-        configDir;
+    let sourceRoot = customSourceRoot;
+    if (!sourceRoot) {
+        const resolvedRoot = commonAncestorDir([configDir, ...sourceFiles.map(file => path.dirname(file))]);
+        if (!resolvedRoot) {
+            // Only reachable when the files span roots that share no ancestor,
+            // such as two Windows drives. Falling back to the config directory
+            // would guarantee an escape and report it as one, which says nothing
+            // about the actual cause.
+            throw new Error(
+                `The Vendure config and the files it imports span multiple filesystem roots, so no common source root exists. ` +
+                    `Set pathAdapter.sourceRoot to the directory the compiled output should be relative to.`,
+            );
+        }
+        sourceRoot = resolvedRoot;
+    }
 
     // 4. Transpile each file individually
     // Note: emitDecoratorMetadata with transpileModule emits `Object` for all

--- a/packages/dashboard/vite/utils/compiler.ts
+++ b/packages/dashboard/vite/utils/compiler.ts
@@ -15,10 +15,7 @@ import { createPathTransformer } from './path-transformer.js';
 import { discoverPlugins } from './plugin-discovery.js';
 import { findTsConfigPaths } from './tsconfig-utils.js';
 
-const defaultPathAdapter: Required<
-    Pick<PathAdapter, 'getCompiledConfigPath' | 'transformTsConfigPathMappings'>
-> = {
-    getCompiledConfigPath: ({ outputPath, configFileName }) => path.join(outputPath, configFileName),
+const defaultPathAdapter: Required<Pick<PathAdapter, 'transformTsConfigPathMappings'>> = {
     transformTsConfigPathMappings: ({ patterns }) => patterns,
 };
 
@@ -67,6 +64,38 @@ export function commonAncestorDir(dirs: string[], pathImpl: PathImpl = path): st
         }
     }
     return ancestor;
+}
+
+/**
+ * The source root used when no explicit `pathAdapter.sourceRoot` is set: the
+ * deepest directory containing the config and every local file it imports.
+ *
+ * For a config whose imports all sit alongside or below it, that is exactly its
+ * own directory, so the layout is unchanged. It only widens when a collected
+ * file lives above the config — otherwise the emit would produce a leading `..`
+ * and write that file outside outputPath, past the package.json written there
+ * to declare the output's module type.
+ *
+ * `pathImpl` is injectable so the multi-root failure can be exercised on any
+ * platform; production callers use the default.
+ */
+export function resolveDefaultSourceRoot(
+    configDir: string,
+    importedDirs: string[],
+    pathImpl: PathImpl = path,
+): string {
+    const resolvedRoot = commonAncestorDir([configDir, ...importedDirs], pathImpl);
+    if (!resolvedRoot) {
+        // Only reachable when the files span roots that share no ancestor,
+        // such as two Windows drives. Falling back to the config directory
+        // would guarantee an escape and report it as one, which says nothing
+        // about the actual cause.
+        throw new Error(
+            `The Vendure config and the files it imports span multiple filesystem roots, so no common source root exists. ` +
+                `Set pathAdapter.sourceRoot to the directory the compiled output should be relative to.`,
+        );
+    }
+    return resolvedRoot;
 }
 
 export interface PackageScannerConfig {
@@ -124,8 +153,6 @@ async function withCompileLock<T>(key: string, fn: () => Promise<T>): Promise<T>
 
 async function compileInternal(options: CompilerOptions): Promise<CompileResult> {
     const { vendureConfigPath, outputPath, pathAdapter, logger = noopLogger, pluginPackageScanner } = options;
-    const getCompiledConfigPath =
-        pathAdapter?.getCompiledConfigPath ?? defaultPathAdapter.getCompiledConfigPath;
     const transformTsConfigPathMappings =
         pathAdapter?.transformTsConfigPathMappings ?? defaultPathAdapter.transformTsConfigPathMappings;
 
@@ -134,12 +161,18 @@ async function compileInternal(options: CompilerOptions): Promise<CompileResult>
 
     // 1. Compile TypeScript files
     const compileStart = Date.now();
-    const { sourceRoot } = await compileTypeScript({
-        inputPath: vendureConfigPath,
+    const { sourceRoot, tsConfigInfo, sourceFiles } = await resolveSourceContext(
+        vendureConfigPath,
+        pathAdapter?.sourceRoot,
+        logger,
+    );
+    await compileTypeScript({
         outputPath,
+        sourceRoot,
+        tsConfigInfo,
+        sourceFiles,
         logger,
         module: options.module ?? 'commonjs',
-        sourceRoot: pathAdapter?.sourceRoot,
     });
     logger.info(`TypeScript compilation completed in ${Date.now() - compileStart}ms`);
 
@@ -233,32 +266,22 @@ async function writePackageJson(outputPath: string, module?: 'commonjs' | 'esm')
 }
 
 /**
- * Compiles TypeScript files to JavaScript using per-file transpilation.
+ * Resolves the source root the compiled output is laid out relative to, and
+ * returns everything `compileTypeScript` needs so each step runs exactly once.
  *
- * Instead of using `ts.createProgram()` (which resolves all imports including
- * node_modules type definitions and can OOM on projects with heavy dependencies),
- * this function:
- * 1. Walks the import tree via lightweight AST parsing to find all local source files
- * 2. Transpiles each file individually with `ts.transpileModule()` (no type resolution)
- *
- * This avoids loading massive `.d.ts` files from packages like `openai`, `ai`, etc.
- * See: https://github.com/vendurehq/vendure/issues/4559
+ * An explicit `pathAdapter.sourceRoot` wins unchanged. The default is computed
+ * by `resolveDefaultSourceRoot` from the config directory and every directory
+ * collected from its import tree.
  */
-async function compileTypeScript({
-    inputPath,
-    outputPath,
-    logger,
-    module,
-    sourceRoot: customSourceRoot,
-}: {
-    inputPath: string;
-    outputPath: string;
-    logger: Logger;
-    module: 'commonjs' | 'esm';
-    sourceRoot?: string;
-}): Promise<{ sourceRoot: string }> {
-    await fs.ensureDir(outputPath);
-
+async function resolveSourceContext(
+    inputPath: string,
+    customSourceRoot: string | undefined,
+    logger: Logger,
+): Promise<{
+    sourceRoot: string;
+    tsConfigInfo?: { baseUrl: string; paths: Record<string, string[]> };
+    sourceFiles: string[];
+}> {
     // Find tsconfig paths for resolving path aliases in the import tree
     const originalTsConfigInfo = await findTsConfigPaths(
         inputPath,
@@ -270,52 +293,73 @@ async function compileTypeScript({
     logger.debug(`tsConfig paths: ${JSON.stringify(originalTsConfigInfo?.paths, null, 2)}`);
     logger.debug(`tsConfig baseUrl: ${originalTsConfigInfo?.baseUrl ?? 'UNKNOWN'}`);
 
-    // 1. Collect all local source files by walking the import tree
+    // Collect all local source files by walking the import tree
     const collectStart = Date.now();
     const sourceFiles = await collectLocalSourceFiles(inputPath, originalTsConfigInfo);
     logger.debug(`Collected ${sourceFiles.length} source files in ${Date.now() - collectStart}ms`);
 
-    // 2. Build path transformer for ESM mode
+    let sourceRoot = customSourceRoot;
+    if (!sourceRoot) {
+        sourceRoot = resolveDefaultSourceRoot(
+            path.dirname(inputPath),
+            sourceFiles.map(file => path.dirname(file)),
+        );
+    }
+    if (path.relative(sourceRoot, path.dirname(inputPath)) !== '') {
+        // Widening keeps an upward import inside outputPath (#5086), but it
+        // also moves the config off the output root. Surface that layout
+        // change rather than letting users discover it in the emitted tree.
+        logger.warn(
+            `Source root widened to "${sourceRoot}" so every file the config imports stays inside outputPath.`,
+        );
+    } else {
+        logger.debug(`Resolved source root: ${sourceRoot}`);
+    }
+
+    return { sourceRoot, tsConfigInfo: originalTsConfigInfo, sourceFiles };
+}
+
+/**
+ * Compiles TypeScript files to JavaScript using per-file transpilation.
+ *
+ * Instead of using `ts.createProgram()` (which resolves all imports including
+ * node_modules type definitions and can OOM on projects with heavy dependencies),
+ * this function:
+ * 1. Transpiles each given source file individually with `ts.transpileModule()` (no type resolution)
+ * 2. Validates every emit lands inside outputPath before writing anything
+ *
+ * This avoids loading massive `.d.ts` files from packages like `openai`, `ai`, etc.
+ * See: https://github.com/vendurehq/vendure/issues/4559
+ */
+async function compileTypeScript({
+    outputPath,
+    logger,
+    module,
+    sourceRoot,
+    tsConfigInfo,
+    sourceFiles,
+}: {
+    outputPath: string;
+    logger: Logger;
+    module: 'commonjs' | 'esm';
+    sourceRoot: string;
+    tsConfigInfo?: { baseUrl: string; paths: Record<string, string[]> };
+    sourceFiles: string[];
+}): Promise<void> {
+    await fs.ensureDir(outputPath);
+
+    // Build path transformer for ESM mode
     // This is necessary because tsconfig-paths.register() only works for CommonJS require(),
     // not for ESM import(). We need to transform the import paths during transpilation.
     let pathTransformer: ts.TransformerFactory<ts.SourceFile> | undefined;
-    if (module === 'esm' && originalTsConfigInfo) {
+    if (module === 'esm' && tsConfigInfo) {
         logger.debug('Adding path transformer for ESM mode');
         pathTransformer = createPathTransformer({
-            baseUrl: originalTsConfigInfo.baseUrl,
-            paths: originalTsConfigInfo.paths,
+            baseUrl: tsConfigInfo.baseUrl,
+            paths: tsConfigInfo.paths,
         });
     }
 
-    // 3. Determine the source root for computing output directory structure.
-    // Compiled files preserve their directory structure relative to this root.
-    // In monorepos, set pathAdapter.sourceRoot to the workspace root so that
-    // e.g. apps/server/src/config.ts → {output}/apps/server/src/config.js.
-    //
-    // The default is the deepest directory containing the config and every file
-    // it imports. For a config whose imports all sit alongside or below it, that
-    // is exactly its own directory, so the layout is unchanged. It only widens
-    // when a collected file lives above the config — otherwise `path.relative`
-    // below would produce a leading `..` and emit that file outside outputPath,
-    // past the package.json written to mark the output's module type.
-    const configDir = path.dirname(inputPath);
-    let sourceRoot = customSourceRoot;
-    if (!sourceRoot) {
-        const resolvedRoot = commonAncestorDir([configDir, ...sourceFiles.map(file => path.dirname(file))]);
-        if (!resolvedRoot) {
-            // Only reachable when the files span roots that share no ancestor,
-            // such as two Windows drives. Falling back to the config directory
-            // would guarantee an escape and report it as one, which says nothing
-            // about the actual cause.
-            throw new Error(
-                `The Vendure config and the files it imports span multiple filesystem roots, so no common source root exists. ` +
-                    `Set pathAdapter.sourceRoot to the directory the compiled output should be relative to.`,
-            );
-        }
-        sourceRoot = resolvedRoot;
-    }
-
-    // 4. Transpile each file individually
     // Note: emitDecoratorMetadata with transpileModule emits `Object` for all
     // imported types since there is no type resolver. This is acceptable because
     // the compiled output is only used for config loading and plugin discovery,
@@ -331,6 +375,15 @@ async function compileTypeScript({
         ? { after: [pathTransformer] }
         : undefined;
 
+    // Transpile first and validate every destination before writing anything,
+    // so a rejected compile cannot leave partially written output behind.
+    interface PendingEmit {
+        sourceFile: string;
+        outputFilePath: string;
+        outputText: string;
+    }
+    const pendingEmits: PendingEmit[] = [];
+
     for (const filePath of sourceFiles) {
         const content = await fs.readFile(filePath, 'utf-8');
         const result = ts.transpileModule(content, {
@@ -343,30 +396,30 @@ async function compileTypeScript({
         const relativePath = path.relative(sourceRoot, filePath);
         const outputFilePath = path.join(outputPath, relativePath).replace(/\.tsx?$/, '.js');
 
-        // An emit outside outputPath escapes the package.json written there to
-        // declare the module type, and Node then resolves the file against the
-        // enclosing project instead. Fail here rather than at config load, where
-        // it surfaces as an unrelated "exports is not defined" error.
-        assertWithinOutputPath(outputFilePath, outputPath, filePath);
-
-        await fs.ensureDir(path.dirname(outputFilePath));
-        await fs.writeFile(outputFilePath, result.outputText);
+        pendingEmits.push({ sourceFile: filePath, outputFilePath, outputText: result.outputText });
     }
 
-    return { sourceRoot };
+    for (const emit of pendingEmits) {
+        assertWithinOutputPath(emit.outputFilePath, outputPath);
+    }
+
+    for (const emit of pendingEmits) {
+        await fs.ensureDir(path.dirname(emit.outputFilePath));
+        await fs.writeFile(emit.outputFilePath, emit.outputText);
+    }
 }
 
-function assertWithinOutputPath(outputFilePath: string, outputPath: string, sourceFile: string): void {
-    const relativeToOutput = path.relative(outputPath, outputFilePath);
-    // Compare against a path segment rather than a `..` prefix, so a file whose
-    // own name begins with dots is not mistaken for an escape.
-    const escapes =
-        relativeToOutput === '..' ||
-        relativeToOutput.startsWith(`..${path.sep}`) ||
-        path.isAbsolute(relativeToOutput);
-    if (escapes) {
+function assertWithinOutputPath(outputFilePath: string, outputPath: string): void {
+    // An emit outside outputPath escapes the package.json written there to
+    // declare the module type, and Node then resolves the file against the
+    // enclosing project instead. Fail here rather than at config load, where
+    // it surfaces as an unrelated "exports is not defined" error.
+    //
+    // `isWithin` compares via path.relative against a segment boundary, so a
+    // file whose own name begins with dots is not mistaken for an escape.
+    if (!isWithin(outputPath, outputFilePath)) {
         throw new Error(
-            `Compiling "${sourceFile}" would emit to "${outputFilePath}", which is outside the output directory "${outputPath}". ` +
+            `"${outputFilePath}" is outside the output directory "${outputPath}". ` +
                 `Set pathAdapter.sourceRoot to a directory containing every file the config imports.`,
         );
     }

--- a/packages/dashboard/vite/utils/compiler.ts
+++ b/packages/dashboard/vite/utils/compiler.ts
@@ -29,12 +29,15 @@ const defaultPathAdapter: Required<
 /**
  * Deepest directory containing all of the given paths, or `undefined` when they
  * share no common root (e.g. different Windows drives).
+ *
+ * Exported for testing.
  */
-function commonAncestorDir(dirs: string[]): string | undefined {
+export function commonAncestorDir(dirs: string[]): string | undefined {
     if (dirs.length === 0) {
         return undefined;
     }
-    const segments = dirs.map(dir => path.resolve(dir).split(path.sep));
+    const resolved = dirs.map(dir => path.resolve(dir));
+    const segments = resolved.map(dir => dir.split(path.sep));
     const [first] = segments;
     let shared = 0;
     while (shared < first.length && segments.every(parts => parts[shared] === first[shared])) {
@@ -43,7 +46,12 @@ function commonAncestorDir(dirs: string[]): string | undefined {
     if (shared === 0) {
         return undefined;
     }
-    return first.slice(0, shared).join(path.sep) || path.sep;
+    const joined = first.slice(0, shared).join(path.sep);
+    // A prefix that stops at the filesystem root does not join back into an
+    // absolute path: it yields "" on POSIX and a drive-relative "C:" on Windows.
+    // Both have to become the parsed root, otherwise path.relative() below emits
+    // paths that no longer sit under outputPath.
+    return path.isAbsolute(joined) ? joined : path.parse(resolved[0]).root;
 }
 
 export interface PackageScannerConfig {

--- a/packages/dashboard/vite/utils/compiler.ts
+++ b/packages/dashboard/vite/utils/compiler.ts
@@ -18,9 +18,33 @@ import { findTsConfigPaths } from './tsconfig-utils.js';
 const defaultPathAdapter: Required<
     Pick<PathAdapter, 'getCompiledConfigPath' | 'transformTsConfigPathMappings'>
 > = {
-    getCompiledConfigPath: ({ outputPath, configFileName }) => path.join(outputPath, configFileName),
+    // `configOutputRelativePath` is the config's location within `outputPath`, which
+    // only differs from the bare filename when the source root had to be widened to
+    // keep an upward import inside the output directory.
+    getCompiledConfigPath: ({ outputPath, configFileName, configOutputRelativePath }) =>
+        path.join(outputPath, configOutputRelativePath ?? configFileName),
     transformTsConfigPathMappings: ({ patterns }) => patterns,
 };
+
+/**
+ * Deepest directory containing all of the given paths, or `undefined` when they
+ * share no common root (e.g. different Windows drives).
+ */
+function commonAncestorDir(dirs: string[]): string | undefined {
+    if (dirs.length === 0) {
+        return undefined;
+    }
+    const segments = dirs.map(dir => path.resolve(dir).split(path.sep));
+    const [first] = segments;
+    let shared = 0;
+    while (shared < first.length && segments.every(parts => parts[shared] === first[shared])) {
+        shared++;
+    }
+    if (shared === 0) {
+        return undefined;
+    }
+    return first.slice(0, shared).join(path.sep) || path.sep;
+}
 
 export interface PackageScannerConfig {
     nodeModulesRoot?: string;
@@ -87,7 +111,7 @@ async function compileInternal(options: CompilerOptions): Promise<CompileResult>
 
     // 1. Compile TypeScript files
     const compileStart = Date.now();
-    await compileTypeScript({
+    const { sourceRoot } = await compileTypeScript({
         inputPath: vendureConfigPath,
         outputPath,
         logger,
@@ -119,6 +143,10 @@ async function compileInternal(options: CompilerOptions): Promise<CompileResult>
             inputRootDir: path.dirname(vendureConfigPath),
             outputPath,
             configFileName,
+            // Where the config actually landed under outputPath. Equal to
+            // configFileName unless the source root was widened to keep an
+            // upward import inside the output directory.
+            configOutputRelativePath: path.relative(sourceRoot, vendureConfigPath),
         }),
     ).href.replace(/\.ts$/, '.js');
 
@@ -204,7 +232,7 @@ async function compileTypeScript({
     logger: Logger;
     module: 'commonjs' | 'esm';
     sourceRoot?: string;
-}): Promise<void> {
+}): Promise<{ sourceRoot: string }> {
     await fs.ensureDir(outputPath);
 
     // Find tsconfig paths for resolving path aliases in the import tree
@@ -239,8 +267,18 @@ async function compileTypeScript({
     // Compiled files preserve their directory structure relative to this root.
     // In monorepos, set pathAdapter.sourceRoot to the workspace root so that
     // e.g. apps/server/src/config.ts → {output}/apps/server/src/config.js.
-    // Defaults to the config file's directory, placing it at the output root.
-    const sourceRoot = customSourceRoot ?? path.dirname(inputPath);
+    //
+    // The default is the deepest directory containing the config and every file
+    // it imports. For a config whose imports all sit alongside or below it, that
+    // is exactly its own directory, so the layout is unchanged. It only widens
+    // when a collected file lives above the config — otherwise `path.relative`
+    // below would produce a leading `..` and emit that file outside outputPath,
+    // past the package.json written to mark the output's module type.
+    const configDir = path.dirname(inputPath);
+    const sourceRoot =
+        customSourceRoot ??
+        commonAncestorDir([configDir, ...sourceFiles.map(file => path.dirname(file))]) ??
+        configDir;
 
     // 4. Transpile each file individually
     // Note: emitDecoratorMetadata with transpileModule emits `Object` for all
@@ -270,8 +308,32 @@ async function compileTypeScript({
         const relativePath = path.relative(sourceRoot, filePath);
         const outputFilePath = path.join(outputPath, relativePath).replace(/\.tsx?$/, '.js');
 
+        // An emit outside outputPath escapes the package.json written there to
+        // declare the module type, and Node then resolves the file against the
+        // enclosing project instead. Fail here rather than at config load, where
+        // it surfaces as an unrelated "exports is not defined" error.
+        assertWithinOutputPath(outputFilePath, outputPath, filePath);
+
         await fs.ensureDir(path.dirname(outputFilePath));
         await fs.writeFile(outputFilePath, result.outputText);
+    }
+
+    return { sourceRoot };
+}
+
+function assertWithinOutputPath(outputFilePath: string, outputPath: string, sourceFile: string): void {
+    const relativeToOutput = path.relative(outputPath, outputFilePath);
+    // Compare against a path segment rather than a `..` prefix, so a file whose
+    // own name begins with dots is not mistaken for an escape.
+    const escapes =
+        relativeToOutput === '..' ||
+        relativeToOutput.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relativeToOutput);
+    if (escapes) {
+        throw new Error(
+            `Compiling "${sourceFile}" would emit to "${outputFilePath}", which is outside the output directory "${outputPath}". ` +
+                `Set pathAdapter.sourceRoot to a directory containing every file the config imports.`,
+        );
     }
 }
 

--- a/packages/dashboard/vite/utils/compiler.ts
+++ b/packages/dashboard/vite/utils/compiler.ts
@@ -305,7 +305,11 @@ async function resolveSourceContext(
             sourceFiles.map(file => path.dirname(file)),
         );
     }
-    if (path.relative(sourceRoot, path.dirname(inputPath)) !== '') {
+    if (customSourceRoot) {
+        // An explicit root is the adapter author's deliberate layout choice,
+        // not a widening the compiler decided — report it without alarm.
+        logger.debug(`Using sourceRoot from pathAdapter: ${sourceRoot}`);
+    } else if (path.relative(sourceRoot, path.dirname(inputPath)) !== '') {
         // Widening keeps an upward import inside outputPath (#5086), but it
         // also moves the config off the output root. Surface that layout
         // change rather than letting users discover it in the emitted tree.

--- a/packages/dashboard/vite/utils/compiler.ts
+++ b/packages/dashboard/vite/utils/compiler.ts
@@ -227,6 +227,7 @@ async function compileInternal(options: CompilerOptions): Promise<CompileResult>
 
     await registerTsConfigPaths({
         outputPath,
+        sourceRoot,
         configPath: vendureConfigPath,
         logger,
         phase: 'loading',
@@ -489,16 +490,26 @@ async function collectLocalSourceFiles(
 
 async function registerTsConfigPaths(options: {
     outputPath: string;
+    sourceRoot: string;
     configPath: string;
     logger: Logger;
     phase: 'compiling' | 'loading';
     transformTsConfigPathMappings: Required<PathAdapter>['transformTsConfigPathMappings'];
 }) {
-    const { outputPath, configPath, logger, phase, transformTsConfigPathMappings } = options;
+    const { outputPath, sourceRoot, configPath, logger, phase, transformTsConfigPathMappings } = options;
     const tsConfigInfo = await findTsConfigPaths(configPath, logger, phase, transformTsConfigPathMappings);
     if (tsConfigInfo) {
+        // Path patterns resolve relative to the tsconfig's own baseUrl, but the
+        // runtime registration points imports at the emit root. Re-express the
+        // baseUrl in emitted coordinates so a widened root (#5086) keeps
+        // aliases pointing at the same files: with `<root>/src/tsconfig.json`
+        // using baseUrl "." and the root widened to `<root>`, aliases must
+        // resolve against `<outputPath>/src`, not `<outputPath>`.
+        const emittedBaseUrl = isWithin(sourceRoot, tsConfigInfo.baseUrl)
+            ? path.join(outputPath, path.relative(sourceRoot, tsConfigInfo.baseUrl))
+            : outputPath;
         const params: RegisterParams = {
-            baseUrl: outputPath,
+            baseUrl: emittedBaseUrl,
             paths: tsConfigInfo.paths,
         };
         logger.debug(`Registering tsconfig paths: ${JSON.stringify(params, null, 2)}`);


### PR DESCRIPTION
# Description

Fixes #5086.

`compileTypeScript` defaulted its source root to the config file's own directory, so a config importing from above it — `../shared/util.js` — produced a relative path with a leading `..` and the compiled file was written outside `outputPath`. That places it past the `package.json` the compiler writes to declare the output's module type, so Node resolves it against the enclosing project instead and fails with `exports is not defined in ES module scope`.

The approach here was proposed by @Refaat-alktifan in #5086: derive the source root from the nearest common ancestor of the collected source graph, so parent imports keep their relative topology and stay inside `outputPath`.

Three changes:

- **Source root.** Defaults to the deepest directory containing the config and every file it imports. The config's own directory takes part in that calculation, so a project whose imports all sit alongside or below the config gets exactly the previous root and an unchanged layout. It only widens where the old default would have emitted outside `outputPath`. An explicit `pathAdapter.sourceRoot` still wins, and a widened default is announced with a warning log.
- **Compiled config path.** Unchanged for custom adapters: `getCompiledConfigPath` keeps deciding where the config is imported from. When no adapter supplies it, the default follows the emit — the config's path relative to the resolved source root, which is the bare filename unless the root widened.
- **Guard.** Emitting outside `outputPath` now throws at compile time before anything is written, instead of surfacing later as an unrelated module-scope error.

Tests cover the upward import, a downward-import control asserting the layout does not change, an explicit `sourceRoot`, a custom compiled-config path beside a widened root, the multi-root error, and a filename beginning with dots (which must not be mistaken for an escape). Fixtures place an ESM `package.json` above `outputPath`, so on `master` the escaped emit fails to load with the reported `exports is not defined in ES module scope`; the leading-dot case loads fine there and is covered by layout assertions.

# Breaking changes

One behavioural addition to call out in the release notes: a compile that would emit outside `outputPath` now throws instead of writing anyway. Projects that never escape are unaffected, and custom `getCompiledConfigPath` adapters keep their contract — but a CommonJS setup with a deliberately narrow `pathAdapter.sourceRoot` that relied on the escaped file still resolving will now need to widen that root. Also note the default root can widen above the config directory (announced with a warning log), which moves emitted files deeper; tsconfig `baseUrl` is remapped accordingly.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788448833&installation_model_id=20193&pr_number=5090&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5090&signature=9eb67e21aad9d8a388dcdb9259606f9ac199faa9c7b1773314374e63b06b0439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

