### PR TITLE
feat(dashboard): add per file upload progress modal for assets

### DIFF
--- a/packages/dashboard/src/i18n/locales/ar.po
+++ b/packages/dashboard/src/i18n/locales/ar.po
@@ -82,6 +82,13 @@ msgstr "شقة، جناح، إلخ."
 msgid "No more items"
 msgstr "لا توجد عناصر أخرى"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "تحرير الرابط"
@@ -443,7 +450,7 @@ msgstr "لا توجد أدوات لإضافتها"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "خطأ غير معروف"
@@ -577,7 +584,7 @@ msgstr "مجموعة جديدة"
 msgid "Insights"
 msgstr "الرؤى"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "إدراج جدول {row} في {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "إزالة من المنطقة"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "حدد من اللغات المتاحة عالميًا لهذه القناة"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "فشل إزالة العميل من المجموعة"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "يساوي"
 msgid "Source File"
 msgstr "الملف المصدر"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "مطلوب استرداد بقيمة {formattedDiff}. حدد مبالغ الدفع وأدخل ملاحظة للمتابعة."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "فشل في إنشاء المتغيرات"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "فشل في إزالة العملاء من المجموعة"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "يتوسطه خط"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "بائع جديد"
 msgid "Search tax categories..."
 msgstr "البحث في فئات الضريبة..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "تحرير الصورة"
@@ -6817,6 +6844,10 @@ msgstr "يحدد مستوى المخزون الذي يعتبر عنده هذا �
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "إنشاء خيارات المنتج"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/ar.po
+++ b/packages/dashboard/src/i18n/locales/ar.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "تحديد عناصر"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "إعادة حساب الشحن"
 msgid "Assets"
 msgstr "الملفات"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "سيؤدي هذا إلى إزالة جميع مجموعات الخيارات من هذا المنتج والعودة إلى اختيار إعداد المتغيرات."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "فشل في إنشاء المتغيرات"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "يحدد مستوى المخزون الذي يعتبر عنده هذا الشكل نفد من المخزون. استخدام قيمة سالبة يمكّن دعم الطلب المسبق. يمكن تجاوزه بواسطة أشكال المنتج."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} قابل للاسترداد)"
 msgid "Identifier"
 msgstr "المعرف"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "اختيار معالج التنفيذ"
@@ -6173,6 +6186,11 @@ msgstr "تم إنشاء طريقة الشحن بنجاح"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "مجموعة عملاء جديدة"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "تسطير"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "إغلاق"
 

--- a/packages/dashboard/src/i18n/locales/bg.po
+++ b/packages/dashboard/src/i18n/locales/bg.po
@@ -82,6 +82,13 @@ msgstr "Апартамент, офис и др."
 msgid "No more items"
 msgstr "Няма повече елементи"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Редакция на връзката"
@@ -446,7 +453,7 @@ msgstr "Няма уиджети за добавяне"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Неизвестна грешка"
@@ -583,7 +590,7 @@ msgstr "Нова колекция"
 msgid "Insights"
 msgstr "Анализи"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1938,6 +1945,7 @@ msgstr "Вмъкни таблица {row} на {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2272,6 +2280,10 @@ msgstr "Премахни от зона"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Изберете от глобално наличните езици за този канал"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3239,6 +3251,10 @@ msgstr "Неуспешно премахване на клиент от груп�
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4667,6 +4683,10 @@ msgstr "е равно на"
 msgid "Source File"
 msgstr "Изходен файл"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5032,6 +5052,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Изисква се възстановяване на сума от {formattedDiff}. Изберете суми за плащане и въведете бележка, за да продължите."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5157,10 +5181,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Неуспешно създаване на варианти"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5905,7 +5928,7 @@ msgid "Failed to remove customers from group"
 msgstr "Неуспешно премахване на клиенти от групата"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6558,7 +6581,7 @@ msgid "Strikethrough"
 msgstr "Зачертан"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6822,6 +6845,10 @@ msgstr "Нов продавач"
 msgid "Search tax categories..."
 msgstr "Търсене на данъчни категории..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Редакция на изображението"
@@ -6849,6 +6876,10 @@ msgstr "Задава нивото на наличност, при което т�
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Създай опции за продукти"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/bg.po
+++ b/packages/dashboard/src/i18n/locales/bg.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Изберете елементи"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3065,6 +3065,10 @@ msgstr "Преизчисляване на доставката"
 msgid "Assets"
 msgstr "Медия"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Това ще премахне всички групи опции от този продукт и ще се върне към избора за настройка на варианти."
@@ -5153,6 +5157,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Неуспешно създаване на варианти"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Задава нивото на наличност, при което този вариант се счита за изчерпан. Използването на отрицателна стойност позволява поддръжка на резервни поръчки. Може да се замени от варианти на продукта."
@@ -5721,6 +5730,10 @@ msgstr "({maxRefundable} възстановими)"
 msgid "Identifier"
 msgstr "Идентификатор"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Избери обработчик на изпълнение"
@@ -6205,6 +6218,11 @@ msgstr "Методът на доставка е създаден успешно"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Нова клиентска група"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7044,6 +7062,7 @@ msgid "Underline"
 msgstr "Подчертан"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Затваряне"
 

--- a/packages/dashboard/src/i18n/locales/cs.po
+++ b/packages/dashboard/src/i18n/locales/cs.po
@@ -82,6 +82,13 @@ msgstr "Byt, apartmá apod."
 msgid "No more items"
 msgstr "Žádné další položky"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Upravit odkaz"
@@ -443,7 +450,7 @@ msgstr "Žádné widgety k přidání"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Neznámá chyba"
@@ -577,7 +584,7 @@ msgstr "Nová kolekce"
 msgid "Insights"
 msgstr "Přehledy"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "Vložit tabulku {row} × {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Odebrat ze zóny"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Vyberte z globálně dostupných jazyků pro tento kanál"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "Nepodařilo se odebrat zákazníka ze skupiny"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "je rovno"
 msgid "Source File"
 msgstr "Zdrojový soubor"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Je vyžadován refund ve výši {formattedDiff}. Vyberte částky plateb a zadejte poznámku pro pokračování."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Nepodařilo se vytvořit varianty"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Nepodařilo se odebrat zákazníky ze skupiny"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Přeškrtnuté"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "Nový prodejce"
 msgid "Search tax categories..."
 msgstr "Hledat daňové kategorie..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Upravit obrázek"
@@ -6817,6 +6844,10 @@ msgstr "Nastavuje skladovou úroveň, při které je tato varianta považována 
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Vytvořit volby produktu"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/cs.po
+++ b/packages/dashboard/src/i18n/locales/cs.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Vybrat položky"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Přepočítat dopravu"
 msgid "Assets"
 msgstr "Soubory"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Tímto se odeberou všechny skupiny voleb z tohoto produktu a vrátíte se k výběru nastavení variant."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Nepodařilo se vytvořit varianty"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Nastavuje skladovou úroveň, při které je tato varianta považována za vyprodanou. Použití záporné hodnoty umožňuje podporu předobjednávek. Může být přepsáno variantami produktu."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} vratitelných)"
 msgid "Identifier"
 msgstr "Identifikátor"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Vyberte zpracovatele vyřízení"
@@ -6173,6 +6186,11 @@ msgstr "Způsob dopravy byl úspěšně vytvořen"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Nová skupina zákazníků"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Podtržené"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Zavřít"
 

--- a/packages/dashboard/src/i18n/locales/de.po
+++ b/packages/dashboard/src/i18n/locales/de.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Artikel auswählen"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Versand neu berechnen"
 msgid "Assets"
 msgstr "Assets"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Dadurch werden alle Optionsgruppen von diesem Produkt entfernt und Sie kehren zur Varianteneinrichtung zurück."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Varianten konnten nicht erstellt werden"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Legt den Lagerbestand fest, bei dem diese Variante als nicht vorrätig gilt. Ein negativer Wert ermöglicht die Unterstützung von Nachbestellungen. Kann von Produktvarianten überschrieben werden."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} erstattungsfähig)"
 msgid "Identifier"
 msgstr "Bezeichner"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Fulfillment-Handler auswählen"
@@ -6173,6 +6186,11 @@ msgstr "Versandmethode erfolgreich erstellt"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Neue Kundengruppe"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Unterstrichen"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Schließen"
 

--- a/packages/dashboard/src/i18n/locales/de.po
+++ b/packages/dashboard/src/i18n/locales/de.po
@@ -82,6 +82,13 @@ msgstr "Wohnung, Suite, etc."
 msgid "No more items"
 msgstr "Keine weiteren Artikel"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Link bearbeiten"
@@ -443,7 +450,7 @@ msgstr "Keine Widgets zum Hinzufügen"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Unbekannter Fehler"
@@ -577,7 +584,7 @@ msgstr "Neue Sammlung"
 msgid "Insights"
 msgstr "Einblicke"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "{row} x {col} Tabelle einfügen"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Aus Zone entfernen"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Aus global verfügbaren Sprachen für diesen Kanal auswählen"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "Fehler beim Entfernen des Kunden aus der Gruppe"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "ist gleich"
 msgid "Source File"
 msgstr "Quelldatei"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Eine Rückerstattung von {formattedDiff} ist erforderlich. Wählen Sie Zahlungsbeträge und geben Sie eine Notiz ein, um fortzufahren."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Varianten konnten nicht erstellt werden"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Kunden konnten nicht aus der Gruppe entfernt werden"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Durchgestrichen"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "Neuer Verkäufer"
 msgid "Search tax categories..."
 msgstr "Steuerkategorien suchen..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Bild bearbeiten"
@@ -6817,6 +6844,10 @@ msgstr "Legt den Lagerbestand fest, bei dem diese Variante als nicht vorrätig g
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Produktoptionen erstellen"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/en.po
+++ b/packages/dashboard/src/i18n/locales/en.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Select items"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr "Uploading assets..."
+#~ msgid "Uploading assets..."
+#~ msgstr "Uploading assets..."
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Recalculate shipping"
 msgid "Assets"
 msgstr "Assets"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr "Uploading..."
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "This will remove all option groups from this product and return to the variant setup choice."
@@ -5130,6 +5134,11 @@ msgstr "Search tags..."
 msgid "Failed to create variants"
 msgstr "Failed to create variants"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr "Upload progress for {0} files"
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} refundable)"
 msgid "Identifier"
 msgstr "Identifier"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr "Uploading assets"
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Select a fulfillment handler"
@@ -6173,6 +6186,11 @@ msgstr "Successfully created shipping method"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "New Customer Group"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr "{doneCount} of {0} done"
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Underline"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Close"
 

--- a/packages/dashboard/src/i18n/locales/en.po
+++ b/packages/dashboard/src/i18n/locales/en.po
@@ -82,6 +82,13 @@ msgstr "Apartment, suite, etc."
 msgid "No more items"
 msgstr "No more items"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Edit link"
@@ -443,7 +450,7 @@ msgstr "No widgets to add"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Unknown error"
@@ -577,7 +584,7 @@ msgstr "New collection"
 msgid "Insights"
 msgstr "Insights"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr "Failed to upload assets"
 
@@ -1926,6 +1933,7 @@ msgstr "Insert {row} by {col} table"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Remove from zone"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Select from globally available languages for this channel"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr "Upload timed out"
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3220,6 +3232,10 @@ msgstr "Failed to remove customer from group"
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
 msgstr "1 property"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
+msgstr "Upload failed (HTTP {detail})"
 
 #: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
@@ -4647,6 +4663,10 @@ msgstr "is equal to"
 msgid "Source File"
 msgstr "Source File"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr "Upload failed — check your connection"
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr "Assign {entityType} to channels"
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr "File exceeds the server upload size limit"
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr "Search tags..."
 msgid "Failed to create variants"
 msgstr "Failed to create variants"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr "Upload progress for {0} files"
+#~ msgid "Upload progress for {0} files"
+#~ msgstr "Upload progress for {0} files"
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Failed to remove customers from group"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr "Failed to upload {0} assets"
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Strikethrough"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr "Uploaded {0} assets"
 
@@ -6790,6 +6813,10 @@ msgstr "New Seller"
 msgid "Search tax categories..."
 msgstr "Search tax categories..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr "Upload failed — invalid server response"
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Edit image"
@@ -6817,6 +6844,10 @@ msgstr "Sets the stock level at which this variant is considered to be out of st
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Create product options"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr "Upload cancelled"
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/es.po
+++ b/packages/dashboard/src/i18n/locales/es.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Seleccionar elementos"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Recalcular envío"
 msgid "Assets"
 msgstr "Recursos"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Esto eliminará todos los grupos de opciones de este producto y volverá a la selección de configuración de variantes."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Error al crear las variantes"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Establece el nivel de stock en el que esta variante se considera agotada. El uso de un valor negativo habilita el soporte de pedidos pendientes. Puede ser anulado por las variantes de producto."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} reembolsable)"
 msgid "Identifier"
 msgstr "Identificador"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Seleccionar un controlador de cumplimiento"
@@ -6173,6 +6186,11 @@ msgstr "Método de envío creado correctamente"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Nuevo Grupo de Clientes"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Subrayado"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Cerrar"
 

--- a/packages/dashboard/src/i18n/locales/es.po
+++ b/packages/dashboard/src/i18n/locales/es.po
@@ -82,6 +82,13 @@ msgstr "Apartamento, suite, etc."
 msgid "No more items"
 msgstr "No hay más elementos"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Editar enlace"
@@ -443,7 +450,7 @@ msgstr "No hay widgets para agregar"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Error desconocido"
@@ -577,7 +584,7 @@ msgstr "Nueva colección"
 msgid "Insights"
 msgstr "Información"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "Insertar tabla de {row} por {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Eliminar de la zona"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Seleccione entre los idiomas disponibles globalmente para este canal"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "Error al quitar cliente del grupo"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "es igual a"
 msgid "Source File"
 msgstr "Archivo de origen"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Se requiere un reembolso de {formattedDiff}. Seleccione los importes de pago e ingrese una nota para continuar."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Error al crear las variantes"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Error al eliminar clientes del grupo"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Tachado"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "Nuevo Vendedor"
 msgid "Search tax categories..."
 msgstr "Buscar categorías de impuestos..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Editar imagen"
@@ -6817,6 +6844,10 @@ msgstr "Establece el nivel de stock en el que esta variante se considera agotada
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Crear opciones de producto"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/fa.po
+++ b/packages/dashboard/src/i18n/locales/fa.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "انتخاب موارد"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "محاسبه مجدد هزینه ارسال"
 msgid "Assets"
 msgstr "فایل‌ها"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "این عمل تمام گروه‌های گزینه را از این محصول حذف کرده و به انتخاب تنظیم گونه بازمی‌گردد."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "ایجاد گونه‌ها ناموفق بود"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "سطح موجودی را تنظیم می‌کند که در آن این نوع اتمام موجودی در نظر گرفته می‌شود. استفاده از مقدار منفی پشتیبانی از پیش‌سفارش را فعال می‌کند. می‌تواند توسط انواع محصول لغو شود."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} قابل بازپرداخت)"
 msgid "Identifier"
 msgstr "شناسه"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "انتخاب مدیریت تحویل"
@@ -6173,6 +6186,11 @@ msgstr "روش ارسال با موفقیت ایجاد شد"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "گروه مشتری جدید"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "زیرخط"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "بستن"
 

--- a/packages/dashboard/src/i18n/locales/fa.po
+++ b/packages/dashboard/src/i18n/locales/fa.po
@@ -82,6 +82,13 @@ msgstr "آپارتمان، سوئیت و غیره"
 msgid "No more items"
 msgstr "موردی دیگر وجود ندارد"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "ویرایش پیوند"
