### PR TITLE
fix(core): Bump file-type to ^21.3.1 (GHSA-5v7r-6r5c-r473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+#### Security
+
+* **core** Bump `file-type` to `^21.3.1` to fix an infinite loop on malformed ASF input (#5099) [GHSA-5v7r-6r5c-r473](https://github.com/advisories/GHSA-5v7r-6r5c-r473)
+* **asset-server-plugin** Bump `file-type` to `^21.3.1` (#5099) [GHSA-5v7r-6r5c-r473](https://github.com/advisories/GHSA-5v7r-6r5c-r473)
+* **core** Note: `file-type` v21 renames four MIME types to their IANA registrations (`audio/x-flac` to `audio/flac`, `video/x-matroska` to `video/matroska`, `application/x-apache-arrow` to `application/vnd.apache.arrow.file`, `application/x-parquet` to `application/vnd.apache.parquet`). If you list any of the old values explicitly in `assetOptions.permittedFileTypes`, update them, otherwise those uploads will be rejected. The default wildcard config (`image/*`, `video/*`, `audio/*`, `.pdf`) is unaffected.
+
 ## <small>3.7.2 (2026-08-03)</small>
 
 #### Security

--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,7 @@
     },
     "packages/admin-ui": {
       "name": "@vendure/admin-ui",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "dependencies": {
         "@angular/animations": "^19.2.4",
         "@angular/cdk": "^19.2.7",
@@ -148,7 +148,7 @@
     },
     "packages/admin-ui-plugin": {
       "name": "@vendure/admin-ui-plugin",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "dependencies": {
         "date-fns": "^4.0.0",
         "express-rate-limit": "^7.5.0",
@@ -167,11 +167,11 @@
     },
     "packages/asset-server-plugin": {
       "name": "@vendure/asset-server-plugin",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "dependencies": {
         "@types/express": "^5.0.1",
         "express": "^5.1.0",
-        "file-type": "^19.0.0",
+        "file-type": "^21.3.1",
         "fs-extra": "^11.2.0",
         "mime-types": "^3.0.2",
         "sharp": "~0.34.5",
@@ -181,15 +181,15 @@
         "@aws-sdk/lib-storage": "^3.529.1",
         "@types/fs-extra": "^11.0.4",
         "@types/mime-types": "^3.0.1",
-        "@vendure/common": "3.7.0",
-        "@vendure/core": "3.7.0",
+        "@vendure/common": "3.7.2",
+        "@vendure/core": "3.7.2",
         "rimraf": "^5.0.5",
         "typescript": "5.8.2",
       },
     },
     "packages/cli": {
       "name": "@vendure/cli",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "bin": {
         "vendure": "dist/cli.js",
       },
@@ -218,7 +218,7 @@
     },
     "packages/common": {
       "name": "@vendure/common",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "devDependencies": {
         "rimraf": "^5.0.5",
         "typescript": "5.8.2",
@@ -226,7 +226,7 @@
     },
     "packages/core": {
       "name": "@vendure/core",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "dependencies": {
         "@apollo/server": "^4.12.2",
         "@graphql-tools/stitch": "^10.1.16",
@@ -237,7 +237,7 @@
         "@nestjs/platform-express": "^11.0.12",
         "@nestjs/typeorm": "^11.0.0",
         "@types/express": "^5.0.1",
-        "@vendure/common": "3.7.1",
+        "@vendure/common": "3.7.2",
         "bcrypt": "^6.0.0",
         "cookie-session": "^2.1.0",
         "cron-time-generator": "^2.0.3",
@@ -246,7 +246,7 @@
         "csv-parse": "^6.2.1",
         "dataloader": "^2.2.3",
         "express": "^5.1.0",
-        "file-type": "^19.0.0",
+        "file-type": "^21.3.1",
         "fs-extra": "^11.2.0",
         "graphql": "^16.11.0",
         "graphql-scalars": "^1.24.2",
@@ -299,7 +299,7 @@
     },
     "packages/create": {
       "name": "@vendure/create",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "bin": {
         "create": "./index.js",
       },
@@ -329,7 +329,7 @@
     },
     "packages/dashboard": {
       "name": "@vendure/dashboard",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "dependencies": {
         "@babel/core": "^7.29.0",
         "@babel/preset-react": "^7.28.5",
@@ -429,7 +429,7 @@
     },
     "packages/dev-server": {
       "name": "dev-server",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "dependencies": {
         "@nestjs/axios": "^4.0.0",
         "@vendure/asset-server-plugin": "3.7.1",
@@ -456,7 +456,7 @@
     },
     "packages/email-plugin": {
       "name": "@vendure/email-plugin",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "dependencies": {
         "@types/nodemailer": "^8.0.1",
         "dateformat": "^3.0.3",
@@ -479,7 +479,7 @@
     },
     "packages/graphiql-plugin": {
       "name": "@vendure/graphiql-plugin",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "dependencies": {
         "express": "^5.1.0",
       },
@@ -501,7 +501,7 @@
     },
     "packages/harden-plugin": {
       "name": "@vendure/harden-plugin",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "dependencies": {
         "graphql-query-complexity": "^0.12.0",
       },
@@ -515,7 +515,7 @@
     },
     "packages/job-queue-plugin": {
       "name": "@vendure/job-queue-plugin",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "devDependencies": {
         "@vendure/common": "3.6.3",
         "@vendure/core": "3.6.3",
@@ -535,7 +535,7 @@
     },
     "packages/telemetry-plugin": {
       "name": "@vendure/telemetry-plugin",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^2.0.0",
@@ -562,7 +562,7 @@
     },
     "packages/testing": {
       "name": "@vendure/testing",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
         "@vendure/common": "3.6.3",
@@ -586,7 +586,7 @@
     },
     "packages/ui-devkit": {
       "name": "@vendure/ui-devkit",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "dependencies": {
         "@angular-devkit/build-angular": "^19.2.5",
         "@angular/cli": "^19.2.5",
@@ -3549,7 +3549,7 @@
 
     "file-selector": ["file-selector@2.1.2", "", { "dependencies": { "tslib": "^2.7.0" } }, "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig=="],
 
-    "file-type": ["file-type@19.6.0", "", { "dependencies": { "get-stream": "^9.0.1", "strtok3": "^9.0.1", "token-types": "^6.0.0", "uint8array-extras": "^1.3.0" } }, ""],
+    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
 
     "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
@@ -4653,8 +4653,6 @@
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
-    "peek-readable": ["peek-readable@5.4.2", "", {}, "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg=="],
-
     "pg": ["pg@8.16.3", "", { "dependencies": { "pg-connection-string": "^2.9.1", "pg-pool": "^3.10.1", "pg-protocol": "^1.10.3", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.2.7" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw=="],
 
     "pg-cloudflare": ["pg-cloudflare@1.2.7", "", {}, "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg=="],
@@ -5263,7 +5261,7 @@
 
     "strnum": ["strnum@2.1.2", "", {}, "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="],
 
-    "strtok3": ["strtok3@9.1.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^5.3.1" } }, "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw=="],
+    "strtok3": ["strtok3@10.3.4", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg=="],
 
     "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
 
@@ -6375,8 +6373,6 @@
 
     "figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
-    "file-type/get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, ""],
-
     "filelist/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
     "find-cache-dir/make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
@@ -7435,8 +7431,6 @@
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "@nestjs/common/file-type/strtok3": ["strtok3@10.3.4", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg=="],
-
     "@nestjs/graphql/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "@npmcli/arborist/npm-package-arg/proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
@@ -7692,8 +7686,6 @@
     "eslint/globals/type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
 
     "express/body-parser/raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
-
-    "file-type/get-stream/is-stream": ["is-stream@4.0.1", "", {}, ""],
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/packages/asset-server-plugin/package.json
+++ b/packages/asset-server-plugin/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "@types/express": "^5.0.1",
         "express": "^5.1.0",
-        "file-type": "^19.0.0",
+        "file-type": "^21.3.1",
         "fs-extra": "^11.2.0",
         "mime-types": "^3.0.2",
         "sharp": "~0.34.5"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,7 @@
         "csv-parse": "^6.2.1",
         "dataloader": "^2.2.3",
         "express": "^5.1.0",
-        "file-type": "^19.0.0",
+        "file-type": "^21.3.1",
         "fs-extra": "^11.2.0",
         "graphql": "^16.11.0",
         "graphql-scalars": "^1.24.2",


### PR DESCRIPTION
## What

Bumps the `file-type` dependency from `^19.0.0` to `^21.3.1` in `@vendure/core` and `@vendure/asset-server-plugin`.

## Why

`file-type@19.6.0` is affected by [GHSA-5v7r-6r5c-r473](https://github.com/advisories/GHSA-5v7r-6r5c-r473): an infinite loop in the ASF parser on malformed input with a zero-size sub-header. Both packages call `fileTypeFromBuffer` on user-uploaded asset data, so the vulnerable path is reachable via asset upload. Patched in `file-type@21.3.1`.

The `fileTypeFromBuffer` API is unchanged across 19 to 21, so no call-site changes are needed. The repo already requires Node `^20.19.0 || >=22.12.0`, satisfying v21's Node >= 20 requirement.

One v21 breaking change is user-visible. Four MIME types were corrected to their formal IANA registrations:

| v19 | v21 |
| --- | --- |
| `audio/x-flac` | `audio/flac` |
| `video/x-matroska` | `video/matroska` |
| `application/x-apache-arrow` | `application/vnd.apache.arrow.file` |
| `application/x-parquet` | `application/vnd.apache.parquet` |

`getPermittedMimeTypeError` validates the content-detected MIME against `assetOptions.permittedFileTypes`. The defaults are wildcards (`image/*`, `video/*`, `audio/*`, `.pdf`) so they absorb the change, but anyone listing one of the old values explicitly will start rejecting valid uploads. Documented in the changelog.

Note: `@nestjs/common` pins `file-type@21.2.0` exactly, which is still inside the vulnerable range. That resolution is owned by NestJS and needs an upstream bump; it is not addressed here.

## Verification

- `packages/core` asset e2e suite: 26/26 passed (sqlite)
- `packages/asset-server-plugin` e2e suite: 35/35 passed (sqlite)
- `bun.lock` resolves `file-type` to 21.3.4 for both packages

Relates to OSS-692.

https://claude.ai/code/session_01PYg1vgCkngRoqhHRzUetgJ
