### PR TITLE
chore(repo): Add TypeORM version test harness

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,6 +10,10 @@ inputs:
         required: false
         # Pinned. Bump explicitly when re-validating against a newer Bun.
         default: '1.3.10'
+    typeorm:
+        description: 'TypeORM profile from scripts/typeorm/profiles.json. Leave empty to install the versions declared in the workspace.'
+        required: false
+        default: ''
 runs:
     using: 'composite'
     steps:
@@ -20,5 +24,14 @@ runs:
           with:
               bun-version: ${{ inputs.bun-version }}
         - name: Install dependencies
+          if: inputs.typeorm == ''
           shell: bash
           run: bun install --frozen-lockfile
+        # Applying a profile rewrites the root overrides, so the lockfile is
+        # expected to change and cannot be installed frozen.
+        - name: Install dependencies (TypeORM ${{ inputs.typeorm }})
+          if: inputs.typeorm != ''
+          shell: bash
+          run: |
+              node scripts/typeorm/use-version.mjs "${{ inputs.typeorm }}"
+              node scripts/typeorm/verify.mjs

--- a/.github/workflows/typeorm_v1.yml
+++ b/.github/workflows/typeorm_v1.yml
@@ -29,28 +29,9 @@ concurrency:
 # the e2e-* jobs because GitHub Actions supports neither YAML anchors nor
 # service reuse. Update all four copies together.
 jobs:
-    should-run:
-        name: should run
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-        outputs:
-            run: ${{ steps.check.outputs.run }}
-        steps:
-            - id: check
-              run: |
-                  if [ "${{ github.event_name }}" != "pull_request" ]; then
-                    echo "run=true" >> "$GITHUB_OUTPUT"
-                  elif ${{ contains(github.event.pull_request.labels.*.name, 'typeorm-v1') }}; then
-                    echo "run=true" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "run=false" >> "$GITHUB_OUTPUT"
-                  fi
-
     build:
         name: build
-        needs: should-run
-        if: needs.should-run.outputs.run == 'true'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'typeorm-v1')
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -64,8 +45,7 @@ jobs:
 
     unit-tests:
         name: unit tests
-        needs: should-run
-        if: needs.should-run.outputs.run == 'true'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'typeorm-v1')
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -81,8 +61,7 @@ jobs:
 
     e2e-sqljs:
         name: e2e (sqljs)
-        needs: should-run
-        if: needs.should-run.outputs.run == 'true'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'typeorm-v1')
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -106,8 +85,7 @@ jobs:
 
     e2e-mariadb:
         name: e2e (mariadb)
-        needs: should-run
-        if: needs.should-run.outputs.run == 'true'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'typeorm-v1')
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -139,8 +117,7 @@ jobs:
 
     e2e-mysql:
         name: e2e (mysql)
-        needs: should-run
-        if: needs.should-run.outputs.run == 'true'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'typeorm-v1')
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -172,8 +149,7 @@ jobs:
 
     e2e-postgres:
         name: e2e (postgres)
-        needs: should-run
-        if: needs.should-run.outputs.run == 'true'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'typeorm-v1')
         runs-on: ubuntu-latest
         permissions:
             contents: read

--- a/.github/workflows/typeorm_v1.yml
+++ b/.github/workflows/typeorm_v1.yml
@@ -1,0 +1,205 @@
+name: TypeORM v1 compatibility
+
+# Runs the database-backed suites against TypeORM v1 while support for it is
+# being built. It is deliberately a separate workflow from Build & Test: these
+# jobs are expected to fail until the migration is finished, and a permanently
+# red job inside the required matrix trains people to ignore the required
+# matrix. Once every job here is green, fold them into build_and_test.yml as a
+# `typeorm` matrix axis and delete this file.
+#
+# Add the `typeorm-v1` label to a pull request to run it against that PR.
+
+on:
+    workflow_dispatch:
+    schedule:
+        # Nightly, so regressions in either TypeORM v1 or Vendure surface without
+        # anyone having to remember to trigger a run.
+        - cron: '0 3 * * *'
+    pull_request:
+        types: [opened, reopened, synchronize, labeled]
+
+env:
+    CI: true
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+# NOTE: As in build_and_test.yml, the service definitions are duplicated across
+# the e2e-* jobs because GitHub Actions supports neither YAML anchors nor
+# service reuse. Update all four copies together.
+jobs:
+    should-run:
+        name: should run
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        outputs:
+            run: ${{ steps.check.outputs.run }}
+        steps:
+            - id: check
+              run: |
+                  if [ "${{ github.event_name }}" != "pull_request" ]; then
+                    echo "run=true" >> "$GITHUB_OUTPUT"
+                  elif ${{ contains(github.event.pull_request.labels.*.name, 'typeorm-v1') }}; then
+                    echo "run=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "run=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+    build:
+        name: build
+        needs: should-run
+        if: needs.should-run.outputs.run == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+            - uses: ./.github/actions/setup
+              with:
+                  typeorm: '1'
+            - name: Build
+              run: bun run build
+
+    unit-tests:
+        name: unit tests
+        needs: should-run
+        if: needs.should-run.outputs.run == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+            - uses: ./.github/actions/setup
+              with:
+                  typeorm: '1'
+            - name: Build (continues past type errors)
+              run: node scripts/typeorm/build-for-tests.mjs
+            - name: Unit tests
+              run: node scripts/typeorm/run-db-tests.mjs --unit-only
+
+    e2e-sqljs:
+        name: e2e (sqljs)
+        needs: should-run
+        if: needs.should-run.outputs.run == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        services:
+            redis:
+                image: redis:7.4.1
+                ports:
+                    - 6379
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+            - uses: ./.github/actions/setup
+              with:
+                  typeorm: '1'
+            - name: Build (continues past type errors)
+              run: node scripts/typeorm/build-for-tests.mjs
+            - name: e2e tests
+              env:
+                  E2E_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
+                  DB: sqljs
+              run: node scripts/typeorm/run-db-tests.mjs --e2e-only
+
+    e2e-mariadb:
+        name: e2e (mariadb)
+        needs: should-run
+        if: needs.should-run.outputs.run == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        services:
+            mariadb:
+                image: mariadb:11.5
+                env:
+                    MARIADB_ROOT_PASSWORD: password
+                ports:
+                    - 3306
+                options: --health-cmd="mariadb-admin ping -h localhost -u vendure -ppassword" --health-interval=10s --health-timeout=5s --health-retries=3
+            redis:
+                image: redis:7.4.1
+                ports:
+                    - 6379
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+            - uses: ./.github/actions/setup
+              with:
+                  typeorm: '1'
+            - name: Build (continues past type errors)
+              run: node scripts/typeorm/build-for-tests.mjs
+            - name: e2e tests
+              env:
+                  E2E_MARIADB_PORT: ${{ job.services.mariadb.ports['3306'] }}
+                  E2E_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
+                  DB: mariadb
+              run: node scripts/typeorm/run-db-tests.mjs --e2e-only
+
+    e2e-mysql:
+        name: e2e (mysql)
+        needs: should-run
+        if: needs.should-run.outputs.run == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        services:
+            mysql:
+                image: vendure/mysql-8-native-auth:latest
+                env:
+                    MYSQL_ROOT_PASSWORD: password
+                ports:
+                    - 3306
+                options: --health-cmd="mysqladmin ping --silent" --health-interval=10s --health-timeout=20s --health-retries=10
+            redis:
+                image: redis:7.4.1
+                ports:
+                    - 6379
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+            - uses: ./.github/actions/setup
+              with:
+                  typeorm: '1'
+            - name: Build (continues past type errors)
+              run: node scripts/typeorm/build-for-tests.mjs
+            - name: e2e tests
+              env:
+                  E2E_MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
+                  E2E_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
+                  DB: mysql
+              run: node scripts/typeorm/run-db-tests.mjs --e2e-only
+
+    e2e-postgres:
+        name: e2e (postgres)
+        needs: should-run
+        if: needs.should-run.outputs.run == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        services:
+            postgres:
+                image: postgres:16
+                env:
+                    POSTGRES_USER: vendure
+                    POSTGRES_PASSWORD: password
+                ports:
+                    - 5432
+                options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
+            redis:
+                image: redis:7.4.1
+                ports:
+                    - 6379
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+            - uses: ./.github/actions/setup
+              with:
+                  typeorm: '1'
+            - name: Build (continues past type errors)
+              run: node scripts/typeorm/build-for-tests.mjs
+            - name: e2e tests
+              env:
+                  E2E_POSTGRES_PORT: ${{ job.services.postgres.ports['5432'] }}
+                  E2E_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
+                  DB: postgres
+              run: node scripts/typeorm/run-db-tests.mjs --e2e-only