@@ -443,7 +450,7 @@ msgstr "ابزارکی برای افزودن وجود ندارد"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "خطای ناشناخته"
@@ -577,7 +584,7 @@ msgstr "مجموعه جدید"
 msgid "Insights"
 msgstr "بینش‌ها"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "درج جدول {row} در {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "حذف از منطقه"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "از زبان‌های موجود سراسری برای این کانال انتخاب کنید"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "حذف مشتری از گروه ناموفق بود"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "مساوی است با"
 msgid "Source File"
 msgstr "فایل منبع"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "استرداد به مبلغ {formattedDiff} مورد نیاز است. مبالغ پرداخت را انتخاب کرده و یادداشتی برای ادامه وارد کنید."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "ایجاد گونه‌ها ناموفق بود"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "حذف مشتریان از گروه با خطا مواجه شد"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "خط‌خورده"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "فروشنده جدید"
 msgid "Search tax categories..."
 msgstr "جستجوی دسته‌های مالیاتی..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "ویرایش تصویر"
@@ -6817,6 +6844,10 @@ msgstr "سطح موجودی را تنظیم می‌کند که در آن این 
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "ایجاد گزینه‌های محصول"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/fr.po
+++ b/packages/dashboard/src/i18n/locales/fr.po
@@ -82,6 +82,13 @@ msgstr "Appartement, suite, etc."
 msgid "No more items"
 msgstr "Aucun autre élément"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Modifier le lien"
@@ -443,7 +450,7 @@ msgstr "Aucun widget à ajouter"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Erreur inconnue"
@@ -577,7 +584,7 @@ msgstr "Nouvelle collection"
 msgid "Insights"
 msgstr "Aperçus"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "Insérer un tableau de {row} par {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Supprimer de la zone"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Sélectionnez parmi les langues globalement disponibles pour ce canal"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "Échec de la suppression du client du groupe"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "est égal à"
 msgid "Source File"
 msgstr "Fichier source"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Un remboursement de {formattedDiff} est requis. Sélectionnez les montants de paiement et saisissez une note pour continuer."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Échec de la création des variantes"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Échec de la suppression des clients du groupe"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Barré"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "Nouveau vendeur"
 msgid "Search tax categories..."
 msgstr "Rechercher des catégories de taxe..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Modifier l'image"
@@ -6817,6 +6844,10 @@ msgstr "Définit le niveau de stock à partir duquel cette variante est considé
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Créer des options de produit"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/fr.po
+++ b/packages/dashboard/src/i18n/locales/fr.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Sélectionner des éléments"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Recalculer les frais de livraison"
 msgid "Assets"
 msgstr "Ressources"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Cela supprimera tous les groupes d'options de ce produit et reviendra au choix de configuration des variantes."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Échec de la création des variantes"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Définit le niveau de stock à partir duquel cette variante est considérée comme en rupture de stock. L'utilisation d'une valeur négative active le support de commande en attente. Peut être remplacé par les variantes de produit."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} remboursable)"
 msgid "Identifier"
 msgstr "Identifiant"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Sélectionner un gestionnaire de traitement"
@@ -6173,6 +6186,11 @@ msgstr "Mode de livraison créé avec succès"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Nouveau groupe de clients"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Souligné"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Fermer"
 

--- a/packages/dashboard/src/i18n/locales/he.po
+++ b/packages/dashboard/src/i18n/locales/he.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "בחר פריטים"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "חישוב מחדש של המשלוח"
 msgid "Assets"
 msgstr "קבצים"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "פעולה זו תסיר את כל קבוצות האפשרויות ממוצר זה ותחזור לבחירת הגדרת הגרסאות."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "יצירת הגרסאות נכשלה"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "מגדיר את רמת המלאי שבה גרסה זו נחשבת אזלת מלאי. שימוש בערך שלילי מאפשר תמיכה בהזמנה מראש. ניתן לעקוף על ידי גרסאות מוצר."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} ניתן להחזר)"
 msgid "Identifier"
 msgstr "מזהה"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "בחר מטפל במשלוח"
@@ -6173,6 +6186,11 @@ msgstr "שיטת משלוח נוצרה בהצלחה"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "קבוצת לקוחות חדשה"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "קו תחתון"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "סגירה"
 

--- a/packages/dashboard/src/i18n/locales/he.po
+++ b/packages/dashboard/src/i18n/locales/he.po
@@ -82,6 +82,13 @@ msgstr "דירה, יחידה וכו'"
 msgid "No more items"
 msgstr "אין פריטים נוספים"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "ערוך קישור"
@@ -443,7 +450,7 @@ msgstr "אין ווידג'טים להוספה"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "שגיאה לא ידועה"
@@ -577,7 +584,7 @@ msgstr "אוסף חדש"
 msgid "Insights"
 msgstr "תובנות"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "הוסף טבלה של {row} על {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "הסר מהאזור"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "בחר מתוך השפות הזמינות גלובלית עבור ערוץ זה"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "הסרת הלקוח מהקבוצה נכשלה"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "שווה ל"
 msgid "Source File"
 msgstr "קובץ מקור"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "נדרש החזר כספי של {formattedDiff}. בחר סכומי תשלום והזן הערה כדי להמשיך."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "יצירת הגרסאות נכשלה"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "הסרת לקוחות מהקבוצה נכשלה"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "קו חוצה"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "מוכר חדש"
 msgid "Search tax categories..."
 msgstr "חיפוש קטגוריות מס..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "ערוך תמונה"
@@ -6817,6 +6844,10 @@ msgstr "מגדיר את רמת המלאי שבה גרסה זו נחשבת אזל
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "צור אפשרויות מוצר"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/hr.po
+++ b/packages/dashboard/src/i18n/locales/hr.po
@@ -82,6 +82,13 @@ msgstr "Stan, apartman itd."
 msgid "No more items"
 msgstr "Nema više stavki"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Uredi poveznicu"
@@ -443,7 +450,7 @@ msgstr "Nema widgeta za dodavanje"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Nepoznata greška"
@@ -577,7 +584,7 @@ msgstr "Nova kolekcija"
 msgid "Insights"
 msgstr "Uvidi"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "Umetni tablicu {row} × {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Ukloni iz zone"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Odaberite iz globalno dostupnih jezika za ovaj kanal"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "Uklanjanje kupca iz grupe nije uspjelo"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "jednako je"
 msgid "Source File"
 msgstr "Izvorna datoteka"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Potreban je povrat novca u iznosu {formattedDiff}. Odaberite iznose plaćanja i unesite bilješku za nastavak."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Stvaranje varijanti nije uspjelo"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Nije uspjelo uklanjanje kupaca iz grupe"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Precrtano"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "Novi prodavač"
 msgid "Search tax categories..."
 msgstr "Pretraži porezne kategorije..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Uredi sliku"
@@ -6817,6 +6844,10 @@ msgstr "Postavlja razinu zaliha pri kojoj se ova varijanta smatra rasprodanom. K
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Stvori opcije proizvoda"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/hr.po
+++ b/packages/dashboard/src/i18n/locales/hr.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Odaberi stavke"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Preračunaj dostavu"
 msgid "Assets"
 msgstr "Datoteke"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Ovo će ukloniti sve grupe opcija s ovog proizvoda i vratiti se na izbor postavljanja varijanti."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Stvaranje varijanti nije uspjelo"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Postavlja razinu zaliha pri kojoj se ova varijanta smatra rasprodanom. Korištenje negativne vrijednosti omogućuje podršku za prednarudžbe. Može se nadjačati varijantama proizvoda."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} povratno)"
 msgid "Identifier"
 msgstr "Identifikator"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Odaberite obrađivač isporuke"
@@ -6173,6 +6186,11 @@ msgstr "Način dostave uspješno stvoren"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Nova grupa kupaca"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Podcrtano"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Zatvori"
 

--- a/packages/dashboard/src/i18n/locales/hu.po
+++ b/packages/dashboard/src/i18n/locales/hu.po
@@ -82,6 +82,13 @@ msgstr "Emelet, ajtó stb."
 msgid "No more items"
 msgstr "Nincs több elem"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Hivatkozás szerkesztése"
@@ -443,7 +450,7 @@ msgstr "Nincs hozzáadható widget"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Ismeretlen hiba"
@@ -577,7 +584,7 @@ msgstr "Új gyűjtemény"
 msgid "Insights"
 msgstr "Elemzések"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "{row} x {col} méretű táblázat beszúrása"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2251,6 +2259,10 @@ msgstr "Eltávolítás a zónából"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Válasszon a csatorna számára globálisan elérhető nyelvek közül"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3209,6 +3221,10 @@ msgstr "Vásárló eltávolítása a csoportból sikertelen"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4634,6 +4650,10 @@ msgstr "egyenlő"
 msgid "Source File"
 msgstr "Forrásfájl"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -4996,6 +5016,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "{formattedDiff} összegű visszatérítés szükséges. A folytatáshoz válassza ki a fizetési összegeket és adjon meg egy megjegyzést."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5121,10 +5145,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Nem sikerült létrehozni a variánsokat"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5863,7 +5886,7 @@ msgid "Failed to remove customers from group"
 msgstr "Nem sikerült eltávolítani az ügyfeleket a csoportból"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6513,7 +6536,7 @@ msgid "Strikethrough"
 msgstr "Áthúzott"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6777,6 +6800,10 @@ msgstr "Új eladó"
 msgid "Search tax categories..."
 msgstr "Adókategóriák keresése..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Kép szerkesztése"
@@ -6804,6 +6831,10 @@ msgstr "Beállítja azt a készletszintet, amelynél ez a termékváltozat kész
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Termékopciók létrehozása"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/hu.po
+++ b/packages/dashboard/src/i18n/locales/hu.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Válasszon elemeket"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3038,6 +3038,10 @@ msgstr "Szállítási díj újraszámítása"
 msgid "Assets"
 msgstr "Média"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Ez eltávolítja az összes opciócsoportot ebből a termékből és visszatér a variáns beállítási lehetőséghez."
@@ -5117,6 +5121,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Nem sikerült létrehozni a variánsokat"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Beállítja azt a készletszintet, amelynél ez a termékváltozat készleten kívülinek minősül. Negatív érték használata lehetővé teszi az utórendelés támogatását. Felülírható termékváltozatok által."
@@ -5679,6 +5688,10 @@ msgstr "({maxRefundable} visszatéríthető)"
 msgid "Identifier"
 msgstr "Azonosító"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Válasszon teljesítéskezelőt"
@@ -6160,6 +6173,11 @@ msgstr "A szállítási mód sikeresen létrehozva"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Új vásárlói csoport"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -6990,6 +7008,7 @@ msgid "Underline"
 msgstr "Aláhúzott"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Bezárás"
 

--- a/packages/dashboard/src/i18n/locales/it.po
+++ b/packages/dashboard/src/i18n/locales/it.po
@@ -82,6 +82,13 @@ msgstr "Appartamento, suite, ecc."
 msgid "No more items"
 msgstr "Nessun altro articolo"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Modifica link"
@@ -443,7 +450,7 @@ msgstr "Nessun widget da aggiungere"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Errore sconosciuto"
@@ -577,7 +584,7 @@ msgstr "Nuova collezione"
 msgid "Insights"
 msgstr "Approfondimenti"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "Inserisci tabella {row} per {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Rimuovi dalla zona"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Seleziona tra le lingue disponibili globalmente per questo canale"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "Impossibile rimuovere cliente dal gruppo"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "è uguale a"
 msgid "Source File"
 msgstr "File sorgente"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "È richiesto un rimborso di {formattedDiff}. Seleziona gli importi dei pagamenti e inserisci una nota per procedere."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Impossibile creare le varianti"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Impossibile rimuovere i clienti dal gruppo"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Barrato"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "Nuovo venditore"
 msgid "Search tax categories..."
 msgstr "Cerca categorie fiscali..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Modifica immagine"
@@ -6817,6 +6844,10 @@ msgstr "Imposta il livello di scorta al quale questa variante è considerata esa
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Crea opzioni prodotto"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/it.po
+++ b/packages/dashboard/src/i18n/locales/it.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Seleziona articoli"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Ricalcola spedizione"
 msgid "Assets"
 msgstr "Risorse"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Questa azione rimuoverà tutti i gruppi di opzioni da questo prodotto e tornerai alla scelta di configurazione delle varianti."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Impossibile creare le varianti"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Imposta il livello di scorta al quale questa variante è considerata esaurita. L'utilizzo di un valore negativo abilita il supporto per ordini arretrati. Può essere sostituito dalle varianti prodotto."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} rimborsabile)"
 msgid "Identifier"
 msgstr "Identificativo"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Seleziona un gestore di evasione"
@@ -6173,6 +6186,11 @@ msgstr "Metodo di spedizione creato con successo"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Nuovo gruppo clienti"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Sottolineato"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Chiudi"
 

--- a/packages/dashboard/src/i18n/locales/ja.po
+++ b/packages/dashboard/src/i18n/locales/ja.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "アイテムを選択"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "送料を再計算"
 msgid "Assets"
 msgstr "アセット"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "この商品からすべてのオプショングループが削除され、バリエーション設定の選択に戻ります。"
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "バリエーションの作成に失敗しました"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "このバリエーションが在庫切れと見なされる在庫レベルを設定します。負の値を使用すると、バックオーダーサポートが有効になります。商品バリエーションで上書きできます。"
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} 返金可能)"
 msgid "Identifier"
 msgstr "識別子"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "フルフィルメントハンドラーを選択"
@@ -6173,6 +6186,11 @@ msgstr "配送方法を正常に作成しました"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "新しい顧客グループ"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "下線"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "閉じる"
 

--- a/packages/dashboard/src/i18n/locales/ja.po
+++ b/packages/dashboard/src/i18n/locales/ja.po
@@ -82,6 +82,13 @@ msgstr "マンション、スイートなど"
 msgid "No more items"
 msgstr "これ以上のアイテムはありません"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "リンクを編集"
@@ -443,7 +450,7 @@ msgstr "追加できるウィジェットがありません"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "不明なエラー"
@@ -577,7 +584,7 @@ msgstr "新しいコレクション"
 msgid "Insights"
 msgstr "インサイト"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "{row}×{col}の表を挿入"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "ゾーンから削除"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "このチャネルでグローバルに利用可能な言語から選択"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "グループからの顧客の削除に失敗しました"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "と等しい"
 msgid "Source File"
 msgstr "ソースファイル"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr "{entityType}をチャネルに割り当て"
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "{formattedDiff} の返金が必要です。支払い金額を選択し、メモを入力して続行してください。"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "バリエーションの作成に失敗しました"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "グループからの顧客の削除に失敗しました"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "取り消し線"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "新しい販売者"
 msgid "Search tax categories..."
 msgstr "税カテゴリを検索..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "画像を編集"
@@ -6817,6 +6844,10 @@ msgstr "このバリエーションが在庫切れと見なされる在庫レベ
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "商品オプションを作成"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/ko.po
+++ b/packages/dashboard/src/i18n/locales/ko.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "항목 선택"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3030,6 +3030,10 @@ msgstr "배송비 재계산"
 msgid "Assets"
 msgstr "에셋"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "이 상품에서 모든 옵션 그룹이 제거되고 변형 설정 선택으로 돌아갑니다."
@@ -5089,6 +5093,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "변형 생성 실패"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "이 변형이 품절로 간주되는 재고 수준을 설정합니다. 음수 값을 사용하면 예약 주문이 지원됩니다. 상품 변형으로 재정의할 수 있습니다."
@@ -5651,6 +5660,10 @@ msgstr "({maxRefundable} 환불 가능)"
 msgid "Identifier"
 msgstr "식별자"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "이행 처리기 선택"
