### PR TITLE
fix(core): Guard against removing promotions from default channel

### DIFF
--- a/packages/core/e2e/promotion.e2e-spec.ts
+++ b/packages/core/e2e/promotion.e2e-spec.ts
@@ -377,6 +377,19 @@ describe('Promotion resolver', () => {
             expect(promotions.totalItems).toBe(0);
         });
 
+        // #5093 — cannot remove a Promotion from the default channel
+        it('cannot remove a Promotion from the default channel', async () => {
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            await expect(
+                adminClient.query(removePromotionsFromChannelDocument, {
+                    input: {
+                        channelId: 'T_1',
+                        promotionIds: [promotion.id],
+                    },
+                }),
+            ).rejects.toThrow('Items cannot be removed from the default Channel');
+        });
+
         it('cannot delete a Promotion belonging to another channel', async () => {
             // promotion belongs to default channel only (removed from second channel above)
             adminClient.setChannelToken(SECOND_CHANNEL_TOKEN);

--- a/packages/core/src/service/services/promotion.service.ts
+++ b/packages/core/src/service/services/promotion.service.ts
@@ -239,6 +239,10 @@ export class PromotionService {
         if (!hasPermission) {
             throw new ForbiddenError();
         }
+        const defaultChannel = await this.channelService.getDefaultChannel(ctx);
+        if (idsAreEqual(input.channelId, defaultChannel.id)) {
+            throw new UserInputError('error.items-cannot-be-removed-from-default-channel');
+        }
         const promotions = await this.connection.findByIdsInChannel(
             ctx,
             Promotion,


### PR DESCRIPTION
## Description

Fixes #5093

`PromotionService.removePromotionsFromChannel` had no guard preventing removal from the default channel. An admin with `UpdatePromotion` could strip a promotion out of the default channel entirely, orphaning it.

Every sibling service already guards against this:
- `shipping-method.service.ts`
- `stock-location.service.ts`
- `facet.service.ts`
- `collection.service.ts`
- `payment-method.service.ts`

All use the same 3-line pattern:
```ts
const defaultChannel = await this.channelService.getDefaultChannel(ctx);
if (idsAreEqual(input.channelId, defaultChannel.id)) {
    throw new UserInputError('error.items-cannot-be-removed-from-default-channel');
}
```

`promotion.service.ts` was the only one missing it. This PR adds the identical guard.

## Breaking changes

No breaking changes. This only prevents an operation that was never intended to succeed.

## Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788538063&installation_model_id=20193&pr_number=5096&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5096&signature=720d9ea37b2cae981e70808b1cc41d68f052d84f473cb9f8d86a79524aff45a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->