--- a/.github/workflows/typeorm_v1.yml
+++ b/.github/workflows/typeorm_v1.yml
@@ -1,11 +1,10 @@
 name: TypeORM v1 compatibility
 
-# Runs the database-backed suites against TypeORM v1 while support for it is
-# being built. It is deliberately a separate workflow from Build & Test: these
-# jobs are expected to fail until the migration is finished, and a permanently
-# red job inside the required matrix trains people to ignore the required
-# matrix. Once every job here is green, fold them into build_and_test.yml as a
-# `typeorm` matrix axis and delete this file.
+# Runs the database-backed suites against TypeORM v1 while support for it is being
+# built. These jobs are expected to fail until that work is finished, which is why
+# they are kept out of Build & Test: a job that is always red stops being read.
+# Once they all pass, move them into build_and_test.yml as a `typeorm` matrix axis
+# and delete this file.
 #
 # Add the `typeorm-v1` label to a pull request to run it against that PR.
 

--- a/.github/workflows/typeorm_v1.yml
+++ b/.github/workflows/typeorm_v1.yml
@@ -16,6 +16,10 @@ on:
         # anyone having to remember to trigger a run.
         - cron: '0 3 * * *'
     pull_request:
+        branches:
+            - master
+            - major
+            - minor
         types: [opened, reopened, synchronize, labeled]
 
 env:

--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,6 @@ plans/
 # Scratch files produced by the translation tooling
 missing-translations.txt
 translations.txt
+
+# Lockfile snapshot taken by scripts/typeorm/use-version.mjs
+bun.lock.typeorm-profile-backup

--- a/package.json
+++ b/package.json
@@ -31,7 +31,11 @@
     "generate-changelog": "ts-node scripts/changelogs/generate-changelog.ts",
     "publish-release": "lerna version -m \"chore: Publish %s\" --no-push --force-publish --exact",
     "publish-prerelease": "lerna version -m \"chore: Pre-release %s\" prerelease --exact --no-push --force-publish --preid next --dist-tag next",
-    "publish-local": "lerna version --force-publish --no-git-tag-version && cd scripts && ./publish-to-verdaccio.sh"
+    "publish-local": "lerna version --force-publish --no-git-tag-version && cd scripts && ./publish-to-verdaccio.sh",
+    "typeorm:use": "node scripts/typeorm/use-version.mjs",
+    "typeorm:verify": "node scripts/typeorm/verify.mjs",
+    "build:for-tests": "node scripts/typeorm/build-for-tests.mjs",
+    "test:db": "node scripts/typeorm/run-db-tests.mjs"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.1.0",

--- a/scripts/typeorm/README.md
+++ b/scripts/typeorm/README.md
@@ -37,10 +37,10 @@ Applying a profile saves a copy of `bun.lock` first, and `--reset` puts it back 
 frozen. Without that, the reset install would float every dependency to the newest version its
 declared range allows, leaving the workspace on different versions from the ones it started on.
 
-`test:db` verifies the install before running anything. That check matters more than it looks:
-entity metadata is registered against a single `typeorm` module instance, so if a second copy
-ends up nested somewhere in `node_modules`, the suites fail in ways that read like genuine
-version incompatibilities. `bun run typeorm:verify` runs the same check on its own.
+`test:db` verifies the install before running anything. Entity metadata is registered against a
+single `typeorm` module instance, so a second copy nested somewhere in `node_modules` makes the
+suites fail in ways that read like genuine version incompatibilities. `bun run typeorm:verify`
+runs the same check on its own.
 
 ## Building while type errors remain
 
@@ -55,9 +55,9 @@ error leaves `dist/` without the schema files and the server then fails to boot 
 definitions were found", which tells you nothing about the actual incompatibility.
 
 `build:for-tests` runs each stage separately and keeps going. `tsc` emits its output even when
-it reports errors, so everything needed to boot a server is produced. Type errors are not
-being hidden: the `build` job in `typeorm_v1.yml` reports those, and the e2e jobs use this
-script to give the second, independent signal of which calls fail once the code is running.
+it reports errors, so everything needed to boot a server is produced. The `build` job in
+`typeorm_v1.yml` still compiles strictly and reports the type errors, so the e2e jobs are free
+to report what fails once the code is running.
 
 ## In CI
 
@@ -66,10 +66,10 @@ installs the committed lockfile, which is what `build_and_test.yml` does and wha
 project its v0.3 coverage.
 
 The v1 runs live in `typeorm_v1.yml`, separate from `build_and_test.yml`, because they are
-expected to fail until the migration is finished and a permanently red job inside the required
-matrix teaches people to ignore the required matrix. It runs nightly, on demand, and on any
-pull request labelled `typeorm-v1`. When every job in it passes, move them into
-`build_and_test.yml` as a `typeorm` matrix axis and delete the separate workflow.
+expected to fail until the migration is finished and a job that is always red stops being read.
+It runs nightly, on demand, and on any pull request labelled `typeorm-v1`. When every job in it
+passes, move them into `build_and_test.yml` as a `typeorm` matrix axis and delete the separate
+workflow.
 
 ## Adding a version
 

--- a/scripts/typeorm/README.md
+++ b/scripts/typeorm/README.md
@@ -33,6 +33,10 @@ bun run typeorm:use --reset
 `bun run typeorm:use` rewrites `package.json` and `bun.lock`. Run `--reset` before committing;
 a stray `typeormProfile` field in the root `package.json` is the tell that you forgot.
 
+Applying a profile saves a copy of `bun.lock` first, and `--reset` puts it back and installs
+frozen. Without that, the reset install would float every dependency to the newest version its
+declared range allows, leaving the workspace on different versions from the ones it started on.
+
 `test:db` verifies the install before running anything. That check matters more than it looks:
 entity metadata is registered against a single `typeorm` module instance, so if a second copy
 ends up nested somewhere in `node_modules`, the suites fail in ways that read like genuine