@@ -6109,6 +6122,11 @@ msgstr "배송 방법이 생성되었습니다"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "새 고객 그룹"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -6931,6 +6949,7 @@ msgid "Underline"
 msgstr ""
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "닫기"
 

--- a/packages/dashboard/src/i18n/locales/ko.po
+++ b/packages/dashboard/src/i18n/locales/ko.po
@@ -82,6 +82,13 @@ msgstr "아파트, 스위트 등"
 msgid "No more items"
 msgstr "더 이상 항목 없음"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "링크 편집"
@@ -439,7 +446,7 @@ msgstr ""
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "알 수 없는 오류"
@@ -565,7 +572,7 @@ msgstr "새 컬렉션"
 msgid "Insights"
 msgstr "인사이트"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1918,6 +1925,7 @@ msgstr ""
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2243,6 +2251,10 @@ msgstr "지역에서 제거"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "이 채널에서 전역적으로 사용 가능한 언어 중 선택"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3201,6 +3213,10 @@ msgstr "그룹에서 고객 제거 실패"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4610,6 +4626,10 @@ msgstr "같음"
 msgid "Source File"
 msgstr "소스 파일"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -4972,6 +4992,10 @@ msgstr "{entityType}을(를) 채널에 할당"
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "{formattedDiff}의 환불이 필요합니다. 결제 금액을 선택하고 메모를 입력하여 계속하세요."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5093,10 +5117,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "변형 생성 실패"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5823,7 +5846,7 @@ msgid "Failed to remove customers from group"
 msgstr "그룹에서 고객을 제거하지 못했습니다"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6450,7 +6473,7 @@ msgid "Strikethrough"
 msgstr ""
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6714,6 +6737,10 @@ msgstr "새 판매자"
 msgid "Search tax categories..."
 msgstr ""
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "이미지 편집"
@@ -6741,6 +6768,10 @@ msgstr "이 변형이 품절로 간주되는 재고 수준을 설정합니다. �
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "상품 옵션 생성"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/nb.po
+++ b/packages/dashboard/src/i18n/locales/nb.po
@@ -82,6 +82,13 @@ msgstr "Leilighet, suite, etc."
 msgid "No more items"
 msgstr "Ingen flere varer"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Rediger lenke"
@@ -443,7 +450,7 @@ msgstr "Ingen widgeter å legge til"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Ukjent feil"
@@ -577,7 +584,7 @@ msgstr "Ny samling"
 msgid "Insights"
 msgstr "Innsikt"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "Sett inn {row} x {col}-tabell"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Fjern fra sone"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Velg fra globalt tilgjengelige språk for denne kanalen"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "Kunne ikke fjerne kunde fra gruppe"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "er lik"
 msgid "Source File"
 msgstr "Kildefil"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "En refusjon på {formattedDiff} er nødvendig. Velg betalingsbeløp og skriv inn en merknad for å fortsette."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Kunne ikke opprette variantene"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Kunne ikke fjerne kunder fra gruppen"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Gjennomstreking"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "Ny selger"
 msgid "Search tax categories..."
 msgstr "Søk etter skattekategorier..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Rediger bilde"
@@ -6817,6 +6844,10 @@ msgstr "Setter lagernivået der denne varianten anses som utsolgt. Bruk av en ne
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Opprett produktopsjoner"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/nb.po
+++ b/packages/dashboard/src/i18n/locales/nb.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Velg varer"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Beregn frakt på nytt"
 msgid "Assets"
 msgstr "Ressurser"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Dette vil fjerne alle opsjonsgrupper fra dette produktet og returnere til variantoppsettsvalget."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Kunne ikke opprette variantene"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Setter lagernivået der denne varianten anses som utsolgt. Bruk av en negativ verdi aktiverer restordrestøtte. Kan overstyres av produktvarianter."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} refunderbart)"
 msgid "Identifier"
 msgstr "Identifikator"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Velg en håndterer for ordreoppfyllelse"
@@ -6173,6 +6186,11 @@ msgstr "Fraktmetode opprettet"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Ny kundegruppe"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Understreking"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Lukk"
 

--- a/packages/dashboard/src/i18n/locales/ne.po
+++ b/packages/dashboard/src/i18n/locales/ne.po
@@ -82,6 +82,13 @@ msgstr "अपार्टमेन्ट, सुइट, आदि"
 msgid "No more items"
 msgstr "थप वस्तुहरू छैनन्"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "लिङ्क सम्पादन गर्नुहोस्"
@@ -443,7 +450,7 @@ msgstr "थप्नका लागि कुनै विजेटहरू �
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "अज्ञात त्रुटि"
@@ -577,7 +584,7 @@ msgstr "नयाँ संग्रह"
 msgid "Insights"
 msgstr "अन्तर्दृष्टि"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "{row} x {col} तालिका सम्मिलित गर्न�
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "क्षेत्रबाट हटाउनुहोस्"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "यस च्यानलको लागि विश्वव्यापी रूपमा उपलब्ध भाषाहरूबाट चयन गर्नुहोस्"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "समूहबाट ग्राहक हटाउन असफल"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "बराबर छ"
 msgid "Source File"
 msgstr "स्रोत फाइल"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "{formattedDiff} को फिर्ता आवश्यक छ। भुक्तानी रकम चयन गर्नुहोस् र जारी राख्न टिप्पणी प्रविष्ट गर्नुहोस्।"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "भेरियन्टहरू सिर्जना गर्न असफल भयो"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "समूहबाट ग्राहकहरू हटाउन असफल भयो"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "स्ट्राइकथ्रु"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "नयाँ विक्रेता"
 msgid "Search tax categories..."
 msgstr "कर वर्गहरू खोज्नुहोस्..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "छवि सम्पादन गर्नुहोस्"
@@ -6817,6 +6844,10 @@ msgstr "यो भेरियन्ट स्टक बाहिर मान�
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "उत्पादन विकल्पहरू सिर्जना गर्नुहोस्"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/ne.po
+++ b/packages/dashboard/src/i18n/locales/ne.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "वस्तुहरू चयन गर्नुहोस्"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "ढुवानी पुन: गणना गर्नुहोस्"
 msgid "Assets"
 msgstr "सम्पत्तिहरू"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "यसले यो उत्पादनबाट सबै विकल्प समूहहरू हटाउनेछ र भेरियन्ट सेटअप छनोटमा फर्काउनेछ।"
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "भेरियन्टहरू सिर्जना गर्न असफल भयो"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "यो भेरियन्ट स्टक बाहिर मानिने स्टक स्तर सेट गर्दछ। नकारात्मक मान प्रयोग गर्दा ब्याकअर्डर समर्थन सक्षम हुन्छ। उत्पादन भेरियन्टहरूद्वारा ओभरराइड गर्न सकिन्छ।"
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} फिर्ता गर्न मिल्ने)"
 msgid "Identifier"
 msgstr "पहिचानकर्ता"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "फुलफिलमेन्ट ह्यान्डलर चयन गर्नुहोस्"
@@ -6173,6 +6186,11 @@ msgstr "ढुवानी विधि सफलतापूर्वक सि
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "नयाँ ग्राहक समूह"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "अन्डरलाइन"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "बन्द गर्नुहोस्"
 

--- a/packages/dashboard/src/i18n/locales/nl.po
+++ b/packages/dashboard/src/i18n/locales/nl.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Selecteer items"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3042,6 +3042,10 @@ msgstr "Verzendkosten herberekenen"
 msgid "Assets"
 msgstr "Middelen"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Dit verwijdert alle optiegroepen van dit product en keert terug naar de variantkeuze."
@@ -5121,6 +5125,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Aanmaken van varianten mislukt"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Stelt het voorraadniveau in waarbij deze variant als uitverkocht wordt beschouwd. Het gebruik van een negatieve waarde schakelt ondersteuning voor nabestellingen in. Kan worden overschreven door productvarianten."
@@ -5687,6 +5696,10 @@ msgstr "({maxRefundable} restitueerbaar)"
 msgid "Identifier"
 msgstr "Identificatie"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Selecteer een fulfilmenthandler"
@@ -6168,6 +6181,11 @@ msgstr "Verzendmethode succesvol aangemaakt"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Nieuwe klantengroep"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7002,6 +7020,7 @@ msgid "Underline"
 msgstr "Onderstrepen"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Sluiten"
 

--- a/packages/dashboard/src/i18n/locales/nl.po
+++ b/packages/dashboard/src/i18n/locales/nl.po
@@ -82,6 +82,13 @@ msgstr "Appartement, suite, etc."
 msgid "No more items"
 msgstr "Geen items meer"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Link bewerken"
@@ -443,7 +450,7 @@ msgstr "Geen widgets om toe te voegen"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Onbekende fout"
@@ -577,7 +584,7 @@ msgstr "Nieuwe collectie"
 msgid "Insights"
 msgstr "Inzichten"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1930,6 +1937,7 @@ msgstr "Tabel van {row} bij {col} invoegen"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2255,6 +2263,10 @@ msgstr "Uit zone verwijderen"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Selecteer uit globaal beschikbare talen voor dit kanaal"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3213,6 +3225,10 @@ msgstr "Klant uit groep verwijderen mislukt"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4638,6 +4654,10 @@ msgstr "is gelijk aan"
 msgid "Source File"
 msgstr "Bronbestand"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5000,6 +5020,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Een terugbetaling van {formattedDiff} is vereist. Selecteer betalingsbedragen en voer een notitie in om door te gaan."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5125,10 +5149,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Aanmaken van varianten mislukt"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5871,7 +5894,7 @@ msgid "Failed to remove customers from group"
 msgstr "Klanten konden niet uit de groep worden verwijderd"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6521,7 +6544,7 @@ msgid "Strikethrough"
 msgstr "Doorhalen"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6785,6 +6808,10 @@ msgstr "Nieuwe verkoper"
 msgid "Search tax categories..."
 msgstr "Belastingcategorieën zoeken..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Afbeelding bewerken"
@@ -6812,6 +6839,10 @@ msgstr "Stelt het voorraadniveau in waarbij deze variant als uitverkocht wordt b
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Productopties aanmaken"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/pl.po
+++ b/packages/dashboard/src/i18n/locales/pl.po
@@ -82,6 +82,13 @@ msgstr "Mieszkanie, apartament itp."
 msgid "No more items"
 msgstr "Nie ma więcej pozycji"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Edytuj link"
@@ -443,7 +450,7 @@ msgstr "Brak widgetów do dodania"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Nieznany błąd"
@@ -577,7 +584,7 @@ msgstr "Nowa kolekcja"
 msgid "Insights"
 msgstr "Statystyki"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "Wstaw tabelę {row} × {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Usuń ze strefy"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Wybierz spośród języków dostępnych globalnie dla tego kanału"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "Nie udało się usunąć klienta z grupy"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "jest równe"
 msgid "Source File"
 msgstr "Plik źródłowy"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Wymagany jest zwrot w wysokości {formattedDiff}. Wybierz kwoty płatności i wprowadź notatkę, aby kontynuować."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Nie udało się utworzyć wariantów"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Nie udało się usunąć klientów z grupy"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Przekreślenie"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "Nowy sprzedawca"
 msgid "Search tax categories..."
 msgstr "Szukaj kategorii podatkowych..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Edytuj obraz"
@@ -6817,6 +6844,10 @@ msgstr "Ustawia poziom magazynowy, przy którym ten wariant jest uważany za nie
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Utwórz opcje produktu"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/pl.po
+++ b/packages/dashboard/src/i18n/locales/pl.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Wybierz pozycje"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Przelicz wysyłkę"
 msgid "Assets"
 msgstr "Zasoby"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Spowoduje to usunięcie wszystkich grup opcji z tego produktu i powrót do wyboru konfiguracji wariantów."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Nie udało się utworzyć wariantów"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Ustawia poziom magazynowy, przy którym ten wariant jest uważany za niedostępny. Użycie wartości ujemnej umożliwia obsługę zamówień wstecznych. Może zostać zastąpiony przez warianty produktu."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} do zwrotu)"
 msgid "Identifier"
 msgstr "Identyfikator"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Wybierz moduł obsługi realizacji"
@@ -6173,6 +6186,11 @@ msgstr "Pomyślnie utworzono metodę wysyłki"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Nowa grupa klientów"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Podkreślenie"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Zamknij"
 

--- a/packages/dashboard/src/i18n/locales/pt_BR.po
+++ b/packages/dashboard/src/i18n/locales/pt_BR.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Selecionar itens"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Recalcular frete"
 msgid "Assets"
 msgstr "Recursos"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Isso removera todos os grupos de opcoes deste produto e retornara a escolha de configuracao de variantes."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Falha ao criar variantes"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Define o nível de estoque no qual esta variante é considerada fora de estoque. Usar um valor negativo habilita suporte a pedidos em atraso. Pode ser substituído por variantes de produto."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} reembolsável)"
 msgid "Identifier"
 msgstr "Identificador"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Selecionar um manipulador de atendimento"
@@ -6173,6 +6186,11 @@ msgstr "Método de envio criado com sucesso"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Novo grupo de clientes"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Sublinhado"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Fechar"
 

--- a/packages/dashboard/src/i18n/locales/pt_BR.po
+++ b/packages/dashboard/src/i18n/locales/pt_BR.po
@@ -82,6 +82,13 @@ msgstr "Apartamento, suíte, etc."
 msgid "No more items"
 msgstr "Não há mais itens"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Editar link"
@@ -443,7 +450,7 @@ msgstr "Nenhum widget para adicionar"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Erro desconhecido"
@@ -577,7 +584,7 @@ msgstr "Nova coleção"
 msgid "Insights"
 msgstr "Insights"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "Inserir tabela de {row} por {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Remover da zona"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Selecione entre os idiomas disponíveis globalmente para este canal"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "Falha ao remover cliente do grupo"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "é igual a"
 msgid "Source File"
 msgstr "Arquivo de origem"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Um reembolso de {formattedDiff} é necessário. Selecione os valores de pagamento e insira uma nota para prosseguir."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Falha ao criar variantes"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Falha ao remover clientes do grupo"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Tachado"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "Novo vendedor"
 msgid "Search tax categories..."
 msgstr "Pesquisar categorias fiscais..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Editar imagem"
@@ -6817,6 +6844,10 @@ msgstr "Define o nível de estoque no qual esta variante é considerada fora de 
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Criar opções de produto"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/pt_PT.po
+++ b/packages/dashboard/src/i18n/locales/pt_PT.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Selecionar itens"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Recalcular envio"
 msgid "Assets"
 msgstr "Recursos"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Isto removera todos os grupos de opcoes deste produto e regressara a escolha de configuracao de variantes."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Falha ao criar variantes"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Define o nível de stock no qual esta variante é considerada esgotada. Usar um valor negativo ativa suporte a encomendas pendentes. Pode ser substituído por variantes de produto."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} reembolsável)"
 msgid "Identifier"
 msgstr "Identificador"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Selecionar um manipulador de atendimento"
@@ -6173,6 +6186,11 @@ msgstr "Método de envio criado com sucesso"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Novo grupo de clientes"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Sublinhado"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Fechar"
 

--- a/packages/dashboard/src/i18n/locales/pt_PT.po
+++ b/packages/dashboard/src/i18n/locales/pt_PT.po
@@ -82,6 +82,13 @@ msgstr "Apartamento, suite, etc."
 msgid "No more items"
 msgstr "Não há mais itens"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Editar ligação"
