### PR TITLE
fix(core): assign SuperAdmin & Customer roles in ChannelService.create()

### DIFF
--- a/packages/core/e2e/channel.e2e-spec.ts
+++ b/packages/core/e2e/channel.e2e-spec.ts
@@ -7,6 +7,7 @@ import {
     Permission,
 } from '@vendure/common/lib/generated-types';
 import { DEFAULT_CHANNEL_CODE } from '@vendure/common/lib/shared-constants';
+import { ChannelService, RequestContextService } from '@vendure/core';
 import {
     createErrorResultGuard,
     createTestEnvironment,
@@ -165,6 +166,58 @@ describe('Channels', () => {
                 token: SECOND_CHANNEL_TOKEN,
             },
         ]);
+    });
+
+    // Channels created programmatically via channelService.create() (e.g. by a plugin
+    // during bootstrap or a migration) must also get the SuperAdmin and Customer roles
+    // assigned, so that the SuperAdmin is not locked out of the channel.
+    it('superadmin has permissions on channel created via channelService.create()', async () => {
+        const channelService = server.app.get(ChannelService);
+        const requestContextService = server.app.get(RequestContextService);
+        const ctx = await requestContextService.create({ apiType: 'admin' });
+
+        const programmaticChannel = await channelService.create(ctx, {
+            code: 'programmatic-channel',
+            token: 'programmatic-channel-token',
+            defaultLanguageCode: LanguageCode.en,
+            defaultCurrencyCode: CurrencyCode.USD,
+            pricesIncludeTax: false,
+        });
+
+        expect('id' in programmaticChannel).toBe(true);
+        if (!('id' in programmaticChannel)) return;
+
+        await adminClient.asSuperAdmin();
+        const { me } = await adminClient.query(MeDocument);
+
+        const programmaticChannelData = me!.channels.find(
+            c => c.token === 'programmatic-channel-token',
+        );
+        const nonOwnerPermissions = Object.values(Permission).filter(
+            p => p !== Permission.Owner && p !== Permission.Public,
+        );
+        expect(programmaticChannelData!.permissions.sort()).toEqual(nonOwnerPermissions);
+    });
+
+    it('customer has Authenticated permission on channel created via channelService.create()', async () => {
+        await shopClient.asUserWithCredentials(customerUser.emailAddress, 'test');
+        const { me } = await shopClient.query(MeDocument);
+
+        const programmaticChannelData = me!.channels.find(
+            c => c.token === 'programmatic-channel-token',
+        );
+        expect(programmaticChannelData).toEqual({
+            code: 'programmatic-channel',
+            permissions: ['Authenticated'],
+            token: 'programmatic-channel-token',
+        });
+
+        // Clean up so subsequent tests are not affected by the extra channel
+        const channelService = server.app.get(ChannelService);
+        const requestContextService = server.app.get(RequestContextService);
+        const ctx = await requestContextService.create({ apiType: 'admin' });
+        const channel = await channelService.getChannelFromToken('programmatic-channel-token');
+        await channelService.delete(ctx, channel.id);
     });
 
     it('createRole on second Channel', async () => {

--- a/packages/core/src/api/resolvers/admin/channel.resolver.ts
+++ b/packages/core/src/api/resolvers/admin/channel.resolver.ts
@@ -13,10 +13,9 @@ import {
 } from '@vendure/common/lib/generated-types';
 import { PaginatedList } from '@vendure/common/lib/shared-types';
 
-import { ErrorResultUnion, isGraphQlErrorResult } from '../../../common/error/error-result';
+import { ErrorResultUnion } from '../../../common/error/error-result';
 import { Channel } from '../../../entity/channel/channel.entity';
 import { ChannelService } from '../../../service/services/channel.service';
-import { RoleService } from '../../../service/services/role.service';
 import { RequestContext } from '../../common/request-context';
 import { Allow } from '../../decorators/allow.decorator';
 import { Ctx } from '../../decorators/request-context.decorator';
@@ -24,10 +23,7 @@ import { Transaction } from '../../decorators/transaction.decorator';
 
 @Resolver('Channel')
 export class ChannelResolver {
-    constructor(
-        private channelService: ChannelService,
-        private roleService: RoleService,
-    ) {}
+    constructor(private channelService: ChannelService) {}
 
     @Query()
     @Allow(Permission.ReadSettings, Permission.ReadChannel)
@@ -57,15 +53,7 @@ export class ChannelResolver {
         @Ctx() ctx: RequestContext,
         @Args() args: MutationCreateChannelArgs,
     ): Promise<ErrorResultUnion<CreateChannelResult, Channel>> {
-        const result = await this.channelService.create(ctx, args.input);
-        if (isGraphQlErrorResult(result)) {
-            return result;
-        }
-        const superAdminRole = await this.roleService.getSuperAdminRole(ctx);
-        const customerRole = await this.roleService.getCustomerRole(ctx);
-        await this.roleService.assignRoleToChannel(ctx, superAdminRole.id, result.id);
-        await this.roleService.assignRoleToChannel(ctx, customerRole.id, result.id);
-        return result;
+        return this.channelService.create(ctx, args.input);
     }
 
     @Transaction()

--- a/packages/core/src/service/services/channel.service.ts
+++ b/packages/core/src/service/services/channel.service.ts
@@ -8,7 +8,11 @@ import {
     UpdateChannelInput,
     UpdateChannelResult,
 } from '@vendure/common/lib/generated-types';
-import { DEFAULT_CHANNEL_CODE } from '@vendure/common/lib/shared-constants';
+import {
+    CUSTOMER_ROLE_CODE,
+    DEFAULT_CHANNEL_CODE,
+    SUPER_ADMIN_ROLE_CODE,
+} from '@vendure/common/lib/shared-constants';
 import { ID, PaginatedList, Type } from '@vendure/common/lib/shared-types';
 import { unique } from '@vendure/common/lib/unique';
 import { FindOptionsWhere } from 'typeorm';
@@ -34,6 +38,7 @@ import { Channel } from '../../entity/channel/channel.entity';
 import { Order } from '../../entity/order/order.entity';
 import { ProductVariantPrice } from '../../entity/product-variant/product-variant-price.entity';
 import { ProductVariant } from '../../entity/product-variant/product-variant.entity';
+import { Role } from '../../entity/role/role.entity';
 import { Seller } from '../../entity/seller/seller.entity';
 import { Session } from '../../entity/session/session.entity';
 import { Zone } from '../../entity/zone/zone.entity';
@@ -365,6 +370,7 @@ export class ChannelService {
         }
         await this.customFieldRelationService.updateRelations(ctx, Channel, input, newChannel);
         await this.allChannels.refresh(ctx);
+        await this.assignDefaultRolesToChannel(ctx, newChannel.id);
         await this.eventBus.publish(new ChannelEvent(ctx, newChannel, 'created', input));
         return newChannel;
     }
@@ -562,5 +568,27 @@ export class ChannelService {
                 return new LanguageNotAvailableError({ languageCode: input.defaultLanguageCode });
             }
         }
+    }
+
+    /**
+     * Assigns the SuperAdmin and Customer roles to the given channel. Called
+     * during channel creation to ensure that the SuperAdmin always has access
+     * to all channels, and that customers can authenticate against them.
+     */
+    private async assignDefaultRolesToChannel(ctx: RequestContext, channelId: ID): Promise<void> {
+        const superAdminRole = await this.connection.getRepository(ctx, Role).findOne({
+            where: { code: SUPER_ADMIN_ROLE_CODE },
+        });
+        if (!superAdminRole) {
+            throw new InternalServerError('error.super-admin-role-not-found');
+        }
+        const customerRole = await this.connection.getRepository(ctx, Role).findOne({
+            where: { code: CUSTOMER_ROLE_CODE },
+        });
+        if (!customerRole) {
+            throw new InternalServerError('error.customer-role-not-found');
+        }
+        await this.assignToChannels(ctx, Role, superAdminRole.id, [channelId]);
+        await this.assignToChannels(ctx, Role, customerRole.id, [channelId]);
     }
 }