--- a/scripts/typeorm/README.md
+++ b/scripts/typeorm/README.md
@@ -1,0 +1,74 @@
+# TypeORM version test harness
+
+Vendure is moving towards supporting both TypeORM v0.3 and v1 from the same source, so that
+existing projects can stay on v0.3 while new ones adopt v1. These scripts run the
+database-backed test suites against either version.
+
+## Why the version has to be forced
+
+`typeorm` is a direct dependency of `@vendure/core`, not a peer dependency, so you cannot pick
+the version at install time. Instead, each profile in `profiles.json` is written into the root
+`package.json` as a set of `overrides`, which bun applies to workspace packages' direct
+dependencies. The root already uses the same mechanism to keep `graphql` on one version.
+
+A profile covers more than `typeorm` itself. TypeORM v1 requires `@nestjs/typeorm` 11.0.1 or
+later (earlier releases declare a `typeorm` peer range of `^0.3.0`) and `better-sqlite3` v12.
+
+## Running the suites
+
+```sh
+# Switch the workspace to TypeORM v1 and install
+bun run typeorm:use 1
+
+# Run the unit and e2e suites against whichever profile is active
+bun run test:db                  # sqljs
+DB=postgres bun run test:db      # postgres
+bun run test:db --e2e-only
+bun run test:db --scope @vendure/core
+
+# Go back to the versions declared in the workspace
+bun run typeorm:use --reset
+```
+
+`bun run typeorm:use` rewrites `package.json` and `bun.lock`. Run `--reset` before committing;
+a stray `typeormProfile` field in the root `package.json` is the tell that you forgot.
+
+`test:db` verifies the install before running anything. That check matters more than it looks:
+entity metadata is registered against a single `typeorm` module instance, so if a second copy
+ends up nested somewhere in `node_modules`, the suites fail in ways that read like genuine
+version incompatibilities. `bun run typeorm:verify` runs the same check on its own.
+
+## Building while type errors remain
+
+```sh
+bun run build:for-tests
+```
+
+While the migration is in progress the packages do not typecheck against v1, and `bun run
+build` stops at the first error. `@vendure/core` builds in three stages joined by `&&` — the
+main compile, the CLI compile, and a copy of the static `.graphql` schema files — so one type
+error leaves `dist/` without the schema files and the server then fails to boot with "No type
+definitions were found", which tells you nothing about the actual incompatibility.
+
+`build:for-tests` runs each stage separately and keeps going. `tsc` emits its output even when
+it reports errors, so everything needed to boot a server is produced. Type errors are not
+being hidden: the `build` job in `typeorm_v1.yml` reports those, and the e2e jobs use this
+script to give the second, independent signal of which calls fail once the code is running.
+
+## In CI
+
+The `.github/actions/setup` action takes a `typeorm` input naming a profile. With no input it
+installs the committed lockfile, which is what `build_and_test.yml` does and what gives the
+project its v0.3 coverage.
+
+The v1 runs live in `typeorm_v1.yml`, separate from `build_and_test.yml`, because they are
+expected to fail until the migration is finished and a permanently red job inside the required
+matrix teaches people to ignore the required matrix. It runs nightly, on demand, and on any
+pull request labelled `typeorm-v1`. When every job in it passes, move them into
+`build_and_test.yml` as a `typeorm` matrix axis and delete the separate workflow.
+
+## Adding a version
+
+Add an entry to `profiles.json` naming every package that has to move together with that
+TypeORM version. `use-version.mjs` clears the packages named by _all_ profiles before applying
+the requested one, so switching between profiles never leaves a stale override behind.

--- a/scripts/typeorm/build-for-tests.mjs
+++ b/scripts/typeorm/build-for-tests.mjs
@@ -3,15 +3,12 @@
  * Runs the same builds as `lerna run ci`, but without stopping at type errors, so
  * that the database-backed suites can run and report what breaks at runtime.
  *
- * Packages are selected exactly as `lerna run ci` selects them, by the presence of
- * a `ci` script, so this builds the same set the e2e jobs in build_and_test.yml
- * build. Packages without a `ci` script are named in the output rather than
- * skipped silently, because several of them do have e2e suites, and "this package
- * was never built" and "this package is incompatible with TypeORM v1" are easy to
- * confuse when the suite fails.
+ * Packages are selected by the presence of a `ci` script, as `lerna run ci` selects
+ * them. Any package without one is named in the output, since some of those have
+ * e2e suites and an unbuilt package fails in ways that read like a version
+ * incompatibility.
  *
- * See scripts/typeorm/README.md for why the stages are run separately rather than
- * left chained with `&&`.
+ * See scripts/typeorm/README.md for why the build stages are run separately.
  *
  * Usage:
  *   node scripts/typeorm/build-for-tests.mjs
@@ -27,9 +24,8 @@ const repoRoot = path.resolve(scriptDir, '..', '..');
 const order = topologicalPackageOrder();
 const failed = [];
 