@@ -443,7 +450,7 @@ msgstr "Nenhum widget para adicionar"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Erro desconhecido"
@@ -577,7 +584,7 @@ msgstr "Nova coleção"
 msgid "Insights"
 msgstr "Informações"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "Inserir tabela de {row} por {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Remover da zona"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Selecione entre os idiomas disponíveis globalmente para este canal"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "Falha ao remover cliente do grupo"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "é igual a"
 msgid "Source File"
 msgstr "Ficheiro de origem"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "É necessário um reembolso de {formattedDiff}. Selecione os valores de pagamento e insira uma nota para prosseguir."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Falha ao criar variantes"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Falha ao remover clientes do grupo"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Rasurado"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "Novo vendedor"
 msgid "Search tax categories..."
 msgstr "Pesquisar categorias fiscais..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Editar imagem"
@@ -6817,6 +6844,10 @@ msgstr "Define o nível de stock no qual esta variante é considerada esgotada. 
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Criar opções de produto"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/ro.po
+++ b/packages/dashboard/src/i18n/locales/ro.po
@@ -82,6 +82,13 @@ msgstr "Apartament, bloc, etc."
 msgid "No more items"
 msgstr "Nu mai sunt elemente"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Editează link"
@@ -419,7 +426,7 @@ msgstr "Niciun widget de adăugat"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Eroare necunoscută"
@@ -549,7 +556,7 @@ msgstr "Colecție nouă"
 msgid "Insights"
 msgstr "Perspective"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1873,6 +1880,7 @@ msgstr "Inserează tabel de {row} pe {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2190,6 +2198,10 @@ msgstr "Elimină din zonă"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Selectează din limbile disponibile global pentru acest canal"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3135,6 +3147,10 @@ msgstr "Nu s-a putut elimina clientul din grup"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4528,6 +4544,10 @@ msgstr "este egal cu"
 msgid "Source File"
 msgstr "Fișier sursă"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
@@ -4877,6 +4897,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Este necesară o rambursare de {formattedDiff}. Selectează sumele de plată și introdu o notă pentru a continua."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -4998,10 +5022,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Nu s-au putut crea variantele"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5712,7 +5735,7 @@ msgid "Failed to remove customers from group"
 msgstr "Eliminarea clienților din grup a eșuat"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6334,7 +6357,7 @@ msgid "Strikethrough"
 msgstr "Tăiat"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6594,6 +6617,10 @@ msgstr "Vânzător Nou"
 msgid "Search tax categories..."
 msgstr "Caută categorii de taxă..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Editează imagine"
@@ -6617,6 +6644,10 @@ msgstr "mai mare sau egal"
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Setează nivelul stocului la care această variantă este considerată a fi în afara stocului. Folosirea unei valori negative activează suportul pentru comenzi în așteptare."
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/ro.po
+++ b/packages/dashboard/src/i18n/locales/ro.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Selectează elementele"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -2969,6 +2969,10 @@ msgstr "Recalculează livrarea"
 msgid "Assets"
 msgstr "Resurse"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Se vor elimina toate grupurile de opțiuni de pe acest produs și veți reveni la alegerea configurării variantelor."
@@ -4994,6 +4998,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Nu s-au putut crea variantele"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Setează nivelul de stoc la care o variantă este considerată a fi în afara stocului. Folosirea unei valori negative activează suportul pentru precomandă. Poate fi suprascris de variantele de produs."
@@ -5540,6 +5549,10 @@ msgstr "({maxRefundable} rambursabil)"
 msgid "Identifier"
 msgstr "Identificator"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Selectează un gestionar de expediere"
@@ -5989,6 +6002,11 @@ msgstr "Metoda de livrare a fost creată cu succes"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Grup Client Nou"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -6803,6 +6821,7 @@ msgid "Underline"
 msgstr "Subliniat"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Închide"
 

--- a/packages/dashboard/src/i18n/locales/ru.po
+++ b/packages/dashboard/src/i18n/locales/ru.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Выбрать элементы"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Пересчитать доставку"
 msgid "Assets"
 msgstr "Ресурсы"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Это удалит все группы опций из этого товара и вернёт к выбору настройки вариантов."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Не удалось создать варианты"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Устанавливает уровень запасов, при котором этот вариант считается отсутствующим на складе. Использование отрицательного значения включает поддержку предзаказов. Может быть переопределено вариантами товара."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} к возврату)"
 msgid "Identifier"
 msgstr "Идентификатор"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Выберите обработчик выполнения заказа"
@@ -6173,6 +6186,11 @@ msgstr "Способ доставки успешно создан"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Новая группа клиентов"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Подчёркнутый"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Закрыть"
 

--- a/packages/dashboard/src/i18n/locales/ru.po
+++ b/packages/dashboard/src/i18n/locales/ru.po
@@ -82,6 +82,13 @@ msgstr "Квартира, офис и т.д."
 msgid "No more items"
 msgstr "Больше нет элементов"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Редактировать ссылку"
@@ -443,7 +450,7 @@ msgstr "Нет виджетов для добавления"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Неизвестная ошибка"
@@ -577,7 +584,7 @@ msgstr "Новая коллекция"
 msgid "Insights"
 msgstr "Аналитика"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "Вставить таблицу {row} на {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Удалить из зоны"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Выберите из глобально доступных языков для этого канала"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "Не удалось удалить клиента из группы"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "равно"
 msgid "Source File"
 msgstr "Исходный файл"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Требуется возврат в размере {formattedDiff}. Выберите суммы платежей и введите примечание для продолжения."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Не удалось создать варианты"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Не удалось удалить клиентов из группы"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Зачёркнутый"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "Новый продавец"
 msgid "Search tax categories..."
 msgstr "Поиск налоговых категорий..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Редактировать изображение"
@@ -6817,6 +6844,10 @@ msgstr "Устанавливает уровень запасов, при кот�
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Создать опции товара"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/sv.po
+++ b/packages/dashboard/src/i18n/locales/sv.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Välj artiklar"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Beräkna om frakt"
 msgid "Assets"
 msgstr "Tillgångar"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Detta tar bort alla alternativgrupper från produkten och återgår till variantval."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Misslyckades med att skapa varianter"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Anger lagernivån vid vilken denna variant anses vara slut i lager. Användning av negativt värde aktiverar restorderstöd. Kan åsidosättas av produktvarianter."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} återbetalningsbart)"
 msgid "Identifier"
 msgstr "Identifierare"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Välj en fulfillment-hanterare"
@@ -6173,6 +6186,11 @@ msgstr "Fraktmetod skapades"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Ny kundgrupp"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Understruken"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Stäng"
 

--- a/packages/dashboard/src/i18n/locales/sv.po
+++ b/packages/dashboard/src/i18n/locales/sv.po
@@ -82,6 +82,13 @@ msgstr "Lägenhet, svit, etc."
 msgid "No more items"
 msgstr "Inga fler artiklar"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Redigera länk"
@@ -443,7 +450,7 @@ msgstr "Inga widgetar att lägga till"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Okänt fel"
@@ -577,7 +584,7 @@ msgstr "Ny kollektion"
 msgid "Insights"
 msgstr "Insikter"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "Infoga {row} x {col}-tabell"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Ta bort från zon"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Välj från globalt tillgängliga språk för denna kanal"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "Misslyckades att ta bort kund från grupp"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "är lika med"
 msgid "Source File"
 msgstr "Källfil"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "En återbetalning på {formattedDiff} krävs. Välj betalningsbelopp och ange en anteckning för att fortsätta."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Misslyckades med att skapa varianter"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Det gick inte att ta bort kunder från gruppen"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Genomstruken"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "Ny säljare"
 msgid "Search tax categories..."
 msgstr "Sök skattekategorier..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Redigera bild"
@@ -6817,6 +6844,10 @@ msgstr "Anger lagernivån vid vilken denna variant anses vara slut i lager. Anv�
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Skapa produktalternativ"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/tr.po
+++ b/packages/dashboard/src/i18n/locales/tr.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Öğe seç"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Kargoyu yeniden hesapla"
 msgid "Assets"
 msgstr "Varlıklar"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Bu, bu üründeki tüm seçenek gruplarını kaldıracak ve varyant kurulum seçimine geri dönecektir."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Varyantlar oluşturulamadı"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Bu varyantın stokta olmadığı kabul edilen stok seviyesini ayarlar. Negatif değer kullanmak sipariş öncesi desteğini etkinleştirir. Ürün varyantları tarafından geçersiz kılınabilir."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} iade edilebilir)"
 msgid "Identifier"
 msgstr "Tanımlayıcı"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Bir gönderim işleyici seçin"
@@ -6173,6 +6186,11 @@ msgstr "Kargo yöntemi başarıyla oluşturuldu"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Yeni Müşteri Grubu"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Altı çizili"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Kapat"
 

--- a/packages/dashboard/src/i18n/locales/tr.po
+++ b/packages/dashboard/src/i18n/locales/tr.po
@@ -82,6 +82,13 @@ msgstr "Daire, suit, vb."
 msgid "No more items"
 msgstr "Başka öğe yok"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Bağlantıyı düzenle"
@@ -443,7 +450,7 @@ msgstr "Eklenecek widget yok"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Bilinmeyen hata"
@@ -577,7 +584,7 @@ msgstr "Yeni koleksiyon"
 msgid "Insights"
 msgstr "İçgörüler"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "{row} x {col} tablo ekle"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Bölgeden kaldır"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Bu kanal için genel olarak kullanılabilir dillerden seçin"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "Müşteri gruptan kaldırılamadı"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "eşittir"
 msgid "Source File"
 msgstr "Kaynak dosya"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "{formattedDiff} tutarında iade gerekiyor. Ödeme tutarlarını seçin ve devam etmek için not girin."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Varyantlar oluşturulamadı"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Müşteriler gruptan kaldırılamadı"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Üstü çizili"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "Yeni Satıcı"
 msgid "Search tax categories..."
 msgstr "Vergi kategorisi ara..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Görseli düzenle"
@@ -6817,6 +6844,10 @@ msgstr "Bu varyantın stokta olmadığı kabul edilen stok seviyesini ayarlar. N
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Ürün seçenekleri oluştur"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/uk.po
+++ b/packages/dashboard/src/i18n/locales/uk.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Вибрати елементи"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "Перерахувати доставку"
 msgid "Assets"
 msgstr "Ресурси"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Це видалить усі групи опцій з цього товару та поверне до вибору налаштування варіантів."
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Не вдалося створити варіанти"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Встановлює рівень запасів, при якому цей варіант вважається відсутнім на складі. Використання від'ємного значення вмикає підтримку попередніх замовлень. Може бути перевизначено варіантами товару."
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} до повернення)"
 msgid "Identifier"
 msgstr "Ідентифікатор"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Виберіть обробник виконання замовлення"
@@ -6173,6 +6186,11 @@ msgstr "Спосіб доставки успішно створено"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Нова група клієнтів"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "Підкреслений"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Закрити"
 

--- a/packages/dashboard/src/i18n/locales/uk.po
+++ b/packages/dashboard/src/i18n/locales/uk.po
@@ -82,6 +82,13 @@ msgstr "Квартира, офіс тощо"
 msgid "No more items"
 msgstr "Більше немає елементів"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Редагувати посилання"
@@ -443,7 +450,7 @@ msgstr "Немає віджетів для додавання"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Невідома помилка"
@@ -577,7 +584,7 @@ msgstr "Нова колекція"
 msgid "Insights"
 msgstr "Аналітика"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "Вставити таблицю {row} на {col}"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "Видалити із зони"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Виберіть з глобально доступних мов для цього каналу"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "Не вдалося видалити клієнта з групи"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "дорівнює"
 msgid "Source File"
 msgstr "Вихідний файл"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Потрібне повернення в розмірі {formattedDiff}. Виберіть суми платежів та введіть примітку для продовження."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Не вдалося створити варіанти"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "Не вдалося видалити клієнтів із групи"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "Закреслений"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "Новий продавець"
 msgid "Search tax categories..."
 msgstr "Пошук податкових категорій..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Редагувати зображення"
@@ -6817,6 +6844,10 @@ msgstr "Встановлює рівень запасів, при якому це
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Створити опції товару"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/uz.po
+++ b/packages/dashboard/src/i18n/locales/uz.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "Elementlarni tanlang"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -2969,6 +2969,10 @@ msgstr "Yetkazib berishni qayta hisoblash"
 msgid "Assets"
 msgstr "Assetlar"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Bu mahsulotdagi barcha optsiya guruhlarini olib tashlaydi va variant sozlash tanloviga qaytaradi."
@@ -4994,6 +4998,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Variantlarni yaratib bo'lmadi"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Variant zaxirasi tugagan deb hisoblanadigan darajani belgilaydi. Manfiy qiymat oldindan buyurtma imkonini yoqadi. Mahsulot variantlari buni bekor qilishi mumkin."
@@ -5540,6 +5549,10 @@ msgstr "({maxRefundable} qaytarilishi mumkin)"
 msgid "Identifier"
 msgstr "Identifikator"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Buyurtmani bajarish ishlovchisini tanlang"
@@ -5989,6 +6002,11 @@ msgstr "Yetkazib berish usuli muvaffaqiyatli yaratildi"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Yangi mijozlar guruhi"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -6803,6 +6821,7 @@ msgid "Underline"
 msgstr "Tagiga chizilgan"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "Yopish"
 

--- a/packages/dashboard/src/i18n/locales/uz.po
+++ b/packages/dashboard/src/i18n/locales/uz.po
@@ -82,6 +82,13 @@ msgstr "Kvartira, ofis va h.k."
 msgid "No more items"
 msgstr "Boshqa elementlar yo'q"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "Havolani tahrirlash"
@@ -419,7 +426,7 @@ msgstr "Qo'shish uchun vidjetlar yo'q"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Noma'lum xato"
@@ -549,7 +556,7 @@ msgstr "Yangi to'plam"
 msgid "Insights"
 msgstr "Tahlillar"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1873,6 +1880,7 @@ msgstr "{row} x {col} jadval qo'shish"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2190,6 +2198,10 @@ msgstr "Hududdan olib tashlash"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Ushbu kanal uchun global mavjud tillardan tanlang"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3135,6 +3147,10 @@ msgstr "Mijozni guruhdan olib tashlab boʻlmadi"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4528,6 +4544,10 @@ msgstr "ga teng"
 msgid "Source File"
 msgstr "Manba fayl"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
@@ -4877,6 +4897,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "{formattedDiff} miqdorida pul qaytarish talab qilinadi. To'lov summalarini tanlang va davom etish uchun eslatma kiriting."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -4998,10 +5022,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "Variantlarni yaratib bo'lmadi"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5712,7 +5735,7 @@ msgid "Failed to remove customers from group"
 msgstr "Mijozlarni guruhdan olib tashlab bolmadi"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6334,7 +6357,7 @@ msgid "Strikethrough"
 msgstr "Ustiga chizilgan"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6594,6 +6617,10 @@ msgstr "Yangi sotuvchi"
 msgid "Search tax categories..."
 msgstr "Soliq toifalarini qidirish..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Rasmni tahrirlash"
@@ -6617,6 +6644,10 @@ msgstr "dan katta yoki teng"
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Ushbu variant zaxirada tugagan deb hisoblanadigan zaxira darajasini belgilaydi. Manfiy qiymat oldindan buyurtmani yoqadi."
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/zh_Hans.po
+++ b/packages/dashboard/src/i18n/locales/zh_Hans.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "选择项目"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "重新计算运费"
 msgid "Assets"
 msgstr "资源"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "这将移除此产品的所有选项组并返回变体设置选择。"
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "创建变体失败"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "设置将此变体视为缺货的库存水平。使用负值可启用延期交货支持。可由商品变体覆盖。"
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} 可退款)"
 msgid "Identifier"
 msgstr "标识符"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "选择履约处理器"
