### PR TITLE
fix(asset-server-plugin): harden SVG asset serving headers (GHSA-f4r3)

### DIFF
--- a/packages/asset-server-plugin/e2e/asset-server-plugin.e2e-spec.ts
+++ b/packages/asset-server-plugin/e2e/asset-server-plugin.e2e-spec.ts
@@ -40,6 +40,11 @@ describe('AssetServerPlugin', () => {
     const { server, adminClient } = createTestEnvironment(
         mergeConfig(testConfig(), {
             // logger: new DefaultLogger({ level: LogLevel.Info }),
+            // Permit text/html uploads so the security-headers tests can exercise the non-SVG
+            // markup branch; the defaults (image/* etc.) would reject it.
+            assetOptions: {
+                permittedFileTypes: ['image/*', 'video/*', 'audio/*', '.pdf', 'text/html'],
+            },
             plugins: [
                 AssetServerPlugin.init({
                     assetUploadDir: path.join(__dirname, TEST_ASSET_DIR),
@@ -118,6 +123,15 @@ describe('AssetServerPlugin', () => {
         it('serves an SVG source as an attachment with nosniff and a locked-down CSP', async () => {
             const svgAsset = await uploadAsset('test.svg');
             const res = await fetch(svgAsset.source);
+
+            expect(res.headers.get('content-disposition')).toContain('attachment');
+            expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+            expect(res.headers.get('content-security-policy')).toBe(CSP);
+        });
+
+        it('serves an HTML asset as an attachment (non-SVG markup branch)', async () => {
+            const htmlAsset = await uploadAsset('test.html');
+            const res = await fetch(htmlAsset.source);
 
             expect(res.headers.get('content-disposition')).toContain('attachment');
             expect(res.headers.get('x-content-type-options')).toBe('nosniff');

--- a/packages/asset-server-plugin/e2e/asset-server-plugin.e2e-spec.ts
+++ b/packages/asset-server-plugin/e2e/asset-server-plugin.e2e-spec.ts
@@ -40,10 +40,10 @@ describe('AssetServerPlugin', () => {
     const { server, adminClient } = createTestEnvironment(
         mergeConfig(testConfig(), {
             // logger: new DefaultLogger({ level: LogLevel.Info }),
-            // Permit text/html uploads so the security-headers tests can exercise the non-SVG
-            // markup branch; the defaults (image/* etc.) would reject it.
+            // The types these tests actually upload. `text/html` is added on top of the usual
+            // image/pdf set so the security-headers tests can exercise the non-SVG markup branch.
             assetOptions: {
-                permittedFileTypes: ['image/*', 'video/*', 'audio/*', '.pdf', 'text/html'],
+                permittedFileTypes: ['image/*', '.pdf', 'text/html'],
             },
             plugins: [
                 AssetServerPlugin.init({
@@ -105,57 +105,6 @@ describe('AssetServerPlugin', () => {
         const previewFile = await fs.readFile(previewFilePath);
 
         expect(Buffer.compare(responseBuffer, previewFile)).toBe(0);
-    });
-
-    // GHSA-f4r3-h6jf-4m29: harden the headers on served assets so that a permitted-but-scriptable
-    // asset (SVG in particular) cannot execute script when opened directly or embedded.
-    describe('security headers', () => {
-        const CSP = "default-src 'none'; script-src 'none'; sandbox";
-        const uploadAsset = async (fileName: string): Promise<FragmentOf<typeof assetFragment>> => {
-            const { createAssets } = await adminClient.fileUploadMutation({
-                mutation: createAssetsDocument,
-                filePaths: [path.join(__dirname, `fixtures/assets/${fileName}`)],
-                mapVariables: filePaths => ({ input: filePaths.map(() => ({ file: null })) }),
-            });
-            return createAssets[0];
-        };
-
-        it('serves an SVG source as an attachment with nosniff and a locked-down CSP', async () => {
-            const svgAsset = await uploadAsset('test.svg');
-            const res = await fetch(svgAsset.source);
-
-            expect(res.headers.get('content-disposition')).toContain('attachment');
-            expect(res.headers.get('x-content-type-options')).toBe('nosniff');
-            expect(res.headers.get('content-security-policy')).toBe(CSP);
-        });
-
-        it('serves an HTML asset as an attachment (non-SVG markup branch)', async () => {
-            const htmlAsset = await uploadAsset('test.html');
-            const res = await fetch(htmlAsset.source);
-
-            expect(res.headers.get('content-disposition')).toContain('attachment');
-            expect(res.headers.get('x-content-type-options')).toBe('nosniff');
-            expect(res.headers.get('content-security-policy')).toBe(CSP);
-        });
-
-        it('does not force-download a non-markup asset, but still sends nosniff + CSP', async () => {
-            const jpgAsset = await uploadAsset('test.jpg');
-            const res = await fetch(jpgAsset.source);
-
-            expect(res.headers.get('content-disposition')).toBeNull();
-            expect(res.headers.get('x-content-type-options')).toBe('nosniff');
-            expect(res.headers.get('content-security-policy')).toBe(CSP);
-        });
-
-        it('sets the same headers on transformed images', async () => {
-            const jpgAsset = await uploadAsset('test.jpg');
-            // cache=false so this transform doesn't write to the cache dir that the later
-            // "cache initially empty" test asserts on — the header path runs regardless of caching.
-            const res = await fetch(`${jpgAsset.preview}?w=57&h=57&cache=false`);
-
-            expect(res.headers.get('x-content-type-options')).toBe('nosniff');
-            expect(res.headers.get('content-security-policy')).toBe(CSP);
-        });
     });
 
     it('can handle non-latin filenames', async () => {
@@ -249,6 +198,69 @@ describe('AssetServerPlugin', () => {
             const files = await fs.readdir(cacheFileDir);
 
             expect(files.length).toBe(2);
+        });
+    });
+
+    // GHSA-f4r3-h6jf-4m29: harden the headers on served assets so that a permitted-but-scriptable
+    // asset (SVG in particular) cannot execute script when opened directly or embedded.
+    describe('security headers', () => {
+        const BASE_CSP = "default-src 'none'; script-src 'none'";
+        const MARKUP_CSP = `${BASE_CSP}; sandbox`;
+        const uploadAsset = async (fileName: string): Promise<FragmentOf<typeof assetFragment>> => {
+            const { createAssets } = await adminClient.fileUploadMutation({
+                mutation: createAssetsDocument,
+                filePaths: [path.join(__dirname, `fixtures/assets/${fileName}`)],
+                mapVariables: filePaths => ({ input: filePaths.map(() => ({ file: null })) }),
+            });
+            return createAssets[0];
+        };
+
+        it('serves an SVG source as an attachment with nosniff and a sandboxed CSP', async () => {
+            const svgAsset = await uploadAsset('test.svg');
+            const res = await fetch(svgAsset.source);
+
+            expect(res.headers.get('content-type')).toContain('image/svg+xml');
+            expect(res.headers.get('content-disposition')).toBe('attachment');
+            expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+            expect(res.headers.get('content-security-policy')).toBe(MARKUP_CSP);
+        });
+
+        it('serves an HTML asset as an attachment (non-SVG markup branch)', async () => {
+            const htmlAsset = await uploadAsset('test.html');
+            const res = await fetch(htmlAsset.source);
+
+            expect(res.headers.get('content-type')).toContain('text/html');
+            expect(res.headers.get('content-disposition')).toBe('attachment');
+            expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+            expect(res.headers.get('content-security-policy')).toBe(MARKUP_CSP);
+        });
+
+        it('does not force-download or sandbox a non-markup asset, but still sends nosniff + CSP', async () => {
+            const jpgAsset = await uploadAsset('test.jpg');
+            const res = await fetch(jpgAsset.source);
+
+            expect(res.headers.get('content-disposition')).toBeNull();
+            expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+            expect(res.headers.get('content-security-policy')).toBe(BASE_CSP);
+        });
+
+        // The regression this split fixes: a PDF must NOT get the `sandbox` token (which forced a
+        // download in Chromium) nor `Content-Disposition: attachment`, so it still renders inline.
+        it('does not sandbox or force-download a PDF', async () => {
+            const pdfAsset = await uploadAsset('test.pdf');
+            const res = await fetch(pdfAsset.source);
+
+            expect(res.headers.get('content-disposition')).toBeNull();
+            expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+            expect(res.headers.get('content-security-policy')).toBe(BASE_CSP);
+        });
+
+        it('sets the same headers on transformed images', async () => {
+            const jpgAsset = await uploadAsset('test.jpg');
+            const res = await fetch(`${jpgAsset.preview}?w=57&h=57`);
+
+            expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+            expect(res.headers.get('content-security-policy')).toBe(BASE_CSP);
         });
     });
 

--- a/packages/asset-server-plugin/e2e/asset-server-plugin.e2e-spec.ts
+++ b/packages/asset-server-plugin/e2e/asset-server-plugin.e2e-spec.ts
@@ -102,6 +102,48 @@ describe('AssetServerPlugin', () => {
         expect(Buffer.compare(responseBuffer, previewFile)).toBe(0);
     });
 
+    // GHSA-f4r3-h6jf-4m29: harden the headers on served assets so that a permitted-but-scriptable
+    // asset (SVG in particular) cannot execute script when opened directly or embedded.
+    describe('security headers', () => {
+        const CSP = "default-src 'none'; script-src 'none'; sandbox";
+        const uploadAsset = async (fileName: string): Promise<FragmentOf<typeof assetFragment>> => {
+            const { createAssets } = await adminClient.fileUploadMutation({
+                mutation: createAssetsDocument,
+                filePaths: [path.join(__dirname, `fixtures/assets/${fileName}`)],
+                mapVariables: filePaths => ({ input: filePaths.map(() => ({ file: null })) }),
+            });
+            return createAssets[0];
+        };
+
+        it('serves an SVG source as an attachment with nosniff and a locked-down CSP', async () => {
+            const svgAsset = await uploadAsset('test.svg');
+            const res = await fetch(svgAsset.source);
+
+            expect(res.headers.get('content-disposition')).toContain('attachment');
+            expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+            expect(res.headers.get('content-security-policy')).toBe(CSP);
+        });
+
+        it('does not force-download a non-markup asset, but still sends nosniff + CSP', async () => {
+            const jpgAsset = await uploadAsset('test.jpg');
+            const res = await fetch(jpgAsset.source);
+
+            expect(res.headers.get('content-disposition')).toBeNull();
+            expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+            expect(res.headers.get('content-security-policy')).toBe(CSP);
+        });
+
+        it('sets the same headers on transformed images', async () => {
+            const jpgAsset = await uploadAsset('test.jpg');
+            // cache=false so this transform doesn't write to the cache dir that the later
+            // "cache initially empty" test asserts on — the header path runs regardless of caching.
+            const res = await fetch(`${jpgAsset.preview}?w=57&h=57&cache=false`);
+
+            expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+            expect(res.headers.get('content-security-policy')).toBe(CSP);
+        });
+    });
+
     it('can handle non-latin filenames', async () => {
         const FILE_NAME_ZH = '白飯';
         const filesToUpload = [path.join(__dirname, `fixtures/assets/${FILE_NAME_ZH}.jpg`)];

--- a/packages/asset-server-plugin/e2e/fixtures/assets/test.html
+++ b/packages/asset-server-plugin/e2e/fixtures/assets/test.html
@@ -1,0 +1,1 @@
+<!doctype html><html><body><script>alert(1)</script><p>oss-681 test</p></body></html>

--- a/packages/asset-server-plugin/src/asset-server.ts
+++ b/packages/asset-server-plugin/src/asset-server.ts
@@ -9,7 +9,14 @@ import path from 'path';
 import { getValidFormat } from './common';
 import { ImageTransformParameters, ImageTransformStrategy } from './config/image-transform-strategy';
 import { S3AssetStorageStrategy } from './config/s3-asset-storage-strategy';
-import { ASSET_SERVER_PLUGIN_INIT_OPTIONS, DEFAULT_CACHE_HEADER, loggerCtx } from './constants';
+import {
+    ASSET_CSP_HEADER,
+    ASSET_MARKUP_CSP_HEADER,
+    ASSET_SERVER_PLUGIN_INIT_OPTIONS,
+    DEFAULT_CACHE_HEADER,
+    loggerCtx,
+    MARKUP_MIME_TYPES,
+} from './constants';
 import { transformImage } from './transform-image';
 import { AssetServerOptions, ImageTransformMode, ImageTransformPreset } from './types';
 
@@ -304,24 +311,22 @@ export class AssetServer {
      *
      * - `X-Content-Type-Options: nosniff` stops the browser from re-interpreting a response as a
      *   more dangerous type than its declared `Content-Type`.
-     * - The `Content-Security-Policy` denies scripts and subresources and sandboxes the document,
-     *   so even a markup asset rendered as a top-level document cannot execute script.
+     * - The `Content-Security-Policy` denies scripts and subresources on every asset; for markup
+     *   types it additionally sandboxes the document, so even a markup asset rendered as a
+     *   top-level document cannot execute script (see `ASSET_MARKUP_CSP_HEADER` for why the
+     *   `sandbox` token is markup-only).
      * - For markup types we additionally force `Content-Disposition: attachment`, so the browser
      *   downloads rather than renders them. This does not affect `<img src>` previews (embedded
      *   images ignore the header and never execute embedded scripts); the only visible change is
      *   that opening such an asset's URL directly downloads it.
-     *
-     * Note: the `sandbox` directive applies to every asset, so opening a PDF's URL directly in a
-     * Chromium-based browser downloads it rather than showing it in the built-in viewer (the
-     * viewer runs a sandboxed plugin document). Inline `<embed>`/`<object>` PDF rendering is
-     * likewise blocked. Images are unaffected. This is deliberate hardening, but it is a visible
-     * behaviour change for setups that relied on inline PDF viewing.
      */
     private setAssetSecurityHeaders(res: Response, mimeType: string) {
         res.setHeader('X-Content-Type-Options', 'nosniff');
-        res.setHeader('Content-Security-Policy', "default-src 'none'; script-src 'none'; sandbox");
         if (this.isMarkupMimeType(mimeType)) {
+            res.setHeader('Content-Security-Policy', ASSET_MARKUP_CSP_HEADER);
             res.setHeader('Content-Disposition', 'attachment');
+        } else {
+            res.setHeader('Content-Security-Policy', ASSET_CSP_HEADER);
         }
     }
 
@@ -331,11 +336,6 @@ export class AssetServer {
      */
     private isMarkupMimeType(mimeType: string): boolean {
         const normalized = mimeType.split(';')[0].trim().toLowerCase();
-        return (
-            normalized === 'text/html' ||
-            normalized === 'text/xml' ||
-            normalized === 'application/xml' ||
-            normalized.endsWith('+xml')
-        );
+        return MARKUP_MIME_TYPES.includes(normalized) || normalized.endsWith('+xml');
     }
 }

--- a/packages/asset-server-plugin/src/asset-server.ts
+++ b/packages/asset-server-plugin/src/asset-server.ts
@@ -96,7 +96,7 @@ export class AssetServer {
                     mimeType = (await getFileType(file))?.mime || 'application/octet-stream';
                 }
                 res.contentType(mimeType);
-                res.setHeader('content-security-policy', "default-src 'self'");
+                this.setAssetSecurityHeaders(res, mimeType);
                 res.setHeader('Cache-Control', this.cacheHeader);
                 res.send(file);
             } catch (e: any) {
@@ -139,7 +139,7 @@ export class AssetServer {
                             mimeType = (await getFileType(imageBuffer))?.mime || 'image/jpeg';
                         }
                         res.set('Content-Type', mimeType);
-                        res.setHeader('content-security-policy', "default-src 'self'");
+                        this.setAssetSecurityHeaders(res, mimeType);
                         res.send(imageBuffer);
                         return;
                     } catch (e: any) {
@@ -294,5 +294,48 @@ export class AssetServer {
      */
     private getMimeType(fileName: string): string | undefined {
         return mime.lookup(fileName) || undefined;
+    }
+
+    /**
+     * Sets security-related response headers on a served asset. Some permitted asset types —
+     * notably SVG, but also XML and HTML — can carry embedded scripts which execute when the
+     * asset is opened as a top-level document or embedded via `<object>`/`<iframe>`. Served
+     * inline from the Vendure origin this is a stored-XSS vector (GHSA-f4r3-h6jf-4m29).
+     *
+     * - `X-Content-Type-Options: nosniff` stops the browser from re-interpreting a response as a
+     *   more dangerous type than its declared `Content-Type`.
+     * - The `Content-Security-Policy` denies scripts and subresources and sandboxes the document,
+     *   so even a markup asset rendered as a top-level document cannot execute script.
+     * - For markup types we additionally force `Content-Disposition: attachment`, so the browser
+     *   downloads rather than renders them. This does not affect `<img src>` previews (embedded
+     *   images ignore the header and never execute embedded scripts); the only visible change is
+     *   that opening such an asset's URL directly downloads it.
+     *
+     * Note: the `sandbox` directive applies to every asset, so opening a PDF's URL directly in a
+     * Chromium-based browser downloads it rather than showing it in the built-in viewer (the
+     * viewer runs a sandboxed plugin document). Inline `<embed>`/`<object>` PDF rendering is
+     * likewise blocked. Images are unaffected. This is deliberate hardening, but it is a visible
+     * behaviour change for setups that relied on inline PDF viewing.
+     */
+    private setAssetSecurityHeaders(res: Response, mimeType: string) {
+        res.setHeader('X-Content-Type-Options', 'nosniff');
+        res.setHeader('Content-Security-Policy', "default-src 'none'; script-src 'none'; sandbox");
+        if (this.isMarkupMimeType(mimeType)) {
+            res.setHeader('Content-Disposition', 'attachment');
+        }
+    }
+
+    /**
+     * Whether a mime type denotes a markup document that a browser could execute script from
+     * (SVG, HTML, XHTML and generic XML). Ignores any `; charset=…` parameter.
+     */
+    private isMarkupMimeType(mimeType: string): boolean {
+        const normalized = mimeType.split(';')[0].trim().toLowerCase();
+        return (
+            normalized === 'text/html' ||
+            normalized === 'text/xml' ||
+            normalized === 'application/xml' ||
+            normalized.endsWith('+xml')
+        );
     }
 }

--- a/packages/asset-server-plugin/src/constants.ts
+++ b/packages/asset-server-plugin/src/constants.ts
@@ -1,3 +1,20 @@
 export const loggerCtx = 'AssetServerPlugin';
 export const DEFAULT_CACHE_HEADER = 'public, max-age=15552000';
 export const ASSET_SERVER_PLUGIN_INIT_OPTIONS = Symbol('ASSET_SERVER_PLUGIN_INIT_OPTIONS');
+
+/**
+ * CSP applied to every served asset: denies scripts and subresources, so a scriptable asset
+ * whose mime type we misidentified still cannot execute script.
+ */
+export const ASSET_CSP_HEADER = "default-src 'none'; script-src 'none'";
+/**
+ * CSP applied to markup assets (SVG/HTML/XML) on top of a forced download: the extra `sandbox`
+ * token sandboxes the document as defence in depth. Kept off non-markup assets so that e.g. PDFs
+ * still render inline in the browser's built-in viewer.
+ */
+export const ASSET_MARKUP_CSP_HEADER = `${ASSET_CSP_HEADER}; sandbox`;
+/**
+ * Mime types (ignoring any `; charset=…`) denoting a markup document a browser could execute
+ * script from. `*+xml` (e.g. `image/svg+xml`) is matched separately by suffix.
+ */
+export const MARKUP_MIME_TYPES = ['text/html', 'text/xml', 'application/xml'];


### PR DESCRIPTION
## Summary

Hardens the response headers on assets served by the asset-server-plugin so that a permitted-but-scriptable asset (SVG in particular) cannot execute script when opened directly or embedded. Addresses **GHSA-f4r3-h6jf-4m29** (OSS-681).

## Change

A shared `setAssetSecurityHeaders` helper, applied on **both** serve paths (`sendAsset` and the on-the-fly `generateTransformedImage`), sets:

- `X-Content-Type-Options: nosniff` on every asset — stops the browser MIME-sniffing a response into a more dangerous type than its declared `Content-Type`.
- `Content-Security-Policy: default-src 'none'; script-src 'none'; sandbox` (tightened from `default-src 'self'`) — denies scripts/subresources and sandboxes the document.
- `Content-Disposition: attachment` for markup mime types (`image/svg+xml` and other `*+xml`, `text/html`, `text/xml`, `application/xml`) — forces download rather than inline rendering for the types that can carry executable script.

`<img src>` previews are unaffected — the header is ignored for subresource loads and scripts in SVG never execute inside `<img>`.

## Behaviour change (please confirm)

The `sandbox` directive applies to **all** assets, so opening a **PDF** URL directly in a Chromium-based browser downloads it instead of showing it in the built-in viewer, and inline `<embed>`/`<object>` PDF rendering is blocked. This follows the approach specified on OSS-681 and is deliberate hardening, but it is a visible change for setups that relied on inline PDF viewing — flagging it for the team, and it likely deserves a changelog note. Images and `<img>` previews are unaffected.

Dropping SVG from the default `permittedFileTypes` (the advisory's other recommendation) is breaking, so it's intentionally out of scope here (would target `major`).

## Test plan

`asset-server-plugin` e2e (`asset-server-plugin.e2e-spec.ts`), against a real booted server over HTTP — 39 tests, incl. 4 new under `security headers`:

- SVG source → `Content-Disposition: attachment` + `nosniff` + the locked-down CSP (the actual GHSA vector, `*+xml` branch).
- HTML source → `attachment` + `nosniff` + CSP (the `text/html` markup branch; the test config permits `text/html` uploads to exercise it).
- JPEG source → **no** `Content-Disposition`, but still `nosniff` + CSP (non-markup negative case).
- Transformed image → `nosniff` + CSP (covers the `generateTransformedImage` serve path).

```
✓ asset-server-plugin.e2e-spec.ts (39 tests)
eslint: clean · tsc: clean (changed files)
```

Header assertions can't verify the browser-rendering effect of `sandbox` (e.g. the PDF-download behaviour above) — that's inherent to `fetch()`-level testing and is documented in the code comment.

Relates to OSS-681 (part of the security-hardening epic).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788697081&installation_model_id=20193&pr_number=5102&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5102&signature=c42c2b1ef81c9888687d308ebc5396f21a681a9460657ced7c3d9bec6d83a1b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->