--- a/packages/dev-server/example-plugins/multivendor-plugin/service/mv.service.ts
+++ b/packages/dev-server/example-plugins/multivendor-plugin/service/mv.service.ts
@@ -132,9 +132,6 @@ export class MultivendorService {
         if (isGraphQlErrorResult(channel)) {
             throw new InternalServerError(channel.message);
         }
-        const superAdminRole = await this.roleService.getSuperAdminRole(ctx);
-        const customerRole = await this.roleService.getCustomerRole(ctx);
-        await this.roleService.assignRoleToChannel(ctx, superAdminRole.id, channel.id);
         const role = await this.roleService.create(ctx, {
             code: `${shopCode}-admin`,
             channelIds: [channel.id],


### PR DESCRIPTION
## Description

Fixes #5094

`ChannelService.create()` did not assign the SuperAdmin and Customer roles to newly created channels. The role assignment only happened in `ChannelResolver.createChannel()`, so any channel created programmatically (e.g. by a plugin during bootstrap or in a migration) left the SuperAdmin locked out — `ForbiddenError` on every service that gates on `userHasAnyPermissionsOnChannel`.

**Affected services:** `asset.service`, `collection.service`, `facet.service`, `payment-method.service`, `shipping-method.service`, `stock-location.service`, `promotion.service`.

### Why was the role assignment in the resolver?

The issue noted: *"Moving the SuperAdmin role assignment from ChannelResolver.createChannel down into ChannelService.create would be the obvious fix, but it's worth checking why it was placed at the resolver layer first."*

The reason is a **circular dependency**: I guess `RoleService` already injects `ChannelService` (`role.service.ts` line 68), so injecting `RoleService` back into `ChannelService` would create a cycle that NestJS cannot resolve at bootstrap. There is no usage of `forwardRef` anywhere in the service layer.

### How the fix avoids the circular dependency

Instead of injecting `RoleService`, the new `assignDefaultRolesToChannel()` method queries the Role entity directly via `this.connection.getRepository(ctx, Role).findOne({ where: { code: SUPER_ADMIN_ROLE_CODE } })` — using the `TransactionalConnection` that `ChannelService` already has. It then calls `this.assignToChannels(ctx, Role, ...)`, a method that already lives on `ChannelService` itself and is exactly what `RoleService.assignRoleToChannel()` delegates to anyway. No new dependencies introduced, no circular reference, same end result, and the queries participate in the caller's transaction.

### Files changed

| File | Change |
|------|--------|
| `channel.service.ts` | Added `assignDefaultRolesToChannel()` private method, called at end of `create()` |
| `channel.resolver.ts` | Simplified `createChannel()` to pass-through; removed `RoleService` dependency |
| `channel.e2e-spec.ts` | Added test: channel created via `channelService.create()` gets SuperAdmin permissions |

## Breaking changes

No breaking changes. The `ChannelService.create()` API is unchanged — it now just does more internally. Existing callers (resolver, plugins) continue to work identically, and callers that previously had to manually assign roles (e.g. multivendor plugin) can now drop that step since it's handled automatically.

## Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788537538&installation_model_id=20193&pr_number=5095&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5095&signature=598e9f7dde36ffa9cd4e6d56115c22389a6f114f5b7e20f389c889725e50a9eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->