@@ -6173,6 +6186,11 @@ msgstr "成功创建配送方式"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "新客户组"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "下划线"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "关闭"
 

--- a/packages/dashboard/src/i18n/locales/zh_Hans.po
+++ b/packages/dashboard/src/i18n/locales/zh_Hans.po
@@ -82,6 +82,13 @@ msgstr "公寓、套房等"
 msgid "No more items"
 msgstr "没有更多项目"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "编辑链接"
@@ -443,7 +450,7 @@ msgstr "没有可添加的小部件"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "未知错误"
@@ -577,7 +584,7 @@ msgstr "新集合"
 msgid "Insights"
 msgstr "洞察"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "插入 {row}×{col} 表格"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "从区域移除"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "从此渠道的全局可用语言中选择"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "从组中删除客户失败"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "等于"
 msgid "Source File"
 msgstr "源文件"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "需要退款 {formattedDiff}。选择付款金额并输入备注以继续。"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "创建变体失败"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "从组中移除客户失败"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "删除线"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "新卖家"
 msgid "Search tax categories..."
 msgstr "搜索税务类别..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "编辑图片"
@@ -6817,6 +6844,10 @@ msgstr "设置将此变体视为缺货的库存水平。使用负值可启用延
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "创建商品选项"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/zh_Hant.po
+++ b/packages/dashboard/src/i18n/locales/zh_Hant.po
@@ -82,6 +82,13 @@ msgstr "公寓、套房等"
 msgid "No more items"
 msgstr "沒有更多項目"
 
+#. placeholder {0}: fileUploads.length
+#. placeholder {1}: fileUploads.length
+#. placeholder {2}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{0, plural, one {Upload progress for {1} file} other {Upload progress for {2} files}}"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/link-bubble-menu.tsx
 msgid "Edit link"
 msgstr "編輯連結"
@@ -443,7 +450,7 @@ msgstr "沒有可新增的小工具"
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 #: src/app/routes/_authenticated/_profile/profile.tsx
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 #: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "未知錯誤"
@@ -577,7 +584,7 @@ msgstr "新增集合"
 msgid "Insights"
 msgstr "洞察"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload assets"
 msgstr ""
 
@@ -1926,6 +1933,7 @@ msgstr "插入 {row}×{col} 表格"
 #: src/lib/components/data-table/views-sheet.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx
 #: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
 #: src/lib/components/shared/confirmation-dialog.tsx
 #: src/lib/components/shared/customer-address-form.tsx
@@ -2257,6 +2265,10 @@ msgstr "從區域移除"
 #: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "從此通路的全域可用語言中選取"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload timed out"
+msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
@@ -3219,6 +3231,10 @@ msgstr "從群組中移除客戶失敗"
 
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx
 msgid "1 property"
+msgstr ""
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed (HTTP {detail})"
 msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx
@@ -4647,6 +4663,10 @@ msgstr "等於"
 msgid "Source File"
 msgstr "來源檔案"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — check your connection"
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
@@ -5009,6 +5029,10 @@ msgstr ""
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "需要退款 {formattedDiff}。選取付款金額並輸入備註以繼續。"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "File exceeds the server upload size limit"
+msgstr ""
+
 #: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/order-table.tsx
 #: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -5134,10 +5158,9 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "建立變體失敗"
 
-#. placeholder {0}: fileUploads.length
 #: src/lib/components/shared/asset/asset-upload-modal.tsx
-msgid "Upload progress for {0} files"
-msgstr ""
+#~ msgid "Upload progress for {0} files"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
@@ -5876,7 +5899,7 @@ msgid "Failed to remove customers from group"
 msgstr "從群組中移除客戶失敗"
 
 #. placeholder {0}: failedAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Failed to upload {0} assets"
 msgstr ""
 
@@ -6526,7 +6549,7 @@ msgid "Strikethrough"
 msgstr "刪除線"
 
 #. placeholder {0}: createdAssets.length
-#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-picker-dialog.tsx
 msgid "Uploaded {0} assets"
 msgstr ""
 
@@ -6790,6 +6813,10 @@ msgstr "新增賣家"
 msgid "Search tax categories..."
 msgstr "搜尋稅務類別..."
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload failed — invalid server response"
+msgstr ""
+
 #: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "編輯圖片"
@@ -6817,6 +6844,10 @@ msgstr "設定將此變體視為缺貨的庫存水準。使用負值可啟用延
 #: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "建立商品選項"
+
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload cancelled"
+msgstr ""
 
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 #: src/lib/components/layout/manage-languages-dialog.tsx

--- a/packages/dashboard/src/i18n/locales/zh_Hant.po
+++ b/packages/dashboard/src/i18n/locales/zh_Hant.po
@@ -27,8 +27,8 @@ msgid "Select items"
 msgstr "選取項目"
 
 #: src/lib/components/shared/asset/asset-gallery.tsx
-msgid "Uploading assets..."
-msgstr ""
+#~ msgid "Uploading assets..."
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 #: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -3048,6 +3048,10 @@ msgstr "重新計算運費"
 msgid "Assets"
 msgstr "資源"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading..."
+msgstr ""
+
 #: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "這將移除此產品的所有選項群組並返回變體設定選擇。"
@@ -5130,6 +5134,11 @@ msgstr ""
 msgid "Failed to create variants"
 msgstr "建立變體失敗"
 
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Upload progress for {0} files"
+msgstr ""
+
 #: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "設定將此變體視為缺貨的庫存水準。使用負值可啟用延期交貨支援。可由商品變體覆寫。"
@@ -5692,6 +5701,10 @@ msgstr "({maxRefundable} 可退款)"
 msgid "Identifier"
 msgstr "識別碼"
 
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "Uploading assets"
+msgstr ""
+
 #: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "選擇履行處理器"
@@ -6173,6 +6186,11 @@ msgstr "成功建立配送方式"
 #: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "新增客戶群組"
+
+#. placeholder {0}: fileUploads.length
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
+msgid "{doneCount} of {0} done"
+msgstr ""
 
 #: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
@@ -7007,6 +7025,7 @@ msgid "Underline"
 msgstr "底線"
 
 #: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
+#: src/lib/components/shared/asset/asset-upload-modal.tsx
 msgid "Close"
 msgstr "關閉"
 

--- a/packages/dashboard/src/lib/components/shared/asset/asset-documents.ts
+++ b/packages/dashboard/src/lib/components/shared/asset/asset-documents.ts
@@ -1,0 +1,25 @@
+import { assetFragment } from '@/vdb/graphql/fragments.js';
+import { graphql } from '@/vdb/graphql/graphql.js';
+
+export const createAssetsDocument = graphql(
+    `
+        mutation CreateAssets($input: [CreateAssetInput!]!) {
+            createAssets(input: $input) {
+                __typename
+                ...Asset
+                ... on Asset {
+                    tags {
+                        id
+                        createdAt
+                        updatedAt
+                        value
+                    }
+                }
+                ... on ErrorResult {
+                    message
+                }
+            }
+        }
+    `,
+    [assetFragment],
+);

--- a/packages/dashboard/src/lib/components/shared/asset/asset-gallery.tsx
+++ b/packages/dashboard/src/lib/components/shared/asset/asset-gallery.tsx
@@ -61,28 +61,6 @@ const getAssetListDocument = graphql(
     [assetFragment],
 );
 
-export const createAssetsDocument = graphql(
-    `
-        mutation CreateAssets($input: [CreateAssetInput!]!) {
-            createAssets(input: $input) {
-                ...Asset
-                ... on Asset {
-                    tags {
-                        id
-                        createdAt
-                        updatedAt
-                        value
-                    }
-                }
-                ... on ErrorResult {
-                    message
-                }
-            }
-        }
-    `,
-    [assetFragment],
-);
-
 // Mirrors the @vendure-io/ui data-table band swap: while assets are selected
 // the bulk bar takes the search bar's place. Fade out then in, 100ms per
 // phase; mode="wait" keeps the rows sequential so they never stack.
@@ -264,6 +242,19 @@ export function AssetGallery({
         void queryClient.invalidateQueries({ queryKey: ['AssetGallery'] });
         void queryClient.invalidateQueries({ queryKey: [PaginatedListDataTableKey] });
     }, [clearSelection, queryClient]);
