### PR TITLE
refactor(core): Replace the removed TypeORM Connection API with DataSource

### DIFF
--- a/.github/workflows/typeorm_v1.yml
+++ b/.github/workflows/typeorm_v1.yml
@@ -14,11 +14,10 @@ on:
         # Nightly, so regressions in either TypeORM v1 or Vendure surface without
         # anyone having to remember to trigger a run.
         - cron: '0 3 * * *'
+    # No base-branch filter: the `typeorm-v1` label is the only gate, applied per job
+    # below. A pull request stacked on another feature branch does not target master,
+    # major or minor, and filtering on the base would silently skip every one of them.
     pull_request:
-        branches:
-            - master
-            - major
-            - minor
         types: [opened, reopened, synchronize, labeled]
 
 env:

--- a/packages/core/e2e/fixtures/test-payment-methods.ts
+++ b/packages/core/e2e/fixtures/test-payment-methods.ts
@@ -133,7 +133,7 @@ export const singleStageRefundFailingPaymentMethod = new PaymentMethodHandler({
     createRefund: async (ctx, input, amount, order, payment, args) => {
         const paymentWithRefunds = await connection
             .getRepository(ctx, Payment)
-            .findOne({ where: { id: payment.id }, relations: ['refunds'] });
+            .findOne({ where: { id: payment.id }, relations: { refunds: true } });
         const isFirstRefundAttempt = paymentWithRefunds?.refunds.length === 0;
         const metadata = isFirstRefundAttempt ? { errorMessage: 'Service temporarily unavailable' } : {};
         return {

--- a/packages/core/e2e/fixtures/test-plugins/hydration-test-plugin.ts
+++ b/packages/core/e2e/fixtures/test-plugins/hydration-test-plugin.ts
@@ -36,7 +36,7 @@ export class TestAdminPluginResolver {
     async hydrateProduct(@Ctx() ctx: RequestContext, @Args() args: { id: ID }) {
         const product = await this.connection.getRepository(ctx, Product).findOne({
             where: { id: args.id },
-            relations: ['facetValues'],
+            relations: { facetValues: true },
         });
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         await this.entityHydrator.hydrate(ctx, product!, {

--- a/packages/core/e2e/fixtures/test-plugins/issue-2453/services/campaign.service.ts
+++ b/packages/core/e2e/fixtures/test-plugins/issue-2453/services/campaign.service.ts
@@ -54,7 +54,7 @@ export class CampaignService {
     findOne(ctx: RequestContext, id: ID): Promise<Translated<Campaign> | undefined | null> {
         return this.connection
             .getRepository(ctx, Campaign)
-            .findOne({ where: { id }, relations: ['promotion'] })
+            .findOne({ where: { id }, relations: { promotion: true } })
             .then(campaignItem => {
                 return campaignItem && translateDeep(campaignItem, ctx.languageCode, ['promotion']);
             });
@@ -63,7 +63,7 @@ export class CampaignService {
     findOneByCode(ctx: RequestContext, code: string): Promise<Translated<Campaign> | undefined | null> {
         return this.connection
             .getRepository(ctx, Campaign)
-            .findOne({ where: { code }, relations: ['promotion'] })
+            .findOne({ where: { code }, relations: { promotion: true } })
             .then(campaignItem => {
                 return campaignItem && translateDeep(campaignItem, ctx.languageCode, ['promotion']);
             });

--- a/packages/core/e2e/guest-checkout-strategy.e2e-spec.ts
+++ b/packages/core/e2e/guest-checkout-strategy.e2e-spec.ts
@@ -64,7 +64,7 @@ class TestGuestCheckoutStrategy implements GuestCheckoutStrategy {
         }
         if (TestGuestCheckoutStrategy.createNewCustomerOnEmailAddressConflict === true) {
             const existing = await this.connection.getRepository(ctx, Customer).findOne({
-                relations: ['channels'],
+                relations: { channels: true },
                 where: {
                     emailAddress: input.emailAddress,
                     deletedAt: IsNull(),

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -7,7 +7,7 @@ import { getConnectionToken } from '@nestjs/typeorm';
 import { DEFAULT_COOKIE_NAME } from '@vendure/common/lib/shared-constants';
 import { Type } from '@vendure/common/lib/shared-types';
 import { satisfies } from 'semver';
-import { Connection, DataSourceOptions, EntitySubscriberInterface } from 'typeorm';
+import { DataSource, DataSourceOptions, EntitySubscriberInterface } from 'typeorm';
 import cookieSession = require('cookie-session');
 
 import { InternalServerError } from './common/error/errors';
@@ -510,7 +510,7 @@ function disableSynchronize(userConfig: Readonly<RuntimeVendureConfig>): Readonl
  * @param worker
  */
 async function validateDbTablesForWorker(worker: INestApplicationContext) {
-    const connection: Connection = worker.get(getConnectionToken());
+    const connection: DataSource = worker.get(getConnectionToken());
     await new Promise<void>(async (resolve, reject) => {
         const checkForTables = async (): Promise<boolean> => {
             try {

--- a/packages/core/src/common/injector.ts
+++ b/packages/core/src/common/injector.ts
@@ -1,7 +1,7 @@
 import { Type } from '@nestjs/common';
 import { ContextId, ModuleRef } from '@nestjs/core';
 import { getConnectionToken } from '@nestjs/typeorm';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 
 /**
  * @description

--- a/packages/core/src/common/injector.ts
+++ b/packages/core/src/common/injector.ts
@@ -1,7 +1,5 @@
 import { Type } from '@nestjs/common';
 import { ContextId, ModuleRef } from '@nestjs/core';
-import { getConnectionToken } from '@nestjs/typeorm';
-import { DataSource } from 'typeorm';
 
 /**
  * @description

--- a/packages/core/src/connection/find-options-object-to-array.ts
+++ b/packages/core/src/connection/find-options-object-to-array.ts
@@ -1,21 +1,20 @@
-import { FindOneOptions } from 'typeorm';
-import { FindOptionsRelationByString } from 'typeorm/find-options/FindOptionsRelations';
+import { FindOptionsRelations } from 'typeorm';
 
 /**
  * Some internal APIs depend on the TypeORM FindOptions `relations` property being a string array.
  * This function converts the new-style FindOptionsRelations object to a string array.
  */
 export function findOptionsObjectToArray<T>(
-    input: NonNullable<FindOneOptions['relations']>,
+    input: FindOptionsRelations<T> | string[],
     parentKey?: string,
-): FindOptionsRelationByString {
+): string[] {
     if (Array.isArray(input)) {
         return input;
     }
     const keys = Object.keys(input);
 
     return keys.reduce((acc: string[], key: string) => {
-        const value = input[key as any];
+        const value = (input as Record<string, any>)[key];
         const path = parentKey ? `${parentKey}.${key}` : key;
 
         acc.push(path); // Push parent key instead of path

--- a/packages/core/src/connection/transaction-subscriber.ts
+++ b/packages/core/src/connection/transaction-subscriber.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectConnection } from '@nestjs/typeorm';
 import { lastValueFrom, merge, ObservableInput, Subject } from 'rxjs';
 import { delay, filter, map, take, tap } from 'rxjs/operators';
-import { Connection, EntitySubscriberInterface } from 'typeorm';
+import { DataSource, EntitySubscriberInterface } from 'typeorm';
 import { EntityManager } from 'typeorm/entity-manager/EntityManager';
 import { QueryRunner } from 'typeorm/query-runner/QueryRunner';
 import { TransactionCommitEvent } from 'typeorm/subscriber/event/TransactionCommitEvent';
@@ -26,7 +26,7 @@ export interface TransactionSubscriberEvent {
     /**
      * Connection used in the event.
      */
-    connection: Connection;
+    connection: DataSource;
     /**
      * QueryRunner used in the event transaction.
      * All database operations in the subscribed event listener should be performed using this query runner instance.
@@ -50,7 +50,7 @@ export interface TransactionSubscriberEvent {
 export class TransactionSubscriber implements EntitySubscriberInterface {
     private subject$ = new Subject<TransactionSubscriberEvent>();
 
-    constructor(@InjectConnection() private connection: Connection) {
+    constructor(@InjectConnection() private connection: DataSource) {
         if (!connection.subscribers.find(subscriber => subscriber.constructor === TransactionSubscriber)) {
             connection.subscribers.push(this);
         }

--- a/packages/core/src/migrate.ts
+++ b/packages/core/src/migrate.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'crypto';
 import fs from 'fs-extra';
 import path from 'path';
 import pc from 'picocolors';
-import { Connection, createConnection, DataSourceOptions } from 'typeorm';
+import { DataSource, DataSourceOptions } from 'typeorm';
 import { MysqlDriver } from 'typeorm/driver/mysql/MysqlDriver';
 import { camelCase } from 'typeorm/util/StringUtils';
 
@@ -56,7 +56,7 @@ export interface MigrationOptions {
  */
 export async function runMigrations(userConfig: Partial<VendureConfig>): Promise<string[]> {
     const config = await preBootstrapConfig(userConfig);
-    const connection = await createConnection(createConnectionOptions(config));
+    const connection = await createDataSource(createDataSourceOptions(config));
     const migrationsRan: string[] = [];
     try {
         const migrations = await disableForeignKeysForSqLite(connection, () =>
@@ -76,13 +76,13 @@ export async function runMigrations(userConfig: Partial<VendureConfig>): Promise
         }
     } finally {
         await checkMigrationStatus(connection);
-        await connection.close();
+        await connection.destroy();
         resetConfig();
     }
     return migrationsRan;
 }
 
-async function checkMigrationStatus(connection: Connection) {
+async function checkMigrationStatus(connection: DataSource) {
     const builderLog = await connection.driver.createSchemaBuilder().log();
     if (builderLog.upQueries.length) {
         log(
@@ -105,7 +105,7 @@ async function checkMigrationStatus(connection: Connection) {
  */
 export async function revertLastMigration(userConfig: Partial<VendureConfig>) {
     const config = await preBootstrapConfig(userConfig);
-    const connection = await createConnection(createConnectionOptions(config));
+    const connection = await createDataSource(createDataSourceOptions(config));
     try {
         await disableForeignKeysForSqLite(connection, () =>
             connection.undoLastMigration({ transaction: 'each' }),
@@ -119,7 +119,7 @@ export async function revertLastMigration(userConfig: Partial<VendureConfig>) {
             process.exitCode = 1;
         }
     } finally {
-        await connection.close();
+        await connection.destroy();
         resetConfig();
     }
 }
@@ -139,7 +139,7 @@ export async function generateMigration(
     const config = await preBootstrapConfig(userConfig);
     const { connection, cleanup } = options.fromEmpty
         ? await createEmptyDatabaseConnection(config)
-        : { connection: await createConnection(createConnectionOptions(config)), cleanup: undefined };
+        : { connection: await createDataSource(createDataSourceOptions(config)), cleanup: undefined };
 
     let migrationName: string | undefined;
     try {
@@ -173,11 +173,11 @@ export async function generateMigration(
             log(pc.yellow('No changes in database schema were found - cannot generate a migration.'));
         }
     } finally {
-        // Nested so that a failing connection.close() still drops the shadow database (cleanup)
+        // Nested so that a failing connection.destroy() still drops the shadow database (cleanup)
         // and resets the config, rather than orphaning the shadow DB and leaking the admin
         // connection.
         try {
-            await connection.close();
+            await connection.destroy();
         } finally {
             if (cleanup) {
                 await cleanup();
@@ -188,7 +188,7 @@ export async function generateMigration(
     return migrationName;
 }
 
-function createConnectionOptions(userConfig: Partial<VendureConfig>): DataSourceOptions {
+function createDataSourceOptions(userConfig: Partial<VendureConfig>): DataSourceOptions {
     return Object.assign({ logging: ['query', 'error', 'schema'] }, userConfig.dbConnectionOptions, {
         subscribers: [],
         synchronize: false,
@@ -198,11 +198,15 @@ function createConnectionOptions(userConfig: Partial<VendureConfig>): DataSource
     });
 }
 
+function createDataSource(options: DataSourceOptions): Promise<DataSource> {
+    return new DataSource(options).initialize();
+}
+
 interface EmptyDatabaseConnection {
-    connection: Connection;
+    connection: DataSource;
     /**
      * Tears down any temporary database that was provisioned. Must be called *after* the
-     * {@link connection} has been closed.
+     * {@link connection} has been destroyed.
      */
     cleanup?: () => Promise<void>;
 }
@@ -219,7 +223,7 @@ interface EmptyDatabaseConnection {
 async function createEmptyDatabaseConnection(
     config: Partial<VendureConfig>,
 ): Promise<EmptyDatabaseConnection> {
-    const baseOptions = createConnectionOptions(config);
+    const baseOptions = createDataSourceOptions(config);
     switch (baseOptions.type) {
         // aurora-postgres/aurora-mysql are intentionally excluded: they connect over the Aurora
         // Data API, where `CREATE DATABASE` is not supported the same way, and this has not been
@@ -232,7 +236,7 @@ async function createEmptyDatabaseConnection(
         case 'better-sqlite3':
         case 'sqlite':
         case 'sqljs':
-            return { connection: await createConnection(emptySqliteOptions(baseOptions)) };
+            return { connection: await createDataSource(emptySqliteOptions(baseOptions)) };
         default:
             throw new Error(
                 `Generating a migration from an empty database is not supported for the "${baseOptions.type}" ` +
@@ -294,9 +298,8 @@ async function provisionShadowDatabase(
 
     // An admin connection to the *configured* database, used only to create and later drop the
     // temporary shadow database.
-    const admin = await createConnection({
+    const admin = await createDataSource({
         ...master,
-        name: `vendure-shadow-admin-${shadowName}`,
         entities: [],
         migrations: [],
         logging: false,
@@ -314,27 +317,24 @@ async function provisionShadowDatabase(
     try {
         await admin.query(`CREATE DATABASE ${quotedName}${charsetClause}`);
     } catch (e: any) {
-        await admin.close();
+        await admin.destroy();
         throw new Error(
             `Could not create the temporary shadow database ${shadowName}. Ensure the configured database ` +
                 `user has permission to create databases. Original error: ${e.message as string}`,
         );
     }
 
-    let connection: Connection;
+    let connection: DataSource;
     try {
         // `withDatabase` retargets the shadow connection at shadowName, accounting for a database
         // embedded in a connection `url` (which would otherwise override the top-level `database`
         // and point the shadow connection back at the real configured database).
-        connection = await createConnection({
-            ...withDatabase(master, shadowName),
-            name: `vendure-shadow-${shadowName}`,
-        } as DataSourceOptions);
+        connection = await createDataSource(withDatabase(master, shadowName));
     } catch (e) {
         // The shadow database was created but we could not connect to it - drop it so it is not
         // left behind, then surface the original error.
         await admin.query(`DROP DATABASE IF EXISTS ${quotedName}`).catch(() => undefined);
-        await admin.close();
+        await admin.destroy();
         throw e;
     }
 
@@ -352,7 +352,7 @@ async function provisionShadowDatabase(
                 }
                 await admin.query(`DROP DATABASE IF EXISTS ${quotedName}`);
             } finally {
-                await admin.close();
+                await admin.destroy();
             }
         },
     };
@@ -383,7 +383,7 @@ function emptySqliteOptions(baseOptions: DataSourceOptions): DataSourceOptions {
  * is a work-around for the issue.
  * See https://github.com/typeorm/typeorm/issues/2576#issuecomment-499506647
  */
-async function disableForeignKeysForSqLite<T>(connection: Connection, work: () => Promise<T>): Promise<T> {
+async function disableForeignKeysForSqLite<T>(connection: DataSource, work: () => Promise<T>): Promise<T> {
     const isSqLite = connection.options.type === 'sqlite' || connection.options.type === 'better-sqlite3';
     if (isSqLite) {
         await connection.query('PRAGMA foreign_keys=OFF');

--- a/packages/core/src/migrate.ts
+++ b/packages/core/src/migrate.ts
@@ -359,23 +359,19 @@ async function provisionShadowDatabase(
 }
 
 function emptySqliteOptions(baseOptions: DataSourceOptions): DataSourceOptions {
-    const shared = {
-        ...baseOptions,
-        name: `vendure-shadow-${uniqueShadowSuffix()}`,
-    };
     if (baseOptions.type === 'sqljs') {
         // For sqljs the database can be a Uint8Array of saved bytes; unset it (and the save
         // callback/location) so the shadow really is an empty in-memory database, not a restored
         // copy of a populated one.
         return {
-            ...shared,
+            ...baseOptions,
             location: undefined,
             database: undefined,
             autoSave: false,
             autoSaveCallback: undefined,
         } as unknown as DataSourceOptions;
     }
-    return { ...shared, database: ':memory:' } as DataSourceOptions;
+    return { ...baseOptions, database: ':memory:' } as DataSourceOptions;
 }
 
 /**

--- a/packages/core/src/plugin/default-job-queue-plugin/sql-job-queue-strategy.ts
+++ b/packages/core/src/plugin/default-job-queue-plugin/sql-job-queue-strategy.ts
@@ -1,6 +1,6 @@
 import { JobListOptions, JobState } from '@vendure/common/lib/generated-types';
 import { ID, PaginatedList } from '@vendure/common/lib/shared-types';
-import { Brackets, Connection, EntityManager, FindOptionsWhere, In, LessThan } from 'typeorm';
+import { Brackets, DataSource, EntityManager, FindOptionsWhere, In, LessThan } from 'typeorm';
 
 import { Injector } from '../../common/injector';
 import { InspectableJobQueueStrategy, JobQueueStrategy } from '../../config';
@@ -20,7 +20,7 @@ import { JobRecord } from './job-record.entity';
  * @docsCategory JobQueue
  */
 export class SqlJobQueueStrategy extends PollingJobQueueStrategy implements InspectableJobQueueStrategy {
-    private rawConnection: Connection | undefined;
+    private rawConnection: DataSource | undefined;
     private connection: TransactionalConnection | undefined;
     private listQueryBuilder: ListQueryBuilder;
 
@@ -222,8 +222,8 @@ export class SqlJobQueueStrategy extends PollingJobQueueStrategy implements Insp
         return deleteCount;
     }
 
-    private connectionAvailable(connection: Connection | undefined): connection is Connection {
-        return !!this.rawConnection && this.rawConnection.isConnected;
+    private connectionAvailable(connection: DataSource | undefined): connection is DataSource {
+        return !!this.rawConnection && this.rawConnection.isInitialized;
     }
 
     private toRecord(job: Job<any>, data?: any, retries?: number): JobRecord {

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -5,6 +5,7 @@ import { SelectQueryBuilder } from 'typeorm';
 
 import { RequestContext } from '../../../api/common/request-context';
 import { InternalServerError } from '../../../common/error/errors';
+import { findOptionsArrayToObject } from '../../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../../connection/transactional-connection';
 import { VendureEntity } from '../../../entity/base/base.entity';
 import { ProductVariant } from '../../../entity/product-variant/product-variant.entity';
@@ -136,7 +137,9 @@ export class EntityHydrator {
                 hydratedQb.setFindOptions({
                     relationLoadStrategy: 'query',
                     where: { id: target.id },
-                    relations: missingRelations.filter(relationPath => !joinedRelations.has(relationPath)),
+                    relations: findOptionsArrayToObject(
+                        missingRelations.filter(relationPath => !joinedRelations.has(relationPath)),
+                    ),
                 });
                 const hydrated = await hydratedQb.getOne();
                 const propertiesToAdd = unique(missingRelations.map(relation => relation.split('.')[0]));

--- a/packages/core/src/service/helpers/list-query-builder/parse-channel-param.ts
+++ b/packages/core/src/service/helpers/list-query-builder/parse-channel-param.ts
@@ -1,5 +1,5 @@
 import { ID, Type } from '@vendure/common/lib/shared-types';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 
 import { VendureEntity } from '../../../entity/base/base.entity';
 
@@ -10,7 +10,7 @@ import { WhereCondition } from './parse-filter-params';
  * which are assigned to the channel specified by channelId,
  */
 export function parseChannelParam<T extends VendureEntity>(
-    connection: Connection,
+    connection: DataSource,
     entity: Type<T>,
     channelId: ID,
     entityAlias?: string,

--- a/packages/core/src/service/helpers/translatable-saver/translatable-saver.ts
+++ b/packages/core/src/service/helpers/translatable-saver/translatable-saver.ts
@@ -96,7 +96,7 @@ export class TranslatableSaver {
             relationLoadStrategy: 'query',
             loadEagerRelations: false,
             where: { base: { id: input.id } } as Translation<T>,
-            relations: ['base'],
+            relations: { base: true },
         } as FindManyOptions<Translation<T>>);
 
         const differ = new TranslationDiffer(translationType, this.connection);

--- a/packages/core/src/service/helpers/utils/tree-relations-qb-joiner.ts
+++ b/packages/core/src/service/helpers/utils/tree-relations-qb-joiner.ts
@@ -1,4 +1,4 @@
-import { EntityMetadata, FindOneOptions, SelectQueryBuilder } from 'typeorm';
+import { EntityMetadata, FindOptionsRelations, SelectQueryBuilder } from 'typeorm';
 import { EntityTarget } from 'typeorm/common/EntityTarget';
 import { DriverUtils } from 'typeorm/driver/DriverUtils';
 
@@ -33,7 +33,8 @@ function isTreeEntityMetadata(metadata: EntityMetadata): boolean {
  *
  * @param {SelectQueryBuilder<T>} qb - The query builder instance for joining relations.
  * @param {EntityTarget<T>} entity - The target entity class or schema name, used to access entity metadata.
- * @param {string[]} [requestedRelations=[]] - An array of relation paths (e.g., 'parent.children') to join dynamically.
+ * @param {FindOptionsRelations<T> | string[]} [requestedRelations={}] - The relations to join dynamically, either in
+ * the TypeORM object form or as an array of dotted paths (e.g., 'parent.children').
  * @param {number} [maxEagerDepth=1] - Limits the depth of eager relation joins to avoid excessively deep joins.
  * @returns {Map<string, string>} - A Map of joined relation paths to their aliases, aiding in tracking and preventing duplicates.
  * @template T - The entity type, extending VendureEntity for compatibility with Vendure's data layer.
@@ -54,7 +55,7 @@ function isTreeEntityMetadata(metadata: EntityMetadata): boolean {
 export function joinTreeRelationsDynamically<T extends VendureEntity>(
     qb: SelectQueryBuilder<T>,
     entity: EntityTarget<T>,
-    requestedRelations: FindOneOptions['relations'] = {},
+    requestedRelations: FindOptionsRelations<T> | string[] = {},
     maxEagerDepth: number = 1,
 ): Map<string, string> {
     const joinedRelations = new Map<string, string>();

--- a/packages/core/src/service/services/facet.service.ts
+++ b/packages/core/src/service/services/facet.service.ts
@@ -111,7 +111,7 @@ export class FacetService {
         facetCodeOrLang: string | LanguageCode,
         lang?: LanguageCode,
     ): Promise<Translated<Facet> | undefined> {
-        const relations = ['values', 'values.facet'];
+        const relations = { values: { facet: true } };
         const [repository, facetCode, languageCode, channelLanguageCode] =
             ctxOrFacetCode instanceof RequestContext
                 ? [
@@ -295,7 +295,7 @@ export class FacetService {
         }
         const facetsToAssign = await this.connection
             .getRepository(ctx, Facet)
-            .find({ where: { id: In(input.facetIds) }, relations: ['values'] });
+            .find({ where: { id: In(input.facetIds) }, relations: { values: true } });
         const valuesToAssign = facetsToAssign.reduce(
             (values, facet) => [...values, ...facet.values],
             [] as FacetValue[],
@@ -341,7 +341,7 @@ export class FacetService {
         }
         const facetsToRemove = await this.connection
             .getRepository(ctx, Facet)
-            .find({ where: { id: In(input.facetIds) }, relations: ['values'] });
+            .find({ where: { id: In(input.facetIds) }, relations: { values: true } });
 
         const results: Array<ErrorResultUnion<RemoveFacetFromChannelResult, Facet>> = [];
 

--- a/packages/testing/src/data-population/clear-all-tables.ts
+++ b/packages/testing/src/data-population/clear-all-tables.ts
@@ -1,6 +1,6 @@
 import { VendureConfig } from '@vendure/core';
 import { preBootstrapConfig } from '@vendure/core/dist/bootstrap';
-import { createConnection } from 'typeorm';
+import { DataSource } from 'typeorm';
 
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-floating-promises */
@@ -13,14 +13,14 @@ export async function clearAllTables(config: VendureConfig, logging = true) {
     }
     config = await preBootstrapConfig(config);
     const entityIdStrategy = config.entityIdStrategy ?? config.entityOptions?.entityIdStrategy;
-    const connection = await createConnection({ ...config.dbConnectionOptions });
+    const connection = await new DataSource({ ...config.dbConnectionOptions }).initialize();
     try {
         await connection.synchronize(true);
     } catch (err: any) {
         console.error('Error occurred when attempting to clear tables!');
         console.log(err);
     } finally {
-        await connection.close();
+        await connection.destroy();
     }
     if (logging) {
         console.log('Done!');


### PR DESCRIPTION
Fourth in the series for the TypeORM v1 work tracked in vendurehq/vendure#5105.

**Stacked on vendurehq/vendure#5120**, so the base branch here is `mbromley/oss-696-support-typeorm-v1-alongside-v03` rather than `minor`. The two commits on top of that branch are this PR. It needs retargeting once the PRs below it merge.

## What this does

Replaces every use of the TypeORM connection API that v1 removed. All of it is a straight rename to APIs which already exist in 0.3.28, so this lands on `minor` and works on both versions with no version-specific code.

| Removed in v1 | Replacement | Where |
| -- | -- | -- |
| `Connection` | `DataSource` | `migrate.ts`, `bootstrap.ts`, `transaction-subscriber.ts`, `sql-job-queue-strategy.ts`, `injector.ts`, `parse-channel-param.ts` |
| `createConnection()` | `new DataSource().initialize()` | `migrate.ts`, `@vendure/testing`'s `clear-all-tables.ts` |
| `DataSource.isConnected` | `DataSource.isInitialized` | `sql-job-queue-strategy.ts` |
| `DataSource.close()` | `DataSource.destroy()` | `migrate.ts`, `clear-all-tables.ts` |
| `DataSourceOptions.name` | dropped, see below | `migrate.ts` |

I found `close()` and `DataSourceOptions.name` by diffing the published `DataSource` typings between 0.3.31 and 1.1.0 rather than working from the error list, since the error list only shows what the compiler can see. The full set of members present in 0.3 and gone in v1 is `close`, `connect`, `isConnected`, `getCustomRepository` and `name`. Of those, only `close` and `isConnected` were in use.

## Why dropping the connection `name` is safe

`provisionShadowDatabase()` gave its two temporary connections explicit names. That was necessary under `createConnection()`, which calls `getConnectionManager().create(options)` and throws `AlreadyHasActiveConnectionError` if a connection with the same name is already initialised, defaulting to `"default"`.

`new DataSource(options).initialize()` does not touch the global connection manager at all, so there is no registry for the names to collide in and nothing reads them back. All three sites in `migrate.ts` are covered: the shadow-admin connection, the shadow connection, and the in-memory sqlite options. Nothing in the repository uses `getConnection()` or `getConnectionManager()`, so removing the names loses no behaviour on 0.3 and removes a piece of global state.

This also accounts for the two `as DataSourceOptions` casts noted on the issue as "no longer overlapping, most likely fallout from the driver union changing". It was not the driver union: `name` was removed from `BaseDataSourceOptions` in v1, and both cast errors disappear once it goes.

## The one public type change

`TransactionSubscriberEvent.connection` is declared as `Connection` and becomes `DataSource`. In 0.3, `Connection` is an empty deprecated subclass of `DataSource` which adds no members, so nothing a consumer could be calling is lost. TypeORM constructs `DataSource` and never `Connection`, so the value carried by that event was already a plain `DataSource` and the declared type was too narrow. The property keeps its name, so no consumer code changes.

## Results

Against `typeorm@0.3.28`:

- strict `tsc` clean on both `@vendure/core` and `@vendure/testing`
- full unit suite passes, 90 files and 1277 tests
- on sqljs, the `job-queue`, `job-queue-concurrency`, `database-transactions`, `migrate-asset-translations` and `migrate-product-option-groups` e2e suites pass
- on postgres, the same suites pass, plus `migrate-from-empty`, which is the only coverage of the shadow database code and is skipped on sqljs. It asserts the shadow database is both created and cleaned up, which is the behaviour the `name` removal touches.

Against `typeorm@1.1.0`:

- type errors in `@vendure/core` drop from 36 to 23, with the `Connection`/`createConnection` cluster and both `migrate.ts` cast errors gone
- e2e suites now run to completion with no infrastructure failures at all: zero "Connection not available", zero `reading 'driver'`, zero unhandled rejections
- across `collection`, `list-query-builder`, `asset`, `entity-hydrator`, `custom-field-relations`, `job-queue` and `database-transactions`, **133 tests now pass on v1**, against zero at the original baseline. `job-queue` and `database-transactions` pass outright.

## Two findings for the issue, neither addressed here

**vendurehq/vendure#5107 is not quite complete, and it is the cause of most of the remaining e2e failures.** 19 occurrences of `String-array "relations" syntax has been removed` still appear, from two places:

- `EntityHydratorService` passes a string array into `setFindOptions({ relations })`, which fails all 26 `entity-hydrator` e2e tests
- `FacetService.findByCode()` passes a string array to a raw repository `findOne()`. The importer calls it, so seed data import fails with "1 errors encountered when importing product data", FacetValues are never created, and dozens of downstream assertions then fail on missing data. This is why `collection.e2e-spec.ts` reports "Could not find a FacetValue with the code electronics" and `asset.e2e-spec.ts` sees 1 asset instead of 4.

These are the same sites as the 8 remaining `string[]` is not assignable to `FindOptionsRelations` type errors. They are invisible on 0.3, where the string array form still typechecks and still works. Worth fixing in #5107 before it merges, since the seed data failure makes every other v1 number look worse than it is.

**One failure that looks like a genuine v1 behavioural difference.** `custom-field-relations.e2e-spec.ts` dies during `ChannelService.initChannels` with `Cannot read properties of undefined (reading 'profile')` inside `OrmUtils.deepValue`, reached from `loadRelation` in `SelectQueryBuilder`. That is a `relationLoadStrategy: 'query'` path and does not look like string-array residue. It belongs with the behavioural-changes item on the issue.

Relates to vendurehq/vendure#5105

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789024366&installation_model_id=20193&pr_number=5121&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5121&signature=cbebe5be922c6ddea712415904d559242498cc5b63c9d39843c76c6e54a4abef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