-// The local `.bin` directories, searched in the order a package manager would.
-// Commands are resolved against these to an absolute path rather than being
-// looked up through PATH at spawn time.
+// Searched in the order a package manager would, to resolve each command to an
+// absolute path instead of relying on PATH at spawn time.
 const binDirs = [
     path.join(repoRoot, 'node_modules', '.bin'),
     ...order.map(pkg => path.join(pkg.location, 'node_modules', '.bin')),
@@ -126,9 +122,8 @@ function resolveLocalBin(command) {
 
 /**
  * Orders the workspace packages so that each one is built after the packages it
- * depends on. Derived from the manifests directly rather than by shelling out to
- * lerna, which keeps the build order available even when the workspace is in a
- * half-installed state.
+ * depends on. Read from the manifests so that the order is still available when the
+ * workspace is half-installed.
  */
 function topologicalPackageOrder() {
     const packagesDir = path.join(repoRoot, 'packages');

--- a/scripts/typeorm/build-for-tests.mjs
+++ b/scripts/typeorm/build-for-tests.mjs
@@ -29,13 +29,13 @@ const repoRoot = path.resolve(scriptDir, '..', '..');
 const order = topologicalPackageOrder();
 const failed = [];
 
-// A package manager puts the local `.bin` directories on PATH before running a
-// script; spawning the commands directly does not, so it is done here.
-const binPath = [
+// The local `.bin` directories, searched in the order a package manager would.
+// Commands are resolved against these to an absolute path rather than being
+// looked up through PATH at spawn time.
+const binDirs = [
     path.join(repoRoot, 'node_modules', '.bin'),
     ...order.map(pkg => path.join(pkg.location, 'node_modules', '.bin')),
-].join(path.delimiter);
-const env = { ...process.env, PATH: `${binPath}${path.delimiter}${process.env.PATH ?? ''}` };
+];
 
 for (const { name, location } of order) {
     const manifest = JSON.parse(fs.readFileSync(path.join(location, 'package.json'), 'utf8'));
@@ -46,7 +46,14 @@ for (const { name, location } of order) {
     console.log(`\n--- ${name}`);
     for (const stage of stages) {
         console.log(`$ ${stage}`);
-        const result = spawnSync(stage, { cwd: location, stdio: 'inherit', shell: true, env });
+        const [command, ...commandArgs] = stage.split(/\s+/);
+        const executable = resolveLocalBin(command);
+        if (!executable) {
+            console.log(`  skipped: no local binary named "${command}"`);
+            failed.push(`${name}: ${stage}`);
+            continue;
+        }
+        const result = spawnSync(executable, commandArgs, { cwd: location, stdio: 'inherit' });
         if (result.status !== 0) {
             failed.push(`${name}: ${stage}`);
         }
@@ -89,16 +96,71 @@ function resolveBuildStages(manifest) {
         .filter(Boolean);
 }
 
-function topologicalPackageOrder() {
-    const result = spawnSync('bunx', ['lerna', 'list', '--toposort', '--json', '--all'], {
-        cwd: repoRoot,
-        encoding: 'utf8',
-    });
-    if (result.status !== 0) {
-        console.error(result.stderr);
-        throw new Error('Could not determine the package build order via lerna.');
+/**
+ * Finds `command` in the workspace's `.bin` directories and returns its absolute
+ * path, or undefined if it is not installed.
+ */
+function resolveLocalBin(command) {
+    const candidates =
+        process.platform === 'win32' ? [`${command}.cmd`, `${command}.exe`, command] : [command];
+    for (const dir of binDirs) {
+        for (const candidate of candidates) {
+            const full = path.join(dir, candidate);
+            if (fs.existsSync(full)) {
+                return full;
+            }
+        }
     }
-    // lerna prints progress on stdout before the JSON payload.
-    const json = result.stdout.slice(result.stdout.indexOf('['));
-    return JSON.parse(json);
+    return undefined;
+}
+
+/**
+ * Orders the workspace packages so that each one is built after the packages it
+ * depends on. Derived from the manifests directly rather than by shelling out to
+ * lerna, which keeps the build order available even when the workspace is in a
+ * half-installed state.
+ */
+function topologicalPackageOrder() {
+    const packagesDir = path.join(repoRoot, 'packages');
+    const packages = fs
+        .readdirSync(packagesDir, { withFileTypes: true })
+        .filter(entry => entry.isDirectory())
+        .map(entry => path.join(packagesDir, entry.name))
+        .filter(location => fs.existsSync(path.join(location, 'package.json')))
+        .map(location => {
+            const manifest = JSON.parse(fs.readFileSync(path.join(location, 'package.json'), 'utf8'));
+            return {
+                name: manifest.name,
+                location,
+                deps: Object.keys({ ...manifest.dependencies, ...manifest.devDependencies }),
+            };
+        });
+
+    const byName = new Map(packages.map(pkg => [pkg.name, pkg]));
+    const ordered = [];
+    const visiting = new Set();
+    const visited = new Set();
+
+    const visit = pkg => {
+        if (visited.has(pkg.name) || visiting.has(pkg.name)) {
+            // A cycle between workspace packages is not something this script can
+            // resolve, so the package is emitted where it was first reached.
+            return;
+        }
+        visiting.add(pkg.name);
+        for (const dep of pkg.deps) {
+            const depPkg = byName.get(dep);
+            if (depPkg) {
+                visit(depPkg);
+            }
+        }
+        visiting.delete(pkg.name);
+        visited.add(pkg.name);
+        ordered.push({ name: pkg.name, location: pkg.location });
+    };
+
+    for (const pkg of packages) {
+        visit(pkg);
+    }
+    return ordered;
 }

--- a/scripts/typeorm/build-for-tests.mjs
+++ b/scripts/typeorm/build-for-tests.mjs
@@ -1,19 +1,17 @@
 #!/usr/bin/env node
 /**
- * Builds the workspace as far as it will go, without stopping at type errors,
- * so that the database-backed suites can run and report what breaks at runtime.
+ * Runs the same builds as `lerna run ci`, but without stopping at type errors, so
+ * that the database-backed suites can run and report what breaks at runtime.
  *
- * This exists because of how the build scripts are chained. `@vendure/core`'s
- * build runs three stages joined by `&&`: the main compile, the CLI compile,
- * and a copy of the static `.graphql` schema files. `tsc` still emits output
- * when it reports type errors, but its non-zero exit stops the chain, so a
- * single type error leaves `dist/` without the schema files. The server then
- * fails to boot with "No type definitions were found", which says nothing about
- * the actual incompatibility.
+ * Packages are selected exactly as `lerna run ci` selects them, by the presence of
+ * a `ci` script, so this builds the same set the e2e jobs in build_and_test.yml
+ * build. Packages without a `ci` script are named in the output rather than
+ * skipped silently, because several of them do have e2e suites, and "this package
+ * was never built" and "this package is incompatible with TypeORM v1" are easy to
+ * confuse when the suite fails.
  *
- * Type errors are not swallowed by doing this — the `build` job in the same
- * workflow reports them. This script gives the second, independent signal:
- * which calls fail once the code is actually running.
+ * See scripts/typeorm/README.md for why the stages are run separately rather than
+ * left chained with `&&`.
  *
  * Usage:
  *   node scripts/typeorm/build-for-tests.mjs
@@ -37,10 +35,13 @@ const binDirs = [
     ...order.map(pkg => path.join(pkg.location, 'node_modules', '.bin')),
 ];
 
+const notBuilt = [];
+
 for (const { name, location } of order) {
     const manifest = JSON.parse(fs.readFileSync(path.join(location, 'package.json'), 'utf8'));
     const stages = resolveBuildStages(manifest);
     if (stages.length === 0) {
+        notBuilt.push({ name, hasE2e: Boolean(manifest.scripts?.e2e) });
         continue;
     }
     console.log(`\n--- ${name}`);
@@ -67,6 +68,15 @@ if (failed.length) {
     }
 } else {
     console.log('\nAll build stages passed.');
+}
+
+const skippedWithE2e = notBuilt.filter(pkg => pkg.hasE2e);
+if (skippedWithE2e.length) {
+    console.log(
+        `\nNot built (no \`ci\` script), but has an e2e suite that \`lerna run e2e\` will run: ` +
+            `${skippedWithE2e.map(pkg => pkg.name).join(', ')}. ` +
+            'A failure in those suites may be a missing build rather than a TypeORM incompatibility.',
+    );
 }
 
 // Always succeeds: reporting build failures is the job of the `build` job, and

--- a/scripts/typeorm/build-for-tests.mjs
+++ b/scripts/typeorm/build-for-tests.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Builds the workspace as far as it will go, without stopping at type errors,
+ * so that the database-backed suites can run and report what breaks at runtime.
+ *
+ * This exists because of how the build scripts are chained. `@vendure/core`'s
+ * build runs three stages joined by `&&`: the main compile, the CLI compile,
+ * and a copy of the static `.graphql` schema files. `tsc` still emits output
+ * when it reports type errors, but its non-zero exit stops the chain, so a
+ * single type error leaves `dist/` without the schema files. The server then
+ * fails to boot with "No type definitions were found", which says nothing about
+ * the actual incompatibility.
+ *
+ * Type errors are not swallowed by doing this — the `build` job in the same
+ * workflow reports them. This script gives the second, independent signal:
+ * which calls fail once the code is actually running.
+ *
+ * Usage:
+ *   node scripts/typeorm/build-for-tests.mjs
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..', '..');
+
+const order = topologicalPackageOrder();
+const failed = [];
+
+// A package manager puts the local `.bin` directories on PATH before running a
+// script; spawning the commands directly does not, so it is done here.
+const binPath = [
+    path.join(repoRoot, 'node_modules', '.bin'),
+    ...order.map(pkg => path.join(pkg.location, 'node_modules', '.bin')),
+].join(path.delimiter);
+const env = { ...process.env, PATH: `${binPath}${path.delimiter}${process.env.PATH ?? ''}` };
+
+for (const { name, location } of order) {
+    const manifest = JSON.parse(fs.readFileSync(path.join(location, 'package.json'), 'utf8'));
+    const stages = resolveBuildStages(manifest);
+    if (stages.length === 0) {
+        continue;
+    }
+    console.log(`\n--- ${name}`);
+    for (const stage of stages) {
+        console.log(`$ ${stage}`);
+        const result = spawnSync(stage, { cwd: location, stdio: 'inherit', shell: true, env });
+        if (result.status !== 0) {
+            failed.push(`${name}: ${stage}`);
+        }
+    }
+}
+
+if (failed.length) {
+    console.log(`\n${failed.length} build stage(s) reported errors; output was still emitted:`);
+    for (const entry of failed) {
+        console.log(`  ${entry}`);
+    }
+} else {
+    console.log('\nAll build stages passed.');
+}
+
+// Always succeeds: reporting build failures is the job of the `build` job, and
+// exiting non-zero here would stop the tests this script exists to enable.
+process.exit(0);
+
+/**
+ * Returns the `ci` script's stages, split on `&&` so each runs regardless of
+ * whether the previous one exited non-zero. One level of `npm run <script>`
+ * indirection is followed, which covers the `ci` -> `build` alias the packages
+ * use. Splitting on `&&` assumes no build command contains `&&` inside a quoted
+ * argument, which holds for every package script in this repo.
+ */
+function resolveBuildStages(manifest) {
+    const scripts = manifest.scripts ?? {};
+    let script = scripts.ci;
+    if (!script) {
+        return [];
+    }
+    const alias = /^(?:npm|bun|yarn) run ([\w:-]+)$/.exec(script.trim());
+    if (alias && scripts[alias[1]]) {
+        script = scripts[alias[1]];
+    }
+    return script
+        .split('&&')
+        .map(stage => stage.trim())
+        .filter(Boolean);
+}
+
+function topologicalPackageOrder() {
+    const result = spawnSync('bunx', ['lerna', 'list', '--toposort', '--json', '--all'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+    });
+    if (result.status !== 0) {
+        console.error(result.stderr);
+        throw new Error('Could not determine the package build order via lerna.');
+    }
+    // lerna prints progress on stdout before the JSON payload.
+    const json = result.stdout.slice(result.stdout.indexOf('['));
+    return JSON.parse(json);
+}

--- a/scripts/typeorm/profiles.json
+++ b/scripts/typeorm/profiles.json
@@ -1,0 +1,15 @@
+{
+    "//": "Dependency sets used to run the database-backed test suites against each supported TypeORM major. Each profile is applied as a set of `overrides` in the root package.json. `@nestjs/typeorm` must be >= 11.0.1 for both profiles, because that is the first release whose `typeorm` peer range admits v1.",
+    "profiles": {
+        "0.3": {
+            "typeorm": "0.3.31",
+            "@nestjs/typeorm": "11.0.3",
+            "better-sqlite3": "11.10.0"
+        },
+        "1": {
+            "typeorm": "1.1.0",
+            "@nestjs/typeorm": "11.0.3",
+            "better-sqlite3": "12.11.1"
+        }
+    }
+}

--- a/scripts/typeorm/profiles.json
+++ b/scripts/typeorm/profiles.json
@@ -1,5 +1,6 @@
 {
     "//": "Dependency sets used to run the database-backed test suites against each supported TypeORM major. Each profile is applied as a set of `overrides` in the root package.json. `@nestjs/typeorm` must be >= 11.0.1 for both profiles, because that is the first release whose `typeorm` peer range admits v1.",
+    "//0.3": "Pinned exactly, and deliberately separate from `use-version.mjs --reset`. Reset returns the workspace to the ranges declared in packages/core/package.json, which float; this profile fixes the version so that a v0.3 run and a v1 run compared against each other differ only by the thing under test. The pins are not kept in sync with core's ranges automatically — when core's typeorm range moves, update this too.",
     "profiles": {
         "0.3": {
             "typeorm": "0.3.31",

--- a/scripts/typeorm/run-db-tests.mjs
+++ b/scripts/typeorm/run-db-tests.mjs
@@ -29,6 +29,15 @@ const unitOnly = args.includes('--unit-only');
 const scopeIndex = args.indexOf('--scope');
 const scope = scopeIndex === -1 ? undefined : args[scopeIndex + 1];
 
+if (e2eOnly && unitOnly) {
+    console.error('--e2e-only and --unit-only select nothing when combined. Pass at most one.');
+    process.exit(1);
+}
+if (scopeIndex !== -1 && !scope) {
+    console.error('--scope needs a package name, e.g. --scope @vendure/core');
+    process.exit(1);
+}
+
 const verify = spawnSync(process.execPath, [path.join(scriptDir, 'verify.mjs')], {
     cwd: repoRoot,
     stdio: 'inherit',

--- a/scripts/typeorm/run-db-tests.mjs
+++ b/scripts/typeorm/run-db-tests.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Runs the test suites that talk to a database, against whichever TypeORM
+ * profile the workspace is currently set to.
+ *
+ * The suites themselves are the normal `test` and `e2e` scripts. This wrapper
+ * exists so that a run is verified and labelled: it refuses to start against a
+ * broken install, and it states the TypeORM version and database engine that
+ * were actually exercised. Without that, a log full of failures gives no way to
+ * tell a real incompatibility from a mis-resolved dependency.
+ *
+ * Usage:
+ *   node scripts/typeorm/run-db-tests.mjs              # unit + e2e, sqljs
+ *   DB=postgres node scripts/typeorm/run-db-tests.mjs  # unit + e2e, postgres
+ *   node scripts/typeorm/run-db-tests.mjs --e2e-only
+ *   node scripts/typeorm/run-db-tests.mjs --scope @vendure/core
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..', '..');
+
+const args = process.argv.slice(2);
+const e2eOnly = args.includes('--e2e-only');
+const unitOnly = args.includes('--unit-only');
+const scopeIndex = args.indexOf('--scope');
+const scope = scopeIndex === -1 ? undefined : args[scopeIndex + 1];
+
+const verify = spawnSync(process.execPath, [path.join(scriptDir, 'verify.mjs')], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+});
+if (verify.status !== 0) {
+    process.exit(verify.status ?? 1);
+}
+
+const typeormVersion = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'node_modules', 'typeorm', 'package.json'), 'utf8'),
+).version;
+const dbEngine = process.env.DB || 'sqljs';
+
+console.log(`\nRunning database tests against typeorm@${typeormVersion} on ${dbEngine}.\n`);
+
+const scopeArgs = scope ? ['--scope', scope] : [];
+const suites = [
+    ...(e2eOnly ? [] : [{ name: 'unit', args: ['run', 'test', ...scopeArgs, '--stream', '--no-bail'] }]),
+    ...(unitOnly ? [] : [{ name: 'e2e', args: ['run', 'e2e', ...scopeArgs, '--stream', '--no-bail'] }]),
+];
+
+const failed = [];
+for (const suite of suites) {
+    const result = spawnSync('bunx', ['lerna', ...suite.args], {
+        cwd: repoRoot,
+        stdio: 'inherit',
+        env: { ...process.env, DB: dbEngine },
+    });
+    if (result.status !== 0) {
+        failed.push(suite.name);
+    }
+}
+
+console.log(
+    `\ntypeorm@${typeormVersion} on ${dbEngine}: ${failed.length ? `${failed.join(', ')} failed` : 'all suites passed'}`,
+);
+process.exit(failed.length ? 1 : 0);

--- a/scripts/typeorm/run-db-tests.mjs
+++ b/scripts/typeorm/run-db-tests.mjs
@@ -50,9 +50,17 @@ const suites = [
     ...(unitOnly ? [] : [{ name: 'e2e', args: ['run', 'e2e', ...scopeArgs, '--stream', '--no-bail'] }]),
 ];
 
+// Run lerna's entry point under the current Node binary, so neither the
+// executable nor the runtime is resolved through PATH.
+const lernaCli = path.join(repoRoot, 'node_modules', 'lerna', 'dist', 'cli.js');
+if (!fs.existsSync(lernaCli)) {
+    console.error(`Could not find lerna at ${lernaCli}. Run \`bun install\` first.`);
+    process.exit(1);
+}
+
 const failed = [];
 for (const suite of suites) {
-    const result = spawnSync('bunx', ['lerna', ...suite.args], {
+    const result = spawnSync(process.execPath, [lernaCli, ...suite.args], {
         cwd: repoRoot,
         stdio: 'inherit',
         env: { ...process.env, DB: dbEngine },

--- a/scripts/typeorm/use-version.mjs
+++ b/scripts/typeorm/use-version.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Switches the whole workspace onto one of the TypeORM profiles defined in
+ * `profiles.json`, so the database-backed test suites can be run against each
+ * supported TypeORM major.
+ *
+ * `typeorm` is a direct dependency of `@vendure/core` rather than a peer
+ * dependency, so the version cannot be selected per-install. The profile is
+ * applied as a set of root-level `overrides`, which bun honours for workspace
+ * packages' direct dependencies.
+ *
+ * Usage:
+ *   node scripts/typeorm/use-version.mjs 1          # switch to TypeORM v1 and install
+ *   node scripts/typeorm/use-version.mjs 0.3        # switch back to TypeORM v0.3 and install
+ *   node scripts/typeorm/use-version.mjs --reset    # drop the profile and restore the default install
+ *   node scripts/typeorm/use-version.mjs 1 --no-install
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..', '..');
+const rootPackageJsonPath = path.join(repoRoot, 'package.json');
+const PROFILE_FIELD = 'typeormProfile';
+
+const args = process.argv.slice(2);
+const install = !args.includes('--no-install');
+const reset = args.includes('--reset');
+const requested = args.find(arg => !arg.startsWith('--'));
+
+const { profiles } = JSON.parse(fs.readFileSync(path.join(scriptDir, 'profiles.json'), 'utf8'));
+
+if (!reset && !requested) {
+    console.error(
+        `Specify a profile (${Object.keys(profiles).join(', ')}) or --reset.\n` +
+            'See scripts/typeorm/README.md for details.',
+    );
+    process.exit(1);
+}
+if (requested && !profiles[requested]) {
+    console.error(
+        `Unknown TypeORM profile "${requested}". Available profiles: ${Object.keys(profiles).join(', ')}.`,
+    );
+    process.exit(1);
+}
+
+const rootPackageJsonSource = fs.readFileSync(rootPackageJsonPath, 'utf8');
+const rootPackageJson = JSON.parse(rootPackageJsonSource);
+const indent = /\n(\s+)"/.exec(rootPackageJsonSource)?.[1] ?? '  ';
+const overrides = { ...(rootPackageJson.overrides ?? {}) };
+
+// Every package named by any profile is removed first, so switching between
+// profiles never leaves a stale override behind.
+for (const profile of Object.values(profiles)) {
+    for (const name of Object.keys(profile)) {
+        delete overrides[name];
+    }
+}
+
+if (reset) {
+    delete rootPackageJson[PROFILE_FIELD];
+    console.log('Removed the TypeORM profile; the workspace will install its default versions.');
+} else {
+    Object.assign(overrides, profiles[requested]);
+    rootPackageJson[PROFILE_FIELD] = requested;
+    console.log(`Applying TypeORM profile "${requested}":`);
+    for (const [name, version] of Object.entries(profiles[requested])) {
+        console.log(`  ${name}@${version}`);
+    }
+}
+
+rootPackageJson.overrides = overrides;
+fs.writeFileSync(rootPackageJsonPath, `${JSON.stringify(rootPackageJson, null, indent)}\n`);
+
+if (!install) {
+    console.log('\nSkipped install (--no-install). Run `bun install` to apply.');
+    process.exit(0);
+}
+
+if (reset && !args.includes('--keep-lockfile')) {
+    // Without this the reset install floats every dependency to the newest
+    // version its declared range allows, which is not the state the profile was
+    // applied on top of. Pass --keep-lockfile to skip.
+    console.log('\nRestoring bun.lock from git…');
+    try {
+        execFileSync('git', ['checkout', '--', 'bun.lock'], { cwd: repoRoot, stdio: 'inherit' });
+        console.log('Installing…');
+        execFileSync('bun', ['install', '--frozen-lockfile'], { cwd: repoRoot, stdio: 'inherit' });
+        console.log('\nThe workspace is back on its committed dependency versions.');
+        process.exit(0);
+    } catch {
+        console.log('Could not restore bun.lock from git; installing without it.');
+    }
+}
+
+// Applying a profile rewrites the overrides, so the lockfile is expected to
+// change and --frozen-lockfile cannot be used.
+console.log('\nInstalling…');
+execFileSync('bun', ['install'], { cwd: repoRoot, stdio: 'inherit' });
+
+if (!reset) {
+    console.log(
+        '\npackage.json and bun.lock now hold profile-specific versions. ' +
+            'Run `node scripts/typeorm/use-version.mjs --reset` before committing.',
+    );
+}

--- a/scripts/typeorm/use-version.mjs
+++ b/scripts/typeorm/use-version.mjs
@@ -4,10 +4,8 @@
  * `profiles.json`, so the database-backed test suites can be run against each
  * supported TypeORM major.
  *
- * `typeorm` is a direct dependency of `@vendure/core` rather than a peer
- * dependency, so the version cannot be selected per-install. The profile is
- * applied as a set of root-level `overrides`, which bun honours for workspace
- * packages' direct dependencies.
+ * The profile is applied as a set of root-level `overrides`. See
+ * scripts/typeorm/README.md for why the version has to be forced that way.
  *
  * Usage:
  *   node scripts/typeorm/use-version.mjs 1          # switch to TypeORM v1 and install
@@ -104,12 +102,10 @@ if (reset) {
 }
 
 console.log('\nInstalling…');
-// Resolved through PATH by necessity: bun is the workspace's package manager and
-// is not installed into the workspace itself. NOSONAR
-execFileSync('bun', frozen ? ['install', '--frozen-lockfile'] : ['install'], {
-    cwd: repoRoot,
-    stdio: 'inherit',
-});
+const installArgs = frozen ? ['install', '--frozen-lockfile'] : ['install'];
+// NOSONAR - bun is the workspace's package manager and is not installed into the
+// workspace, so there is no path to resolve it to other than through PATH.
+execFileSync('bun', installArgs, { cwd: repoRoot, stdio: 'inherit' }); // NOSONAR
 
 if (reset) {
     console.log('\nThe workspace is back on its committed dependency versions.');

--- a/scripts/typeorm/use-version.mjs
+++ b/scripts/typeorm/use-version.mjs
@@ -82,10 +82,8 @@ if (!install) {
 
 let frozen = false;
 if (reset) {
-    // A plain reset install floats every dependency to the newest version its
-    // declared range allows, which is not the state the profile was applied on
-    // top of. The lockfile saved when the profile was applied is put back so the
-    // workspace returns to exactly the versions it had.
+    // Restored rather than reinstalled, because a plain install floats every
+    // dependency to the newest version its declared range allows.
     if (fs.existsSync(lockfileBackupPath)) {
         fs.copyFileSync(lockfileBackupPath, lockfilePath);
         fs.rmSync(lockfileBackupPath);

--- a/scripts/typeorm/use-version.mjs
+++ b/scripts/typeorm/use-version.mjs
@@ -23,6 +23,9 @@ import { fileURLToPath } from 'node:url';
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..', '..');
 const rootPackageJsonPath = path.join(repoRoot, 'package.json');
+const lockfilePath = path.join(repoRoot, 'bun.lock');
+// Gitignored alongside the lockfile it copies; see .gitignore.
+const lockfileBackupPath = path.join(repoRoot, 'bun.lock.typeorm-profile-backup');
 const PROFILE_FIELD = 'typeormProfile';
 
 const args = process.argv.slice(2);
@@ -79,28 +82,38 @@ if (!install) {
     process.exit(0);
 }
 
-if (reset && !args.includes('--keep-lockfile')) {
-    // Without this the reset install floats every dependency to the newest
-    // version its declared range allows, which is not the state the profile was
-    // applied on top of. Pass --keep-lockfile to skip.
-    console.log('\nRestoring bun.lock from git…');
-    try {
-        execFileSync('git', ['checkout', '--', 'bun.lock'], { cwd: repoRoot, stdio: 'inherit' });
-        console.log('Installing…');
-        execFileSync('bun', ['install', '--frozen-lockfile'], { cwd: repoRoot, stdio: 'inherit' });
-        console.log('\nThe workspace is back on its committed dependency versions.');
-        process.exit(0);
-    } catch {
-        console.log('Could not restore bun.lock from git; installing without it.');
+let frozen = false;
+if (reset) {
+    // A plain reset install floats every dependency to the newest version its
+    // declared range allows, which is not the state the profile was applied on
+    // top of. The lockfile saved when the profile was applied is put back so the
+    // workspace returns to exactly the versions it had.
+    if (fs.existsSync(lockfileBackupPath)) {
+        fs.copyFileSync(lockfileBackupPath, lockfilePath);
+        fs.rmSync(lockfileBackupPath);
+        frozen = true;
+        console.log('\nRestored the lockfile saved when the profile was applied.');
+    } else {
+        console.log(
+            '\nNo saved lockfile found, so dependencies will resolve afresh within their ' +
+                'declared ranges. Check bun.lock before committing.',
+        );
     }
+} else if (!fs.existsSync(lockfileBackupPath) && fs.existsSync(lockfilePath)) {
+    fs.copyFileSync(lockfilePath, lockfileBackupPath);
 }
 
-// Applying a profile rewrites the overrides, so the lockfile is expected to
-// change and --frozen-lockfile cannot be used.
 console.log('\nInstalling…');
-execFileSync('bun', ['install'], { cwd: repoRoot, stdio: 'inherit' });
+// Resolved through PATH by necessity: bun is the workspace's package manager and
+// is not installed into the workspace itself. NOSONAR
+execFileSync('bun', frozen ? ['install', '--frozen-lockfile'] : ['install'], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+});
 
-if (!reset) {
+if (reset) {
+    console.log('\nThe workspace is back on its committed dependency versions.');
+} else {
     console.log(
         '\npackage.json and bun.lock now hold profile-specific versions. ' +
             'Run `node scripts/typeorm/use-version.mjs --reset` before committing.',

--- a/scripts/typeorm/verify.mjs
+++ b/scripts/typeorm/verify.mjs
@@ -3,10 +3,8 @@
  * Asserts that the installed TypeORM matches the profile the workspace is set
  * to, and that exactly one copy of it is installed.
  *
- * Both checks are worth making before a test run. A hoisting quirk or a stale
- * `node_modules` can leave the intended version in the root while a workspace
- * package resolves a nested copy of the other major, and the resulting test
- * failures look like genuine incompatibilities rather than a bad install.
+ * See scripts/typeorm/README.md for why a split install is worth ruling out
+ * before a test run.
  *
  * Usage:
  *   node scripts/typeorm/verify.mjs            # check against the profile in package.json
@@ -54,13 +52,19 @@ if (!expected) {
     process.exit(0);
 }
 
-const expectedMajor = expected.split('.')[0];
-const actualMajor = actual.split('.')[0];
-if (expectedMajor !== actualMajor) {
+// Profiles pin exact versions, so the installed copy is compared against the pin
+// rather than against the profile name. Comparing the leading digit would let any
+// 0.x.y satisfy the "0.3" profile, which defeats the point of pinning.
+const { profiles } = JSON.parse(fs.readFileSync(path.join(scriptDir, 'profiles.json'), 'utf8'));
+const pinned = profiles[expected]?.typeorm;
+if (!pinned) {
+    console.error(`\nUnknown TypeORM profile "${expected}". Check package.json and profiles.json.`);
+    process.exit(1);
+}
+if (pinned !== actual) {
     console.error(
-        `\nProfile "${expected}" was requested but typeorm@${actual} is installed. ` +
-            'Run `node scripts/typeorm/use-version.mjs ' +
-            `${expected}\` to reinstall.`,
+        `\nProfile "${expected}" pins typeorm@${pinned} but typeorm@${actual} is installed. ` +
+            `Run \`node scripts/typeorm/use-version.mjs ${expected}\` to reinstall.`,
     );
     process.exit(1);
 }

--- a/scripts/typeorm/verify.mjs
+++ b/scripts/typeorm/verify.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Asserts that the installed TypeORM matches the profile the workspace is set
+ * to, and that exactly one copy of it is installed.
+ *
+ * Both checks are worth making before a test run. A hoisting quirk or a stale
+ * `node_modules` can leave the intended version in the root while a workspace
+ * package resolves a nested copy of the other major, and the resulting test
+ * failures look like genuine incompatibilities rather than a bad install.
+ *
+ * Usage:
+ *   node scripts/typeorm/verify.mjs            # check against the profile in package.json
+ *   node scripts/typeorm/verify.mjs --expect 1 # check against an explicit profile
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..', '..');
+const PROFILE_FIELD = 'typeormProfile';
+
+const args = process.argv.slice(2);
+const expectFlagIndex = args.indexOf('--expect');
+const rootPackageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+const expected = expectFlagIndex === -1 ? rootPackageJson[PROFILE_FIELD] : args[expectFlagIndex + 1];
+
+const installs = findTypeormInstalls();
+
+if (installs.length === 0) {
+    console.error('No installed copy of typeorm found. Run `bun install` first.');
+    process.exit(1);
+}
+
+for (const { version, location } of installs) {
+    console.log(`typeorm@${version}  ${location}`);
+}
+
+const distinctVersions = [...new Set(installs.map(i => i.version))];
+if (distinctVersions.length > 1) {
+    console.error(
+        `\nFound ${distinctVersions.length} different typeorm versions installed (${distinctVersions.join(
+            ', ',
+        )}). Entity metadata is registered against a single typeorm instance, so a split install ` +
+            'produces failures unrelated to version compatibility. Delete node_modules and reinstall.',
+    );
+    process.exit(1);
+}
+
+const [actual] = distinctVersions;
+
+if (!expected) {
+    console.log(`\nNo TypeORM profile is set; using typeorm@${actual}.`);
+    process.exit(0);
+}
+
+const expectedMajor = expected.split('.')[0];
+const actualMajor = actual.split('.')[0];
+if (expectedMajor !== actualMajor) {
+    console.error(
+        `\nProfile "${expected}" was requested but typeorm@${actual} is installed. ` +
+            'Run `node scripts/typeorm/use-version.mjs ' +
+            `${expected}\` to reinstall.`,
+    );
+    process.exit(1);
+}
+
+console.log(`\nTypeORM profile "${expected}" verified: typeorm@${actual}.`);
+
+/**
+ * Looks for typeorm in the root, in each workspace package, and one level of
+ * nesting under the root `node_modules` — the places bun can put a second copy.
+ */
+function findTypeormInstalls() {
+    const candidateRoots = [
+        path.join(repoRoot, 'node_modules'),
+        ...listDirs(path.join(repoRoot, 'packages')).map(dir => path.join(dir, 'node_modules')),
+        ...listDirs(path.join(repoRoot, 'node_modules')).flatMap(dir =>
+            path.basename(dir).startsWith('@')
+                ? listDirs(dir).map(scoped => path.join(scoped, 'node_modules'))
+                : [path.join(dir, 'node_modules')],
+        ),
+    ];
+
+    const found = [];
+    for (const modulesDir of candidateRoots) {
+        const manifest = path.join(modulesDir, 'typeorm', 'package.json');
+        if (fs.existsSync(manifest)) {
+            found.push({
+                version: JSON.parse(fs.readFileSync(manifest, 'utf8')).version,
+                location: path.relative(repoRoot, path.dirname(manifest)),
+            });
+        }
+    }
+    return found;
+}
+
+function listDirs(dir) {
+    if (!fs.existsSync(dir)) {
+        return [];
+    }
+    return fs
+        .readdirSync(dir, { withFileTypes: true })
+        .filter(entry => entry.isDirectory() && entry.name !== 'typeorm')
+        .map(entry => path.join(dir, entry.name));
+}

--- a/scripts/typeorm/verify.mjs
+++ b/scripts/typeorm/verify.mjs
@@ -52,9 +52,8 @@ if (!expected) {
     process.exit(0);
 }
 
-// Profiles pin exact versions, so the installed copy is compared against the pin
-// rather than against the profile name. Comparing the leading digit would let any
-// 0.x.y satisfy the "0.3" profile, which defeats the point of pinning.
+// Compared against the version the profile pins, not its name: "0.3" is a label,
+// and matching on it loosely would accept any 0.x.y.
 const { profiles } = JSON.parse(fs.readFileSync(path.join(scriptDir, 'profiles.json'), 'utf8'));
 const pinned = profiles[expected]?.typeorm;
 if (!pinned) {


### PR DESCRIPTION
Adds a harness for running the database-backed test suites against either TypeORM v0.3 or v1, so support for both can be built and verified from one codebase. No runtime code changes.

Relates to #5105

## Using it

```sh
bun run typeorm:use 1          # switch the workspace to TypeORM v1
bun run build:for-tests        # build, continuing past type errors
bun run test:db                # unit + e2e, sqljs
DB=postgres bun run test:db    # unit + e2e, postgres
bun run typeorm:use --reset    # back to the committed versions
```

## How it works

`typeorm` is a direct dependency of `@vendure/core` rather than a peer dependency, so you can't pick the version at install time. Each profile in `scripts/typeorm/profiles.json` is applied as a set of root-level `overrides`, which is the same mechanism the repo already uses to keep `graphql` on a single version. A profile covers more than `typeorm` itself: v1 needs `@nestjs/typeorm` 11.0.1 or later, because earlier releases declare a `typeorm` peer range of `^0.3.0`, and it needs `better-sqlite3` v12.

`typeorm:verify` checks that exactly one copy of TypeORM is installed and that it's the one you asked for. Entity metadata is registered against a single module instance, so a second copy nested somewhere in `node_modules` produces failures that read exactly like genuine version incompatibilities. `test:db` runs this check before it runs anything else.

`build:for-tests` runs each build stage separately instead of chaining them with `&&`. `@vendure/core` builds in three stages — the main compile, the CLI compile, and a copy of the static `.graphql` schema files — and while the migration is in progress the main compile fails, so `dist/` never gets its schema files. The server then refuses to boot with "No type definitions were found", which says nothing about the TypeORM incompatibility underneath. `tsc` emits its output even when it reports errors, so running the stages separately gets you a bootable server to test against. The strict compile still happens in the workflow's `build` job, so type errors are still reported.

## CI

`typeorm_v1.yml` runs build, unit tests and e2e against v1 across sqljs, mariadb, mysql and postgres. It's deliberately separate from Build & Test rather than a matrix axis on it: these jobs will be red until the migration is finished, and a permanently red job sitting inside the required matrix teaches everyone to stop reading the required matrix. It runs nightly, on demand, and on any PR labelled `typeorm-v1`. Once it's all green the jobs fold into `build_and_test.yml` as a `typeorm` axis and the separate workflow goes away.

`.github/actions/setup` gains an optional `typeorm` input naming a profile. With no input it installs the committed lockfile exactly as before, so Build & Test is unaffected.

## Checks done

Switched to v1, ran the suites, reset, and confirmed `bun.lock` was restored to its committed state and the same e2e spec passes on 0.3 again.

First run against v1, for reference — full breakdown in #5105:

- 86 of core's 87 unit test files pass unchanged; `migrate.spec.ts` fails on the removal of `createConnection`
- e2e boots the server, wires up Nest, builds the GraphQL schema, then dies in `ZoneService.initZones` on the removed string-array `relations` syntax
- `@vendure/core` produces 184 type errors, 127 of them array `relations` and `select` in find options

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788952039&installation_model_id=20193&pr_number=5106&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5106&signature=d48b828936d2b0adfa9ffe37458c6848b71f0296039b219b06f8e230357b6f51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->