+
+    // Invalidated by prefix (not the fully-parameterised queryKey above) so this
+    // stays correct even if page/search/sort changed while the upload was running.
+    // Skipped entirely when nothing succeeded, since there's nothing new to show.
+    const handleUploadComplete = useCallback(
+        (summary: { succeededCount: number; failedCount: number }) => {
+            if (summary.succeededCount > 0) {
+                void queryClient.invalidateQueries({ queryKey: ['AssetGallery'] });
+                void queryClient.invalidateQueries({ queryKey: [PaginatedListDataTableKey] });
+            }
+        },
+        [queryClient],
+    );
     const adaptedBulkActions = useMemo(
         () => adaptAssetBulkActions(bulkActions, refetchAssets),
         [bulkActions, refetchAssets],
@@ -798,7 +789,7 @@ export function AssetGallery({
         <AssetUploadModal
             files={pendingFiles}
             open={uploadModalOpen}
-            onComplete={() => queryClient.invalidateQueries({ queryKey })}
+            onComplete={handleUploadComplete}
             onClose={() => setUploadModalOpen(false)}
         />
         </>

--- a/packages/dashboard/src/lib/components/shared/asset/asset-gallery.tsx
+++ b/packages/dashboard/src/lib/components/shared/asset/asset-gallery.tsx
@@ -24,18 +24,18 @@ import { ActionBarItem } from '@/vdb/framework/layout-engine/action-bar-item-wra
 import { PageActionBar } from '@/vdb/framework/layout-engine/page-layout.js';
 import { api } from '@/vdb/graphql/api.js';
 import { assetFragment, AssetFragment } from '@/vdb/graphql/fragments.js';
-import { graphql, ResultOf } from '@/vdb/graphql/graphql.js';
+import { graphql } from '@/vdb/graphql/graphql.js';
 import { formatFileSize } from '@/vdb/lib/utils.js';
 import { Plural, Trans, useLingui } from '@lingui/react/macro';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ColumnFiltersState, SortingState } from '@tanstack/react-table';
 import { Link } from '@tanstack/react-router';
 import { useDebounce } from '@uidotdev/usehooks';
-import { ChevronRight, LayoutGrid, LayoutList, Loader2, Search, Upload, X } from 'lucide-react';
+import { ChevronRight, LayoutGrid, LayoutList, Search, Upload, X } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { DragEvent, memo, useCallback, useMemo, useRef, useState } from 'react';
+import { AssetUploadModal } from './asset-upload-modal.js';
 import { useDropzone } from 'react-dropzone';
-import { toast } from 'sonner';
 import {
     AssetGridTagFilter,
     AssetTagFacetedFilter,
@@ -312,31 +312,9 @@ export function AssetGallery({
 
     const assets = (data?.assets.items ?? []) as Asset[];
 
-    const { mutate: createAssets, isPending: isUploading } = useMutation({
-        mutationFn: api.mutate(createAssetsDocument),
-        onSuccess: (result: ResultOf<typeof createAssetsDocument>) => {
-            const createdAssets = result.createAssets.filter(asset => 'id' in asset);
-            const failedAssets = result.createAssets.filter(asset => 'message' in asset);
+    const [pendingFiles, setPendingFiles] = useState<File[]>([]);
+    const [uploadModalOpen, setUploadModalOpen] = useState(false);
 
-            if (createdAssets.length > 0) {
-                toast.success(t`Uploaded ${createdAssets.length} assets`);
-            }
-            if (failedAssets.length > 0) {
-                toast.error(t`Failed to upload ${failedAssets.length} assets`, {
-                    description: failedAssets.map(asset => ('message' in asset ? asset.message : '')).join(', '),
-                });
-            }
-            queryClient.invalidateQueries({ queryKey: ['AssetGallery'] });
-            queryClient.invalidateQueries({ queryKey: [PaginatedListDataTableKey] });
-        },
-        onError: error => {
-            toast.error(t`Failed to upload assets`, {
-                description: error instanceof Error ? error.message : t`Unknown error`,
-            });
-        },
-    });
-
-    // Setup dropzone
     const onDrop = useCallback(
         (acceptedFiles: File[]) => {
             if (acceptedFiles.length === 0) {
@@ -346,9 +324,10 @@ export function AssetGallery({
                 onFilesDropped(acceptedFiles);
                 return;
             }
-            createAssets({ input: acceptedFiles.map(file => ({ file })) });
+            setPendingFiles(acceptedFiles);
+            setUploadModalOpen(true);
         },
-        [createAssets, onFilesDropped],
+        [onFilesDropped],
     );
 
     const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop, noClick: true });
@@ -452,15 +431,15 @@ export function AssetGallery({
         fileInput.addEventListener('change', event => {
             const target = event.target as HTMLInputElement;
             if (target.files) {
-                const filesList = Array.from(target.files);
-                onDrop(filesList);
+                onDrop(Array.from(target.files));
             }
         });
         fileInput.click();
     };
 
     return (
-        <div className={`relative flex flex-col w-full ${fixedHeight ? 'h-[600px]' : 'h-full'} ${className}`}>
+        <>
+            <div className={`relative flex flex-col w-full ${fixedHeight ? 'h-[600px]' : 'h-full'} ${className}`}>
             {showHeader && (
                 <div className="space-y-4 mb-4 flex-shrink-0">
                     <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
@@ -575,17 +554,8 @@ export function AssetGallery({
                             )}
                             <PageActionBar>
                                 <ActionBarItem itemId="upload-assets-button">
-                                    <Button
-                                        type="button"
-                                        onClick={openFileDialog}
-                                        disabled={isUploading}
-                                        className="whitespace-nowrap"
-                                    >
-                                        {isUploading ? (
-                                            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                                        ) : (
-                                            <Upload className="h-4 w-4 mr-2" />
-                                        )}
+                                    <Button type="button" onClick={openFileDialog} className="whitespace-nowrap">
+                                        <Upload className="h-4 w-4 mr-2" />
                                         <Trans>Upload</Trans>
                                     </Button>
                                 </ActionBarItem>
@@ -627,13 +597,6 @@ export function AssetGallery({
                     <div className="absolute inset-0 bg-background/80 backdrop-blur-sm z-10 flex flex-col items-center justify-center rounded-md">
                         <Upload className="h-12 w-12 text-primary mb-2" />
                         <p className="text-center font-medium"><Trans>Drop files here to upload</Trans></p>
-                    </div>
-                )}
-
-                {isUploading && (
-                    <div className="absolute inset-0 bg-background/70 backdrop-blur-sm z-10 flex flex-col items-center justify-center rounded-md">
-                        <Loader2 className="h-10 w-10 text-primary animate-spin mb-3" />
-                        <p className="text-center font-medium"><Trans>Uploading assets...</Trans></p>
                     </div>
                 )}
 
@@ -831,6 +794,14 @@ export function AssetGallery({
                 </div>
             )}
         </div>
+
+        <AssetUploadModal
+            files={pendingFiles}
+            open={uploadModalOpen}
+            onComplete={() => queryClient.invalidateQueries({ queryKey })}
+            onClose={() => setUploadModalOpen(false)}
+        />
+        </>
     );
 }
 

--- a/packages/dashboard/src/lib/components/shared/asset/asset-picker-dialog.tsx
+++ b/packages/dashboard/src/lib/components/shared/asset/asset-picker-dialog.tsx
@@ -10,8 +10,14 @@ import {
 } from '@/vdb/components/ui/dialog.js';
 import { getDashboardActionBarItems } from '@/vdb/framework/layout-engine/layout-extensions.js';
 import { PageContext } from '@/vdb/framework/layout-engine/page-provider.js';
-import { useState } from 'react';
+import { api } from '@/vdb/graphql/api.js';
+import { ResultOf } from '@/vdb/graphql/graphql.js';
+import { useLingui } from '@lingui/react/macro';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
 
+import { createAssetsDocument } from './asset-documents.js';
 import { Asset, AssetGallery } from './asset-gallery.js';
 
 /**
@@ -84,10 +90,45 @@ export function AssetPickerDialog({
     const extensionActionBarItems = pageId
         ? getDashboardActionBarItems(pageId).filter(item => item.type !== 'dropdown')
         : [];
+    const queryClient = useQueryClient();
+    const { t } = useLingui();
 
     const handleAssetSelect = (assets: Asset[]) => {
         setSelectedAssets(assets);
     };
+
+    // AssetGallery's own upload path opens a progress modal, which would nest
+    // a second Dialog inside this picker's Dialog — Base UI dismiss events
+    // from the inner one can then close the outer one too, discarding the
+    // selection. Uploading directly here (no modal) avoids that entirely.
+    const { mutate: createAssets } = useMutation({
+        mutationFn: api.mutate(createAssetsDocument),
+        onSuccess: (result: ResultOf<typeof createAssetsDocument>) => {
+            const createdAssets = result.createAssets.filter(asset => asset.__typename === 'Asset');
+            const failedAssets = result.createAssets.filter(asset => asset.__typename !== 'Asset');
+            if (createdAssets.length > 0) {
+                toast.success(t`Uploaded ${createdAssets.length} assets`);
+            }
+            if (failedAssets.length > 0) {
+                toast.error(t`Failed to upload ${failedAssets.length} assets`, {
+                    description: failedAssets.map(asset => ('message' in asset ? asset.message : '')).join(', '),
+                });
+            }
+            void queryClient.invalidateQueries({ queryKey: ['AssetGallery'] });
+        },
+        onError: error => {
+            toast.error(t`Failed to upload assets`, {
+                description: error instanceof Error ? error.message : t`Unknown error`,
+            });
+        },
+    });
+
+    const handleFilesDropped = useCallback(
+        (droppedFiles: File[]) => {
+            createAssets({ input: droppedFiles.map(file => ({ file })) });
+        },
+        [createAssets],
+    );
 
     const handleConfirm = () => {
         onSelect(selectedAssets);
@@ -112,6 +153,7 @@ export function AssetPickerDialog({
                             initialSelectedAssets={initialSelectedAssets}
                             fixedHeight={false}
                             displayBulkActions={false}
+                            onFilesDropped={handleFilesDropped}
                         />
                     </div>
 

--- a/packages/dashboard/src/lib/components/shared/asset/asset-upload-modal.spec.ts
+++ b/packages/dashboard/src/lib/components/shared/asset/asset-upload-modal.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+    allUploadsFinished,
+    interpretUploadResult,
+    overallProgress,
+    runWithConcurrencyLimit,
+    withUpdatedUpload,
+} from './asset-upload-modal.js';
+
+function upload(status: 'queued' | 'uploading' | 'done' | 'error', progress = 0) {
+    return { file: new File(['x'], 'x.png'), status, progress };
+}
+
+describe('overallProgress', () => {
+    it('returns 0 for an empty list', () => {
+        expect(overallProgress([])).toBe(0);
+    });
+
+    it('averages progress across all files', () => {
+        expect(overallProgress([upload('uploading', 0), upload('uploading', 100)])).toBe(50);
+    });
+
+    it('rounds to the nearest whole percent', () => {
+        expect(overallProgress([upload('uploading', 0), upload('uploading', 0), upload('uploading', 100)])).toBe(33);
+    });
+});
+
+describe('allUploadsFinished', () => {
+    it('is false for an empty list', () => {
+        expect(allUploadsFinished([])).toBe(false);
+    });
+
+    it('is false while any file is still queued or uploading', () => {
+        expect(allUploadsFinished([upload('done'), upload('uploading')])).toBe(false);
+    });
+
+    it('is true once every file has reached a terminal status', () => {
+        expect(allUploadsFinished([upload('done'), upload('error')])).toBe(true);
+    });
+});
+
+describe('withUpdatedUpload', () => {
+    it('patches only the upload at the given index', () => {
+        const uploads = [upload('queued'), upload('queued')];
+
+        const result = withUpdatedUpload(uploads, 1, { status: 'uploading', progress: 40 });
+
+        expect(result[0]).toEqual(uploads[0]);
+        expect(result[1]).toMatchObject({ status: 'uploading', progress: 40 });
+    });
+});
+
+describe('interpretUploadResult', () => {
+    it('passes a transport-level failure straight through', () => {
+        const result = interpretUploadResult({ success: false, code: 'NETWORK_ERROR' });
+
+        expect(result).toEqual({ success: false, code: 'NETWORK_ERROR', detail: undefined });
+    });
+
+    it('is a success when the server returns an Asset', () => {
+        const result = interpretUploadResult({
+            success: true,
+            data: { createAssets: [{ __typename: 'Asset', id: '1' }] } as any,
+        });
+
+        expect(result).toEqual({ success: true });
+    });
+
+    it('is a REJECTED failure when the server accepts the request but rejects the file', () => {
+        const result = interpretUploadResult({
+            success: true,
+            data: { createAssets: [{ __typename: 'MimeTypeError', message: 'Invalid mime type' }] } as any,
+        });
+
+        expect(result).toEqual({ success: false, code: 'REJECTED', detail: 'Invalid mime type' });
+    });
+});
+
+describe('runWithConcurrencyLimit', () => {
+    it('runs every item exactly once', async () => {
+        const items = [1, 2, 3, 4, 5];
+        const seen: number[] = [];
+
+        await runWithConcurrencyLimit(items, 2, async item => {
+            seen.push(item);
+        });
+
+        expect(seen.sort()).toEqual(items);
+    });
+
+    it('never runs more than `limit` items at the same time', async () => {
+        const items = [1, 2, 3, 4, 5, 6];
+        let active = 0;
+        let maxActive = 0;
+
+        await runWithConcurrencyLimit(items, 2, async () => {
+            active++;
+            maxActive = Math.max(maxActive, active);
+            await new Promise(resolve => setTimeout(resolve, 5));
+            active--;
+        });
+
+        expect(maxActive).toBeLessThanOrEqual(2);
+    });
+});

--- a/packages/dashboard/src/lib/components/shared/asset/asset-upload-modal.tsx
+++ b/packages/dashboard/src/lib/components/shared/asset/asset-upload-modal.tsx
@@ -1,0 +1,235 @@
+import { Button } from '@/vdb/components/ui/button.js';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/vdb/components/ui/dialog.js';
+import { Progress } from '@/vdb/components/ui/progress.js';
+import { LS_KEY_SELECTED_CHANNEL_TOKEN, LS_KEY_SESSION_TOKEN, LS_KEY_USER_SETTINGS } from '@/vdb/constants.js';
+import { getApiBaseUrl } from '@/vdb/utils/config-utils.js';
+import { Trans } from '@lingui/react/macro';
+import { print } from 'graphql';
+import { CheckCircle2, Clock, Loader2, XCircle } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { uiConfig } from 'virtual:vendure-ui-config';
+import { createAssetsDocument } from './asset-gallery.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type UploadStatus = 'queued' | 'uploading' | 'done' | 'error';
+
+interface FileUpload {
+    file: File;
+    status: UploadStatus;
+    progress: number; // 0–100
+    error?: string;
+}
+
+type UploadResult = { success: true } | { success: false; error: string };
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+function isTerminalStatus(upload: FileUpload): boolean {
+    return upload.status === 'done' || upload.status === 'error';
+}
+
+function allUploadsFinished(uploads: FileUpload[]): boolean {
+    return uploads.length > 0 && uploads.every(isTerminalStatus);
+}
+
+function overallProgress(uploads: FileUpload[]): number {
+    if (uploads.length === 0) return 0;
+    const total = uploads.reduce((sum, upload) => sum + upload.progress, 0);
+    return Math.round(total / uploads.length);
+}
+
+function withUpdatedUpload(
+    uploads: FileUpload[],
+    index: number,
+    patch: Partial<FileUpload>,
+): FileUpload[] {
+    return uploads.map((upload, i) => (i === index ? { ...upload, ...patch } : upload));
+}
+
+// ─── XHR upload ───────────────────────────────────────────────────────────────
+
+// XHR is used instead of fetch because fetch has no upload.onprogress event.
+// Each file is sent as its own request so we get 0-100% progress per file.
+
+function buildApiUrl(): string {
+    let url = `${getApiBaseUrl()}/${uiConfig.api.adminApiPath}`;
+    try {
+        const settings = JSON.parse(localStorage.getItem(LS_KEY_USER_SETTINGS) ?? '{}');
+        if (settings.contentLanguage) {
+            url += `?languageCode=${settings.contentLanguage}`;
+        }
+    } catch {}
+    return url;
+}
+
+function applyAuthHeaders(xhr: XMLHttpRequest): void {
+    const sessionToken = localStorage.getItem(LS_KEY_SESSION_TOKEN);
+    const channelToken = localStorage.getItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
+    if (sessionToken) xhr.setRequestHeader('Authorization', `Bearer ${sessionToken}`);
+    if (channelToken) xhr.setRequestHeader(uiConfig.api.channelTokenKey, channelToken);
+}
+
+function buildMultipartBody(file: File): FormData {
+    const body = new FormData();
+    body.append(
+        'operations',
+        JSON.stringify({ query: print(createAssetsDocument), variables: { input: [{ file: null }] } }),
+    );
+    body.append('map', JSON.stringify({ '0': ['variables.input.0.file'] }));
+    body.append('0', file, file.name);
+    return body;
+}
+
+function parseGraphqlResponse(responseText: string): UploadResult {
+    try {
+        const json = JSON.parse(responseText);
+        const graphqlError = json?.errors?.[0]?.message;
+        if (graphqlError) return { success: false, error: graphqlError };
+    } catch {}
+    return { success: true };
+}
+
+function parseServerResponse(xhr: XMLHttpRequest): UploadResult {
+    if (xhr.status === 413) return { success: false, error: 'File exceeds the server upload size limit' };
+    if (xhr.status < 200 || xhr.status >= 300) return { success: false, error: `Upload failed (HTTP ${xhr.status})` };
+    return parseGraphqlResponse(xhr.responseText);
+}
+
+function sendUploadRequest(
+    file: File,
+    onProgress: (percent: number) => void,
+): Promise<UploadResult> {
+    return new Promise(resolve => {
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', buildApiUrl());
+        applyAuthHeaders(xhr);
+
+        xhr.upload.onprogress = e => {
+            if (e.lengthComputable) {
+                onProgress(Math.round((e.loaded / e.total) * 100));
+            }
+        };
+
+        xhr.onload = () => resolve(parseServerResponse(xhr));
+        xhr.onerror = () => resolve({ success: false, error: 'Upload failed — check your connection' });
+
+        xhr.send(buildMultipartBody(file));
+    });
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export interface AssetUploadModalProps {
+    files: File[];
+    open: boolean;
+    onClose: () => void;
+    onComplete: () => void;
+}
+
+export function AssetUploadModal({ files, open, onClose, onComplete }: AssetUploadModalProps) {
+    const [fileUploads, setFileUploads] = useState<FileUpload[]>([]);
+
+    useEffect(() => {
+        if (!open || !files.length) return;
+
+        const initialUploads: FileUpload[] = files.map(file => ({
+            file,
+            status: 'queued',
+            progress: 0,
+        }));
+        setFileUploads(initialUploads);
+
+        let active = true;
+
+        async function uploadSingleFile(fileUpload: FileUpload, index: number): Promise<void> {
+            setFileUploads(prev => withUpdatedUpload(prev, index, { status: 'uploading' }));
+
+            const result = await sendUploadRequest(fileUpload.file, percent => {
+                if (active) setFileUploads(prev => withUpdatedUpload(prev, index, { progress: percent }));
+            });
+
+            if (!active) return;
+
+            if (result.success) {
+                setFileUploads(prev => withUpdatedUpload(prev, index, { status: 'done', progress: 100 }));
+            } else {
+                setFileUploads(prev => withUpdatedUpload(prev, index, { status: 'error', error: result.error }));
+            }
+        }
+
+        async function uploadAll(): Promise<void> {
+            await Promise.all(initialUploads.map((upload, index) => uploadSingleFile(upload, index)));
+            if (active) onComplete();
+        }
+
+        uploadAll();
+
+        return () => {
+            active = false;
+        };
+    }, [open, files]);
+
+    const doneCount = fileUploads.filter(u => u.status === 'done').length;
+
+    return (
+        <Dialog open={open} onOpenChange={isOpen => { if (!isOpen && allUploadsFinished(fileUploads)) onClose(); }}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>
+                        <Trans>Uploading assets</Trans>
+                    </DialogTitle>
+                    <DialogDescription className="sr-only">
+                        <Trans>Upload progress for {fileUploads.length} files</Trans>
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-1">
+                    <div className="flex justify-between text-sm text-muted-foreground">
+                        <span>
+                            <Trans>{doneCount} of {fileUploads.length} done</Trans>
+                        </span>
+                        <span>{overallProgress(fileUploads)}%</span>
+                    </div>
+                    <Progress value={overallProgress(fileUploads)} />
+                </div>
+
+                <div className="space-y-3 max-h-72 overflow-y-auto">
+                    {fileUploads.map((upload, index) => (
+                        <div key={index} className="space-y-1">
+                            <div className="flex items-center gap-2 text-sm">
+                                <UploadStatusIcon status={upload.status} />
+                                <span className="flex-1 truncate">{upload.file.name}</span>
+                                <span className="text-muted-foreground shrink-0">{upload.progress}%</span>
+                            </div>
+                            <Progress value={upload.progress} />
+                            {upload.error && <p className="text-xs text-destructive">{upload.error}</p>}
+                        </div>
+                    ))}
+                </div>
+
+                <DialogFooter>
+                    <Button onClick={onClose} disabled={!allUploadsFinished(fileUploads)}>
+                        {allUploadsFinished(fileUploads) ? <Trans>Close</Trans> : <Trans>Uploading...</Trans>}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function UploadStatusIcon({ status }: { status: UploadStatus }) {
+    switch (status) {
+        case 'queued':    return <Clock        className="h-4 w-4 text-muted-foreground shrink-0" />;
+        case 'uploading': return <Loader2      className="h-4 w-4 animate-spin text-primary shrink-0" />;
+        case 'done':      return <CheckCircle2 className="h-4 w-4 text-success shrink-0" />;
+        case 'error':     return <XCircle      className="h-4 w-4 text-destructive shrink-0" />;
+    }
+}

--- a/packages/dashboard/src/lib/components/shared/asset/asset-upload-modal.tsx
+++ b/packages/dashboard/src/lib/components/shared/asset/asset-upload-modal.tsx
@@ -159,16 +159,20 @@ export function AssetUploadModal({ files, open, onClose, onComplete }: AssetUplo
                 outcomes[index] = await uploadSingleFile(upload, index);
             });
 
-            if (controller.signal.aborted) return;
-
+            // Report the summary even when aborted: files that finished
+            // before the cancel already exist on the server and need the
+            // gallery to refresh, even though the batch as a whole didn't
+            // fully succeed.
             const succeededCount = outcomes.filter(o => o.success).length;
             onCompleteRef.current({ succeededCount, failedCount: outcomes.length - succeededCount });
-            if (succeededCount === outcomes.length) {
+            if (!controller.signal.aborted && succeededCount === outcomes.length) {
                 onCloseRef.current();
             }
         }
 
-        uploadAll();
+        uploadAll().catch(error => {
+            console.error('Unexpected error while uploading assets:', error);
+        });
 
         return () => {
             controller.abort();

--- a/packages/dashboard/src/lib/components/shared/asset/asset-upload-modal.tsx
+++ b/packages/dashboard/src/lib/components/shared/asset/asset-upload-modal.tsx
@@ -8,27 +8,40 @@ import {
     DialogTitle,
 } from '@/vdb/components/ui/dialog.js';
 import { Progress } from '@/vdb/components/ui/progress.js';
-import { LS_KEY_SELECTED_CHANNEL_TOKEN, LS_KEY_SESSION_TOKEN, LS_KEY_USER_SETTINGS } from '@/vdb/constants.js';
-import { getApiBaseUrl } from '@/vdb/utils/config-utils.js';
-import { Trans } from '@lingui/react/macro';
-import { print } from 'graphql';
+import { api, UploadErrorCode, UploadWithProgressResult } from '@/vdb/graphql/api.js';
+import { ResultOf } from '@/vdb/graphql/graphql.js';
+import { Plural, Trans } from '@lingui/react/macro';
 import { CheckCircle2, Clock, Loader2, XCircle } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import { uiConfig } from 'virtual:vendure-ui-config';
-import { createAssetsDocument } from './asset-gallery.js';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createAssetsDocument } from './asset-documents.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 type UploadStatus = 'queued' | 'uploading' | 'done' | 'error';
 
+// A file can also be rejected by the server (e.g. wrong mime type) even
+// though the request itself succeeded, so this extends the transport-level
+// UploadErrorCode with that data-level outcome.
+export type UploadItemErrorCode = UploadErrorCode | 'REJECTED';
+
 interface FileUpload {
     file: File;
     status: UploadStatus;
     progress: number; // 0–100
-    error?: string;
+    errorCode?: UploadItemErrorCode;
+    errorDetail?: string;
 }
 
-type UploadResult = { success: true } | { success: false; error: string };
+export type UploadItemResult =
+    | { success: true }
+    | { success: false; code: UploadItemErrorCode; detail?: string };
+
+export interface UploadSummary {
+    succeededCount: number;
+    failedCount: number;
+}
+
+const MAX_CONCURRENT_UPLOADS = 4;
 
 // ─── Pure helpers ─────────────────────────────────────────────────────────────
 
@@ -36,93 +49,48 @@ function isTerminalStatus(upload: FileUpload): boolean {
     return upload.status === 'done' || upload.status === 'error';
 }
 
-function allUploadsFinished(uploads: FileUpload[]): boolean {
+export function allUploadsFinished(uploads: FileUpload[]): boolean {
     return uploads.length > 0 && uploads.every(isTerminalStatus);
 }
 
-function overallProgress(uploads: FileUpload[]): number {
+export function overallProgress(uploads: FileUpload[]): number {
     if (uploads.length === 0) return 0;
     const total = uploads.reduce((sum, upload) => sum + upload.progress, 0);
     return Math.round(total / uploads.length);
 }
 
-function withUpdatedUpload(
-    uploads: FileUpload[],
-    index: number,
-    patch: Partial<FileUpload>,
-): FileUpload[] {
+export function withUpdatedUpload(uploads: FileUpload[], index: number, patch: Partial<FileUpload>): FileUpload[] {
     return uploads.map((upload, i) => (i === index ? { ...upload, ...patch } : upload));
 }
 
-// ─── XHR upload ───────────────────────────────────────────────────────────────
-
-// XHR is used instead of fetch because fetch has no upload.onprogress event.
-// Each file is sent as its own request so we get 0-100% progress per file.
-
-function buildApiUrl(): string {
-    let url = `${getApiBaseUrl()}/${uiConfig.api.adminApiPath}`;
-    try {
-        const settings = JSON.parse(localStorage.getItem(LS_KEY_USER_SETTINGS) ?? '{}');
-        if (settings.contentLanguage) {
-            url += `?languageCode=${settings.contentLanguage}`;
-        }
-    } catch {}
-    return url;
-}
-
-function applyAuthHeaders(xhr: XMLHttpRequest): void {
-    const sessionToken = localStorage.getItem(LS_KEY_SESSION_TOKEN);
-    const channelToken = localStorage.getItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
-    if (sessionToken) xhr.setRequestHeader('Authorization', `Bearer ${sessionToken}`);
-    if (channelToken) xhr.setRequestHeader(uiConfig.api.channelTokenKey, channelToken);
-}
-
-function buildMultipartBody(file: File): FormData {
-    const body = new FormData();
-    body.append(
-        'operations',
-        JSON.stringify({ query: print(createAssetsDocument), variables: { input: [{ file: null }] } }),
-    );
-    body.append('map', JSON.stringify({ '0': ['variables.input.0.file'] }));
-    body.append('0', file, file.name);
-    return body;
-}
-
-function parseGraphqlResponse(responseText: string): UploadResult {
-    try {
-        const json = JSON.parse(responseText);
-        const graphqlError = json?.errors?.[0]?.message;
-        if (graphqlError) return { success: false, error: graphqlError };
-    } catch {}
+export function interpretUploadResult(
+    result: UploadWithProgressResult<ResultOf<typeof createAssetsDocument>>,
+): UploadItemResult {
+    if (!result.success) {
+        return { success: false, code: result.code, detail: result.detail };
+    }
+    const created = result.data.createAssets[0];
+    if (created.__typename !== 'Asset') {
+        return { success: false, code: 'REJECTED', detail: created.message };
+    }
     return { success: true };
 }
 
-function parseServerResponse(xhr: XMLHttpRequest): UploadResult {
-    if (xhr.status === 413) return { success: false, error: 'File exceeds the server upload size limit' };
-    if (xhr.status < 200 || xhr.status >= 300) return { success: false, error: `Upload failed (HTTP ${xhr.status})` };
-    return parseGraphqlResponse(xhr.responseText);
-}
-
-function sendUploadRequest(
-    file: File,
-    onProgress: (percent: number) => void,
-): Promise<UploadResult> {
-    return new Promise(resolve => {
-        const xhr = new XMLHttpRequest();
-        xhr.open('POST', buildApiUrl());
-        applyAuthHeaders(xhr);
-
-        xhr.upload.onprogress = e => {
-            if (e.lengthComputable) {
-                onProgress(Math.round((e.loaded / e.total) * 100));
-            }
-        };
-
-        xhr.onload = () => resolve(parseServerResponse(xhr));
-        xhr.onerror = () => resolve({ success: false, error: 'Upload failed — check your connection' });
-
-        xhr.send(buildMultipartBody(file));
-    });
+// Runs `worker` over `items` with at most `limit` running concurrently,
+// rather than firing every upload at once (see MAX_CONCURRENT_UPLOADS).
+export async function runWithConcurrencyLimit<T>(
+    items: T[],
+    limit: number,
+    worker: (item: T, index: number) => Promise<void>,
+): Promise<void> {
+    let cursor = 0;
+    async function runNext(): Promise<void> {
+        const index = cursor++;
+        if (index >= items.length) return;
+        await worker(items[index], index);
+        return runNext();
+    }
+    await Promise.all(Array.from({ length: Math.min(limit, items.length) }, runNext));
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -131,11 +99,20 @@ export interface AssetUploadModalProps {
     files: File[];
     open: boolean;
     onClose: () => void;
-    onComplete: () => void;
+    onComplete: (summary: UploadSummary) => void;
 }
 
 export function AssetUploadModal({ files, open, onClose, onComplete }: AssetUploadModalProps) {
     const [fileUploads, setFileUploads] = useState<FileUpload[]>([]);
+    const abortControllerRef = useRef<AbortController | null>(null);
+
+    // Latest-value refs so the upload effect below (deliberately scoped to
+    // [open, files]) always calls the current onComplete/onClose rather than
+    // whichever closure was captured when the upload started.
+    const onCompleteRef = useRef(onComplete);
+    onCompleteRef.current = onComplete;
+    const onCloseRef = useRef(onClose);
+    onCloseRef.current = onClose;
 
     useEffect(() => {
         if (!open || !files.length) return;
@@ -147,47 +124,78 @@ export function AssetUploadModal({ files, open, onClose, onComplete }: AssetUplo
         }));
         setFileUploads(initialUploads);
 
-        let active = true;
+        const controller = new AbortController();
+        abortControllerRef.current = controller;
 
-        async function uploadSingleFile(fileUpload: FileUpload, index: number): Promise<void> {
+        async function uploadSingleFile(fileUpload: FileUpload, index: number): Promise<UploadItemResult> {
             setFileUploads(prev => withUpdatedUpload(prev, index, { status: 'uploading' }));
 
-            const result = await sendUploadRequest(fileUpload.file, percent => {
-                if (active) setFileUploads(prev => withUpdatedUpload(prev, index, { progress: percent }));
-            });
+            const result = await api.uploadWithProgress<ResultOf<typeof createAssetsDocument>>(
+                createAssetsDocument,
+                { input: [{ file: fileUpload.file }] },
+                {
+                    signal: controller.signal,
+                    onProgress: percent =>
+                        setFileUploads(prev => withUpdatedUpload(prev, index, { progress: percent })),
+                },
+            );
 
-            if (!active) return;
-
-            if (result.success) {
-                setFileUploads(prev => withUpdatedUpload(prev, index, { status: 'done', progress: 100 }));
-            } else {
-                setFileUploads(prev => withUpdatedUpload(prev, index, { status: 'error', error: result.error }));
-            }
+            const outcome = interpretUploadResult(result);
+            setFileUploads(prev =>
+                withUpdatedUpload(
+                    prev,
+                    index,
+                    outcome.success
+                        ? { status: 'done', progress: 100 }
+                        : { status: 'error', errorCode: outcome.code, errorDetail: outcome.detail },
+                ),
+            );
+            return outcome;
         }
 
         async function uploadAll(): Promise<void> {
-            await Promise.all(initialUploads.map((upload, index) => uploadSingleFile(upload, index)));
-            if (active) onComplete();
+            const outcomes: UploadItemResult[] = new Array(initialUploads.length);
+            await runWithConcurrencyLimit(initialUploads, MAX_CONCURRENT_UPLOADS, async (upload, index) => {
+                outcomes[index] = await uploadSingleFile(upload, index);
+            });
+
+            if (controller.signal.aborted) return;
+
+            const succeededCount = outcomes.filter(o => o.success).length;
+            onCompleteRef.current({ succeededCount, failedCount: outcomes.length - succeededCount });
+            if (succeededCount === outcomes.length) {
+                onCloseRef.current();
+            }
         }
 
         uploadAll();
 
         return () => {
-            active = false;
+            controller.abort();
         };
     }, [open, files]);
 
+    const handleCancel = useCallback(() => {
+        abortControllerRef.current?.abort();
+        onClose();
+    }, [onClose]);
+
     const doneCount = fileUploads.filter(u => u.status === 'done').length;
+    const finished = allUploadsFinished(fileUploads);
 
     return (
-        <Dialog open={open} onOpenChange={isOpen => { if (!isOpen && allUploadsFinished(fileUploads)) onClose(); }}>
+        <Dialog open={open} onOpenChange={isOpen => { if (!isOpen && finished) onClose(); }}>
             <DialogContent>
                 <DialogHeader>
                     <DialogTitle>
                         <Trans>Uploading assets</Trans>
                     </DialogTitle>
                     <DialogDescription className="sr-only">
-                        <Trans>Upload progress for {fileUploads.length} files</Trans>
+                        <Plural
+                            value={fileUploads.length}
+                            one={`Upload progress for ${fileUploads.length} file`}
+                            other={`Upload progress for ${fileUploads.length} files`}
+                        />
                     </DialogDescription>
                 </DialogHeader>
 
@@ -210,14 +218,23 @@ export function AssetUploadModal({ files, open, onClose, onComplete }: AssetUplo
                                 <span className="text-muted-foreground shrink-0">{upload.progress}%</span>
                             </div>
                             <Progress value={upload.progress} />
-                            {upload.error && <p className="text-xs text-destructive">{upload.error}</p>}
+                            {upload.errorCode && (
+                                <p className="text-xs text-destructive">
+                                    <UploadErrorText code={upload.errorCode} detail={upload.errorDetail} />
+                                </p>
+                            )}
                         </div>
                     ))}
                 </div>
 
                 <DialogFooter>
-                    <Button onClick={onClose} disabled={!allUploadsFinished(fileUploads)}>
-                        {allUploadsFinished(fileUploads) ? <Trans>Close</Trans> : <Trans>Uploading...</Trans>}
+                    {!finished && (
+                        <Button variant="outline" onClick={handleCancel}>
+                            <Trans>Cancel</Trans>
+                        </Button>
+                    )}
+                    <Button onClick={onClose} disabled={!finished}>
+                        {finished ? <Trans>Close</Trans> : <Trans>Uploading...</Trans>}
                     </Button>
                 </DialogFooter>
             </DialogContent>
@@ -231,5 +248,26 @@ function UploadStatusIcon({ status }: { status: UploadStatus }) {
         case 'uploading': return <Loader2      className="h-4 w-4 animate-spin text-primary shrink-0" />;
         case 'done':      return <CheckCircle2 className="h-4 w-4 text-success shrink-0" />;
         case 'error':     return <XCircle      className="h-4 w-4 text-destructive shrink-0" />;
+    }
+}
+
+function UploadErrorText({ code, detail }: { code: UploadItemErrorCode; detail?: string }) {
+    switch (code) {
+        case 'FILE_TOO_LARGE':
+            return <Trans>File exceeds the server upload size limit</Trans>;
+        case 'HTTP_ERROR':
+            return <Trans>Upload failed (HTTP {detail})</Trans>;
+        case 'NETWORK_ERROR':
+            return <Trans>Upload failed — check your connection</Trans>;
+        case 'TIMEOUT':
+            return <Trans>Upload timed out</Trans>;
+        case 'ABORTED':
+            return <Trans>Upload cancelled</Trans>;
+        case 'INVALID_RESPONSE':
+            return <Trans>Upload failed — invalid server response</Trans>;
+        case 'SERVER_ERROR':
+        case 'REJECTED':
+            // Server-provided message text — already human-readable, not ours to translate.
+            return <>{detail}</>;
     }
 }

--- a/packages/dashboard/src/lib/components/shared/rich-text-editor/rich-text-editor.tsx
+++ b/packages/dashboard/src/lib/components/shared/rich-text-editor/rich-text-editor.tsx
@@ -10,7 +10,7 @@ import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { api } from '../../../graphql/api.js';
-import { createAssetsDocument } from '../asset/asset-gallery.js';
+import { createAssetsDocument } from '../asset/asset-documents.js';
 import { LinkBubbleMenu } from './link-bubble-menu.js';
 import { ResizableImage } from './resizable-image.js';
 import { ResponsiveToolbar } from './responsive-toolbar.js';

--- a/packages/dashboard/src/lib/graphql/api.spec.ts
+++ b/packages/dashboard/src/lib/graphql/api.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { parseUploadResponse } from './api.js';
+
+describe('parseUploadResponse', () => {
+    it('returns success with the parsed data for a clean 200 response', () => {
+        const xhr = {
+            status: 200,
+            responseText: JSON.stringify({ data: { createAssets: [{ __typename: 'Asset', id: '1' }] } }),
+        };
+
+        expect(parseUploadResponse(xhr)).toEqual({
+            success: true,
+            data: { createAssets: [{ __typename: 'Asset', id: '1' }] },
+        });
+    });
+
+    it('returns a FILE_TOO_LARGE failure for a 413 response', () => {
+        const xhr = { status: 413, responseText: '' };
+
+        expect(parseUploadResponse(xhr)).toEqual({ success: false, code: 'FILE_TOO_LARGE' });
+    });
+
+    it('returns a SERVER_ERROR failure when the response has a top-level GraphQL error', () => {
+        const xhr = { status: 200, responseText: JSON.stringify({ errors: [{ message: 'Something went wrong' }] }) };
+
+        expect(parseUploadResponse(xhr)).toEqual({
+            success: false,
+            code: 'SERVER_ERROR',
+            detail: 'Something went wrong',
+        });
+    });
+
+    it('returns an INVALID_RESPONSE failure when a 200 body is not valid JSON', () => {
+        const xhr = { status: 200, responseText: '<html>502 Bad Gateway</html>' };
+
+        expect(parseUploadResponse(xhr)).toEqual({ success: false, code: 'INVALID_RESPONSE' });
+    });
+
+    it('returns an HTTP_ERROR failure for other non-2xx statuses', () => {
+        const xhr = { status: 500, responseText: '' };
+
+        expect(parseUploadResponse(xhr)).toEqual({ success: false, code: 'HTTP_ERROR', detail: '500' });
+    });
+});

--- a/packages/dashboard/src/lib/graphql/api.spec.ts
+++ b/packages/dashboard/src/lib/graphql/api.spec.ts
@@ -36,6 +36,12 @@ describe('parseUploadResponse', () => {
         expect(parseUploadResponse(xhr)).toEqual({ success: false, code: 'INVALID_RESPONSE' });
     });
 
+    it('returns an INVALID_RESPONSE failure when a 200 body has no data', () => {
+        const xhr = { status: 200, responseText: JSON.stringify({}) };
+
+        expect(parseUploadResponse(xhr)).toEqual({ success: false, code: 'INVALID_RESPONSE' });
+    });
+
     it('returns an HTTP_ERROR failure for other non-2xx statuses', () => {
         const xhr = { status: 500, responseText: '' };
 

--- a/packages/dashboard/src/lib/graphql/api.ts
+++ b/packages/dashboard/src/lib/graphql/api.ts
@@ -168,6 +168,8 @@ export type UploadWithProgressResult<T> =
 export interface UploadWithProgressOptions {
     onProgress?: (percent: number) => void;
     signal?: AbortSignal;
+    // Total-request deadline, not an inactivity timeout — opt-in only, since a
+    // large but still-progressing upload would otherwise be killed by a default.
     timeoutMs?: number;
 }
 
@@ -227,21 +229,35 @@ export function parseUploadResponse<T>(xhr: Pick<XMLHttpRequest, 'status' | 'res
         return { success: false, code: 'SERVER_ERROR', detail: graphqlError.message };
     }
 
+    if (!json?.data) {
+        return { success: false, code: 'INVALID_RESPONSE' };
+    }
+
     return { success: true, data: json.data as T };
 }
 
 function uploadWithProgress<T, V extends Variables = Variables>(
     document: RequestDocument | TypedDocumentNode<T, V>,
     variables: V,
-    { onProgress, signal, timeoutMs = 60_000 }: UploadWithProgressOptions = {},
+    { onProgress, signal, timeoutMs }: UploadWithProgressOptions = {},
 ): Promise<UploadWithProgressResult<T>> {
     const documentString = typeof document === 'string' ? document : print(document);
 
     return new Promise(resolve => {
+        // An abort listener added below never fires for a signal that's
+        // already aborted — without this check, an already-cancelled upload
+        // would still be sent to the server.
+        if (signal?.aborted) {
+            resolve({ success: false, code: 'ABORTED' });
+            return;
+        }
+
         const xhr = new XMLHttpRequest();
         xhr.open('POST', buildRequestUrl(API_URL));
         xhr.withCredentials = true;
-        xhr.timeout = timeoutMs;
+        if (timeoutMs !== undefined) {
+            xhr.timeout = timeoutMs;
+        }
         buildRequestHeaders().forEach((value, key) => xhr.setRequestHeader(key, value));
 
         xhr.upload.onprogress = e => {

--- a/packages/dashboard/src/lib/graphql/api.ts
+++ b/packages/dashboard/src/lib/graphql/api.ts
@@ -15,46 +15,69 @@ const API_URL = getApiBaseUrl() + `/${uiConfig.api.adminApiPath}`;
 export type Variables = object;
 export type RequestDocument = string | DocumentNode;
 
+// Shared by the fetch-based client below and by uploadWithProgress, so any
+// header/URL logic added here (auth, channel token, content language) covers
+// both request paths instead of silently missing one of them.
+
+function buildRequestUrl(baseUrl: string): string {
+    let url = baseUrl;
+    try {
+        const userSettings = localStorage.getItem(LS_KEY_USER_SETTINGS);
+        if (userSettings) {
+            const settings = JSON.parse(userSettings);
+            const contentLanguage = settings.contentLanguage;
+            if (contentLanguage) {
+                const urlObj = new URL(url);
+                urlObj.searchParams.set('languageCode', contentLanguage);
+                url = urlObj.toString();
+            }
+        }
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn('Failed to read content language from user settings:', error);
+    }
+    return url;
+}
+
+// The content language selects which translation of the data to return; the display
+// language tells the server which language to write its own descriptions and labels in.
+// Accept-Language is set explicitly because browsers send one of their own from the OS
+// locale, which would otherwise decide it.
+function buildRequestHeaders(existing?: HeadersInit): Headers {
+    const headers = new Headers(existing);
+    const sessionToken = localStorage.getItem(LS_KEY_SESSION_TOKEN);
+    const channelToken = localStorage.getItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
+    if (sessionToken) {
+        headers.set('Authorization', `Bearer ${sessionToken}`);
+    }
+    if (channelToken) {
+        headers.set(uiConfig.api.channelTokenKey, channelToken);
+    }
+    try {
+        const userSettings = localStorage.getItem(LS_KEY_USER_SETTINGS);
+        if (userSettings) {
+            const settings = JSON.parse(userSettings);
+            const displayLanguage = settings.displayLanguage;
+            if (displayLanguage) {
+                headers.set('Accept-Language', displayLanguage.replace(/_/g, '-'));
+            }
+        }
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn('Failed to read display language from user settings:', error);
+    }
+    return headers;
+}
+
+function isChannelNotFoundCode(code: unknown): boolean {
+    return code === 'CHANNEL_NOT_FOUND';
+}
+
 const awesomeClient = new AwesomeGraphQLClient({
     endpoint: API_URL,
     fetch: async (url: string, options: RequestInit = {}) => {
-        // Get the active channel token from localStorage
-        const channelToken = localStorage.getItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
-        const sessionToken = localStorage.getItem(LS_KEY_SESSION_TOKEN);
-        const headers = new Headers(options.headers);
-
-        if (sessionToken) {
-            headers.set('Authorization', `Bearer ${sessionToken}`);
-        }
-        if (channelToken) {
-            headers.set(uiConfig.api.channelTokenKey, channelToken);
-        }
-
-        // The content language selects which translation of the data to return; the display
-        // language tells the server which language to write its own descriptions and labels in.
-        // Accept-Language is set explicitly because browsers send one of their own from the OS
-        // locale, which would otherwise decide it.
-        let finalUrl = url;
-        try {
-            const userSettings = localStorage.getItem(LS_KEY_USER_SETTINGS);
-            if (userSettings) {
-                const settings = JSON.parse(userSettings);
-                const contentLanguage = settings.contentLanguage;
-                const displayLanguage = settings.displayLanguage;
-
-                if (contentLanguage) {
-                    const urlObj = new URL(finalUrl);
-                    urlObj.searchParams.set('languageCode', contentLanguage);
-                    finalUrl = urlObj.toString();
-                }
-                if (displayLanguage) {
-                    headers.set('Accept-Language', displayLanguage.replace(/_/g, '-'));
-                }
-            }
-        } catch (error) {
-            // eslint-disable-next-line no-console
-            console.warn('Failed to read languages from user settings:', error);
-        }
+        const headers = buildRequestHeaders(options.headers);
+        const finalUrl = buildRequestUrl(url);
 
         return fetch(finalUrl, {
             ...options,
@@ -78,10 +101,8 @@ const awesomeClient = new AwesomeGraphQLClient({
  * localhost origin.
  */
 function handleInvalidChannelToken(err: unknown) {
-    if (err instanceof Error) {
-        if ((err as any).extensions?.code === 'CHANNEL_NOT_FOUND') {
-            localStorage.removeItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
-        }
+    if (err instanceof Error && isChannelNotFoundCode((err as any).extensions?.code)) {
+        localStorage.removeItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
     }
 }
 
@@ -124,7 +145,138 @@ function mutate<T, V extends Variables = Variables>(
     }
 }
 
+// ─── Upload with progress ───────────────────────────────────────────────────
+//
+// XHR is used here instead of fetch because fetch has no upload.onprogress
+// event. Header/URL/credentials logic is shared with the client above via
+// buildRequestHeaders/buildRequestUrl so nothing added there is silently
+// missed on this path.
+
+export type UploadErrorCode =
+    | 'FILE_TOO_LARGE'
+    | 'HTTP_ERROR'
+    | 'NETWORK_ERROR'
+    | 'INVALID_RESPONSE'
+    | 'TIMEOUT'
+    | 'ABORTED'
+    | 'SERVER_ERROR';
+
+export type UploadWithProgressResult<T> =
+    | { success: true; data: T }
+    | { success: false; code: UploadErrorCode; detail?: string };
+
+export interface UploadWithProgressOptions {
+    onProgress?: (percent: number) => void;
+    signal?: AbortSignal;
+    timeoutMs?: number;
+}
+
+// Walks a variables object, pulling out any File values per the GraphQL
+// multipart request spec (https://github.com/jaydenseric/graphql-multipart-request-spec).
+function extractFilesAndReplace(value: unknown, currentPath: string, files: Map<string, File>): unknown {
+    if (value instanceof File) {
+        files.set(currentPath, value);
+        return null;
+    }
+    if (Array.isArray(value)) {
+        return value.map((item, index) => extractFilesAndReplace(item, `${currentPath}.${index}`, files));
+    }
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.entries(value).map(([key, val]) => [key, extractFilesAndReplace(val, `${currentPath}.${key}`, files)]),
+        );
+    }
+    return value;
+}
+
+function buildMultipartUploadBody(documentString: string, variables: Variables): FormData {
+    const files = new Map<string, File>();
+    const cleanedVariables = extractFilesAndReplace(variables, 'variables', files);
+
+    const body = new FormData();
+    body.append('operations', JSON.stringify({ query: documentString, variables: cleanedVariables }));
+
+    const fileEntries = [...files.entries()];
+    const map = Object.fromEntries(fileEntries.map(([path], index) => [String(index), [path]]));
+    body.append('map', JSON.stringify(map));
+    fileEntries.forEach(([, file], index) => body.append(String(index), file, file.name));
+
+    return body;
+}
+
+export function parseUploadResponse<T>(xhr: Pick<XMLHttpRequest, 'status' | 'responseText'>): UploadWithProgressResult<T> {
+    if (xhr.status === 413) {
+        return { success: false, code: 'FILE_TOO_LARGE' };
+    }
+    if (xhr.status < 200 || xhr.status >= 300) {
+        return { success: false, code: 'HTTP_ERROR', detail: String(xhr.status) };
+    }
+
+    let json: any;
+    try {
+        json = JSON.parse(xhr.responseText);
+    } catch {
+        return { success: false, code: 'INVALID_RESPONSE' };
+    }
+
+    const graphqlError = json?.errors?.[0];
+    if (graphqlError) {
+        if (isChannelNotFoundCode(graphqlError.extensions?.code)) {
+            localStorage.removeItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
+        }
+        return { success: false, code: 'SERVER_ERROR', detail: graphqlError.message };
+    }
+
+    return { success: true, data: json.data as T };
+}
+
+function uploadWithProgress<T, V extends Variables = Variables>(
+    document: RequestDocument | TypedDocumentNode<T, V>,
+    variables: V,
+    { onProgress, signal, timeoutMs = 60_000 }: UploadWithProgressOptions = {},
+): Promise<UploadWithProgressResult<T>> {
+    const documentString = typeof document === 'string' ? document : print(document);
+
+    return new Promise(resolve => {
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', buildRequestUrl(API_URL));
+        xhr.withCredentials = true;
+        xhr.timeout = timeoutMs;
+        buildRequestHeaders().forEach((value, key) => xhr.setRequestHeader(key, value));
+
+        xhr.upload.onprogress = e => {
+            if (e.lengthComputable) {
+                onProgress?.(Math.round((e.loaded / e.total) * 100));
+            }
+        };
+
+        const onAbortSignal = () => xhr.abort();
+        signal?.addEventListener('abort', onAbortSignal);
+        const cleanup = () => signal?.removeEventListener('abort', onAbortSignal);
+
+        xhr.onload = () => {
+            cleanup();
+            resolve(parseUploadResponse<T>(xhr));
+        };
+        xhr.onerror = () => {
+            cleanup();
+            resolve({ success: false, code: 'NETWORK_ERROR' });
+        };
+        xhr.ontimeout = () => {
+            cleanup();
+            resolve({ success: false, code: 'TIMEOUT' });
+        };
+        xhr.onabort = () => {
+            cleanup();
+            resolve({ success: false, code: 'ABORTED' });
+        };
+
+        xhr.send(buildMultipartUploadBody(documentString, variables));
+    });
+}
+
 export const api = {
     query,
     mutate,
+    uploadWithProgress,
 };

--- a/packages/dashboard/src/lib/index.ts
+++ b/packages/dashboard/src/lib/index.ts
@@ -85,6 +85,7 @@ export * from './components/shared/alerts.js';
 export * from './components/shared/animated-number.js';
 export * from './components/shared/apply-control-props.js';
 export * from './components/shared/asset/asset-bulk-actions.js';
+export * from './components/shared/asset/asset-documents.js';
 export * from './components/shared/asset/asset-focal-point-editor.js';
 export * from './components/shared/asset/asset-gallery.js';
 export * from './components/shared/asset/asset-picker-dialog.js';


### PR DESCRIPTION
## Description

Follow-up to #4940. That PR added a global "Uploading assets..." overlay as
the immediate fix for #4936, but noted that true per-file progress wasn't
possible without moving off the fetch-based mutation. This PR does that
move and adds real per-file progress.

## What changed

Replaces the silent mutation-based upload in `AssetGallery` with a modal
that lists every selected file individually, showing:

- A live 0–100% progress bar per file
- A status icon (uploading / success / error) per file
- Any server-side error for that specific file (e.g. the 20 MB file size
  limit) — without blocking the other files in the batch

## Root cause / approach

`api.mutate` uses the Fetch API, which doesn't expose upload progress
events. This switches asset uploads to XHR (`upload.onprogress`) instead,
with one XHR per file, all files uploading in parallel via `Promise.all`.

## Notes

- Builds on top of #4940 (the loading-indicator overlay this replaces) —
  this branch is stacked on it, so it should merge after #4940.
- Targets `minor` since this is a new feature, not a bug fix.

Fixes #5052

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788525742&installation_model_id=20193&pr_number=5092&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5092&signature=3b32b17887bb542e5b0eb804b2ffec01175fccdfc4696c694921bf4fd41ce116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->