### PR TITLE
refactor(core): Read the TypeORM DataSource through a version-independent accessor

### DIFF
--- a/docs/docs/guides/core-concepts/collections/index.mdx
+++ b/docs/docs/guides/core-concepts/collections/index.mdx
@@ -68,7 +68,7 @@ added to it using the `.andWhere()` method.
 Here's an example of a collection filter which filters by SKU:
 
 ```ts title="src/config/sku-collection-filter.ts"
-import { CollectionFilter, LanguageCode } from '@vendure/core';
+import { CollectionFilter, getDataSource, LanguageCode } from '@vendure/core';
 
 export const skuCollectionFilter = new CollectionFilter({
     args: {
@@ -91,9 +91,9 @@ export const skuCollectionFilter = new CollectionFilter({
     // This is the function that defines the logic of the filter.
     apply: (qb, args) => {
         // Sometimes syntax differs between database types, so we use
-        // the `type` property of the connection options to determine
+        // the `type` property of the DataSource options to determine
         // which syntax to use.
-        const LIKE = qb.connection.options.type === 'postgres' ? 'ILIKE' : 'LIKE';
+        const LIKE = getDataSource(qb).options.type === 'postgres' ? 'ILIKE' : 'LIKE';
 
         return qb.andWhere(`productVariant.sku ${LIKE} :sku`, {
             sku: `%${args.sku}%`

--- a/docs/docs/reference/typescript-api/configuration/collection-filter.mdx
+++ b/docs/docs/reference/typescript-api/configuration/collection-filter.mdx
@@ -16,7 +16,7 @@ Here's a simple example of a custom CollectionFilter:
 *Example*
 
 ```ts
-import { CollectionFilter, LanguageCode } from '@vendure/core';
+import { CollectionFilter, getDataSource, LanguageCode } from '@vendure/core';
 
 export const skuCollectionFilter = new CollectionFilter({
   args: {
@@ -38,7 +38,7 @@ export const skuCollectionFilter = new CollectionFilter({
 
   // This is the function that defines the logic of the filter.
   apply: (qb, args) => {
-    const LIKE = qb.connection.options.type === 'postgres' ? 'ILIKE' : 'LIKE';
+    const LIKE = getDataSource(qb).options.type === 'postgres' ? 'ILIKE' : 'LIKE';
     return qb.andWhere(`productVariant.sku ${LIKE} :sku`, { sku: `%${args.sku}%` });
   },
 });

--- a/docs/docs/reference/typescript-api/data-access/data-source-holder.mdx
+++ b/docs/docs/reference/typescript-api/data-access/data-source-holder.mdx
@@ -11,5 +11,24 @@ but not all, of those classes. Code which has to run on both versions therefore 
 DataSource via [getDataSource](/reference/typescript-api/data-access/get-data-source#getdatasource) rather than naming either property directly.
 
 ```ts title="Signature"
-type DataSourceHolder = { connection: DataSource } | { dataSource: DataSource }
+type DataSourceHolder = {
+    connection?: DataSource;
+    dataSource?: DataSource
+}
 ```
+
+<div className="members-wrapper">
+
+### connection
+
+<MemberInfo kind="property" type={`DataSource`}   />
+
+
+### dataSource
+
+<MemberInfo kind="property" type={`DataSource`}   />
+
+
+
+
+</div>

--- a/docs/docs/reference/typescript-api/data-access/data-source-holder.mdx
+++ b/docs/docs/reference/typescript-api/data-access/data-source-holder.mdx
@@ -1,0 +1,15 @@
+---
+title: "DataSourceHolder"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/get-data-source.ts" sourceLine="14" packageName="@vendure/core" since="3.8.0" />
+
+A TypeORM object which knows the `DataSource` it belongs to, such as a QueryBuilder,
+EntityManager, QueryRunner or EntityMetadata. TypeORM 0.3 names that property `connection`.
+TypeORM 1 renames it to `dataSource` and keeps `connection` as a deprecated alias on some,
+but not all, of those classes. Code which has to run on both versions therefore reads the
+DataSource via [getDataSource](/reference/typescript-api/data-access/get-data-source#getdatasource) rather than naming either property directly.
+
+```ts title="Signature"
+type DataSourceHolder = { connection: DataSource } | { dataSource: DataSource }
+```

--- a/docs/docs/reference/typescript-api/data-access/get-data-source.mdx
+++ b/docs/docs/reference/typescript-api/data-access/get-data-source.mdx
@@ -2,10 +2,11 @@
 title: "GetDataSource"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/connection/get-data-source.ts" sourceLine="35" packageName="@vendure/core" since="3.8.0" />
+<GenerationInfo sourceFile="packages/core/src/connection/get-data-source.ts" sourceLine="36" packageName="@vendure/core" since="3.8.0" />
 
 Returns the `DataSource` that the given TypeORM object belongs to, reading whichever of
-the `dataSource` and `connection` properties the installed version of TypeORM provides.
+the `dataSource` and `connection` properties the installed version of TypeORM provides. Where
+an object carries both, `dataSource` is used, since `connection` is the deprecated alias.
 
 *Example*
 

--- a/docs/docs/reference/typescript-api/data-access/get-data-source.mdx
+++ b/docs/docs/reference/typescript-api/data-access/get-data-source.mdx
@@ -1,0 +1,30 @@
+---
+title: "GetDataSource"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/get-data-source.ts" sourceLine="35" packageName="@vendure/core" since="3.8.0" />
+
+Returns the `DataSource` that the given TypeORM object belongs to, reading whichever of
+the `dataSource` and `connection` properties the installed version of TypeORM provides.
+
+*Example*
+
+```ts
+const collectionFilter = new CollectionFilter({
+  // ...
+  apply: (qb, args) => {
+    const LIKE = getDataSource(qb).options.type === 'postgres' ? 'ILIKE' : 'LIKE';
+    return qb.andWhere(`productVariant.sku ${LIKE} :sku`, { sku: `%${args.sku}%` });
+  },
+});
+```
+
+```ts title="Signature"
+function getDataSource(source: DataSourceHolder): DataSource
+```
+Parameters
+
+### source
+
+<MemberInfo kind="parameter" type={`<a href='/reference/typescript-api/data-access/data-source-holder#datasourceholder'>DataSourceHolder</a>`} />
+

--- a/docs/docs/reference/typescript-api/data-access/list-query-builder.mdx
+++ b/docs/docs/reference/typescript-api/data-access/list-query-builder.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## ListQueryBuilder
 
-<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="209" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="210" packageName="@vendure/core" />
 
 This helper class is used when fetching entities the database from queries which return a [PaginatedList](/reference/typescript-api/common/paginated-list#paginatedlist) type.
 These queries all follow the same format:
@@ -107,7 +107,7 @@ to join that relation.
 </div>
 ## ExtendedListQueryOptions
 
-<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="50" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="51" packageName="@vendure/core" />
 
 Options which can be passed to the ListQueryBuilder's `build()` method.
 

--- a/docs/docs/reference/typescript-api/migration/migrate-asset-translation-data.mdx
+++ b/docs/docs/reference/typescript-api/migration/migrate-asset-translation-data.mdx
@@ -2,7 +2,7 @@
 title: "MigrateAssetTranslationData"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/migration-utils/v3_6_asset_translations.ts" sourceLine="43" packageName="@vendure/core" since="3.6.0" />
+<GenerationInfo sourceFile="packages/core/src/migration-utils/v3_6_asset_translations.ts" sourceLine="45" packageName="@vendure/core" since="3.6.0" />
 
 Populates the new `asset_translation` table with data from the existing `name`
 column on `asset`, using the default channel's language code.

--- a/docs/docs/reference/typescript-api/migration/migrate-product-option-group-data.mdx
+++ b/docs/docs/reference/typescript-api/migration/migrate-product-option-group-data.mdx
@@ -2,7 +2,7 @@
 title: "MigrateProductOptionGroupData"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/migration-utils/v3_6_shared_option_groups.ts" sourceLine="43" packageName="@vendure/core" since="3.6.0" />
+<GenerationInfo sourceFile="packages/core/src/migration-utils/v3_6_shared_option_groups.ts" sourceLine="45" packageName="@vendure/core" since="3.6.0" />
 
 Populates the new join tables for shared, channel-aware ProductOptionGroups
 using data from the existing `productId` FK column on `product_option_group`.

--- a/docs/docs/reference/typescript-api/services/asset-service.mdx
+++ b/docs/docs/reference/typescript-api/services/asset-service.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## AssetService
 
-<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="91" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="92" packageName="@vendure/core" />
 
 Contains methods relating to [Asset](/reference/typescript-api/entities/asset#asset) entities.
 
@@ -105,7 +105,7 @@ Create an Asset from a file stream, for example to create an Asset during data i
 </div>
 ## EntityWithAssets
 
-<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="67" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="68" packageName="@vendure/core" />
 
 Certain entities (Product, ProductVariant, Collection) use this interface
 to model a featured asset and then a list of assets with a defined order.
@@ -137,7 +137,7 @@ interface EntityWithAssets extends VendureEntity {
 </div>
 ## EntityAssetInput
 
-<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="79" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="80" packageName="@vendure/core" />
 
 Used when updating entities which implement [EntityWithAssets](/reference/typescript-api/services/asset-service#entitywithassets).
 

--- a/packages/core/src/config/catalog/collection-filter.ts
+++ b/packages/core/src/config/catalog/collection-filter.ts
@@ -31,7 +31,7 @@ export interface CollectionFilterConfig<T extends ConfigArgs> extends Configurab
  *
  * @example
  * ```ts
- * import { CollectionFilter, LanguageCode } from '\@vendure/core';
+ * import { CollectionFilter, getDataSource, LanguageCode } from '\@vendure/core';
  *
  * export const skuCollectionFilter = new CollectionFilter({
  *   args: {
@@ -53,7 +53,7 @@ export interface CollectionFilterConfig<T extends ConfigArgs> extends Configurab
  *
  *   // This is the function that defines the logic of the filter.
  *   apply: (qb, args) => {
- *     const LIKE = qb.connection.options.type === 'postgres' ? 'ILIKE' : 'LIKE';
+ *     const LIKE = getDataSource(qb).options.type === 'postgres' ? 'ILIKE' : 'LIKE';
  *     return qb.andWhere(`productVariant.sku ${LIKE} :sku`, { sku: `%${args.sku}%` });
  *   },
  * });

--- a/packages/core/src/config/catalog/default-collection-filters.ts
+++ b/packages/core/src/config/catalog/default-collection-filters.ts
@@ -2,6 +2,7 @@ import { LanguageCode } from '@vendure/common/lib/generated-types';
 
 import { ConfigArgDef } from '../../common/configurable-operation';
 import { UserInputError } from '../../common/error/errors';
+import { getDataSource } from '../../connection/get-data-source';
 import { ProductVariant } from '../../entity/product-variant/product-variant.entity';
 
 import { CollectionFilter } from './collection-filter';
@@ -77,14 +78,15 @@ export const facetValueCollectionFilter = new CollectionFilter({
             const safeIdsConcat = ids.join('_').replace(/-/g, '_');
             const idsName = `ids_${safeIdsConcat}`;
             const countName = `count_${safeIdsConcat}`;
-            const productFacetValues = qb.connection
+            const dataSource = getDataSource(qb);
+            const productFacetValues = dataSource
                 .createQueryBuilder(ProductVariant, 'product_variant')
                 .select('product_variant.id', 'variant_id')
                 .addSelect('facet_value.id', 'facet_value_id')
                 .leftJoin('product_variant.facetValues', 'facet_value')
                 .where(`facet_value.id IN (:...${idsName})`);
 
-            const variantFacetValues = qb.connection
+            const variantFacetValues = dataSource
                 .createQueryBuilder(ProductVariant, 'product_variant')
                 .select('product_variant.id', 'variant_id')
                 .addSelect('facet_value.id', 'facet_value_id')
@@ -92,7 +94,7 @@ export const facetValueCollectionFilter = new CollectionFilter({
                 .leftJoin('product.facetValues', 'facet_value')
                 .where(`facet_value.id IN (:...${idsName})`);
 
-            const union = qb.connection
+            const union = dataSource
                 .createQueryBuilder()
                 .select('union_table.variant_id')
                 .from(
@@ -102,7 +104,7 @@ export const facetValueCollectionFilter = new CollectionFilter({
                 .groupBy('variant_id')
                 .having(`COUNT(*) >= :${countName}`);
 
-            const variantIds = qb.connection
+            const variantIds = dataSource
                 .createQueryBuilder()
                 .select('variant_ids_table.variant_id')
                 .from(`(${union.getQuery()})`, 'variant_ids_table');
@@ -157,7 +159,7 @@ export const variantNameCollectionFilter = new CollectionFilter({
         } else {
             translationAlias = translationsJoin.alias.name;
         }
-        const LIKE = qb.connection.options.type === 'postgres' ? 'ILIKE' : 'LIKE';
+        const LIKE = getDataSource(qb).options.type === 'postgres' ? 'ILIKE' : 'LIKE';
         let clause: string;
         let params: Record<string, string>;
         switch (args.operator) {

--- a/packages/core/src/connection/get-data-source.spec.ts
+++ b/packages/core/src/connection/get-data-source.spec.ts
@@ -17,11 +17,17 @@ describe('getDataSource()', () => {
 
     it('prefers "dataSource" when both are present', () => {
         const deprecatedAlias = {} as DataSource;
-        expect(getDataSource({ dataSource, connection: deprecatedAlias } as any)).toBe(dataSource);
+        expect(getDataSource({ dataSource, connection: deprecatedAlias })).toBe(dataSource);
     });
 
     it('throws when neither property is present', () => {
-        expect(() => getDataSource({} as any)).toThrowError(/Could not resolve a TypeORM DataSource/);
+        expect(() => getDataSource({})).toThrowError(/Could not resolve a TypeORM DataSource/);
+    });
+
+    // Callers reached from untyped code, such as the RelationIdLoader patch, can pass a value the
+    // compiler never checked.
+    it.each([null, undefined])('throws when given %s', value => {
+        expect(() => getDataSource(value as any)).toThrowError(/Could not resolve a TypeORM DataSource/);
     });
 
     // The RelationIdLoader patch in entity/typeorm-relation-id-loader-fix.ts reads the DataSource

--- a/packages/core/src/connection/get-data-source.spec.ts
+++ b/packages/core/src/connection/get-data-source.spec.ts
@@ -1,0 +1,35 @@
+import { DataSource } from 'typeorm';
+import { RelationIdLoader } from 'typeorm/query-builder/RelationIdLoader';
+import { describe, expect, it } from 'vitest';
+
+import { getDataSource } from './get-data-source';
+
+describe('getDataSource()', () => {
+    const dataSource = {} as DataSource;
+
+    it('reads the "connection" property', () => {
+        expect(getDataSource({ connection: dataSource })).toBe(dataSource);
+    });
+
+    it('reads the "dataSource" property', () => {
+        expect(getDataSource({ dataSource })).toBe(dataSource);
+    });
+
+    it('prefers "dataSource" when both are present', () => {
+        const deprecatedAlias = {} as DataSource;
+        expect(getDataSource({ dataSource, connection: deprecatedAlias } as any)).toBe(dataSource);
+    });
+
+    it('throws when neither property is present', () => {
+        expect(() => getDataSource({} as any)).toThrowError(/Could not resolve a TypeORM DataSource/);
+    });
+
+    // The RelationIdLoader patch in entity/typeorm-relation-id-loader-fix.ts reads the DataSource
+    // off a RelationIdLoader instance, whose field is private and renamed between TypeORM versions.
+    // Nothing in that patch is visible to the compiler, so this is the only check that it resolves
+    // against the version of TypeORM actually installed.
+    it('reads the DataSource from a TypeORM RelationIdLoader', () => {
+        const loader = new (RelationIdLoader as any)(dataSource);
+        expect(getDataSource(loader)).toBe(dataSource);
+    });
+});

--- a/packages/core/src/connection/get-data-source.ts
+++ b/packages/core/src/connection/get-data-source.ts
@@ -11,12 +11,13 @@ import { DataSource } from 'typeorm';
  * @docsCategory data-access
  * @since 3.8.0
  */
-export type DataSourceHolder = { connection: DataSource } | { dataSource: DataSource };
+export type DataSourceHolder = { connection?: DataSource; dataSource?: DataSource };
 
 /**
  * @description
  * Returns the {@link DataSource} that the given TypeORM object belongs to, reading whichever of
- * the `dataSource` and `connection` properties the installed version of TypeORM provides.
+ * the `dataSource` and `connection` properties the installed version of TypeORM provides. Where
+ * an object carries both, `dataSource` is used, since `connection` is the deprecated alias.
  *
  * @example
  * ```ts
@@ -33,13 +34,15 @@ export type DataSourceHolder = { connection: DataSource } | { dataSource: DataSo
  * @since 3.8.0
  */
 export function getDataSource(source: DataSourceHolder): DataSource {
-    const typeOrmObject = source as { dataSource?: DataSource; connection?: DataSource };
-    const dataSource = typeOrmObject.dataSource ?? typeOrmObject.connection;
+    // Without these checks the caller fails further on with "cannot read properties of undefined".
+    if (source == null) {
+        throw new Error(`Could not resolve a TypeORM DataSource from ${String(source)}.`);
+    }
+    const dataSource = source.dataSource ?? source.connection;
     if (!dataSource) {
-        // Without this the caller fails further on with "cannot read properties of undefined".
         throw new Error(
             `Could not resolve a TypeORM DataSource from a ${
-                typeOrmObject.constructor?.name ?? typeof source
+                source.constructor?.name ?? typeof source
             }: it has neither a "dataSource" nor a "connection" property.`,
         );
     }

--- a/packages/core/src/connection/get-data-source.ts
+++ b/packages/core/src/connection/get-data-source.ts
@@ -1,0 +1,47 @@
+import { DataSource } from 'typeorm';
+
+/**
+ * @description
+ * A TypeORM object which knows the {@link DataSource} it belongs to, such as a QueryBuilder,
+ * EntityManager, QueryRunner or EntityMetadata. TypeORM 0.3 names that property `connection`.
+ * TypeORM 1 renames it to `dataSource` and keeps `connection` as a deprecated alias on some,
+ * but not all, of those classes. Code which has to run on both versions therefore reads the
+ * DataSource via {@link getDataSource} rather than naming either property directly.
+ *
+ * @docsCategory data-access
+ * @since 3.8.0
+ */
+export type DataSourceHolder = { connection: DataSource } | { dataSource: DataSource };
+
+/**
+ * @description
+ * Returns the {@link DataSource} that the given TypeORM object belongs to, reading whichever of
+ * the `dataSource` and `connection` properties the installed version of TypeORM provides.
+ *
+ * @example
+ * ```ts
+ * const collectionFilter = new CollectionFilter({
+ *   // ...
+ *   apply: (qb, args) => {
+ *     const LIKE = getDataSource(qb).options.type === 'postgres' ? 'ILIKE' : 'LIKE';
+ *     return qb.andWhere(`productVariant.sku ${LIKE} :sku`, { sku: `%${args.sku}%` });
+ *   },
+ * });
+ * ```
+ *
+ * @docsCategory data-access
+ * @since 3.8.0
+ */
+export function getDataSource(source: DataSourceHolder): DataSource {
+    const typeOrmObject = source as { dataSource?: DataSource; connection?: DataSource };
+    const dataSource = typeOrmObject.dataSource ?? typeOrmObject.connection;
+    if (!dataSource) {
+        // Without this the caller fails further on with "cannot read properties of undefined".
+        throw new Error(
+            `Could not resolve a TypeORM DataSource from a ${
+                typeOrmObject.constructor?.name ?? typeof source
+            }: it has neither a "dataSource" nor a "connection" property.`,
+        );
+    }
+    return dataSource;
+}

--- a/packages/core/src/connection/index.ts
+++ b/packages/core/src/connection/index.ts
@@ -1,5 +1,6 @@
 export * from './connection.module';
 export * from './find-options-array-to-object';
+export * from './get-data-source';
 export * from './transaction-subscriber';
 export * from './transactional-connection';
 export * from './types';

--- a/packages/core/src/entity/typeorm-relation-id-loader-fix.ts
+++ b/packages/core/src/entity/typeorm-relation-id-loader-fix.ts
@@ -4,6 +4,8 @@ import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata';
 import { RelationMetadata } from 'typeorm/metadata/RelationMetadata';
 import { RelationIdLoader } from 'typeorm/query-builder/RelationIdLoader';
 
+import { DataSourceHolder, getDataSource } from '../connection/get-data-source';
+
 let patchApplied = false;
 
 /**
@@ -51,9 +53,13 @@ export function patchTypeOrmRelationIdLoader() {
     ]) {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         const originalMethod = proto[methodName];
-        proto[methodName] = async function (relation: RelationMetadata, ...rest: any[]) {
+        proto[methodName] = async function (
+            this: DataSourceHolder,
+            relation: RelationMetadata,
+            ...rest: any[]
+        ) {
             const rows = await originalMethod.apply(this, [relation, ...rest]);
-            return normalizeGroupingKeys(this.connection.driver, relation, rows);
+            return normalizeGroupingKeys(getDataSource(this).driver, relation, rows);
         };
     }
 }

--- a/packages/core/src/migration-utils/v3_6_asset_translations.ts
+++ b/packages/core/src/migration-utils/v3_6_asset_translations.ts
@@ -5,6 +5,8 @@
 // once the migration has run.
 import { QueryRunner } from 'typeorm';
 
+import { getDataSource } from '../connection/get-data-source';
+
 /**
  * @description
  * Populates the new `asset_translation` table with data from the existing `name`
@@ -49,7 +51,7 @@ export async function migrateAssetTranslationData(queryRunner: QueryRunner): Pro
         return;
     }
 
-    const esc = (name: string) => queryRunner.connection.driver.escape(name);
+    const esc = (name: string) => getDataSource(queryRunner).driver.escape(name);
 
     // 1. If there is no asset data to migrate, skip entirely. This covers the
     // fresh-install case where migrations run against an empty database before

--- a/packages/core/src/migration-utils/v3_6_shared_option_groups.ts
+++ b/packages/core/src/migration-utils/v3_6_shared_option_groups.ts
@@ -5,6 +5,8 @@
 // once the migration has run.
 import { QueryRunner } from 'typeorm';
 
+import { getDataSource } from '../connection/get-data-source';
+
 /**
  * @description
  * Populates the new join tables for shared, channel-aware ProductOptionGroups
@@ -50,7 +52,7 @@ export async function migrateProductOptionGroupData(queryRunner: QueryRunner): P
         return;
     }
 
-    const esc = (name: string) => queryRunner.connection.driver.escape(name);
+    const esc = (name: string) => getDataSource(queryRunner).driver.escape(name);
 
     // 1. Populate Product <-> ProductOptionGroup join table from existing FK
     await queryRunner.query(

--- a/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
+++ b/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
@@ -25,6 +25,7 @@ import { Instrument } from '../../../common/instrument-decorator';
 import { ConfigService, CustomFields, Logger } from '../../../config';
 import { TransactionalConnection } from '../../../connection';
 import { findOptionsArrayToObject } from '../../../connection/find-options-array-to-object';
+import { getDataSource } from '../../../connection/get-data-source';
 import { VendureEntity } from '../../../entity';
 import { joinTreeRelationsDynamically } from '../utils/tree-relations-qb-joiner';
 
@@ -310,8 +311,9 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
         const customFieldsForType = this.configService.customFields[entity.name as keyof CustomFields];
         const sortParams = Object.assign({}, options.sort, extendedOptions.orderBy);
         this.applyTranslationConditions(qb, entity, sortParams, extendedOptions.ctx);
+        const dataSource = getDataSource(qb);
         const sort = parseSortParams(
-            qb.connection,
+            dataSource,
             entity,
             sortParams,
             customPropertyMap,
@@ -320,7 +322,7 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
         );
 
         const filter = parseFilterParams({
-            connection: qb.connection,
+            connection: dataSource,
             entity,
             filterParams: options.filter,
             customPropertyMap,
@@ -480,11 +482,12 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
         const newParamKey = `exists_${baseParamKey}`;
 
         // Helper to escape identifiers for the current database driver (handles PostgreSQL quoting)
-        const escapeId = (name: string) => mainQb.connection.driver.escape(name);
+        const { driver } = getDataSource(mainQb);
+        const escapeId = (name: string) => driver.escape(name);
         const escapeTablePath = (path: string) =>
             path
                 .split('.')
-                .map(segment => mainQb.connection.driver.escape(segment))
+                .map(segment => driver.escape(segment))
                 .join('.');
 
         let existsQuery: string;
@@ -840,7 +843,8 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
     ) {
         const languageCode = ctx?.languageCode || this.configService.defaultLanguageCode;
 
-        const { translationColumns } = getColumnMetadata(qb.connection, entity);
+        const dataSource = getDataSource(qb);
+        const { translationColumns } = getColumnMetadata(dataSource, entity);
         const alias = qb.alias;
 
         const sortKeys = Object.keys(sortParams);
@@ -852,12 +856,7 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
         }
 
         if (translationColumns.length && sortingOnTranslatableKey) {
-            const translationsAlias = qb.connection.namingStrategy.joinTableName(
-                alias,
-                'translations',
-                '',
-                '',
-            );
+            const translationsAlias = dataSource.namingStrategy.joinTableName(alias, 'translations', '', '');
             if (!this.isRelationAlreadyJoined(qb, translationsAlias)) {
                 qb.leftJoinAndSelect(`${alias}.translations`, translationsAlias);
             }

--- a/packages/core/src/service/helpers/utils/tree-relations-qb-joiner.ts
+++ b/packages/core/src/service/helpers/utils/tree-relations-qb-joiner.ts
@@ -3,6 +3,7 @@ import { EntityTarget } from 'typeorm/common/EntityTarget';
 import { DriverUtils } from 'typeorm/driver/DriverUtils';
 
 import { findOptionsObjectToArray } from '../../../connection/find-options-object-to-array';
+import { getDataSource } from '../../../connection/get-data-source';
 import { VendureEntity } from '../../../entity';
 
 /**
@@ -62,7 +63,8 @@ export function joinTreeRelationsDynamically<T extends VendureEntity>(
         return joinedRelations;
     }
 
-    const sourceMetadata = qb.connection.getMetadata(entity);
+    const dataSource = getDataSource(qb);
+    const sourceMetadata = dataSource.getMetadata(entity);
     const sourceMetadataIsTree = isTreeEntityMetadata(sourceMetadata);
 
     const processRelation = (
@@ -112,7 +114,7 @@ export function joinTreeRelationsDynamically<T extends VendureEntity>(
             joinConnector = '__';
         }
         const nextAlias = DriverUtils.buildAlias(
-            qb.connection.driver,
+            dataSource.driver,
             { shorten: false, joiner: joinConnector },
             currentAlias,
             part.replace(/\./g, '_'),

--- a/packages/core/src/service/services/asset.service.ts
+++ b/packages/core/src/service/services/asset.service.ts
@@ -33,6 +33,7 @@ import { ChannelAware } from '../../common/types/common-types';
 import { Translated } from '../../common/types/locale-types';
 import { idsAreEqual } from '../../common/utils';
 import { ConfigService } from '../../config/config.service';
+import { getDataSource } from '../../connection/get-data-source';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { AssetTranslation } from '../../entity/asset/asset-translation.entity';
 import { AssetUsage } from '../../entity/asset/asset-usage';
@@ -135,7 +136,7 @@ export class AssetService {
         const tags = options?.tags;
         if (tags && tags.length) {
             const operator = options?.tagsOperator ?? LogicalOperator.AND;
-            const subquery = qb.connection
+            const subquery = getDataSource(qb)
                 .createQueryBuilder()
                 .select('asset.id')
                 .from(Asset, 'asset')


### PR DESCRIPTION
Third in the series for the TypeORM v1 work tracked in vendurehq/vendure#5105.

**Stacked on vendurehq/vendure#5107**, so the base branch here is `refactor/find-options-object-syntax` rather than `minor`. Only the last commit belongs to this PR. It needs retargeting to `minor` once #5107 merges.

## What this does

Adds `getDataSource()`, which returns the `DataSource` that a TypeORM object belongs to by reading whichever of the `dataSource` and `connection` properties the installed version of TypeORM provides. It is applied at every site in `@vendure/core` which reaches for a TypeORM object's `DataSource`.

## What was actually broken

The issue predicted that `.connection` exists only on 0.3 and `.dataSource` only on v1, so that every one of these sites needed the accessor. Reading the published typings for `typeorm@0.3.31` and `typeorm@1.1.0` gives a more precise picture:

| Receiver | 0.3.31 | 1.1.0 | Does `.connection` work on both? |
| -- | -- | -- | -- |
| `QueryBuilder` | `connection` | `dataSource`, plus a deprecated `connection` getter | yes |
| `QueryRunner` | `connection` | `dataSource`, plus a `connection` getter | yes |
| `EntityManager` | `connection` | `dataSource`, plus a `connection` getter | yes |
| `EntityMetadata` | `connection` | getter present in the JS, dropped from the `.d.ts` | at runtime, but not in the types |
| `RelationIdLoader` (private field) | `this.connection` | `this.dataSource` | no |

So of the eighteen sites, exactly one was genuinely broken: the `RelationIdLoader` patch in `packages/core/src/entity/typeorm-relation-id-loader-fix.ts`. That class holds its `DataSource` in a private field, which TypeORM renamed without leaving an alias, because nothing outside the class was supposed to be reading it. That single site produced the 110 or so `Cannot read properties of undefined (reading 'driver')` failures per backend reported on the issue.

The other seventeen sites work on v1 today through the deprecated getter. They are converted here as well, so that they do not break when TypeORM removes it.

The accessor prefers `dataSource` and falls back to `connection`. That ordering means the fallback branch stops being used the moment a workspace moves to v1, rather than keeping every call site on the deprecated property.

## The test

`get-data-source.spec.ts` covers both property shapes, the case where both are present, and the error thrown when neither is. The last test constructs a real `RelationIdLoader` from whichever TypeORM is installed and asserts that the accessor resolves its `DataSource`. That is the check which would have caught the original failure, and it is meaningful under both profiles because the same file runs against both.

The original failure produced no type error at all. The patch assigns through `proto[methodName]`, which is `any`, so there was nothing for the compiler to check. The patched method now declares `this: DataSourceHolder`, which states what it needs from its receiver instead of leaving it implicit, but a monkey-patch against an `any`-typed prototype cannot be fully typechecked, which is why the test matters more than the annotation.

## Results

Against `typeorm@0.3.31`:

- strict `tsc` on `@vendure/core` is clean
- the full unit suite passes, 90 files and 1275 tests
- the `list-query-builder`, `collection`, `custom-field-relations`, `asset` and `entity-hydrator` e2e suites pass on sqljs, 321 tests

Against `typeorm@1.1.0`:

- type errors in `@vendure/core` stay at 36, unchanged from the #5107 baseline
- the unit suite passes
- no `reading 'driver'` failures remain in e2e, down from around 110 per backend

## What this does not fix

The e2e suites still do not complete on v1, but they now stop somewhere else. `SqlJobQueueStrategy.connectionAvailable()` reads `this.rawConnection.isConnected`, and `DataSource.isConnected` was removed in v1, having been deprecated in 0.3 in favour of `isInitialized`. It evaluates to `undefined`, so every job queue call throws "Connection not available" and test data population hangs.

Applying that one-word change locally and rerunning `collection.e2e-spec.ts` on v1 gets the server booting and the suite running: 15 passed, 61 failed and 2 skipped, with the failures being differences in collection contents rather than crashes. That change belongs to the `Connection`/`createConnection` to `DataSource` item on the issue, so it is not included here, but it works on both versions and is worth taking whenever that item is picked up.

Relates to vendurehq/vendure#5105

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788981065&installation_model_id=20193&pr_number=5120&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5120&signature=309a0a39de6d795798976d6c9ece6c1943b70a6cf828ad6e1c97470748cd7c51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->