### PR TITLE
refactor(core): Move @vendure/core off the TypeORM APIs removed in v1

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,6 +10,10 @@ inputs:
         required: false
         # Pinned. Bump explicitly when re-validating against a newer Bun.
         default: '1.3.10'
+    typeorm:
+        description: 'TypeORM profile from scripts/typeorm/profiles.json. Leave empty to install the versions declared in the workspace.'
+        required: false
+        default: ''
 runs:
     using: 'composite'
     steps:
@@ -20,5 +24,14 @@ runs:
           with:
               bun-version: ${{ inputs.bun-version }}
         - name: Install dependencies
+          if: inputs.typeorm == ''
           shell: bash
           run: bun install --frozen-lockfile
+        # Applying a profile rewrites the root overrides, so the lockfile is
+        # expected to change and cannot be installed frozen.
+        - name: Install dependencies (TypeORM ${{ inputs.typeorm }})
+          if: inputs.typeorm != ''
+          shell: bash
+          run: |
+              node scripts/typeorm/use-version.mjs "${{ inputs.typeorm }}"
+              node scripts/typeorm/verify.mjs

--- a/.github/workflows/typeorm_v1.yml
+++ b/.github/workflows/typeorm_v1.yml
@@ -29,28 +29,9 @@ concurrency:
 # the e2e-* jobs because GitHub Actions supports neither YAML anchors nor
 # service reuse. Update all four copies together.
 jobs:
-    should-run:
-        name: should run
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-        outputs:
-            run: ${{ steps.check.outputs.run }}
-        steps:
-            - id: check
-              run: |
-                  if [ "${{ github.event_name }}" != "pull_request" ]; then
-                    echo "run=true" >> "$GITHUB_OUTPUT"
-                  elif ${{ contains(github.event.pull_request.labels.*.name, 'typeorm-v1') }}; then
-                    echo "run=true" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "run=false" >> "$GITHUB_OUTPUT"
-                  fi
-
     build:
         name: build
-        needs: should-run
-        if: needs.should-run.outputs.run == 'true'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'typeorm-v1')
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -64,8 +45,7 @@ jobs:
 
     unit-tests:
         name: unit tests
-        needs: should-run
-        if: needs.should-run.outputs.run == 'true'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'typeorm-v1')
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -81,8 +61,7 @@ jobs:
 
     e2e-sqljs:
         name: e2e (sqljs)
-        needs: should-run
-        if: needs.should-run.outputs.run == 'true'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'typeorm-v1')
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -106,8 +85,7 @@ jobs:
 
     e2e-mariadb:
         name: e2e (mariadb)
-        needs: should-run
-        if: needs.should-run.outputs.run == 'true'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'typeorm-v1')
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -139,8 +117,7 @@ jobs:
 
     e2e-mysql:
         name: e2e (mysql)
-        needs: should-run
-        if: needs.should-run.outputs.run == 'true'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'typeorm-v1')
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -172,8 +149,7 @@ jobs:
 
     e2e-postgres:
         name: e2e (postgres)
-        needs: should-run
-        if: needs.should-run.outputs.run == 'true'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'typeorm-v1')
         runs-on: ubuntu-latest
         permissions:
             contents: read

--- a/.github/workflows/typeorm_v1.yml
+++ b/.github/workflows/typeorm_v1.yml
@@ -1,0 +1,205 @@
+name: TypeORM v1 compatibility
+
+# Runs the database-backed suites against TypeORM v1 while support for it is
+# being built. It is deliberately a separate workflow from Build & Test: these
+# jobs are expected to fail until the migration is finished, and a permanently
+# red job inside the required matrix trains people to ignore the required
+# matrix. Once every job here is green, fold them into build_and_test.yml as a
+# `typeorm` matrix axis and delete this file.
+#
+# Add the `typeorm-v1` label to a pull request to run it against that PR.
+
+on:
+    workflow_dispatch:
+    schedule:
+        # Nightly, so regressions in either TypeORM v1 or Vendure surface without
+        # anyone having to remember to trigger a run.
+        - cron: '0 3 * * *'
+    pull_request:
+        types: [opened, reopened, synchronize, labeled]
+
+env:
+    CI: true
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+# NOTE: As in build_and_test.yml, the service definitions are duplicated across
+# the e2e-* jobs because GitHub Actions supports neither YAML anchors nor
+# service reuse. Update all four copies together.
+jobs:
+    should-run:
+        name: should run
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        outputs:
+            run: ${{ steps.check.outputs.run }}
+        steps:
+            - id: check
+              run: |
+                  if [ "${{ github.event_name }}" != "pull_request" ]; then
+                    echo "run=true" >> "$GITHUB_OUTPUT"
+                  elif ${{ contains(github.event.pull_request.labels.*.name, 'typeorm-v1') }}; then
+                    echo "run=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "run=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+    build:
+        name: build
+        needs: should-run
+        if: needs.should-run.outputs.run == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+            - uses: ./.github/actions/setup
+              with:
+                  typeorm: '1'
+            - name: Build
+              run: bun run build
+
+    unit-tests:
+        name: unit tests
+        needs: should-run
+        if: needs.should-run.outputs.run == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+            - uses: ./.github/actions/setup
+              with:
+                  typeorm: '1'
+            - name: Build (continues past type errors)
+              run: node scripts/typeorm/build-for-tests.mjs
+            - name: Unit tests
+              run: node scripts/typeorm/run-db-tests.mjs --unit-only
+
+    e2e-sqljs:
+        name: e2e (sqljs)
+        needs: should-run
+        if: needs.should-run.outputs.run == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        services:
+            redis:
+                image: redis:7.4.1
+                ports:
+                    - 6379
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+            - uses: ./.github/actions/setup
+              with:
+                  typeorm: '1'
+            - name: Build (continues past type errors)
+              run: node scripts/typeorm/build-for-tests.mjs
+            - name: e2e tests
+              env:
+                  E2E_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
+                  DB: sqljs
+              run: node scripts/typeorm/run-db-tests.mjs --e2e-only
+
+    e2e-mariadb:
+        name: e2e (mariadb)
+        needs: should-run
+        if: needs.should-run.outputs.run == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        services:
+            mariadb:
+                image: mariadb:11.5
+                env:
+                    MARIADB_ROOT_PASSWORD: password
+                ports:
+                    - 3306
+                options: --health-cmd="mariadb-admin ping -h localhost -u vendure -ppassword" --health-interval=10s --health-timeout=5s --health-retries=3
+            redis:
+                image: redis:7.4.1
+                ports:
+                    - 6379
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+            - uses: ./.github/actions/setup
+              with:
+                  typeorm: '1'
+            - name: Build (continues past type errors)
+              run: node scripts/typeorm/build-for-tests.mjs
+            - name: e2e tests
+              env:
+                  E2E_MARIADB_PORT: ${{ job.services.mariadb.ports['3306'] }}
+                  E2E_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
+                  DB: mariadb
+              run: node scripts/typeorm/run-db-tests.mjs --e2e-only
+
+    e2e-mysql:
+        name: e2e (mysql)
+        needs: should-run
+        if: needs.should-run.outputs.run == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        services:
+            mysql:
+                image: vendure/mysql-8-native-auth:latest
+                env:
+                    MYSQL_ROOT_PASSWORD: password
+                ports:
+                    - 3306
+                options: --health-cmd="mysqladmin ping --silent" --health-interval=10s --health-timeout=20s --health-retries=10
+            redis:
+                image: redis:7.4.1
+                ports:
+                    - 6379
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+            - uses: ./.github/actions/setup
+              with:
+                  typeorm: '1'
+            - name: Build (continues past type errors)
+              run: node scripts/typeorm/build-for-tests.mjs
+            - name: e2e tests
+              env:
+                  E2E_MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
+                  E2E_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
+                  DB: mysql
+              run: node scripts/typeorm/run-db-tests.mjs --e2e-only
+
+    e2e-postgres:
+        name: e2e (postgres)
+        needs: should-run
+        if: needs.should-run.outputs.run == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        services:
+            postgres:
+                image: postgres:16
+                env:
+                    POSTGRES_USER: vendure
+                    POSTGRES_PASSWORD: password
+                ports:
+                    - 5432
+                options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
+            redis:
+                image: redis:7.4.1
+                ports:
+                    - 6379
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+            - uses: ./.github/actions/setup
+              with:
+                  typeorm: '1'
+            - name: Build (continues past type errors)
+              run: node scripts/typeorm/build-for-tests.mjs
+            - name: e2e tests
+              env:
+                  E2E_POSTGRES_PORT: ${{ job.services.postgres.ports['5432'] }}
+                  E2E_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
+                  DB: postgres
+              run: node scripts/typeorm/run-db-tests.mjs --e2e-only

--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,6 @@ plans/
 # Scratch files produced by the translation tooling
 missing-translations.txt
 translations.txt
+
+# Lockfile snapshot taken by scripts/typeorm/use-version.mjs
+bun.lock.typeorm-profile-backup

--- a/bun.lock
+++ b/bun.lock
@@ -235,7 +235,7 @@
         "@nestjs/core": "^11.0.12",
         "@nestjs/graphql": "~13.1.0",
         "@nestjs/platform-express": "^11.0.12",
-        "@nestjs/typeorm": "^11.0.0",
+        "@nestjs/typeorm": "^11.0.1",
         "@types/express": "^5.0.1",
         "@vendure/common": "3.7.2",
         "bcrypt": "^6.0.0",
@@ -1621,7 +1621,7 @@
 
     "@nestjs/testing": ["@nestjs/testing@11.1.11", "", { "dependencies": { "tslib": "2.8.1" }, "peerDependencies": { "@nestjs/common": "^11.0.0", "@nestjs/core": "^11.0.0", "@nestjs/microservices": "^11.0.0", "@nestjs/platform-express": "^11.0.0" }, "optionalPeers": ["@nestjs/microservices"] }, "sha512-Po2aZKXlxuySDEh3Gi05LJ7/BtfTAPRZ3KPTrbpNrTmgGr3rFgEGYpQwN50wXYw0pywoICiFLZSZ/qXsplf6NA=="],
 
-    "@nestjs/typeorm": ["@nestjs/typeorm@11.0.0", "", { "peerDependencies": { "@nestjs/common": "^10.0.0 || ^11.0.0", "@nestjs/core": "^10.0.0 || ^11.0.0", "reflect-metadata": "^0.1.13 || ^0.2.0", "rxjs": "^7.2.0", "typeorm": "^0.3.0" } }, "sha512-SOeUQl70Lb2OfhGkvnh4KXWlsd+zA08RuuQgT7kKbzivngxzSo1Oc7Usu5VxCxACQC9wc2l9esOHILSJeK7rJA=="],
+    "@nestjs/typeorm": ["@nestjs/typeorm@11.0.3", "", { "peerDependencies": { "@nestjs/common": "^10.0.0 || ^11.0.0", "@nestjs/core": "^10.0.0 || ^11.0.0", "reflect-metadata": "^0.1.13 || ^0.2.0", "rxjs": "^7.2.0", "typeorm": "^0.3.0 || ^1.0.0-dev" } }, "sha512-zJ+E5l7auVVA7c0PsvcMdyvRPKTUqU5s2ToYmOA2QEsXQ42qbUGtK4+1HlRfpHqBkCSXP+phiH4luvf9DyJNog=="],
 
     "@ng-select/ng-select": ["@ng-select/ng-select@14.9.0", "", { "dependencies": { "tslib": "^2.3.1" }, "peerDependencies": { "@angular/common": "^19.0.0", "@angular/core": "^19.0.0", "@angular/forms": "^19.0.0" } }, "sha512-f/E3EaSVwdKmwvZL43nS961bGaXR90F0Gtb8vA+ub8Hfwqjr1NTI6X7+yu5iMkqfy5ZW5cJdoGvo+kv8zcAkjQ=="],
 

--- a/docs/docs/guides/core-concepts/collections/index.mdx
+++ b/docs/docs/guides/core-concepts/collections/index.mdx
@@ -68,7 +68,7 @@ added to it using the `.andWhere()` method.
 Here's an example of a collection filter which filters by SKU:
 
 ```ts title="src/config/sku-collection-filter.ts"
-import { CollectionFilter, LanguageCode } from '@vendure/core';
+import { CollectionFilter, getDataSource, LanguageCode } from '@vendure/core';
 
 export const skuCollectionFilter = new CollectionFilter({
     args: {
@@ -91,9 +91,9 @@ export const skuCollectionFilter = new CollectionFilter({
     // This is the function that defines the logic of the filter.
     apply: (qb, args) => {
         // Sometimes syntax differs between database types, so we use
-        // the `type` property of the connection options to determine
+        // the `type` property of the DataSource options to determine
         // which syntax to use.
-        const LIKE = qb.connection.options.type === 'postgres' ? 'ILIKE' : 'LIKE';
+        const LIKE = getDataSource(qb).options.type === 'postgres' ? 'ILIKE' : 'LIKE';
 
         return qb.andWhere(`productVariant.sku ${LIKE} :sku`, {
             sku: `%${args.sku}%`

--- a/docs/docs/reference/dashboard/list-views/list-page.mdx
+++ b/docs/docs/reference/dashboard/list-views/list-page.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## ListPage
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/list-page.tsx" sourceLine="503" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/list-page.tsx" sourceLine="524" packageName="@vendure/dashboard" since="3.3.0" />
 
 Auto-generates a list page with columns generated based on the provided query document fields.
 
@@ -129,6 +129,9 @@ interface ListPageProps<T extends TypedDocumentNode<U, V>, U extends ListQuerySh
     facetedFilters?: FacetedFilterConfig<T>;
     rowActions?: RowAction<ListQueryFields<T>>[];
     transformData?: (data: any[]) => any[];
+    transformQueryKey?: (queryKey: any[]) => any[];
+    disableViewOptions?: boolean;
+    includeSelectionColumn?: boolean;
     setTableOptions?: (table: TableOptions<any>) => TableOptions<any>;
     bulkActions?: BulkActionsInput;
     registerRefresher?: PaginatedListRefresherRegisterFn;
@@ -444,6 +447,25 @@ By default, the actions column includes all bulk actions defined in the `bulkAct
 
 Allows the returned list query data to be transformed in some way. This is an advanced feature
 that is not often required.
+### transformQueryKey
+
+<MemberInfo kind="property" type={`(queryKey: any[]) => any[]`}   />
+
+Allows the react-query cache key to be transformed. Use this together with the
+`transformVariables` prop when a page injects extra state into the query
+(e.g. a language selector or a status filter): the default key only reflects page, sorting,
+column filters and the search term, so without transforming the key too, changing the injected
+state serves a stale cached result instead of refetching.
+### disableViewOptions
+
+<MemberInfo kind="property" type={`boolean`}   />
+
+When true, disables the view options (column visibility) control in the table toolbar.
+### includeSelectionColumn
+
+<MemberInfo kind="property" type={`boolean`} default={`true`}   />
+
+When false, the row selection checkbox column will not be included.
 ### setTableOptions
 
 <MemberInfo kind="property" type={`(table: TableOptions<any>) => TableOptions<any>`}   />

--- a/docs/docs/reference/typescript-api/common/bootstrap.mdx
+++ b/docs/docs/reference/typescript-api/common/bootstrap.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## bootstrap
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="196" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="198" packageName="@vendure/core" />
 
 Bootstraps the Vendure server. This is the entry point to the application.
 
@@ -76,7 +76,7 @@ Parameters
 
 ## BootstrapOptions
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="51" packageName="@vendure/core" since="2.2.0" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="53" packageName="@vendure/core" since="2.2.0" />
 
 Additional options that can be used to configure the bootstrap process of the
 Vendure server.

--- a/docs/docs/reference/typescript-api/common/injector.mdx
+++ b/docs/docs/reference/typescript-api/common/injector.mdx
@@ -2,7 +2,7 @@
 title: "Injector"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/common/injector.ts" sourceLine="15" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/common/injector.ts" sourceLine="13" packageName="@vendure/core" />
 
 The Injector wraps the underlying Nestjs `ModuleRef`, allowing injection of providers
 known to the application's dependency injection container. This is intended to enable the injection

--- a/docs/docs/reference/typescript-api/configuration/collection-filter.mdx
+++ b/docs/docs/reference/typescript-api/configuration/collection-filter.mdx
@@ -16,7 +16,7 @@ Here's a simple example of a custom CollectionFilter:
 *Example*
 
 ```ts
-import { CollectionFilter, LanguageCode } from '@vendure/core';
+import { CollectionFilter, getDataSource, LanguageCode } from '@vendure/core';
 
 export const skuCollectionFilter = new CollectionFilter({
   args: {
@@ -38,7 +38,7 @@ export const skuCollectionFilter = new CollectionFilter({
 
   // This is the function that defines the logic of the filter.
   apply: (qb, args) => {
-    const LIKE = qb.connection.options.type === 'postgres' ? 'ILIKE' : 'LIKE';
+    const LIKE = getDataSource(qb).options.type === 'postgres' ? 'ILIKE' : 'LIKE';
     return qb.andWhere(`productVariant.sku ${LIKE} :sku`, { sku: `%${args.sku}%` });
   },
 });

--- a/docs/docs/reference/typescript-api/data-access/data-source-holder.mdx
+++ b/docs/docs/reference/typescript-api/data-access/data-source-holder.mdx
@@ -11,5 +11,24 @@ but not all, of those classes. Code which has to run on both versions therefore 
 DataSource via [getDataSource](/reference/typescript-api/data-access/get-data-source#getdatasource) rather than naming either property directly.
 
 ```ts title="Signature"
-type DataSourceHolder = { connection: DataSource } | { dataSource: DataSource }
+type DataSourceHolder = {
+    connection?: DataSource;
+    dataSource?: DataSource
+}
 ```
+
+<div className="members-wrapper">
+
+### connection
+
+<MemberInfo kind="property" type={`DataSource`}   />
+
+
+### dataSource
+
+<MemberInfo kind="property" type={`DataSource`}   />
+
+
+
+
+</div>

--- a/docs/docs/reference/typescript-api/data-access/data-source-holder.mdx
+++ b/docs/docs/reference/typescript-api/data-access/data-source-holder.mdx
@@ -1,0 +1,15 @@
+---
+title: "DataSourceHolder"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/get-data-source.ts" sourceLine="14" packageName="@vendure/core" since="3.8.0" />
+
+A TypeORM object which knows the `DataSource` it belongs to, such as a QueryBuilder,
+EntityManager, QueryRunner or EntityMetadata. TypeORM 0.3 names that property `connection`.
+TypeORM 1 renames it to `dataSource` and keeps `connection` as a deprecated alias on some,
+but not all, of those classes. Code which has to run on both versions therefore reads the
+DataSource via [getDataSource](/reference/typescript-api/data-access/get-data-source#getdatasource) rather than naming either property directly.
+
+```ts title="Signature"
+type DataSourceHolder = { connection: DataSource } | { dataSource: DataSource }
+```

--- a/docs/docs/reference/typescript-api/data-access/entity-hydrator.mdx
+++ b/docs/docs/reference/typescript-api/data-access/entity-hydrator.mdx
@@ -2,7 +2,7 @@
 title: "EntityHydrator"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts" sourceLine="74" packageName="@vendure/core" since="1.3.0" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts" sourceLine="75" packageName="@vendure/core" since="1.3.0" />
 
 This is a helper class which is used to "hydrate" entity instances, which means to populate them
 with the specified relations. This is useful when writing plugin code which receives an entity,

--- a/docs/docs/reference/typescript-api/data-access/find-options-array-to-object.mdx
+++ b/docs/docs/reference/typescript-api/data-access/find-options-array-to-object.mdx
@@ -1,0 +1,25 @@
+---
+title: "FindOptionsArrayToObject"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/find-options-array-to-object.ts" sourceLine="17" packageName="@vendure/core" since="3.8.0" />
+
+Converts a string array of relation paths into the object form used by the TypeORM
+FindOptions `relations` property. Dotted paths are expanded into nested objects.
+
+*Example*
+
+```ts
+findOptionsArrayToObject<Order>(['customer', 'lines.productVariant']);
+// { customer: true, lines: { productVariant: true } }
+```
+
+```ts title="Signature"
+function findOptionsArrayToObject<T>(input: string[]): FindOptionsRelations<T>
+```
+Parameters
+
+### input
+
+<MemberInfo kind="parameter" type={`string[]`} />
+

--- a/docs/docs/reference/typescript-api/data-access/find-options-relations-input.mdx
+++ b/docs/docs/reference/typescript-api/data-access/find-options-relations-input.mdx
@@ -1,0 +1,12 @@
+---
+title: "FindOptionsRelationsInput"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/types.ts" sourceLine="12" packageName="@vendure/core" since="3.8.0" />
+
+The relations to join when finding an entity. Accepts either the TypeORM object form,
+or an array of dot-separated relation paths as produced by `RelationPaths`.
+
+```ts title="Signature"
+type FindOptionsRelationsInput<T> = FindOptionsRelations<T> | string[]
+```

--- a/docs/docs/reference/typescript-api/data-access/find-options-select-input.mdx
+++ b/docs/docs/reference/typescript-api/data-access/find-options-select-input.mdx
@@ -1,0 +1,12 @@
+---
+title: "FindOptionsSelectInput"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/types.ts" sourceLine="22" packageName="@vendure/core" since="3.8.0" />
+
+The columns to select when finding an entity. Accepts either the TypeORM object form,
+or an array of column names.
+
+```ts title="Signature"
+type FindOptionsSelectInput<T> = FindOptionsSelect<T> | string[]
+```

--- a/docs/docs/reference/typescript-api/data-access/get-data-source.mdx
+++ b/docs/docs/reference/typescript-api/data-access/get-data-source.mdx
@@ -2,10 +2,11 @@
 title: "GetDataSource"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/connection/get-data-source.ts" sourceLine="35" packageName="@vendure/core" since="3.8.0" />
+<GenerationInfo sourceFile="packages/core/src/connection/get-data-source.ts" sourceLine="36" packageName="@vendure/core" since="3.8.0" />
 
 Returns the `DataSource` that the given TypeORM object belongs to, reading whichever of
-the `dataSource` and `connection` properties the installed version of TypeORM provides.
+the `dataSource` and `connection` properties the installed version of TypeORM provides. Where
+an object carries both, `dataSource` is used, since `connection` is the deprecated alias.
 
 *Example*
 

--- a/docs/docs/reference/typescript-api/data-access/get-data-source.mdx
+++ b/docs/docs/reference/typescript-api/data-access/get-data-source.mdx
@@ -1,0 +1,30 @@
+---
+title: "GetDataSource"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/get-data-source.ts" sourceLine="35" packageName="@vendure/core" since="3.8.0" />
+
+Returns the `DataSource` that the given TypeORM object belongs to, reading whichever of
+the `dataSource` and `connection` properties the installed version of TypeORM provides.
+
+*Example*
+
+```ts
+const collectionFilter = new CollectionFilter({
+  // ...
+  apply: (qb, args) => {
+    const LIKE = getDataSource(qb).options.type === 'postgres' ? 'ILIKE' : 'LIKE';
+    return qb.andWhere(`productVariant.sku ${LIKE} :sku`, { sku: `%${args.sku}%` });
+  },
+});
+```
+
+```ts title="Signature"
+function getDataSource(source: DataSourceHolder): DataSource
+```
+Parameters
+
+### source
+
+<MemberInfo kind="parameter" type={`<a href='/reference/typescript-api/data-access/data-source-holder#datasourceholder'>DataSourceHolder</a>`} />
+

--- a/docs/docs/reference/typescript-api/data-access/get-database-type.mdx
+++ b/docs/docs/reference/typescript-api/data-access/get-database-type.mdx
@@ -1,0 +1,17 @@
+---
+title: "GetDatabaseType"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/database-type.ts" sourceLine="24" packageName="@vendure/core" since="3.8.0" />
+
+Returns the name of the TypeORM driver in use, widened to [VendureDatabaseType](/reference/typescript-api/data-access/vendure-database-type#venduredatabasetype).
+
+```ts title="Signature"
+function getDatabaseType(source: DataSource | DataSourceOptions): VendureDatabaseType
+```
+Parameters
+
+### source
+
+<MemberInfo kind="parameter" type={`DataSource | DataSourceOptions`} />
+

--- a/docs/docs/reference/typescript-api/data-access/get-entity-or-throw-options.mdx
+++ b/docs/docs/reference/typescript-api/data-access/get-entity-or-throw-options.mdx
@@ -2,19 +2,19 @@
 title: "GetEntityOrThrowOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/connection/types.ts" sourceLine="10" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/connection/types.ts" sourceLine="56" packageName="@vendure/core" />
 
 Options used by the [TransactionalConnection](/reference/typescript-api/data-access/transactional-connection#transactionalconnection) `getEntityOrThrow` method.
 
 ```ts title="Signature"
-interface GetEntityOrThrowOptions<T = any> extends FindOneOptions<T> {
+interface GetEntityOrThrowOptions<T = any> extends VendureFindOneOptions<T> {
     channelId?: ID;
     retries?: number;
     retryDelay?: number;
     includeSoftDeleted?: boolean;
 }
 ```
-* Extends: `FindOneOptions<T>`
+* Extends: [`VendureFindOneOptions`](/reference/typescript-api/data-access/vendure-find-one-options#vendurefindoneoptions)`<T>`
 
 
 

--- a/docs/docs/reference/typescript-api/data-access/list-query-builder.mdx
+++ b/docs/docs/reference/typescript-api/data-access/list-query-builder.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## ListQueryBuilder
 
-<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="209" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="210" packageName="@vendure/core" />
 
 This helper class is used when fetching entities the database from queries which return a [PaginatedList](/reference/typescript-api/common/paginated-list#paginatedlist) type.
 These queries all follow the same format:
@@ -107,7 +107,7 @@ to join that relation.
 </div>
 ## ExtendedListQueryOptions
 
-<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="50" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="51" packageName="@vendure/core" />
 
 Options which can be passed to the ListQueryBuilder's `build()` method.
 

--- a/docs/docs/reference/typescript-api/data-access/list-query-builder.mdx
+++ b/docs/docs/reference/typescript-api/data-access/list-query-builder.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## ListQueryBuilder
 
-<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="210" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="211" packageName="@vendure/core" />
 
 This helper class is used when fetching entities the database from queries which return a [PaginatedList](/reference/typescript-api/common/paginated-list#paginatedlist) type.
 These queries all follow the same format:
@@ -107,7 +107,7 @@ to join that relation.
 </div>
 ## ExtendedListQueryOptions
 
-<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="51" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="52" packageName="@vendure/core" />
 
 Options which can be passed to the ListQueryBuilder's `build()` method.
 

--- a/docs/docs/reference/typescript-api/data-access/list-query-builder.mdx
+++ b/docs/docs/reference/typescript-api/data-access/list-query-builder.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## ListQueryBuilder
 
-<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="208" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="209" packageName="@vendure/core" />
 
 This helper class is used when fetching entities the database from queries which return a [PaginatedList](/reference/typescript-api/common/paginated-list#paginatedlist) type.
 These queries all follow the same format:
@@ -107,7 +107,7 @@ to join that relation.
 </div>
 ## ExtendedListQueryOptions
 
-<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="49" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="50" packageName="@vendure/core" />
 
 Options which can be passed to the ListQueryBuilder's `build()` method.
 

--- a/docs/docs/reference/typescript-api/data-access/to-type-orm-find-options.mdx
+++ b/docs/docs/reference/typescript-api/data-access/to-type-orm-find-options.mdx
@@ -1,0 +1,22 @@
+---
+title: "ToTypeOrmFindOptions"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/to-typeorm-find-options.ts" sourceLine="31" packageName="@vendure/core" since="3.8.0" />
+
+Converts the `relations` and `select` properties of Vendure's find options into the object
+form TypeORM expects. Call this wherever find options cross from a Vendure API into TypeORM.
+
+Vendure's own APIs accept relation paths as a string array, since that is the shape of
+`RelationPaths` and of the `@Relations()` decorator that produces it. TypeORM only
+accepts the object form.
+
+```ts title="Signature"
+function toTypeOrmFindOptions<T, O extends VendureFindManyOptions<T>>(options: O): TypeOrmFindOptions<T, O>
+```
+Parameters
+
+### options
+
+<MemberInfo kind="parameter" type={`O`} />
+

--- a/docs/docs/reference/typescript-api/data-access/transactional-connection.mdx
+++ b/docs/docs/reference/typescript-api/data-access/transactional-connection.mdx
@@ -2,7 +2,7 @@
 title: "TransactionalConnection"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/connection/transactional-connection.ts" sourceLine="73" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/connection/transactional-connection.ts" sourceLine="75" packageName="@vendure/core" />
 
 The TransactionalConnection is a wrapper around the TypeORM `Connection` object which works in conjunction
 with the [Transaction](/reference/typescript-api/request/transaction-decorator#transaction) decorator to implement per-request transactions. All services which access the
@@ -30,8 +30,8 @@ class TransactionalConnection {
     commitOpenTransaction(ctx: RequestContext) => ;
     rollBackTransaction(ctx: RequestContext) => ;
     getEntityOrThrow(ctx: RequestContext, entityType: Type<T>, id: ID, options: GetEntityOrThrowOptions<T> = {}) => Promise<T>;
-    findOneInChannel(ctx: RequestContext, entity: Type<T>, id: ID, channelId: ID, options: FindOneOptions<T> = {}) => ;
-    findByIdsInChannel(ctx: RequestContext, entity: Type<T>, ids: ID[], channelId: ID, options: FindManyOptions<T>) => ;
+    findOneInChannel(ctx: RequestContext, entity: Type<T>, id: ID, channelId: ID, options: VendureFindOneOptions<T> = {}) => ;
+    findByIdsInChannel(ctx: RequestContext, entity: Type<T>, ids: ID[], channelId: ID, options: VendureFindManyOptions<T>) => ;
 }
 ```
 
@@ -148,13 +148,13 @@ Finds an entity of the given type by ID, or throws an `EntityNotFoundError` if n
 is found.
 ### findOneInChannel
 
-<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, entity: Type<T>, id: <a href='/reference/typescript-api/common/id#id'>ID</a>, channelId: <a href='/reference/typescript-api/common/id#id'>ID</a>, options: FindOneOptions<T> = {}) => `}   />
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, entity: Type<T>, id: <a href='/reference/typescript-api/common/id#id'>ID</a>, channelId: <a href='/reference/typescript-api/common/id#id'>ID</a>, options: <a href='/reference/typescript-api/data-access/vendure-find-one-options#vendurefindoneoptions'>VendureFindOneOptions</a><T> = {}) => `}   />
 
 Like the TypeOrm `Repository.findOne()` method, but limits the results to
 the given Channel.
 ### findByIdsInChannel
 
-<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, entity: Type<T>, ids: <a href='/reference/typescript-api/common/id#id'>ID</a>[], channelId: <a href='/reference/typescript-api/common/id#id'>ID</a>, options: FindManyOptions<T>) => `}   />
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, entity: Type<T>, ids: <a href='/reference/typescript-api/common/id#id'>ID</a>[], channelId: <a href='/reference/typescript-api/common/id#id'>ID</a>, options: <a href='/reference/typescript-api/data-access/vendure-find-many-options#vendurefindmanyoptions'>VendureFindManyOptions</a><T>) => `}   />
 
 Like the TypeOrm `Repository.findByIds()` method, but limits the results to
 the given Channel.

--- a/docs/docs/reference/typescript-api/data-access/type-orm-find-options.mdx
+++ b/docs/docs/reference/typescript-api/data-access/type-orm-find-options.mdx
@@ -1,0 +1,15 @@
+---
+title: "TypeOrmFindOptions"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/to-typeorm-find-options.ts" sourceLine="14" packageName="@vendure/core" since="3.8.0" />
+
+The find options `O` with its `relations` and `select` properties narrowed to the object
+form that TypeORM accepts.
+
+```ts title="Signature"
+type TypeOrmFindOptions<T, O> = Omit<O, 'relations' | 'select'> & {
+    relations?: FindOptionsRelations<T>;
+    select?: FindOptionsSelect<T>;
+}
+```

--- a/docs/docs/reference/typescript-api/data-access/vendure-database-type.mdx
+++ b/docs/docs/reference/typescript-api/data-access/vendure-database-type.mdx
@@ -1,0 +1,16 @@
+---
+title: "VendureDatabaseType"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/database-type.ts" sourceLine="15" packageName="@vendure/core" since="3.8.0" />
+
+The name of the TypeORM driver a Vendure project is configured with.
+
+This is TypeORM's own driver union widened with `sqlite`, which some TypeORM versions
+declare and others do not, even though a project may be configured with it either way.
+Switching on a driver name should use this type rather than `DataSourceOptions['type']`,
+so that the `sqlite` branches stay reachable.
+
+```ts title="Signature"
+type VendureDatabaseType = DataSourceOptions['type'] | 'sqlite'
+```

--- a/docs/docs/reference/typescript-api/data-access/vendure-find-many-options.mdx
+++ b/docs/docs/reference/typescript-api/data-access/vendure-find-many-options.mdx
@@ -1,0 +1,34 @@
+---
+title: "VendureFindManyOptions"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/types.ts" sourceLine="45" packageName="@vendure/core" since="3.8.0" />
+
+The TypeORM `FindManyOptions`, with `relations` and `select` also accepting an array of
+paths.
+
+```ts title="Signature"
+interface VendureFindManyOptions<T = any> extends Omit<FindManyOptions<T>, 'relations' | 'select'> {
+    relations?: FindOptionsRelationsInput<T>;
+    select?: FindOptionsSelectInput<T>;
+}
+```
+* Extends: `Omit<FindManyOptions<T>, 'relations' | 'select'>`
+
+
+
+<div className="members-wrapper">
+
+### relations
+
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/data-access/find-options-relations-input#findoptionsrelationsinput'>FindOptionsRelationsInput</a><T>`}   />
+
+
+### select
+
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/data-access/find-options-select-input#findoptionsselectinput'>FindOptionsSelectInput</a><T>`}   />
+
+
+
+
+</div>

--- a/docs/docs/reference/typescript-api/data-access/vendure-find-many-options.mdx
+++ b/docs/docs/reference/typescript-api/data-access/vendure-find-many-options.mdx
@@ -1,0 +1,34 @@
+---
+title: "VendureFindManyOptions"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/types.ts" sourceLine="45" packageName="@vendure/core" since="3.8.0" />
+
+The TypeORM `FindManyOptions`, widened so that `relations` and `select` also accept the
+array form.
+
+```ts title="Signature"
+interface VendureFindManyOptions<T = any> extends Omit<FindManyOptions<T>, 'relations' | 'select'> {
+    relations?: FindOptionsRelationsInput<T>;
+    select?: FindOptionsSelectInput<T>;
+}
+```
+* Extends: `Omit<FindManyOptions<T>, 'relations' | 'select'>`
+
+
+
+<div className="members-wrapper">
+
+### relations
+
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/data-access/find-options-relations-input#findoptionsrelationsinput'>FindOptionsRelationsInput</a><T>`}   />
+
+
+### select
+
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/data-access/find-options-select-input#findoptionsselectinput'>FindOptionsSelectInput</a><T>`}   />
+
+
+
+
+</div>

--- a/docs/docs/reference/typescript-api/data-access/vendure-find-one-options.mdx
+++ b/docs/docs/reference/typescript-api/data-access/vendure-find-one-options.mdx
@@ -1,0 +1,34 @@
+---
+title: "VendureFindOneOptions"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/types.ts" sourceLine="32" packageName="@vendure/core" since="3.8.0" />
+
+The TypeORM `FindOneOptions`, with `relations` and `select` also accepting an array of
+paths.
+
+```ts title="Signature"
+interface VendureFindOneOptions<T = any> extends Omit<FindOneOptions<T>, 'relations' | 'select'> {
+    relations?: FindOptionsRelationsInput<T>;
+    select?: FindOptionsSelectInput<T>;
+}
+```
+* Extends: `Omit<FindOneOptions<T>, 'relations' | 'select'>`
+
+
+
+<div className="members-wrapper">
+
+### relations
+
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/data-access/find-options-relations-input#findoptionsrelationsinput'>FindOptionsRelationsInput</a><T>`}   />
+
+
+### select
+
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/data-access/find-options-select-input#findoptionsselectinput'>FindOptionsSelectInput</a><T>`}   />
+
+
+
+
+</div>

--- a/docs/docs/reference/typescript-api/data-access/vendure-find-one-options.mdx
+++ b/docs/docs/reference/typescript-api/data-access/vendure-find-one-options.mdx
@@ -1,0 +1,34 @@
+---
+title: "VendureFindOneOptions"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/connection/types.ts" sourceLine="32" packageName="@vendure/core" since="3.8.0" />
+
+The TypeORM `FindOneOptions`, widened so that `relations` and `select` also accept the
+array form.
+
+```ts title="Signature"
+interface VendureFindOneOptions<T = any> extends Omit<FindOneOptions<T>, 'relations' | 'select'> {
+    relations?: FindOptionsRelationsInput<T>;
+    select?: FindOptionsSelectInput<T>;
+}
+```
+* Extends: `Omit<FindOneOptions<T>, 'relations' | 'select'>`
+
+
+
+<div className="members-wrapper">
+
+### relations
+
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/data-access/find-options-relations-input#findoptionsrelationsinput'>FindOptionsRelationsInput</a><T>`}   />
+
+
+### select
+
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/data-access/find-options-select-input#findoptionsselectinput'>FindOptionsSelectInput</a><T>`}   />
+
+
+
+
+</div>

--- a/docs/docs/reference/typescript-api/events/event-types.mdx
+++ b/docs/docs/reference/typescript-api/events/event-types.mdx
@@ -1234,6 +1234,71 @@ class StockMovementEvent extends VendureEvent {
 
 
 </div>
+## StockShortfall
+
+<GenerationInfo sourceFile="packages/core/src/event-bus/events/stock-shortfall-event.ts" sourceLine="16" packageName="@vendure/core" since="3.8.0" />
+
+Describes a single order line whose requested quantity could not be fully allocated
+from available stock.
+
+```ts title="Signature"
+interface StockShortfall {
+    productVariantId: ID;
+    orderLineId: ID;
+    requested: number;
+    allocated: number;
+}
+```
+
+<div className="members-wrapper">
+
+### productVariantId
+
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/common/id#id'>ID</a>`}   />
+
+
+### orderLineId
+
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/common/id#id'>ID</a>`}   />
+
+
+### requested
+
+<MemberInfo kind="property" type={`number`}   />
+
+
+### allocated
+
+<MemberInfo kind="property" type={`number`}   />
+
+
+
+
+</div>
+## StockShortfallEvent
+
+<GenerationInfo sourceFile="packages/core/src/event-bus/events/stock-shortfall-event.ts" sourceLine="35" packageName="@vendure/core" since="3.8.0" />
+
+This event is fired when stock allocation for an Order cannot fully satisfy the requested
+quantities — i.e. the available stock was depleted (e.g. by concurrent orders) between the time
+the cart passed the checkout stock check and the time stock was actually allocated. Because the
+payment may already have been captured, allocation is capped to the available quantity rather than
+failing, and this event is published so that plugins can react (refund, backorder, notify).
+
+```ts title="Signature"
+class StockShortfallEvent extends VendureEvent {
+    constructor(ctx: RequestContext, order: Order, shortfalls: StockShortfall[])
+}
+```
+* Extends: [`VendureEvent`](/reference/typescript-api/events/vendure-event#vendureevent)
+
+
+
+<div className="members-wrapper">
+
+
+
+</div>
 ## TaxCategoryEvent
 
 <GenerationInfo sourceFile="packages/core/src/event-bus/events/tax-category-event.ts" sourceLine="18" packageName="@vendure/core" />

--- a/docs/docs/reference/typescript-api/job-queue/sql-job-queue-strategy.mdx
+++ b/docs/docs/reference/typescript-api/job-queue/sql-job-queue-strategy.mdx
@@ -2,7 +2,7 @@
 title: "SqlJobQueueStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/plugin/default-job-queue-plugin/sql-job-queue-strategy.ts" sourceLine="22" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/plugin/default-job-queue-plugin/sql-job-queue-strategy.ts" sourceLine="23" packageName="@vendure/core" />
 
 A [JobQueueStrategy](/reference/typescript-api/job-queue/job-queue-strategy#jobqueuestrategy) which uses the configured SQL database to persist jobs in the queue.
 This strategy is used by the [DefaultJobQueuePlugin](/reference/typescript-api/job-queue/default-job-queue-plugin#defaultjobqueueplugin).

--- a/docs/docs/reference/typescript-api/migration/generate-migration.mdx
+++ b/docs/docs/reference/typescript-api/migration/generate-migration.mdx
@@ -2,7 +2,7 @@
 title: "GenerateMigration"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/migrate.ts" sourceLine="135" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/migrate.ts" sourceLine="136" packageName="@vendure/core" />
 
 Generates a new migration file based on any schema changes (e.g. adding or removing CustomFields).
 See [TypeORM migration docs](https://typeorm.io/#/migrations) for more information about the

--- a/docs/docs/reference/typescript-api/migration/migrate-asset-translation-data.mdx
+++ b/docs/docs/reference/typescript-api/migration/migrate-asset-translation-data.mdx
@@ -2,7 +2,7 @@
 title: "MigrateAssetTranslationData"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/migration-utils/v3_6_asset_translations.ts" sourceLine="43" packageName="@vendure/core" since="3.6.0" />
+<GenerationInfo sourceFile="packages/core/src/migration-utils/v3_6_asset_translations.ts" sourceLine="45" packageName="@vendure/core" since="3.6.0" />
 
 Populates the new `asset_translation` table with data from the existing `name`
 column on `asset`, using the default channel's language code.

--- a/docs/docs/reference/typescript-api/migration/migrate-product-option-group-data.mdx
+++ b/docs/docs/reference/typescript-api/migration/migrate-product-option-group-data.mdx
@@ -2,7 +2,7 @@
 title: "MigrateProductOptionGroupData"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/migration-utils/v3_6_shared_option_groups.ts" sourceLine="43" packageName="@vendure/core" since="3.6.0" />
+<GenerationInfo sourceFile="packages/core/src/migration-utils/v3_6_shared_option_groups.ts" sourceLine="45" packageName="@vendure/core" since="3.6.0" />
 
 Populates the new join tables for shared, channel-aware ProductOptionGroups
 using data from the existing `productId` FK column on `product_option_group`.

--- a/docs/docs/reference/typescript-api/migration/migration-options.mdx
+++ b/docs/docs/reference/typescript-api/migration/migration-options.mdx
@@ -2,7 +2,7 @@
 title: "MigrationOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/migrate.ts" sourceLine="20" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/migrate.ts" sourceLine="21" packageName="@vendure/core" />
 
 Configuration for generating a new migration script via [generateMigration](/reference/typescript-api/migration/generate-migration#generatemigration).
 

--- a/docs/docs/reference/typescript-api/migration/revert-last-migration.mdx
+++ b/docs/docs/reference/typescript-api/migration/revert-last-migration.mdx
@@ -2,7 +2,7 @@
 title: "RevertLastMigration"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/migrate.ts" sourceLine="106" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/migrate.ts" sourceLine="107" packageName="@vendure/core" />
 
 Reverts the last applied database migration. See [TypeORM migration docs](https://typeorm.io/#/migrations)
 for more information about the underlying migration mechanism.

--- a/docs/docs/reference/typescript-api/migration/run-migrations.mdx
+++ b/docs/docs/reference/typescript-api/migration/run-migrations.mdx
@@ -2,7 +2,7 @@
 title: "RunMigrations"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/migrate.ts" sourceLine="57" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/migrate.ts" sourceLine="58" packageName="@vendure/core" />
 
 Runs any pending database migrations. See [TypeORM migration docs](https://typeorm.io/#/migrations)
 for more information about the underlying migration mechanism.

--- a/docs/docs/reference/typescript-api/products-stock/multi-channel-stock-location-strategy.mdx
+++ b/docs/docs/reference/typescript-api/products-stock/multi-channel-stock-location-strategy.mdx
@@ -2,7 +2,7 @@
 title: "MultiChannelStockLocationStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/catalog/multi-channel-stock-location-strategy.ts" sourceLine="32" packageName="@vendure/core" since="3.1.0" />
+<GenerationInfo sourceFile="packages/core/src/config/catalog/multi-channel-stock-location-strategy.ts" sourceLine="33" packageName="@vendure/core" since="3.1.0" />
 
 The MultiChannelStockLocationStrategy is an implementation of the [StockLocationStrategy](/reference/typescript-api/products-stock/stock-location-strategy#stocklocationstrategy).
 which is suitable for both single- and multichannel setups. It takes into account the active

--- a/docs/docs/reference/typescript-api/request/request-context.mdx
+++ b/docs/docs/reference/typescript-api/request/request-context.mdx
@@ -45,7 +45,7 @@ class RequestContext {
     userHasPermissions(permissions: Permission[]) => boolean;
     userHasAllPermissions(permissions: Permission[]) => boolean;
     serialize() => SerializedRequestContext;
-    copy() => RequestContext;
+    copy(channel?: Channel) => RequestContext;
     req: Request | undefined
     apiType: ApiType
     channel: Channel
@@ -121,11 +121,14 @@ This is useful when you need to send a RequestContext object to another
 process, e.g. to pass it to the Job Queue via the [JobQueueService](/reference/typescript-api/job-queue/job-queue-service#jobqueueservice).
 ### copy
 
-<MemberInfo kind="method" type={`() => <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>`}   />
+<MemberInfo kind="method" type={`(channel?: <a href='/reference/typescript-api/entities/channel#channel'>Channel</a>) => <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>`}   />
 
 Creates a shallow copy of the RequestContext instance. This means that
 mutations to the copy itself will not affect the original, but deep mutations
 (e.g. copy.channel.code = 'new') *will* also affect the original.
+
+Passing a `channel` re-scopes the copy to it, switching language and currency
+to the channel's defaults so downstream logic runs in the target channel.
 ### req
 
 <MemberInfo kind="property" type={`Request | undefined`}   />

--- a/docs/docs/reference/typescript-api/service-helpers/order-modifier.mdx
+++ b/docs/docs/reference/typescript-api/service-helpers/order-modifier.mdx
@@ -2,7 +2,7 @@
 title: "OrderModifier"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/helpers/order-modifier/order-modifier.ts" sourceLine="85" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/order-modifier/order-modifier.ts" sourceLine="86" packageName="@vendure/core" />
 
 This helper is responsible for modifying the contents of an Order.
 

--- a/docs/docs/reference/typescript-api/services/administrator-service.mdx
+++ b/docs/docs/reference/typescript-api/services/administrator-service.mdx
@@ -2,7 +2,7 @@
 title: "AdministratorService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/administrator.service.ts" sourceLine="53" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/administrator.service.ts" sourceLine="54" packageName="@vendure/core" />
 
 Contains methods relating to [Administrator](/reference/typescript-api/entities/administrator#administrator) entities.
 

--- a/docs/docs/reference/typescript-api/services/asset-service.mdx
+++ b/docs/docs/reference/typescript-api/services/asset-service.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## AssetService
 
-<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="91" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="92" packageName="@vendure/core" />
 
 Contains methods relating to [Asset](/reference/typescript-api/entities/asset#asset) entities.
 
@@ -105,7 +105,7 @@ Create an Asset from a file stream, for example to create an Asset during data i
 </div>
 ## EntityWithAssets
 
-<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="67" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="68" packageName="@vendure/core" />
 
 Certain entities (Product, ProductVariant, Collection) use this interface
 to model a featured asset and then a list of assets with a defined order.
@@ -137,7 +137,7 @@ interface EntityWithAssets extends VendureEntity {
 </div>
 ## EntityAssetInput
 
-<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="79" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="80" packageName="@vendure/core" />
 
 Used when updating entities which implement [EntityWithAssets](/reference/typescript-api/services/asset-service#entitywithassets).
 

--- a/docs/docs/reference/typescript-api/services/country-service.mdx
+++ b/docs/docs/reference/typescript-api/services/country-service.mdx
@@ -2,7 +2,7 @@
 title: "CountryService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/country.service.ts" sourceLine="33" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/country.service.ts" sourceLine="34" packageName="@vendure/core" />
 
 Contains methods relating to [Country](/reference/typescript-api/entities/country#country) entities.
 

--- a/docs/docs/reference/typescript-api/services/customer-group-service.mdx
+++ b/docs/docs/reference/typescript-api/services/customer-group-service.mdx
@@ -2,7 +2,7 @@
 title: "CustomerGroupService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/customer-group.service.ts" sourceLine="38" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/customer-group.service.ts" sourceLine="39" packageName="@vendure/core" />
 
 Contains methods relating to [CustomerGroup](/reference/typescript-api/entities/customer-group#customergroup) entities.
 

--- a/docs/docs/reference/typescript-api/services/fulfillment-service.mdx
+++ b/docs/docs/reference/typescript-api/services/fulfillment-service.mdx
@@ -2,7 +2,7 @@
 title: "FulfillmentService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/fulfillment.service.ts" sourceLine="34" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/fulfillment.service.ts" sourceLine="35" packageName="@vendure/core" />
 
 Contains methods relating to [Fulfillment](/reference/typescript-api/entities/fulfillment#fulfillment) entities.
 

--- a/docs/docs/reference/typescript-api/services/order-service.mdx
+++ b/docs/docs/reference/typescript-api/services/order-service.mdx
@@ -2,7 +2,7 @@
 title: "OrderService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/order.service.ts" sourceLine="143" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/order.service.ts" sourceLine="144" packageName="@vendure/core" />
 
 Contains methods relating to [Order](/reference/typescript-api/entities/order#order) entities.
 

--- a/docs/docs/reference/typescript-api/services/order-service.mdx
+++ b/docs/docs/reference/typescript-api/services/order-service.mdx
@@ -2,12 +2,12 @@
 title: "OrderService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/order.service.ts" sourceLine="144" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/order.service.ts" sourceLine="146" packageName="@vendure/core" />
 
 Contains methods relating to [Order](/reference/typescript-api/entities/order#order) entities.
 
 ```ts title="Signature"
-class OrderService {
+class OrderService implements OnApplicationBootstrap {
     constructor(connection: TransactionalConnection, configService: ConfigService, productVariantService: ProductVariantService, customerService: CustomerService, countryService: CountryService, orderCalculator: OrderCalculator, shippingCalculator: ShippingCalculator, orderStateMachine: OrderStateMachine, orderMerger: OrderMerger, paymentService: PaymentService, paymentMethodService: PaymentMethodService, fulfillmentService: FulfillmentService, listQueryBuilder: ListQueryBuilder, refundStateMachine: RefundStateMachine, historyService: HistoryService, promotionService: PromotionService, eventBus: EventBus, channelService: ChannelService, orderModifier: OrderModifier, customFieldRelationService: CustomFieldRelationService, requestCache: RequestContextCacheService, translator: TranslatorService, stockLevelService: StockLevelService)
     getOrderProcessStates() => OrderProcessState[];
     findAll(ctx: RequestContext, options?: OrderListOptions, relations?: RelationPaths<Order>) => Promise<PaginatedList<Order>>;
@@ -76,6 +76,9 @@ class OrderService {
     applyPriceAdjustmentsIfStale(ctx: RequestContext, order: Order) => Promise<Order>;
 }
 ```
+* Implements: OnApplicationBootstrap
+
+
 
 <div className="members-wrapper">
 

--- a/docs/docs/reference/typescript-api/services/product-service.mdx
+++ b/docs/docs/reference/typescript-api/services/product-service.mdx
@@ -2,7 +2,7 @@
 title: "ProductService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/product.service.ts" sourceLine="55" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/product.service.ts" sourceLine="56" packageName="@vendure/core" />
 
 Contains methods relating to [Product](/reference/typescript-api/entities/product#product) entities.
 

--- a/docs/docs/reference/typescript-api/services/promotion-service.mdx
+++ b/docs/docs/reference/typescript-api/services/promotion-service.mdx
@@ -2,7 +2,7 @@
 title: "PromotionService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/promotion.service.ts" sourceLine="58" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/promotion.service.ts" sourceLine="60" packageName="@vendure/core" />
 
 Contains methods relating to [Promotion](/reference/typescript-api/entities/promotion#promotion) entities.
 
@@ -10,7 +10,7 @@ Contains methods relating to [Promotion](/reference/typescript-api/entities/prom
 class PromotionService {
     availableConditions: PromotionCondition[] = [];
     availableActions: PromotionAction[] = [];
-    constructor(connection: TransactionalConnection, configService: ConfigService, channelService: ChannelService, listQueryBuilder: ListQueryBuilder, configArgService: ConfigArgService, customFieldRelationService: CustomFieldRelationService, eventBus: EventBus, translatableSaver: TranslatableSaver, translator: TranslatorService)
+    constructor(connection: TransactionalConnection, configService: ConfigService, channelService: ChannelService, listQueryBuilder: ListQueryBuilder, configArgService: ConfigArgService, customFieldRelationService: CustomFieldRelationService, eventBus: EventBus, translatableSaver: TranslatableSaver, translator: TranslatorService, roleService: RoleService)
     findAll(ctx: RequestContext, options?: ListQueryOptions<Promotion>, relations: RelationPaths<Promotion> = []) => Promise<PaginatedList<Promotion>>;
     findOne(ctx: RequestContext, adjustmentSourceId: ID, relations: RelationPaths<Promotion> = []) => Promise<Promotion | undefined>;
     getPromotionConditions(ctx: RequestContext) => ConfigurableOperationDefinition[];

--- a/docs/docs/reference/typescript-api/services/province-service.mdx
+++ b/docs/docs/reference/typescript-api/services/province-service.mdx
@@ -2,7 +2,7 @@
 title: "ProvinceService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/province.service.ts" sourceLine="32" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/province.service.ts" sourceLine="33" packageName="@vendure/core" />
 
 Contains methods relating to [Province](/reference/typescript-api/entities/province#province) entities.
 

--- a/docs/docs/reference/typescript-api/services/role-service.mdx
+++ b/docs/docs/reference/typescript-api/services/role-service.mdx
@@ -2,7 +2,7 @@
 title: "RoleService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/role.service.ts" sourceLine="55" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/role.service.ts" sourceLine="56" packageName="@vendure/core" />
 
 Contains methods relating to [Role](/reference/typescript-api/entities/role#role) entities.
 

--- a/docs/docs/reference/typescript-api/services/session-service.mdx
+++ b/docs/docs/reference/typescript-api/services/session-service.mdx
@@ -2,7 +2,7 @@
 title: "SessionService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/session.service.ts" sourceLine="34" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/session.service.ts" sourceLine="35" packageName="@vendure/core" />
 
 Contains methods relating to [Session](/reference/typescript-api/entities/session#session) entities.
 

--- a/docs/docs/reference/typescript-api/services/shipping-method-service.mdx
+++ b/docs/docs/reference/typescript-api/services/shipping-method-service.mdx
@@ -2,7 +2,7 @@
 title: "ShippingMethodService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/shipping-method.service.ts" sourceLine="45" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/shipping-method.service.ts" sourceLine="46" packageName="@vendure/core" />
 
 Contains methods relating to [ShippingMethod](/reference/typescript-api/entities/shipping-method#shippingmethod) entities.
 
@@ -10,7 +10,7 @@ Contains methods relating to [ShippingMethod](/reference/typescript-api/entities
 class ShippingMethodService {
     constructor(connection: TransactionalConnection, configService: ConfigService, roleService: RoleService, listQueryBuilder: ListQueryBuilder, channelService: ChannelService, configArgService: ConfigArgService, translatableSaver: TranslatableSaver, customFieldRelationService: CustomFieldRelationService, eventBus: EventBus, translator: TranslatorService)
     findAll(ctx: RequestContext, options?: ListQueryOptions<ShippingMethod>, relations: RelationPaths<ShippingMethod> = []) => Promise<PaginatedList<Translated<ShippingMethod>>>;
-    findOne(ctx: RequestContext, shippingMethodId: ID, includeDeleted:  = false, relations: RelationPaths<ShippingMethod> = []) => Promise<Translated<ShippingMethod> | undefined>;
+    findOne(ctx: RequestContext, shippingMethodId: ID, includeDeleted:  = false, relations: RelationPaths<ShippingMethod> = [], filterOnChannel:  = true) => Promise<Translated<ShippingMethod> | undefined>;
     create(ctx: RequestContext, input: CreateShippingMethodInput) => Promise<Translated<ShippingMethod>>;
     update(ctx: RequestContext, input: UpdateShippingMethodInput) => Promise<Translated<ShippingMethod>>;
     softDelete(ctx: RequestContext, id: ID) => Promise<DeletionResponse>;
@@ -32,7 +32,7 @@ class ShippingMethodService {
 
 ### findOne
 
-<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, shippingMethodId: <a href='/reference/typescript-api/common/id#id'>ID</a>, includeDeleted:  = false, relations: RelationPaths<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> = []) => Promise<Translated<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> | undefined>`}   />
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, shippingMethodId: <a href='/reference/typescript-api/common/id#id'>ID</a>, includeDeleted:  = false, relations: RelationPaths<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> = [], filterOnChannel:  = true) => Promise<Translated<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> | undefined>`}   />
 
 
 ### create

--- a/docs/docs/reference/typescript-api/services/stock-level-service.mdx
+++ b/docs/docs/reference/typescript-api/services/stock-level-service.mdx
@@ -2,7 +2,7 @@
 title: "StockLevelService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/stock-level.service.ts" sourceLine="23" packageName="@vendure/core" since="2.0.0" />
+<GenerationInfo sourceFile="packages/core/src/service/services/stock-level.service.ts" sourceLine="27" packageName="@vendure/core" since="2.0.0" />
 
 The StockLevelService is responsible for managing the stock levels of ProductVariants.
 Whenever you need to adjust the `stockOnHand` or `stockAllocated` for a ProductVariant,
@@ -42,11 +42,19 @@ by the configured [StockLocationStrategy](/reference/typescript-api/products-sto
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, productVariantId: <a href='/reference/typescript-api/common/id#id'>ID</a>, stockLocationId: <a href='/reference/typescript-api/common/id#id'>ID</a>, change: number) => `}   />
 
 Updates the `stockOnHand` for the given [ProductVariant](/reference/typescript-api/entities/product-variant#productvariant) and [StockLocation](/reference/typescript-api/entities/stock-location#stocklocation).
+The write is atomic: the row is locked before reading to prevent lost updates under concurrency.
+When creating a new StockLevel the initial value is the adjustment delta itself — which may be
+negative (e.g. a backorder against a variant with a negative `outOfStockThreshold`) — so the
+row stays consistent with the `StockAdjustment` ledger rather than silently diverging from it.
 ### updateStockAllocatedForLocation
 
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, productVariantId: <a href='/reference/typescript-api/common/id#id'>ID</a>, stockLocationId: <a href='/reference/typescript-api/common/id#id'>ID</a>, change: number) => `}   />
 
 Updates the `stockAllocated` for the given [ProductVariant](/reference/typescript-api/entities/product-variant#productvariant) and [StockLocation](/reference/typescript-api/entities/stock-location#stocklocation).
+The write is atomic: the row is locked before reading to prevent lost updates under concurrency.
+`stockAllocated` is clamped at 0 so a release can never produce a negative value; a clamp that
+actually fires is logged, since it means more was released than was ever allocated (an
+accounting bug that must not be hidden behind a silent clamp).
 
 
 </div>

--- a/docs/docs/reference/typescript-api/services/stock-movement-service.mdx
+++ b/docs/docs/reference/typescript-api/services/stock-movement-service.mdx
@@ -2,7 +2,7 @@
 title: "StockMovementService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/stock-movement.service.ts" sourceLine="41" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/stock-movement.service.ts" sourceLine="45" packageName="@vendure/core" />
 
 Contains methods relating to [StockMovement](/reference/typescript-api/entities/stock-movement#stockmovement) entities.
 

--- a/docs/docs/reference/typescript-api/services/tax-rate-service.mdx
+++ b/docs/docs/reference/typescript-api/services/tax-rate-service.mdx
@@ -2,7 +2,7 @@
 title: "TaxRateService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/tax-rate.service.ts" sourceLine="37" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/tax-rate.service.ts" sourceLine="38" packageName="@vendure/core" />
 
 Contains methods relating to [TaxRate](/reference/typescript-api/entities/tax-rate#taxrate) entities.
 

--- a/docs/docs/reference/typescript-api/testing/driver-options.mdx
+++ b/docs/docs/reference/typescript-api/testing/driver-options.mdx
@@ -1,0 +1,13 @@
+---
+title: "DriverOptions"
+generated: true
+---
+<GenerationInfo sourceFile="packages/testing/src/initializers/test-db-initializer.ts" sourceLine="11" packageName="@vendure/testing" />
+
+The TypeORM options for a particular driver, selected from the `DataSourceOptions` union by
+the driver's `type`. Selecting from the union rather than importing the driver's own options
+module avoids depending on where TypeORM keeps that module.
+
+```ts title="Signature"
+type DriverOptions<T extends DataSourceOptions['type']> = Extract<DataSourceOptions, { type: T }>
+```

--- a/docs/docs/reference/typescript-api/testing/test-db-initializer.mdx
+++ b/docs/docs/reference/typescript-api/testing/test-db-initializer.mdx
@@ -2,7 +2,7 @@
 title: "TestDbInitializer"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/testing/src/initializers/test-db-initializer.ts" sourceLine="23" packageName="@vendure/testing" />
+<GenerationInfo sourceFile="packages/testing/src/initializers/test-db-initializer.ts" sourceLine="32" packageName="@vendure/testing" />
 
 Defines how the e2e TestService sets up a particular DB to run a single test suite.
 The `@vendure/testing` package ships with initializers for sql.js, MySQL & Postgres.
@@ -21,7 +21,7 @@ registerInitializer('cockroachdb', new CockroachDbInitializer());
 ```
 
 ```ts title="Signature"
-interface TestDbInitializer<T extends BaseConnectionOptions> {
+interface TestDbInitializer<T extends DataSourceOptions> {
     init(testFileName: string, connectionOptions: T): Promise<T>;
     populate(populateFn: () => Promise<void>): Promise<void>;
     destroy(): void | Promise<void>;

--- a/docs/docs/reference/typescript-api/worker/bootstrap-worker.mdx
+++ b/docs/docs/reference/typescript-api/worker/bootstrap-worker.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## bootstrapWorker
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="269" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="271" packageName="@vendure/core" />
 
 Bootstraps a Vendure worker. Resolves to a [VendureWorker](/reference/typescript-api/worker/vendure-worker#vendureworker) object containing a reference to the underlying
 NestJs [standalone application](https://docs.nestjs.com/standalone-applications) as well as convenience
@@ -41,7 +41,7 @@ Parameters
 
 ## BootstrapWorkerOptions
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="121" packageName="@vendure/core" since="2.2.0" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="123" packageName="@vendure/core" since="2.2.0" />
 
 Additional options that can be used to configure the bootstrap process of the
 Vendure worker.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -73,7 +73,7 @@
           "title": "Collections",
           "slug": "collections",
           "file": "docs/guides/core-concepts/collections/index.mdx",
-          "lastModified": "2026-02-12T16:47:03+01:00"
+          "lastModified": "2026-08-10T17:40:07+01:00"
         },
         {
           "title": "Cart",
@@ -1396,7 +1396,7 @@
                   "title": "CollectionFilter",
                   "slug": "collection-filter",
                   "file": "docs/reference/typescript-api/configuration/collection-filter.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-10T17:40:07+01:00"
                 },
                 {
                   "title": "DefaultConfig",
@@ -1559,6 +1559,12 @@
                   "lastModified": "2026-01-28T14:49:21+01:00"
                 },
                 {
+                  "title": "DataSourceHolder",
+                  "slug": "data-source-holder",
+                  "file": "docs/reference/typescript-api/data-access/data-source-holder.mdx",
+                  "lastModified": "2026-08-10T20:29:10+01:00"
+                },
+                {
                   "title": "EntityHydrator",
                   "slug": "entity-hydrator",
                   "file": "docs/reference/typescript-api/data-access/entity-hydrator.mdx",
@@ -1583,6 +1589,12 @@
                   "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
+                  "title": "GetDataSource",
+                  "slug": "get-data-source",
+                  "file": "docs/reference/typescript-api/data-access/get-data-source.mdx",
+                  "lastModified": "2026-08-10T20:29:10+01:00"
+                },
+                {
                   "title": "GetEntityOrThrowOptions",
                   "slug": "get-entity-or-throw-options",
                   "file": "docs/reference/typescript-api/data-access/get-entity-or-throw-options.mdx",
@@ -1598,7 +1610,7 @@
                   "title": "ListQueryBuilder",
                   "slug": "list-query-builder",
                   "file": "docs/reference/typescript-api/data-access/list-query-builder.mdx",
-                  "lastModified": "2026-08-10T16:28:08+01:00"
+                  "lastModified": "2026-08-10T17:40:07+01:00"
                 },
                 {
                   "title": "TransactionalConnection",
@@ -2362,13 +2374,13 @@
                   "title": "MigrateAssetTranslationData",
                   "slug": "migrate-asset-translation-data",
                   "file": "docs/reference/typescript-api/migration/migrate-asset-translation-data.mdx",
-                  "lastModified": "2026-07-10T09:53:10+02:00"
+                  "lastModified": "2026-08-10T17:40:07+01:00"
                 },
                 {
                   "title": "MigrateProductOptionGroupData",
                   "slug": "migrate-product-option-group-data",
                   "file": "docs/reference/typescript-api/migration/migrate-product-option-group-data.mdx",
-                  "lastModified": "2026-07-10T09:53:10+02:00"
+                  "lastModified": "2026-08-10T17:40:07+01:00"
                 },
                 {
                   "title": "MigrationOptions",
@@ -2970,7 +2982,7 @@
                   "title": "AssetService",
                   "slug": "asset-service",
                   "file": "docs/reference/typescript-api/services/asset-service.mdx",
-                  "lastModified": "2026-07-23T11:18:30+02:00"
+                  "lastModified": "2026-08-10T17:40:07+01:00"
                 },
                 {
                   "title": "AuthService",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1568,19 +1568,19 @@
                   "title": "FindOptionsRelationsInput",
                   "slug": "find-options-relations-input",
                   "file": "docs/reference/typescript-api/data-access/find-options-relations-input.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "FindOptionsSelectInput",
                   "slug": "find-options-select-input",
                   "file": "docs/reference/typescript-api/data-access/find-options-select-input.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "GetEntityOrThrowOptions",
                   "slug": "get-entity-or-throw-options",
                   "file": "docs/reference/typescript-api/data-access/get-entity-or-throw-options.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "HydrateOptions",
@@ -1592,25 +1592,25 @@
                   "title": "ListQueryBuilder",
                   "slug": "list-query-builder",
                   "file": "docs/reference/typescript-api/data-access/list-query-builder.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "TransactionalConnection",
                   "slug": "transactional-connection",
                   "file": "docs/reference/typescript-api/data-access/transactional-connection.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "VendureFindManyOptions",
                   "slug": "vendure-find-many-options",
                   "file": "docs/reference/typescript-api/data-access/vendure-find-many-options.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "VendureFindOneOptions",
                   "slug": "vendure-find-one-options",
                   "file": "docs/reference/typescript-api/data-access/vendure-find-one-options.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -2920,7 +2920,7 @@
                   "title": "OrderModifier",
                   "slug": "order-modifier",
                   "file": "docs/reference/typescript-api/service-helpers/order-modifier.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "ProductPriceApplicator",
@@ -2958,7 +2958,7 @@
                   "title": "AdministratorService",
                   "slug": "administrator-service",
                   "file": "docs/reference/typescript-api/services/administrator-service.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "AssetService",
@@ -2988,7 +2988,7 @@
                   "title": "CountryService",
                   "slug": "country-service",
                   "file": "docs/reference/typescript-api/services/country-service.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "CustomerChannelAssignmentService",
@@ -3000,7 +3000,7 @@
                   "title": "CustomerGroupService",
                   "slug": "customer-group-service",
                   "file": "docs/reference/typescript-api/services/customer-group-service.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "CustomerService",
@@ -3030,7 +3030,7 @@
                   "title": "FulfillmentService",
                   "slug": "fulfillment-service",
                   "file": "docs/reference/typescript-api/services/fulfillment-service.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "GlobalSettingsService",
@@ -3054,7 +3054,7 @@
                   "title": "OrderService",
                   "slug": "order-service",
                   "file": "docs/reference/typescript-api/services/order-service.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "OrderTestingService",
@@ -3090,7 +3090,7 @@
                   "title": "ProductService",
                   "slug": "product-service",
                   "file": "docs/reference/typescript-api/services/product-service.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "ProductVariantService",
@@ -3102,19 +3102,19 @@
                   "title": "PromotionService",
                   "slug": "promotion-service",
                   "file": "docs/reference/typescript-api/services/promotion-service.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "ProvinceService",
                   "slug": "province-service",
                   "file": "docs/reference/typescript-api/services/province-service.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "RoleService",
                   "slug": "role-service",
                   "file": "docs/reference/typescript-api/services/role-service.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "SearchService",
@@ -3132,7 +3132,7 @@
                   "title": "SessionService",
                   "slug": "session-service",
                   "file": "docs/reference/typescript-api/services/session-service.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "SettingsStoreService",
@@ -3186,7 +3186,7 @@
                   "title": "TaxRateService",
                   "slug": "tax-rate-service",
                   "file": "docs/reference/typescript-api/services/tax-rate-service.mdx",
-                  "lastModified": "2026-08-10T15:27:42Z"
+                  "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
                   "title": "UserService",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1565,6 +1565,12 @@
                   "lastModified": "2026-04-20T16:08:16+02:00"
                 },
                 {
+                  "title": "FindOptionsArrayToObject",
+                  "slug": "find-options-array-to-object",
+                  "file": "docs/reference/typescript-api/data-access/find-options-array-to-object.mdx",
+                  "lastModified": "2026-08-10T17:00:56+01:00"
+                },
+                {
                   "title": "FindOptionsRelationsInput",
                   "slug": "find-options-relations-input",
                   "file": "docs/reference/typescript-api/data-access/find-options-relations-input.mdx",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1234,7 +1234,7 @@
                   "title": "Injector",
                   "slug": "injector",
                   "file": "docs/reference/typescript-api/common/injector.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-11T08:46:12Z"
                 },
                 {
                   "title": "JobState",
@@ -1568,7 +1568,7 @@
                   "title": "EntityHydrator",
                   "slug": "entity-hydrator",
                   "file": "docs/reference/typescript-api/data-access/entity-hydrator.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-11T08:46:12Z"
                 },
                 {
                   "title": "FindOptionsArrayToObject",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2068,7 +2068,7 @@
                   "title": "Event Types",
                   "slug": "event-types",
                   "file": "docs/reference/typescript-api/events/event-types.mdx",
-                  "lastModified": "2026-07-15T15:49:41+02:00"
+                  "lastModified": "2026-08-13T10:10:11Z"
                 },
                 {
                   "title": "EventBus",
@@ -2780,7 +2780,7 @@
                   "title": "MultiChannelStockLocationStrategy",
                   "slug": "multi-channel-stock-location-strategy",
                   "file": "docs/reference/typescript-api/products-stock/multi-channel-stock-location-strategy.mdx",
-                  "lastModified": "2026-01-28T14:49:21+01:00"
+                  "lastModified": "2026-08-13T10:10:11Z"
                 },
                 {
                   "title": "ProductVariantPriceCalculationStrategy",
@@ -2874,7 +2874,7 @@
                   "title": "RequestContext",
                   "slug": "request-context",
                   "file": "docs/reference/typescript-api/request/request-context.mdx",
-                  "lastModified": "2026-08-10T11:56:26+02:00"
+                  "lastModified": "2026-08-13T10:10:11Z"
                 },
                 {
                   "title": "RequestContextService",
@@ -3096,7 +3096,7 @@
                   "title": "OrderService",
                   "slug": "order-service",
                   "file": "docs/reference/typescript-api/services/order-service.mdx",
-                  "lastModified": "2026-08-10T16:28:08+01:00"
+                  "lastModified": "2026-08-13T10:10:11Z"
                 },
                 {
                   "title": "OrderTestingService",
@@ -3186,7 +3186,7 @@
                   "title": "ShippingMethodService",
                   "slug": "shipping-method-service",
                   "file": "docs/reference/typescript-api/services/shipping-method-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-13T10:10:11Z"
                 },
                 {
                   "title": "SlugService",
@@ -3198,7 +3198,7 @@
                   "title": "StockLevelService",
                   "slug": "stock-level-service",
                   "file": "docs/reference/typescript-api/services/stock-level-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-13T10:10:11Z"
                 },
                 {
                   "title": "StockLocationService",
@@ -3210,7 +3210,7 @@
                   "title": "StockMovementService",
                   "slug": "stock-movement-service",
                   "file": "docs/reference/typescript-api/services/stock-movement-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-13T10:10:11Z"
                 },
                 {
                   "title": "TagService",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1198,7 +1198,7 @@
                   "title": "Bootstrap",
                   "slug": "bootstrap",
                   "file": "docs/reference/typescript-api/common/bootstrap.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-11T13:35:59Z"
                 },
                 {
                   "title": "CurrencyCode",
@@ -3554,7 +3554,7 @@
                   "title": "BootstrapWorker",
                   "slug": "bootstrap-worker",
                   "file": "docs/reference/typescript-api/worker/bootstrap-worker.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-11T13:35:59Z"
                 },
                 {
                   "title": "VendureWorker",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3477,6 +3477,12 @@
                   "lastModified": "2026-01-28T14:49:21+01:00"
                 },
                 {
+                  "title": "DriverOptions",
+                  "slug": "driver-options",
+                  "file": "docs/reference/typescript-api/testing/driver-options.mdx",
+                  "lastModified": "2026-08-11T10:14:57Z"
+                },
+                {
                   "title": "ErrorResultGuard",
                   "slug": "error-result-guard",
                   "file": "docs/reference/typescript-api/testing/error-result-guard.mdx",
@@ -3510,7 +3516,7 @@
                   "title": "TestDbInitializer",
                   "slug": "test-db-initializer",
                   "file": "docs/reference/typescript-api/testing/test-db-initializer.mdx",
-                  "lastModified": "2026-01-28T14:49:21+01:00"
+                  "lastModified": "2026-08-11T10:14:57Z"
                 },
                 {
                   "title": "TestEnvironment",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1565,10 +1565,22 @@
                   "lastModified": "2026-04-20T16:08:16+02:00"
                 },
                 {
+                  "title": "FindOptionsRelationsInput",
+                  "slug": "find-options-relations-input",
+                  "file": "docs/reference/typescript-api/data-access/find-options-relations-input.mdx",
+                  "lastModified": "2026-08-10T15:27:42Z"
+                },
+                {
+                  "title": "FindOptionsSelectInput",
+                  "slug": "find-options-select-input",
+                  "file": "docs/reference/typescript-api/data-access/find-options-select-input.mdx",
+                  "lastModified": "2026-08-10T15:27:42Z"
+                },
+                {
                   "title": "GetEntityOrThrowOptions",
                   "slug": "get-entity-or-throw-options",
                   "file": "docs/reference/typescript-api/data-access/get-entity-or-throw-options.mdx",
-                  "lastModified": "2026-01-28T14:49:21+01:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "HydrateOptions",
@@ -1580,13 +1592,25 @@
                   "title": "ListQueryBuilder",
                   "slug": "list-query-builder",
                   "file": "docs/reference/typescript-api/data-access/list-query-builder.mdx",
-                  "lastModified": "2026-07-14T10:51:14+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "TransactionalConnection",
                   "slug": "transactional-connection",
                   "file": "docs/reference/typescript-api/data-access/transactional-connection.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
+                },
+                {
+                  "title": "VendureFindManyOptions",
+                  "slug": "vendure-find-many-options",
+                  "file": "docs/reference/typescript-api/data-access/vendure-find-many-options.mdx",
+                  "lastModified": "2026-08-10T15:27:42Z"
+                },
+                {
+                  "title": "VendureFindOneOptions",
+                  "slug": "vendure-find-one-options",
+                  "file": "docs/reference/typescript-api/data-access/vendure-find-one-options.mdx",
+                  "lastModified": "2026-08-10T15:27:42Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -2896,7 +2920,7 @@
                   "title": "OrderModifier",
                   "slug": "order-modifier",
                   "file": "docs/reference/typescript-api/service-helpers/order-modifier.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "ProductPriceApplicator",
@@ -2934,7 +2958,7 @@
                   "title": "AdministratorService",
                   "slug": "administrator-service",
                   "file": "docs/reference/typescript-api/services/administrator-service.mdx",
-                  "lastModified": "2026-07-23T11:18:30+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "AssetService",
@@ -2964,7 +2988,7 @@
                   "title": "CountryService",
                   "slug": "country-service",
                   "file": "docs/reference/typescript-api/services/country-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "CustomerChannelAssignmentService",
@@ -2976,7 +3000,7 @@
                   "title": "CustomerGroupService",
                   "slug": "customer-group-service",
                   "file": "docs/reference/typescript-api/services/customer-group-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "CustomerService",
@@ -3006,7 +3030,7 @@
                   "title": "FulfillmentService",
                   "slug": "fulfillment-service",
                   "file": "docs/reference/typescript-api/services/fulfillment-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "GlobalSettingsService",
@@ -3030,7 +3054,7 @@
                   "title": "OrderService",
                   "slug": "order-service",
                   "file": "docs/reference/typescript-api/services/order-service.mdx",
-                  "lastModified": "2026-07-22T11:48:45+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "OrderTestingService",
@@ -3066,7 +3090,7 @@
                   "title": "ProductService",
                   "slug": "product-service",
                   "file": "docs/reference/typescript-api/services/product-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "ProductVariantService",
@@ -3078,19 +3102,19 @@
                   "title": "PromotionService",
                   "slug": "promotion-service",
                   "file": "docs/reference/typescript-api/services/promotion-service.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "ProvinceService",
                   "slug": "province-service",
                   "file": "docs/reference/typescript-api/services/province-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "RoleService",
                   "slug": "role-service",
                   "file": "docs/reference/typescript-api/services/role-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "SearchService",
@@ -3108,7 +3132,7 @@
                   "title": "SessionService",
                   "slug": "session-service",
                   "file": "docs/reference/typescript-api/services/session-service.mdx",
-                  "lastModified": "2026-04-28T19:36:30+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "SettingsStoreService",
@@ -3162,7 +3186,7 @@
                   "title": "TaxRateService",
                   "slug": "tax-rate-service",
                   "file": "docs/reference/typescript-api/services/tax-rate-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "UserService",
@@ -4285,7 +4309,7 @@
                   "title": "ListPage",
                   "slug": "list-page",
                   "file": "docs/reference/dashboard/list-views/list-page.mdx",
-                  "lastModified": "2026-07-16T14:41:21+02:00"
+                  "lastModified": "2026-08-10T15:27:42Z"
                 },
                 {
                   "title": "PaginatedListDataTable",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1589,6 +1589,12 @@
                   "lastModified": "2026-08-10T16:28:08+01:00"
                 },
                 {
+                  "title": "GetDatabaseType",
+                  "slug": "get-database-type",
+                  "file": "docs/reference/typescript-api/data-access/get-database-type.mdx",
+                  "lastModified": "2026-08-11T09:38:21Z"
+                },
+                {
                   "title": "GetDataSource",
                   "slug": "get-data-source",
                   "file": "docs/reference/typescript-api/data-access/get-data-source.mdx",
@@ -1617,6 +1623,12 @@
                   "slug": "transactional-connection",
                   "file": "docs/reference/typescript-api/data-access/transactional-connection.mdx",
                   "lastModified": "2026-08-10T16:28:08+01:00"
+                },
+                {
+                  "title": "VendureDatabaseType",
+                  "slug": "vendure-database-type",
+                  "file": "docs/reference/typescript-api/data-access/vendure-database-type.mdx",
+                  "lastModified": "2026-08-11T09:38:21Z"
                 },
                 {
                   "title": "VendureFindManyOptions",
@@ -2316,7 +2328,7 @@
                   "title": "SqlJobQueueStrategy",
                   "slug": "sql-job-queue-strategy",
                   "file": "docs/reference/typescript-api/job-queue/sql-job-queue-strategy.mdx",
-                  "lastModified": "2026-01-28T14:49:21+01:00"
+                  "lastModified": "2026-08-11T09:38:21Z"
                 },
                 {
                   "title": "SubscribableJob",
@@ -2368,7 +2380,7 @@
                   "title": "GenerateMigration",
                   "slug": "generate-migration",
                   "file": "docs/reference/typescript-api/migration/generate-migration.mdx",
-                  "lastModified": "2026-07-14T11:47:02+02:00"
+                  "lastModified": "2026-08-11T09:38:21Z"
                 },
                 {
                   "title": "MigrateAssetTranslationData",
@@ -2386,19 +2398,19 @@
                   "title": "MigrationOptions",
                   "slug": "migration-options",
                   "file": "docs/reference/typescript-api/migration/migration-options.mdx",
-                  "lastModified": "2026-07-14T11:47:02+02:00"
+                  "lastModified": "2026-08-11T09:38:21Z"
                 },
                 {
                   "title": "RevertLastMigration",
                   "slug": "revert-last-migration",
                   "file": "docs/reference/typescript-api/migration/revert-last-migration.mdx",
-                  "lastModified": "2026-07-14T11:47:02+02:00"
+                  "lastModified": "2026-08-11T09:38:21Z"
                 },
                 {
                   "title": "RunMigrations",
                   "slug": "run-migrations",
                   "file": "docs/reference/typescript-api/migration/run-migrations.mdx",
-                  "lastModified": "2026-07-14T11:47:02+02:00"
+                  "lastModified": "2026-08-11T09:38:21Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,11 @@
     "generate-changelog": "ts-node scripts/changelogs/generate-changelog.ts",
     "publish-release": "lerna version -m \"chore: Publish %s\" --no-push --force-publish --exact",
     "publish-prerelease": "lerna version -m \"chore: Pre-release %s\" prerelease --exact --no-push --force-publish --preid next --dist-tag next",
-    "publish-local": "lerna version --force-publish --no-git-tag-version && cd scripts && ./publish-to-verdaccio.sh"
+    "publish-local": "lerna version --force-publish --no-git-tag-version && cd scripts && ./publish-to-verdaccio.sh",
+    "typeorm:use": "node scripts/typeorm/use-version.mjs",
+    "typeorm:verify": "node scripts/typeorm/verify.mjs",
+    "build:for-tests": "node scripts/typeorm/build-for-tests.mjs",
+    "test:db": "node scripts/typeorm/run-db-tests.mjs"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.1.0",

--- a/packages/core/e2e/entity-access-control.e2e-spec.ts
+++ b/packages/core/e2e/entity-access-control.e2e-spec.ts
@@ -164,7 +164,7 @@ class TestEntityAccessControlStrategy extends DefaultEntityAccessControlStrategy
         // role-based category access, or call an external permissions API.
         const products = await this.connection.rawConnection.getRepository(Product).find({
             where: { id: LessThanOrEqual(5) },
-            select: ['id'],
+            select: { id: true },
         });
         this.allowedProductIds.set(
             ctx,

--- a/packages/core/e2e/entity-hydrator.e2e-spec.ts
+++ b/packages/core/e2e/entity-hydrator.e2e-spec.ts
@@ -575,7 +575,7 @@ describe('Entity hydration', () => {
         // Raw-connection queries take the numeric DB id; 'T_1' exists only at the API layer
         const laptop = await connection
             .getRepository(Product)
-            .findOne({ where: { id: 1 }, relations: ['variants'] });
+            .findOne({ where: { id: 1 }, relations: { variants: true } });
         const variantWithAssetId = laptop!.variants[laptop!.variants.length - 1].id;
         const nullAssetVariantCount = laptop!.variants.length - 1;
         // Give exactly one of the variants a featuredAsset; the others keep the
@@ -584,7 +584,7 @@ describe('Entity hydration', () => {
         try {
             const product = await connection
                 .getRepository(Product)
-                .findOne({ where: { id: 1 }, relations: ['variants'] });
+                .findOne({ where: { id: 1 }, relations: { variants: true } });
 
             await server.app.get(EntityHydrator).hydrate(ctx, product!, {
                 relations: ['variants.featuredAsset'],

--- a/packages/core/e2e/fixtures/test-payment-methods.ts
+++ b/packages/core/e2e/fixtures/test-payment-methods.ts
@@ -133,7 +133,7 @@ export const singleStageRefundFailingPaymentMethod = new PaymentMethodHandler({
     createRefund: async (ctx, input, amount, order, payment, args) => {
         const paymentWithRefunds = await connection
             .getRepository(ctx, Payment)
-            .findOne({ where: { id: payment.id }, relations: ['refunds'] });
+            .findOne({ where: { id: payment.id }, relations: { refunds: true } });
         const isFirstRefundAttempt = paymentWithRefunds?.refunds.length === 0;
         const metadata = isFirstRefundAttempt ? { errorMessage: 'Service temporarily unavailable' } : {};
         return {

--- a/packages/core/e2e/fixtures/test-plugins/hydration-test-plugin.ts
+++ b/packages/core/e2e/fixtures/test-plugins/hydration-test-plugin.ts
@@ -36,7 +36,7 @@ export class TestAdminPluginResolver {
     async hydrateProduct(@Ctx() ctx: RequestContext, @Args() args: { id: ID }) {
         const product = await this.connection.getRepository(ctx, Product).findOne({
             where: { id: args.id },
-            relations: ['facetValues'],
+            relations: { facetValues: true },
         });
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         await this.entityHydrator.hydrate(ctx, product!, {

--- a/packages/core/e2e/fixtures/test-plugins/issue-2453/services/campaign.service.ts
+++ b/packages/core/e2e/fixtures/test-plugins/issue-2453/services/campaign.service.ts
@@ -54,7 +54,7 @@ export class CampaignService {
     findOne(ctx: RequestContext, id: ID): Promise<Translated<Campaign> | undefined | null> {
         return this.connection
             .getRepository(ctx, Campaign)
-            .findOne({ where: { id }, relations: ['promotion'] })
+            .findOne({ where: { id }, relations: { promotion: true } })
             .then(campaignItem => {
                 return campaignItem && translateDeep(campaignItem, ctx.languageCode, ['promotion']);
             });
@@ -63,7 +63,7 @@ export class CampaignService {
     findOneByCode(ctx: RequestContext, code: string): Promise<Translated<Campaign> | undefined | null> {
         return this.connection
             .getRepository(ctx, Campaign)
-            .findOne({ where: { code }, relations: ['promotion'] })
+            .findOne({ where: { code }, relations: { promotion: true } })
             .then(campaignItem => {
                 return campaignItem && translateDeep(campaignItem, ctx.languageCode, ['promotion']);
             });

--- a/packages/core/e2e/fulfillment-process.e2e-spec.ts
+++ b/packages/core/e2e/fulfillment-process.e2e-spec.ts
@@ -40,7 +40,7 @@ describe('Fulfillment process', () => {
     const VALIDATION_ERROR_MESSAGE = 'Fulfillment must have a tracking code';
     const customOrderProcess: CustomFulfillmentProcess<'AwaitingPickup'> = {
         init(injector) {
-            initSpy(injector.get(TransactionalConnection).rawConnection.name);
+            initSpy(injector.get(TransactionalConnection).rawConnection.isInitialized);
         },
         transitions: {
             Pending: {
@@ -164,7 +164,7 @@ describe('Fulfillment process', () => {
     describe('CustomFulfillmentProcess', () => {
         it('is injectable', () => {
             expect(initSpy).toHaveBeenCalled();
-            expect(initSpy.mock.calls[0][0]).toBe('default');
+            expect(initSpy.mock.calls[0][0]).toBe(true);
         });
 
         it('replaced transition target', async () => {

--- a/packages/core/e2e/guest-checkout-strategy.e2e-spec.ts
+++ b/packages/core/e2e/guest-checkout-strategy.e2e-spec.ts
@@ -64,7 +64,7 @@ class TestGuestCheckoutStrategy implements GuestCheckoutStrategy {
         }
         if (TestGuestCheckoutStrategy.createNewCustomerOnEmailAddressConflict === true) {
             const existing = await this.connection.getRepository(ctx, Customer).findOne({
-                relations: ['channels'],
+                relations: { channels: true },
                 where: {
                     emailAddress: input.emailAddress,
                     deletedAt: IsNull(),

--- a/packages/core/e2e/lifecycle.e2e-spec.ts
+++ b/packages/core/e2e/lifecycle.e2e-spec.ts
@@ -24,7 +24,7 @@ class TestIdStrategy extends AutoIncrementIdStrategy {
         const productService = injector.get(ProductService);
         const connection = injector.get(TransactionalConnection);
         await new Promise(resolve => setTimeout(resolve, 100));
-        strategyInitSpy(productService.constructor.name, connection.rawConnection.name);
+        strategyInitSpy(productService.constructor.name, connection.rawConnection.isInitialized);
     }
 
     async destroy() {
@@ -41,7 +41,7 @@ const testShippingEligChecker = new ShippingEligibilityChecker({
         const productService = injector.get(ProductService);
         const connection = injector.get(TransactionalConnection);
         await new Promise(resolve => setTimeout(resolve, 100));
-        codInitSpy(productService.constructor.name, connection.rawConnection.name);
+        codInitSpy(productService.constructor.name, connection.rawConnection.isInitialized);
     },
     destroy: async () => {
         await new Promise(resolve => setTimeout(resolve, 100));
@@ -74,7 +74,7 @@ describe('lifecycle hooks for configurable objects', () => {
         it('runs init with Injector', () => {
             expect(strategyInitSpy).toHaveBeenCalled();
             expect(strategyInitSpy.mock.calls[0][0]).toEqual('ProductService');
-            expect(strategyInitSpy.mock.calls[0][1]).toBe('default');
+            expect(strategyInitSpy.mock.calls[0][1]).toBe(true);
         });
 
         it('runs destroy', async () => {
@@ -95,7 +95,7 @@ describe('lifecycle hooks for configurable objects', () => {
         it('runs init with Injector', () => {
             expect(codInitSpy).toHaveBeenCalled();
             expect(codInitSpy.mock.calls[0][0]).toEqual('ProductService');
-            expect(codInitSpy.mock.calls[0][1]).toBe('default');
+            expect(codInitSpy.mock.calls[0][1]).toBe(true);
         });
 
         it('runs destroy', async () => {

--- a/packages/core/e2e/order-process.e2e-spec.ts
+++ b/packages/core/e2e/order-process.e2e-spec.ts
@@ -44,7 +44,7 @@ describe('Order process', () => {
     const VALIDATION_ERROR_MESSAGE = 'Customer must have a company email address';
     const customOrderProcess: CustomOrderProcess<'ValidatingCustomer' | 'PaymentProcessing'> = {
         init(injector) {
-            initSpy(injector.get(TransactionalConnection).rawConnection.name);
+            initSpy(injector.get(TransactionalConnection).rawConnection.isInitialized);
         },
         transitions: {
             AddingItems: {
@@ -180,7 +180,7 @@ describe('Order process', () => {
     describe('CustomOrderProcess', () => {
         it('CustomOrderProcess is injectable', () => {
             expect(initSpy).toHaveBeenCalled();
-            expect(initSpy.mock.calls[0][0]).toBe('default');
+            expect(initSpy.mock.calls[0][0]).toBe(true);
         });
 
         it('replaced transition target', async () => {

--- a/packages/core/e2e/payment-process.e2e-spec.ts
+++ b/packages/core/e2e/payment-process.e2e-spec.ts
@@ -50,7 +50,7 @@ describe('Payment process', () => {
     const PAYMENT_ERROR_MESSAGE = 'Payment is not valid';
     const customPaymentProcess: PaymentProcess<'Validating'> = {
         init(injector) {
-            initSpy(injector.get(TransactionalConnection).rawConnection.name);
+            initSpy(injector.get(TransactionalConnection).rawConnection.isInitialized);
         },
         transitions: {
             Created: {
@@ -180,7 +180,7 @@ describe('Payment process', () => {
 
     it('CustomPaymentProcess is injectable', () => {
         expect(initSpy).toHaveBeenCalled();
-        expect(initSpy.mock.calls[0][0]).toBe('default');
+        expect(initSpy.mock.calls[0][0]).toBe(true);
     });
 
     it('creates Payment in custom state', async () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
         "@nestjs/core": "^11.0.12",
         "@nestjs/graphql": "~13.1.0",
         "@nestjs/platform-express": "^11.0.12",
-        "@nestjs/typeorm": "^11.0.0",
+        "@nestjs/typeorm": "^11.0.1",
         "@types/express": "^5.0.1",
         "@vendure/common": "3.7.2",
         "bcrypt": "^6.0.0",

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -24,6 +24,7 @@ import {
 import { runEntityMetadataModifiers } from './entity/run-entity-metadata-modifiers';
 import { setEntityIdStrategy } from './entity/set-entity-id-strategy';
 import { setMoneyStrategy } from './entity/set-money-strategy';
+import { patchTypeOrmDeepValue } from './entity/typeorm-deep-value-fix';
 import { patchTypeOrmEmbeddedRelationColumns } from './entity/typeorm-embedded-relation-fix';
 import { patchTypeOrmRelationIdLoader } from './entity/typeorm-relation-id-loader-fix';
 import { validateCustomFieldsConfig } from './entity/validate-custom-fields-config';
@@ -324,6 +325,7 @@ export async function preBootstrapConfig(
     Logger.useLogger(config.logger);
     config = await runPluginConfigurations(config);
     const entityIdStrategy = config.entityOptions.entityIdStrategy ?? config.entityIdStrategy;
+    patchTypeOrmDeepValue();
     patchTypeOrmEmbeddedRelationColumns();
     patchTypeOrmRelationIdLoader();
     registerCustomEntityFields(config);

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -7,7 +7,7 @@ import { getConnectionToken } from '@nestjs/typeorm';
 import { DEFAULT_COOKIE_NAME } from '@vendure/common/lib/shared-constants';
 import { Type } from '@vendure/common/lib/shared-types';
 import { satisfies } from 'semver';
-import { Connection, DataSourceOptions, EntitySubscriberInterface } from 'typeorm';
+import { DataSource, DataSourceOptions, EntitySubscriberInterface } from 'typeorm';
 import cookieSession = require('cookie-session');
 
 import { InternalServerError } from './common/error/errors';
@@ -510,7 +510,7 @@ function disableSynchronize(userConfig: Readonly<RuntimeVendureConfig>): Readonl
  * @param worker
  */
 async function validateDbTablesForWorker(worker: INestApplicationContext) {
-    const connection: Connection = worker.get(getConnectionToken());
+    const connection: DataSource = worker.get(getConnectionToken());
     await new Promise<void>(async (resolve, reject) => {
         const checkForTables = async (): Promise<boolean> => {
             try {

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -25,6 +25,7 @@ import { runEntityMetadataModifiers } from './entity/run-entity-metadata-modifie
 import { setEntityIdStrategy } from './entity/set-entity-id-strategy';
 import { setMoneyStrategy } from './entity/set-money-strategy';
 import { patchTypeOrmDeepValue } from './entity/typeorm-deep-value-fix';
+import { patchTypeOrmDuplicateEagerLoad } from './entity/typeorm-duplicate-eager-load-fix';
 import { patchTypeOrmEmbeddedRelationColumns } from './entity/typeorm-embedded-relation-fix';
 import { patchTypeOrmRelationIdLoader } from './entity/typeorm-relation-id-loader-fix';
 import { validateCustomFieldsConfig } from './entity/validate-custom-fields-config';
@@ -326,6 +327,7 @@ export async function preBootstrapConfig(
     config = await runPluginConfigurations(config);
     const entityIdStrategy = config.entityOptions.entityIdStrategy ?? config.entityIdStrategy;
     patchTypeOrmDeepValue();
+    patchTypeOrmDuplicateEagerLoad();
     patchTypeOrmEmbeddedRelationColumns();
     patchTypeOrmRelationIdLoader();
     registerCustomEntityFields(config);

--- a/packages/core/src/common/injector.ts
+++ b/packages/core/src/common/injector.ts
@@ -1,7 +1,7 @@
 import { Type } from '@nestjs/common';
 import { ContextId, ModuleRef } from '@nestjs/core';
 import { getConnectionToken } from '@nestjs/typeorm';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 
 /**
  * @description

--- a/packages/core/src/common/injector.ts
+++ b/packages/core/src/common/injector.ts
@@ -1,7 +1,5 @@
 import { Type } from '@nestjs/common';
 import { ContextId, ModuleRef } from '@nestjs/core';
-import { getConnectionToken } from '@nestjs/typeorm';
-import { DataSource } from 'typeorm';
 
 /**
  * @description

--- a/packages/core/src/config/auth/native-authentication-strategy.ts
+++ b/packages/core/src/config/auth/native-authentication-strategy.ts
@@ -79,7 +79,7 @@ export class NativeAuthenticationStrategy implements AuthenticationStrategy<Nati
     async verifyUserPassword(ctx: RequestContext, userId: ID, password: string): Promise<boolean> {
         const user = await this.connection.getRepository(ctx, User).findOne({
             where: { id: userId },
-            relations: ['authenticationMethods'],
+            relations: { authenticationMethods: true },
         });
         if (!user) {
             return false;
@@ -92,7 +92,7 @@ export class NativeAuthenticationStrategy implements AuthenticationStrategy<Nati
             (
                 await this.connection.getRepository(ctx, NativeAuthenticationMethod).findOne({
                     where: { id: nativeAuthMethod.id },
-                    select: ['passwordHash'],
+                    select: { passwordHash: true },
                 })
             )?.passwordHash ?? '';
         const passwordMatches = await this.passwordCipher.check(password, pw);

--- a/packages/core/src/config/catalog/collection-filter.ts
+++ b/packages/core/src/config/catalog/collection-filter.ts
@@ -31,7 +31,7 @@ export interface CollectionFilterConfig<T extends ConfigArgs> extends Configurab
  *
  * @example
  * ```ts
- * import { CollectionFilter, LanguageCode } from '\@vendure/core';
+ * import { CollectionFilter, getDataSource, LanguageCode } from '\@vendure/core';
  *
  * export const skuCollectionFilter = new CollectionFilter({
  *   args: {
@@ -53,7 +53,7 @@ export interface CollectionFilterConfig<T extends ConfigArgs> extends Configurab
  *
  *   // This is the function that defines the logic of the filter.
  *   apply: (qb, args) => {
- *     const LIKE = qb.connection.options.type === 'postgres' ? 'ILIKE' : 'LIKE';
+ *     const LIKE = getDataSource(qb).options.type === 'postgres' ? 'ILIKE' : 'LIKE';
  *     return qb.andWhere(`productVariant.sku ${LIKE} :sku`, { sku: `%${args.sku}%` });
  *   },
  * });

--- a/packages/core/src/config/catalog/default-collection-filters.ts
+++ b/packages/core/src/config/catalog/default-collection-filters.ts
@@ -2,6 +2,7 @@ import { LanguageCode } from '@vendure/common/lib/generated-types';
 
 import { ConfigArgDef } from '../../common/configurable-operation';
 import { UserInputError } from '../../common/error/errors';
+import { getDataSource } from '../../connection/get-data-source';
 import { ProductVariant } from '../../entity/product-variant/product-variant.entity';
 
 import { CollectionFilter } from './collection-filter';
@@ -77,14 +78,15 @@ export const facetValueCollectionFilter = new CollectionFilter({
             const safeIdsConcat = ids.join('_').replace(/-/g, '_');
             const idsName = `ids_${safeIdsConcat}`;
             const countName = `count_${safeIdsConcat}`;
-            const productFacetValues = qb.connection
+            const dataSource = getDataSource(qb);
+            const productFacetValues = dataSource
                 .createQueryBuilder(ProductVariant, 'product_variant')
                 .select('product_variant.id', 'variant_id')
                 .addSelect('facet_value.id', 'facet_value_id')
                 .leftJoin('product_variant.facetValues', 'facet_value')
                 .where(`facet_value.id IN (:...${idsName})`);
 
-            const variantFacetValues = qb.connection
+            const variantFacetValues = dataSource
                 .createQueryBuilder(ProductVariant, 'product_variant')
                 .select('product_variant.id', 'variant_id')
                 .addSelect('facet_value.id', 'facet_value_id')
@@ -92,7 +94,7 @@ export const facetValueCollectionFilter = new CollectionFilter({
                 .leftJoin('product.facetValues', 'facet_value')
                 .where(`facet_value.id IN (:...${idsName})`);
 
-            const union = qb.connection
+            const union = dataSource
                 .createQueryBuilder()
                 .select('union_table.variant_id')
                 .from(
@@ -102,7 +104,7 @@ export const facetValueCollectionFilter = new CollectionFilter({
                 .groupBy('variant_id')
                 .having(`COUNT(*) >= :${countName}`);
 
-            const variantIds = qb.connection
+            const variantIds = dataSource
                 .createQueryBuilder()
                 .select('variant_ids_table.variant_id')
                 .from(`(${union.getQuery()})`, 'variant_ids_table');
@@ -157,7 +159,7 @@ export const variantNameCollectionFilter = new CollectionFilter({
         } else {
             translationAlias = translationsJoin.alias.name;
         }
-        const LIKE = qb.connection.options.type === 'postgres' ? 'ILIKE' : 'LIKE';
+        const LIKE = getDataSource(qb).options.type === 'postgres' ? 'ILIKE' : 'LIKE';
         let clause: string;
         let params: Record<string, string>;
         switch (args.operator) {

--- a/packages/core/src/config/order/default-order-process.ts
+++ b/packages/core/src/config/order/default-order-process.ts
@@ -266,7 +266,7 @@ export function configureDefaultOrderProcess(options: DefaultOrderProcessOptions
             if (options.checkModificationPayments !== false && fromState === 'Modifying') {
                 const modifications = await connection
                     .getRepository(ctx, OrderModification)
-                    .find({ where: { order: { id: order.id } }, relations: ['refund', 'payment'] });
+                    .find({ where: { order: { id: order.id } }, relations: { refund: true, payment: true } });
                 if (toState === 'ArrangingAdditionalPayment') {
                     if (
                         0 < modifications.length &&
@@ -288,7 +288,7 @@ export function configureDefaultOrderProcess(options: DefaultOrderProcessOptions
                     return;
                 }
                 const existingPayments = await connection.getRepository(ctx, Payment).find({
-                    relations: ['refunds'],
+                    relations: { refunds: true },
                     where: {
                         order: { id: order.id },
                     },

--- a/packages/core/src/connection/database-type.spec.ts
+++ b/packages/core/src/connection/database-type.spec.ts
@@ -1,0 +1,27 @@
+import { DataSource, DataSourceOptions } from 'typeorm';
+import { describe, expect, it } from 'vitest';
+
+import { getDatabaseType } from './database-type';
+
+describe('getDatabaseType()', () => {
+    it('reads the type from DataSourceOptions', () => {
+        expect(getDatabaseType({ type: 'postgres' } as DataSourceOptions)).toBe('postgres');
+    });
+
+    it('reads the type from a DataSource', () => {
+        expect(getDatabaseType({ options: { type: 'better-sqlite3' } } as DataSource)).toBe('better-sqlite3');
+    });
+
+    // The mssql driver options carry an `options` property of their own, which must not be
+    // mistaken for the `options` of a DataSource.
+    it('reads the type from mssql options rather than their nested options bag', () => {
+        const options = { type: 'mssql', options: { instanceName: 'main' } } as DataSourceOptions;
+        expect(getDatabaseType(options)).toBe('mssql');
+    });
+
+    // `sqlite` is declared by some TypeORM versions and not others, but a project may be
+    // configured with it either way, so it has to survive the round trip.
+    it('preserves the sqlite driver name', () => {
+        expect(getDatabaseType({ type: 'sqlite' } as DataSourceOptions)).toBe('sqlite');
+    });
+});

--- a/packages/core/src/connection/database-type.ts
+++ b/packages/core/src/connection/database-type.ts
@@ -1,0 +1,30 @@
+import { DataSource, DataSourceOptions } from 'typeorm';
+
+/**
+ * @description
+ * The name of the TypeORM driver a Vendure project is configured with.
+ *
+ * This is TypeORM's own driver union widened with `sqlite`, which some TypeORM versions
+ * declare and others do not, even though a project may be configured with it either way.
+ * Switching on a driver name should use this type rather than `DataSourceOptions['type']`,
+ * so that the `sqlite` branches stay reachable.
+ *
+ * @docsCategory data-access
+ * @since 3.8.0
+ */
+export type VendureDatabaseType = DataSourceOptions['type'] | 'sqlite';
+
+/**
+ * @description
+ * Returns the name of the TypeORM driver in use, widened to {@link VendureDatabaseType}.
+ *
+ * @docsCategory data-access
+ * @since 3.8.0
+ */
+export function getDatabaseType(source: DataSource | DataSourceOptions): VendureDatabaseType {
+    // Discriminated on `type` rather than `options`, because the mssql driver options carry
+    // an `options` property of their own. Checked structurally rather than with `instanceof`,
+    // so that a DataSource created by a second copy of TypeORM is still recognised.
+    const options = 'type' in source ? source : source.options;
+    return options.type as VendureDatabaseType;
+}

--- a/packages/core/src/connection/find-options-array-to-object.spec.ts
+++ b/packages/core/src/connection/find-options-array-to-object.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { findOptionsArrayToObject } from './find-options-array-to-object';
+import { findOptionsObjectToArray } from './find-options-object-to-array';
+
+describe('findOptionsArrayToObject()', () => {
+    it('returns an empty object for an empty array', () => {
+        expect(findOptionsArrayToObject([])).toEqual({});
+    });
+
+    it('converts top-level relations', () => {
+        expect(findOptionsArrayToObject(['customer', 'lines'])).toEqual({
+            customer: true,
+            lines: true,
+        });
+    });
+
+    it('expands a dotted path into nested objects', () => {
+        expect(findOptionsArrayToObject(['lines.productVariant'])).toEqual({
+            lines: { productVariant: true },
+        });
+    });
+
+    it('expands deeply nested paths', () => {
+        expect(findOptionsArrayToObject(['lines.productVariant.product.facetValues'])).toEqual({
+            lines: { productVariant: { product: { facetValues: true } } },
+        });
+    });
+
+    it('merges sibling paths under a shared parent', () => {
+        expect(findOptionsArrayToObject(['lines.productVariant', 'lines.order'])).toEqual({
+            lines: { productVariant: true, order: true },
+        });
+    });
+
+    it('does not flatten a branch when the parent path is listed after it', () => {
+        expect(findOptionsArrayToObject(['lines.productVariant', 'lines'])).toEqual({
+            lines: { productVariant: true },
+        });
+    });
+
+    it('does not flatten a branch when the parent path is listed before it', () => {
+        expect(findOptionsArrayToObject(['lines', 'lines.productVariant'])).toEqual({
+            lines: { productVariant: true },
+        });
+    });
+
+    it('ignores empty path entries', () => {
+        expect(findOptionsArrayToObject(['customer', ''])).toEqual({ customer: true });
+    });
+
+    it('round-trips with findOptionsObjectToArray', () => {
+        const relations = {
+            customer: true,
+            lines: { productVariant: { product: true } },
+        };
+        const asArray = findOptionsObjectToArray(relations);
+        expect(findOptionsArrayToObject(asArray)).toEqual(relations);
+    });
+});

--- a/packages/core/src/connection/find-options-array-to-object.ts
+++ b/packages/core/src/connection/find-options-array-to-object.ts
@@ -1,0 +1,35 @@
+import { FindOptionsRelations } from 'typeorm';
+
+/**
+ * Converts a string array of relation paths into the object form used by the TypeORM
+ * FindOptions `relations` property. Dotted paths are expanded into nested objects, so
+ * `['customer', 'lines.productVariant']` becomes
+ * `{ customer: true, lines: { productVariant: true } }`.
+ */
+export function findOptionsArrayToObject<T>(input: string[]): FindOptionsRelations<T> {
+    const result: Record<string, any> = {};
+
+    for (const path of input) {
+        if (!path) {
+            continue;
+        }
+        const segments = path.split('.');
+        let node = result;
+        for (const [index, segment] of segments.entries()) {
+            const isLeaf = index === segments.length - 1;
+            if (isLeaf) {
+                // A shorter path may arrive after the longer one that nested it
+                // (`['lines.productVariant', 'lines']`), in which case the branch
+                // already selects the relation and must not be flattened to `true`.
+                node[segment] ??= true;
+            } else {
+                if (node[segment] == null || node[segment] === true) {
+                    node[segment] = {};
+                }
+                node = node[segment];
+            }
+        }
+    }
+
+    return result as FindOptionsRelations<T>;
+}

--- a/packages/core/src/connection/find-options-array-to-object.ts
+++ b/packages/core/src/connection/find-options-array-to-object.ts
@@ -1,10 +1,18 @@
 import { FindOptionsRelations } from 'typeorm';
 
 /**
+ * @description
  * Converts a string array of relation paths into the object form used by the TypeORM
- * FindOptions `relations` property. Dotted paths are expanded into nested objects, so
- * `['customer', 'lines.productVariant']` becomes
- * `{ customer: true, lines: { productVariant: true } }`.
+ * FindOptions `relations` property. Dotted paths are expanded into nested objects.
+ *
+ * @example
+ * ```ts
+ * findOptionsArrayToObject<Order>(['customer', 'lines.productVariant']);
+ * // { customer: true, lines: { productVariant: true } }
+ * ```
+ *
+ * @docsCategory data-access
+ * @since 3.8.0
  */
 export function findOptionsArrayToObject<T>(input: string[]): FindOptionsRelations<T> {
     const result: Record<string, any> = {};

--- a/packages/core/src/connection/find-options-array-to-object.ts
+++ b/packages/core/src/connection/find-options-array-to-object.ts
@@ -19,8 +19,8 @@ export function findOptionsArrayToObject<T>(input: string[]): FindOptionsRelatio
             const isLeaf = index === segments.length - 1;
             if (isLeaf) {
                 // A shorter path may arrive after the longer one that nested it
-                // (`['lines.productVariant', 'lines']`), in which case the branch
-                // already selects the relation and must not be flattened to `true`.
+                // (`['lines.productVariant', 'lines']`). Overwriting that branch with
+                // `true` would drop `productVariant` from the loaded relations.
                 node[segment] ??= true;
             } else {
                 if (node[segment] == null || node[segment] === true) {

--- a/packages/core/src/connection/find-options-object-to-array.ts
+++ b/packages/core/src/connection/find-options-object-to-array.ts
@@ -1,21 +1,20 @@
-import { FindOneOptions } from 'typeorm';
-import { FindOptionsRelationByString } from 'typeorm/find-options/FindOptionsRelations';
+import { FindOptionsRelations } from 'typeorm';
 
 /**
  * Some internal APIs depend on the TypeORM FindOptions `relations` property being a string array.
  * This function converts the new-style FindOptionsRelations object to a string array.
  */
 export function findOptionsObjectToArray<T>(
-    input: NonNullable<FindOneOptions['relations']>,
+    input: FindOptionsRelations<T> | string[],
     parentKey?: string,
-): FindOptionsRelationByString {
+): string[] {
     if (Array.isArray(input)) {
         return input;
     }
     const keys = Object.keys(input);
 
     return keys.reduce((acc: string[], key: string) => {
-        const value = input[key as any];
+        const value = (input as Record<string, any>)[key];
         const path = parentKey ? `${parentKey}.${key}` : key;
 
         acc.push(path); // Push parent key instead of path

--- a/packages/core/src/connection/get-data-source.spec.ts
+++ b/packages/core/src/connection/get-data-source.spec.ts
@@ -17,11 +17,17 @@ describe('getDataSource()', () => {
 
     it('prefers "dataSource" when both are present', () => {
         const deprecatedAlias = {} as DataSource;
-        expect(getDataSource({ dataSource, connection: deprecatedAlias } as any)).toBe(dataSource);
+        expect(getDataSource({ dataSource, connection: deprecatedAlias })).toBe(dataSource);
     });
 
     it('throws when neither property is present', () => {
-        expect(() => getDataSource({} as any)).toThrowError(/Could not resolve a TypeORM DataSource/);
+        expect(() => getDataSource({})).toThrowError(/Could not resolve a TypeORM DataSource/);
+    });
+
+    // Callers reached from untyped code, such as the RelationIdLoader patch, can pass a value the
+    // compiler never checked.
+    it.each([null, undefined])('throws when given %s', value => {
+        expect(() => getDataSource(value as any)).toThrowError(/Could not resolve a TypeORM DataSource/);
     });
 
     // The RelationIdLoader patch in entity/typeorm-relation-id-loader-fix.ts reads the DataSource

--- a/packages/core/src/connection/get-data-source.spec.ts
+++ b/packages/core/src/connection/get-data-source.spec.ts
@@ -1,0 +1,35 @@
+import { DataSource } from 'typeorm';
+import { RelationIdLoader } from 'typeorm/query-builder/RelationIdLoader';
+import { describe, expect, it } from 'vitest';
+
+import { getDataSource } from './get-data-source';
+
+describe('getDataSource()', () => {
+    const dataSource = {} as DataSource;
+
+    it('reads the "connection" property', () => {
+        expect(getDataSource({ connection: dataSource })).toBe(dataSource);
+    });
+
+    it('reads the "dataSource" property', () => {
+        expect(getDataSource({ dataSource })).toBe(dataSource);
+    });
+
+    it('prefers "dataSource" when both are present', () => {
+        const deprecatedAlias = {} as DataSource;
+        expect(getDataSource({ dataSource, connection: deprecatedAlias } as any)).toBe(dataSource);
+    });
+
+    it('throws when neither property is present', () => {
+        expect(() => getDataSource({} as any)).toThrowError(/Could not resolve a TypeORM DataSource/);
+    });
+
+    // The RelationIdLoader patch in entity/typeorm-relation-id-loader-fix.ts reads the DataSource
+    // off a RelationIdLoader instance, whose field is private and renamed between TypeORM versions.
+    // Nothing in that patch is visible to the compiler, so this is the only check that it resolves
+    // against the version of TypeORM actually installed.
+    it('reads the DataSource from a TypeORM RelationIdLoader', () => {
+        const loader = new (RelationIdLoader as any)(dataSource);
+        expect(getDataSource(loader)).toBe(dataSource);
+    });
+});

--- a/packages/core/src/connection/get-data-source.ts
+++ b/packages/core/src/connection/get-data-source.ts
@@ -11,12 +11,13 @@ import { DataSource } from 'typeorm';
  * @docsCategory data-access
  * @since 3.8.0
  */
-export type DataSourceHolder = { connection: DataSource } | { dataSource: DataSource };
+export type DataSourceHolder = { connection?: DataSource; dataSource?: DataSource };
 
 /**
  * @description
  * Returns the {@link DataSource} that the given TypeORM object belongs to, reading whichever of
- * the `dataSource` and `connection` properties the installed version of TypeORM provides.
+ * the `dataSource` and `connection` properties the installed version of TypeORM provides. Where
+ * an object carries both, `dataSource` is used, since `connection` is the deprecated alias.
  *
  * @example
  * ```ts
@@ -33,13 +34,15 @@ export type DataSourceHolder = { connection: DataSource } | { dataSource: DataSo
  * @since 3.8.0
  */
 export function getDataSource(source: DataSourceHolder): DataSource {
-    const typeOrmObject = source as { dataSource?: DataSource; connection?: DataSource };
-    const dataSource = typeOrmObject.dataSource ?? typeOrmObject.connection;
+    // Without these checks the caller fails further on with "cannot read properties of undefined".
+    if (source == null) {
+        throw new Error(`Could not resolve a TypeORM DataSource from ${String(source)}.`);
+    }
+    const dataSource = source.dataSource ?? source.connection;
     if (!dataSource) {
-        // Without this the caller fails further on with "cannot read properties of undefined".
         throw new Error(
             `Could not resolve a TypeORM DataSource from a ${
-                typeOrmObject.constructor?.name ?? typeof source
+                source.constructor?.name ?? typeof source
             }: it has neither a "dataSource" nor a "connection" property.`,
         );
     }

--- a/packages/core/src/connection/get-data-source.ts
+++ b/packages/core/src/connection/get-data-source.ts
@@ -1,0 +1,47 @@
+import { DataSource } from 'typeorm';
+
+/**
+ * @description
+ * A TypeORM object which knows the {@link DataSource} it belongs to, such as a QueryBuilder,
+ * EntityManager, QueryRunner or EntityMetadata. TypeORM 0.3 names that property `connection`.
+ * TypeORM 1 renames it to `dataSource` and keeps `connection` as a deprecated alias on some,
+ * but not all, of those classes. Code which has to run on both versions therefore reads the
+ * DataSource via {@link getDataSource} rather than naming either property directly.
+ *
+ * @docsCategory data-access
+ * @since 3.8.0
+ */
+export type DataSourceHolder = { connection: DataSource } | { dataSource: DataSource };
+
+/**
+ * @description
+ * Returns the {@link DataSource} that the given TypeORM object belongs to, reading whichever of
+ * the `dataSource` and `connection` properties the installed version of TypeORM provides.
+ *
+ * @example
+ * ```ts
+ * const collectionFilter = new CollectionFilter({
+ *   // ...
+ *   apply: (qb, args) => {
+ *     const LIKE = getDataSource(qb).options.type === 'postgres' ? 'ILIKE' : 'LIKE';
+ *     return qb.andWhere(`productVariant.sku ${LIKE} :sku`, { sku: `%${args.sku}%` });
+ *   },
+ * });
+ * ```
+ *
+ * @docsCategory data-access
+ * @since 3.8.0
+ */
+export function getDataSource(source: DataSourceHolder): DataSource {
+    const typeOrmObject = source as { dataSource?: DataSource; connection?: DataSource };
+    const dataSource = typeOrmObject.dataSource ?? typeOrmObject.connection;
+    if (!dataSource) {
+        // Without this the caller fails further on with "cannot read properties of undefined".
+        throw new Error(
+            `Could not resolve a TypeORM DataSource from a ${
+                typeOrmObject.constructor?.name ?? typeof source
+            }: it has neither a "dataSource" nor a "connection" property.`,
+        );
+    }
+    return dataSource;
+}

--- a/packages/core/src/connection/index.ts
+++ b/packages/core/src/connection/index.ts
@@ -1,4 +1,5 @@
 export * from './connection.module';
+export * from './database-type';
 export * from './find-options-array-to-object';
 export * from './get-data-source';
 export * from './transaction-subscriber';

--- a/packages/core/src/connection/index.ts
+++ b/packages/core/src/connection/index.ts
@@ -1,4 +1,5 @@
-export * from './transactional-connection';
-export * from './transaction-subscriber';
 export * from './connection.module';
+export * from './find-options-array-to-object';
+export * from './transaction-subscriber';
+export * from './transactional-connection';
 export * from './types';

--- a/packages/core/src/connection/index.ts
+++ b/packages/core/src/connection/index.ts
@@ -1,5 +1,6 @@
 export * from './connection.module';
 export * from './find-options-array-to-object';
+export * from './get-data-source';
 export * from './transaction-subscriber';
 export * from './transactional-connection';
 export * from './types';

--- a/packages/core/src/connection/index.ts
+++ b/packages/core/src/connection/index.ts
@@ -2,6 +2,7 @@ export * from './connection.module';
 export * from './database-type';
 export * from './find-options-array-to-object';
 export * from './get-data-source';
+export * from './to-typeorm-find-options';
 export * from './transaction-subscriber';
 export * from './transactional-connection';
 export * from './types';

--- a/packages/core/src/connection/to-typeorm-find-options.spec.ts
+++ b/packages/core/src/connection/to-typeorm-find-options.spec.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import { toTypeOrmFindOptions } from './to-typeorm-find-options';
+import { VendureFindManyOptions } from './types';
+
+interface TestProductVariant {
+    id: string;
+    sku: string;
+    product: { id: string; name: string };
+}
+
+interface TestOrder {
+    id: string;
+    code: string;
+    customer: { id: string };
+    lines: Array<{ id: string; productVariant: TestProductVariant }>;
+}
+
+describe('toTypeOrmFindOptions()', () => {
+    it('returns an empty object for empty options', () => {
+        expect(toTypeOrmFindOptions<TestOrder, VendureFindManyOptions<TestOrder>>({})).toEqual({});
+    });
+
+    describe('relations', () => {
+        it('converts an array to the object form', () => {
+            const result = toTypeOrmFindOptions<TestOrder, VendureFindManyOptions<TestOrder>>({
+                relations: ['customer', 'lines.productVariant'],
+            });
+
+            expect(result.relations).toEqual({
+                customer: true,
+                lines: { productVariant: true },
+            });
+        });
+
+        it('converts an empty array to an empty object', () => {
+            const result = toTypeOrmFindOptions<TestOrder, VendureFindManyOptions<TestOrder>>({
+                relations: [],
+            });
+
+            expect(result.relations).toEqual({});
+        });
+
+        it('passes the object form through unchanged', () => {
+            const relations = { customer: true, lines: { productVariant: true } };
+            const result = toTypeOrmFindOptions<TestOrder, VendureFindManyOptions<TestOrder>>({
+                relations,
+            });
+
+            expect(result.relations).toBe(relations);
+        });
+
+        it('omits the property when no relations are given', () => {
+            const result = toTypeOrmFindOptions<TestOrder, VendureFindManyOptions<TestOrder>>({
+                where: { id: '1' },
+            });
+
+            expect('relations' in result).toBe(false);
+        });
+    });
+
+    describe('select', () => {
+        it('converts an array to the object form', () => {
+            const result = toTypeOrmFindOptions<TestOrder, VendureFindManyOptions<TestOrder>>({
+                select: ['id', 'code'],
+            });
+
+            expect(result.select).toEqual({ id: true, code: true });
+        });
+
+        it('expands dotted paths into nested objects', () => {
+            const result = toTypeOrmFindOptions<TestOrder, VendureFindManyOptions<TestOrder>>({
+                select: ['id', 'lines.productVariant.sku'],
+            });
+
+            expect(result.select).toEqual({
+                id: true,
+                lines: { productVariant: { sku: true } },
+            });
+        });
+
+        it('converts an empty array to an empty object', () => {
+            const result = toTypeOrmFindOptions<TestOrder, VendureFindManyOptions<TestOrder>>({
+                select: [],
+            });
+
+            expect(result.select).toEqual({});
+        });
+
+        it('passes the object form through unchanged', () => {
+            const select = { id: true as const, lines: { id: true as const } };
+            const result = toTypeOrmFindOptions<TestOrder, VendureFindManyOptions<TestOrder>>({
+                select,
+            });
+
+            expect(result.select).toBe(select);
+        });
+
+        it('omits the property when no select is given', () => {
+            const result = toTypeOrmFindOptions<TestOrder, VendureFindManyOptions<TestOrder>>({
+                where: { id: '1' },
+            });
+
+            expect('select' in result).toBe(false);
+        });
+    });
+
+    it('converts relations and select in the same call', () => {
+        const result = toTypeOrmFindOptions<TestOrder, VendureFindManyOptions<TestOrder>>({
+            relations: ['customer'],
+            select: ['id'],
+        });
+
+        expect(result).toEqual({
+            relations: { customer: true },
+            select: { id: true },
+        });
+    });
+
+    it('carries the remaining find options through untouched', () => {
+        const where = { code: 'ABC' };
+        const order = { code: 'ASC' as const };
+        const result = toTypeOrmFindOptions<TestOrder, VendureFindManyOptions<TestOrder>>({
+            where,
+            order,
+            take: 10,
+            skip: 20,
+            relations: ['customer'],
+        });
+
+        expect(result.where).toBe(where);
+        expect(result.order).toBe(order);
+        expect(result.take).toBe(10);
+        expect(result.skip).toBe(20);
+    });
+
+    it('does not mutate the options it is given', () => {
+        const options: VendureFindManyOptions<TestOrder> = {
+            relations: ['customer'],
+            select: ['id'],
+        };
+
+        toTypeOrmFindOptions<TestOrder, VendureFindManyOptions<TestOrder>>(options);
+
+        expect(options.relations).toEqual(['customer']);
+        expect(options.select).toEqual(['id']);
+    });
+});

--- a/packages/core/src/connection/to-typeorm-find-options.ts
+++ b/packages/core/src/connection/to-typeorm-find-options.ts
@@ -1,0 +1,35 @@
+import { FindOptionsRelations, FindOptionsSelect } from 'typeorm';
+
+import { findOptionsArrayToObject } from './find-options-array-to-object';
+import { VendureFindManyOptions } from './types';
+
+/**
+ * Converts the `relations` and `select` properties of Vendure's find options into the object
+ * form TypeORM expects. Call this wherever find options cross from a Vendure API into TypeORM.
+ *
+ * Vendure's own APIs accept relation paths as a string array, since that is the shape of
+ * {@link RelationPaths} and of the `@Relations()` decorator that produces it. TypeORM only
+ * accepts the object form.
+ */
+export function toTypeOrmFindOptions<T, O extends VendureFindManyOptions<T>>(
+    options: O,
+): Omit<O, 'relations' | 'select'> & {
+    relations?: FindOptionsRelations<T>;
+    select?: FindOptionsSelect<T>;
+} {
+    const { relations, select, ...rest } = options;
+    return {
+        ...rest,
+        ...(relations !== undefined && {
+            relations: Array.isArray(relations) ? findOptionsArrayToObject<T>(relations) : relations,
+        }),
+        ...(select !== undefined && {
+            select: Array.isArray(select)
+                ? (findOptionsArrayToObject<T>(select) as FindOptionsSelect<T>)
+                : select,
+        }),
+    } as Omit<O, 'relations' | 'select'> & {
+        relations?: FindOptionsRelations<T>;
+        select?: FindOptionsSelect<T>;
+    };
+}

--- a/packages/core/src/connection/to-typeorm-find-options.ts
+++ b/packages/core/src/connection/to-typeorm-find-options.ts
@@ -4,19 +4,33 @@ import { findOptionsArrayToObject } from './find-options-array-to-object';
 import { VendureFindManyOptions } from './types';
 
 /**
+ * @description
+ * The find options `O` with its `relations` and `select` properties narrowed to the object
+ * form that TypeORM accepts.
+ *
+ * @docsCategory data-access
+ * @since 3.8.0
+ */
+export type TypeOrmFindOptions<T, O> = Omit<O, 'relations' | 'select'> & {
+    relations?: FindOptionsRelations<T>;
+    select?: FindOptionsSelect<T>;
+};
+
+/**
+ * @description
  * Converts the `relations` and `select` properties of Vendure's find options into the object
  * form TypeORM expects. Call this wherever find options cross from a Vendure API into TypeORM.
  *
  * Vendure's own APIs accept relation paths as a string array, since that is the shape of
  * {@link RelationPaths} and of the `@Relations()` decorator that produces it. TypeORM only
  * accepts the object form.
+ *
+ * @docsCategory data-access
+ * @since 3.8.0
  */
 export function toTypeOrmFindOptions<T, O extends VendureFindManyOptions<T>>(
     options: O,
-): Omit<O, 'relations' | 'select'> & {
-    relations?: FindOptionsRelations<T>;
-    select?: FindOptionsSelect<T>;
-} {
+): TypeOrmFindOptions<T, O> {
     const { relations, select, ...rest } = options;
     return {
         ...rest,
@@ -28,8 +42,5 @@ export function toTypeOrmFindOptions<T, O extends VendureFindManyOptions<T>>(
                 ? (findOptionsArrayToObject<T>(select) as FindOptionsSelect<T>)
                 : select,
         }),
-    } as Omit<O, 'relations' | 'select'> & {
-        relations?: FindOptionsRelations<T>;
-        select?: FindOptionsSelect<T>;
-    };
+    } as TypeOrmFindOptions<T, O>;
 }

--- a/packages/core/src/connection/transaction-subscriber.ts
+++ b/packages/core/src/connection/transaction-subscriber.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectConnection } from '@nestjs/typeorm';
 import { lastValueFrom, merge, ObservableInput, Subject } from 'rxjs';
 import { delay, filter, map, take, tap } from 'rxjs/operators';
-import { Connection, EntitySubscriberInterface } from 'typeorm';
+import { DataSource, EntitySubscriberInterface } from 'typeorm';
 import { EntityManager } from 'typeorm/entity-manager/EntityManager';
 import { QueryRunner } from 'typeorm/query-runner/QueryRunner';
 import { TransactionCommitEvent } from 'typeorm/subscriber/event/TransactionCommitEvent';
@@ -26,7 +26,7 @@ export interface TransactionSubscriberEvent {
     /**
      * Connection used in the event.
      */
-    connection: Connection;
+    connection: DataSource;
     /**
      * QueryRunner used in the event transaction.
      * All database operations in the subscribed event listener should be performed using this query runner instance.
@@ -50,7 +50,7 @@ export interface TransactionSubscriberEvent {
 export class TransactionSubscriber implements EntitySubscriberInterface {
     private subject$ = new Subject<TransactionSubscriberEvent>();
 
-    constructor(@InjectConnection() private connection: Connection) {
+    constructor(@InjectConnection() private connection: DataSource) {
         if (!connection.subscribers.find(subscriber => subscriber.constructor === TransactionSubscriber)) {
             connection.subscribers.push(this);
         }

--- a/packages/core/src/connection/transaction-subscriber.ts
+++ b/packages/core/src/connection/transaction-subscriber.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectConnection } from '@nestjs/typeorm';
-import { lastValueFrom, merge, ObservableInput, Subject } from 'rxjs';
+import { lastValueFrom, Subject } from 'rxjs';
 import { delay, filter, map, take, tap } from 'rxjs/operators';
 import { Connection, EntitySubscriberInterface } from 'typeorm';
 import { EntityManager } from 'typeorm/entity-manager/EntityManager';
@@ -87,15 +87,17 @@ export class TransactionSubscriber implements EntitySubscriberInterface {
         type?: TransactionSubscriberEventType,
     ): Promise<QueryRunner> {
         if (queryRunner.isTransactionActive) {
-            return lastValueFrom(this.subject$
-                .pipe(
+            return lastValueFrom(
+                this.subject$.pipe(
                     filter(
                         event => !event.queryRunner.isTransactionActive && event.queryRunner === queryRunner,
                     ),
                     take(1),
                     tap(event => {
                         if (type && event.type !== type) {
-                            throw new TransactionSubscriberError(`Unexpected event type: ${event.type}. Expected ${type}.`);
+                            throw new TransactionSubscriberError(
+                                `Unexpected event type: ${event.type}. Expected ${type}.`,
+                            );
                         }
                     }),
                     map(event => event.queryRunner),
@@ -106,7 +108,7 @@ export class TransactionSubscriber implements EntitySubscriberInterface {
                     // in the database-transactions.e2e-spec.ts suite, and a bunch of errors
                     // in the default-search-plugin.e2e-spec.ts suite when using sqljs.
                     delay(0),
-                )
+                ),
             );
         } else {
             return Promise.resolve(queryRunner);

--- a/packages/core/src/connection/transaction-subscriber.ts
+++ b/packages/core/src/connection/transaction-subscriber.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectConnection } from '@nestjs/typeorm';
-import { lastValueFrom, Subject } from 'rxjs';
+import { lastValueFrom, merge, ObservableInput, Subject } from 'rxjs';
 import { delay, filter, map, take, tap } from 'rxjs/operators';
 import { Connection, EntitySubscriberInterface } from 'typeorm';
 import { EntityManager } from 'typeorm/entity-manager/EntityManager';
@@ -87,17 +87,15 @@ export class TransactionSubscriber implements EntitySubscriberInterface {
         type?: TransactionSubscriberEventType,
     ): Promise<QueryRunner> {
         if (queryRunner.isTransactionActive) {
-            return lastValueFrom(
-                this.subject$.pipe(
+            return lastValueFrom(this.subject$
+                .pipe(
                     filter(
                         event => !event.queryRunner.isTransactionActive && event.queryRunner === queryRunner,
                     ),
                     take(1),
                     tap(event => {
                         if (type && event.type !== type) {
-                            throw new TransactionSubscriberError(
-                                `Unexpected event type: ${event.type}. Expected ${type}.`,
-                            );
+                            throw new TransactionSubscriberError(`Unexpected event type: ${event.type}. Expected ${type}.`);
                         }
                     }),
                     map(event => event.queryRunner),
@@ -108,7 +106,7 @@ export class TransactionSubscriber implements EntitySubscriberInterface {
                     // in the database-transactions.e2e-spec.ts suite, and a bunch of errors
                     // in the default-search-plugin.e2e-spec.ts suite when using sqljs.
                     delay(0),
-                ),
+                )
             );
         } else {
             return Promise.resolve(queryRunner);

--- a/packages/core/src/connection/transactional-connection.spec.ts
+++ b/packages/core/src/connection/transactional-connection.spec.ts
@@ -1,0 +1,98 @@
+import {
+    DataSource,
+    Entity,
+    JoinTable,
+    Logger,
+    ManyToMany,
+    ManyToOne,
+    OneToMany,
+    PrimaryGeneratedColumn,
+} from 'typeorm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { RequestContext } from '../api/common/request-context';
+
+import { TransactionalConnection } from './transactional-connection';
+import { FindOptionsRelationsInput } from './types';
+
+@Entity()
+class TestChannel {
+    @PrimaryGeneratedColumn()
+    id: number;
+}
+
+/**
+ * A self-referencing, channel-aware entity. `joinTreeRelationsDynamically` joins
+ * self-referencing relations manually, which is the behaviour these tests cover.
+ */
+@Entity()
+class TestNode {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => TestNode, node => node.children, { nullable: true })
+    parent: TestNode | null;
+
+    @OneToMany(() => TestNode, node => node.parent)
+    children: TestNode[];
+
+    @ManyToMany(() => TestChannel)
+    @JoinTable()
+    channels: TestChannel[];
+}
+
+describe('TransactionalConnection', () => {
+    let executedQueries: string[] = [];
+    const noop = () => undefined;
+    const queryLogger: Logger = {
+        logQuery: query => executedQueries.push(query),
+        logQueryError: noop,
+        logQuerySlow: noop,
+        logSchemaBuild: noop,
+        logMigration: noop,
+        log: noop,
+    };
+    let dataSource: DataSource;
+    let connection: TransactionalConnection;
+    let ctx: RequestContext;
+
+    beforeAll(async () => {
+        dataSource = new DataSource({
+            type: 'sqljs',
+            entities: [TestNode, TestChannel],
+            synchronize: true,
+            logger: queryLogger,
+        });
+        await dataSource.initialize();
+        connection = new TransactionalConnection(dataSource, {} as any, { authOptions: {} } as any);
+        ctx = RequestContext.empty();
+    });
+
+    afterAll(async () => {
+        await dataSource.destroy();
+    });
+
+    describe('findByIdsInChannel', () => {
+        async function collectQueriesFor(relations: FindOptionsRelationsInput<TestNode>): Promise<string[]> {
+            executedQueries = [];
+            await connection.findByIdsInChannel(ctx, TestNode as any, [1], 1, { relations });
+            return executedQueries;
+        }
+
+        // Object-form relations must take the same tree-relation join path as the array
+        // form, rather than falling through to TypeORM's own relation loading.
+        it('joins self-referencing relations given in object form', async () => {
+            const queries = await collectQueriesFor({ parent: true });
+
+            expect(queries).toHaveLength(1);
+            expect(queries[0]).toContain('LEFT JOIN "test_node" "entity_parent"');
+        });
+
+        it('produces the same queries for array and object relations', async () => {
+            const arrayForm = await collectQueriesFor(['parent']);
+            const objectForm = await collectQueriesFor({ parent: true });
+
+            expect(objectForm).toEqual(arrayForm);
+        });
+    });
+});

--- a/packages/core/src/connection/transactional-connection.ts
+++ b/packages/core/src/connection/transactional-connection.ts
@@ -359,7 +359,7 @@ export class TransactionalConnection {
         const qb = this.getRepository(ctx, entity).createQueryBuilder('entity');
         const findOptions = toTypeOrmFindOptions<T, VendureFindOneOptions<T>>(options);
 
-        if (findOptions.relations) {
+        if (findOptions.relations && Object.keys(findOptions.relations).length > 0) {
             const joinedRelations = joinTreeRelationsDynamically(qb, entity, findOptions.relations);
             // Remove any relations which are related to the 'collection' tree, as these are handled separately
             // to avoid duplicate joins.
@@ -404,7 +404,7 @@ export class TransactionalConnection {
         const qb = this.getRepository(ctx, entity).createQueryBuilder('entity');
         const findOptions = toTypeOrmFindOptions<T, VendureFindManyOptions<T>>(options);
 
-        if (findOptions.relations) {
+        if (findOptions.relations && Object.keys(findOptions.relations).length > 0) {
             const joinedRelations = joinTreeRelationsDynamically(
                 qb as SelectQueryBuilder<VendureEntity>,
                 entity,

--- a/packages/core/src/connection/transactional-connection.ts
+++ b/packages/core/src/connection/transactional-connection.ts
@@ -24,9 +24,11 @@ import { ConfigService } from '../config/config.service';
 import { VendureEntity } from '../entity/base/base.entity';
 import { joinTreeRelationsDynamically } from '../service/helpers/utils/tree-relations-qb-joiner';
 
+import { findOptionsArrayToObject } from './find-options-array-to-object';
 import { findOptionsObjectToArray } from './find-options-object-to-array';
+import { toTypeOrmFindOptions } from './to-typeorm-find-options';
 import { TransactionWrapper } from './transaction-wrapper';
-import { GetEntityOrThrowOptions } from './types';
+import { GetEntityOrThrowOptions, VendureFindManyOptions, VendureFindOneOptions } from './types';
 
 /**
  * Repository methods intercepted by the access control Proxy.
@@ -321,7 +323,7 @@ export class TransactionalConnection {
             );
         } else {
             const optionsWithId = {
-                ...options,
+                ...toTypeOrmFindOptions<T, GetEntityOrThrowOptions<T>>(options),
                 where: {
                     ...(options.where || {}),
                     id,
@@ -352,21 +354,24 @@ export class TransactionalConnection {
         entity: Type<T>,
         id: ID,
         channelId: ID,
-        options: FindOneOptions<T> = {},
+        options: VendureFindOneOptions<T> = {},
     ) {
         const qb = this.getRepository(ctx, entity).createQueryBuilder('entity');
+        const findOptions = toTypeOrmFindOptions<T, VendureFindOneOptions<T>>(options);
 
-        if (options.relations) {
-            const joinedRelations = joinTreeRelationsDynamically(qb, entity, options.relations);
+        if (findOptions.relations) {
+            const joinedRelations = joinTreeRelationsDynamically(qb, entity, findOptions.relations);
             // Remove any relations which are related to the 'collection' tree, as these are handled separately
             // to avoid duplicate joins.
-            options.relations = findOptionsObjectToArray(options.relations).filter(
-                relationPath => !joinedRelations.has(relationPath),
+            findOptions.relations = findOptionsArrayToObject<T>(
+                findOptionsObjectToArray(findOptions.relations).filter(
+                    relationPath => !joinedRelations.has(relationPath),
+                ),
             );
         }
         qb.setFindOptions({
             relationLoadStrategy: 'query', // default to query strategy for maximum performance
-            ...options,
+            ...findOptions,
         });
 
         qb.leftJoin('entity.channels', '__channel')
@@ -388,7 +393,7 @@ export class TransactionalConnection {
         entity: Type<T>,
         ids: ID[],
         channelId: ID,
-        options: FindManyOptions<T>,
+        options: VendureFindManyOptions<T>,
     ) {
         // the syntax described in https://github.com/typeorm/typeorm/issues/1239#issuecomment-366955628
         // breaks if the array is empty
@@ -397,21 +402,26 @@ export class TransactionalConnection {
         }
 
         const qb = this.getRepository(ctx, entity).createQueryBuilder('entity');
+        const findOptions = toTypeOrmFindOptions<T, VendureFindManyOptions<T>>(options);
 
-        if (Array.isArray(options.relations) && options.relations.length > 0) {
+        if (findOptions.relations) {
             const joinedRelations = joinTreeRelationsDynamically(
                 qb as SelectQueryBuilder<VendureEntity>,
                 entity,
-                options.relations,
+                findOptions.relations,
             );
             // Remove any relations which are related to the 'collection' tree, as these are handled separately
             // to avoid duplicate joins.
-            options.relations = options.relations.filter(relationPath => !joinedRelations.has(relationPath));
+            findOptions.relations = findOptionsArrayToObject<T>(
+                findOptionsObjectToArray(findOptions.relations).filter(
+                    relationPath => !joinedRelations.has(relationPath),
+                ),
+            );
         }
 
         qb.setFindOptions({
             relationLoadStrategy: 'query', // default to query strategy for maximum performance
-            ...options,
+            ...findOptions,
         });
 
         qb.leftJoin('entity.channels', 'channel')

--- a/packages/core/src/connection/types.ts
+++ b/packages/core/src/connection/types.ts
@@ -1,5 +1,51 @@
 import { ID } from '@vendure/common/lib/shared-types';
-import { FindOneOptions } from 'typeorm';
+import { FindManyOptions, FindOneOptions, FindOptionsRelations, FindOptionsSelect } from 'typeorm';
+
+/**
+ * @description
+ * The relations to join when finding an entity. Accepts either the TypeORM object form,
+ * or an array of dot-separated relation paths as produced by {@link RelationPaths}.
+ *
+ * @docsCategory data-access
+ * @since 3.8.0
+ */
+export type FindOptionsRelationsInput<T> = FindOptionsRelations<T> | string[];
+
+/**
+ * @description
+ * The columns to select when finding an entity. Accepts either the TypeORM object form,
+ * or an array of column names.
+ *
+ * @docsCategory data-access
+ * @since 3.8.0
+ */
+export type FindOptionsSelectInput<T> = FindOptionsSelect<T> | string[];
+
+/**
+ * @description
+ * The TypeORM `FindOneOptions`, widened so that `relations` and `select` also accept the
+ * array form.
+ *
+ * @docsCategory data-access
+ * @since 3.8.0
+ */
+export interface VendureFindOneOptions<T = any> extends Omit<FindOneOptions<T>, 'relations' | 'select'> {
+    relations?: FindOptionsRelationsInput<T>;
+    select?: FindOptionsSelectInput<T>;
+}
+
+/**
+ * @description
+ * The TypeORM `FindManyOptions`, widened so that `relations` and `select` also accept the
+ * array form.
+ *
+ * @docsCategory data-access
+ * @since 3.8.0
+ */
+export interface VendureFindManyOptions<T = any> extends Omit<FindManyOptions<T>, 'relations' | 'select'> {
+    relations?: FindOptionsRelationsInput<T>;
+    select?: FindOptionsSelectInput<T>;
+}
 
 /**
  * @description
@@ -7,7 +53,7 @@ import { FindOneOptions } from 'typeorm';
  *
  * @docsCategory data-access
  */
-export interface GetEntityOrThrowOptions<T = any> extends FindOneOptions<T> {
+export interface GetEntityOrThrowOptions<T = any> extends VendureFindOneOptions<T> {
     /**
      * @description
      * An optional channelId to limit results to entities assigned to the given Channel. Should

--- a/packages/core/src/connection/types.ts
+++ b/packages/core/src/connection/types.ts
@@ -23,8 +23,8 @@ export type FindOptionsSelectInput<T> = FindOptionsSelect<T> | string[];
 
 /**
  * @description
- * The TypeORM `FindOneOptions`, widened so that `relations` and `select` also accept the
- * array form.
+ * The TypeORM `FindOneOptions`, with `relations` and `select` also accepting an array of
+ * paths.
  *
  * @docsCategory data-access
  * @since 3.8.0
@@ -36,8 +36,8 @@ export interface VendureFindOneOptions<T = any> extends Omit<FindOneOptions<T>, 
 
 /**
  * @description
- * The TypeORM `FindManyOptions`, widened so that `relations` and `select` also accept the
- * array form.
+ * The TypeORM `FindManyOptions`, with `relations` and `select` also accepting an array of
+ * paths.
  *
  * @docsCategory data-access
  * @since 3.8.0

--- a/packages/core/src/entity/product-variant/product-variant.entity.ts
+++ b/packages/core/src/entity/product-variant/product-variant.entity.ts
@@ -71,6 +71,7 @@ export class ProductVariant
     currencyCode: CurrencyCode;
 
     @Calculated({
+        relations: ['productVariantPrices'],
         expression: 'productvariant__productVariantPrices.price',
     })
     get price(): number {
@@ -83,6 +84,7 @@ export class ProductVariant
     }
 
     @Calculated({
+        relations: ['productVariantPrices'],
         // Note: this works fine for sorting by priceWithTax, but filtering will return inaccurate
         // results due to this expression not taking taxes into account. This is because the tax
         // rate is calculated at run-time in the application layer based on the current context,

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -5,7 +5,6 @@ import {
     Column,
     ColumnOptions,
     ColumnType,
-    DataSourceOptions,
     getMetadataArgsStorage,
     Index,
     JoinColumn,
@@ -20,6 +19,7 @@ import { DateUtils } from 'typeorm/util/DateUtils';
 import { CustomFieldConfig, CustomFields } from '../config/custom-field/custom-field-types';
 import { Logger } from '../config/logger/vendure-logger';
 import { VendureConfig } from '../config/vendure-config';
+import { getDatabaseType, VendureDatabaseType } from '../connection/database-type';
 
 import { EntityId } from './entity-id.decorator';
 import { EncryptedFieldTransformer } from './value-transformers';
@@ -104,7 +104,7 @@ function registerCustomFieldsForEntity(
     translation = false,
 ) {
     const customFields = config.customFields && config.customFields[entityName];
-    const dbEngine = config.dbConnectionOptions.type;
+    const dbEngine = getDatabaseType(config.dbConnectionOptions);
     if (customFields) {
         for (const customField of customFields) {
             const { name, list, defaultValue, nullable } = customField;
@@ -253,7 +253,7 @@ function registerCustomFieldsForEntity(
     }
 }
 
-function formatDefaultDatetime(dbEngine: DataSourceOptions['type'], datetime: any): Date | string {
+function formatDefaultDatetime(dbEngine: VendureDatabaseType, datetime: any): Date | string {
     if (!datetime) {
         return datetime;
     }
@@ -270,7 +270,7 @@ function formatDefaultDatetime(dbEngine: DataSourceOptions['type'], datetime: an
 }
 
 function getColumnType(
-    dbEngine: DataSourceOptions['type'],
+    dbEngine: VendureDatabaseType,
     type: Exclude<CustomFieldType, 'relation'>,
     isList: boolean,
 ): ColumnType {
@@ -333,7 +333,7 @@ function getColumnType(
     return 'varchar';
 }
 
-function getDefault(customField: CustomFieldConfig, dbEngine: DataSourceOptions['type']) {
+function getDefault(customField: CustomFieldConfig, dbEngine: VendureDatabaseType) {
     const { name, type, list, defaultValue, nullable } = customField;
     if (list && defaultValue) {
         if (dbEngine === 'mysql') {

--- a/packages/core/src/entity/typeorm-deep-value-fix.spec.ts
+++ b/packages/core/src/entity/typeorm-deep-value-fix.spec.ts
@@ -1,0 +1,32 @@
+import { OrmUtils } from 'typeorm/util/OrmUtils';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { patchTypeOrmDeepValue } from './typeorm-deep-value-fix';
+
+describe('patchTypeOrmDeepValue()', () => {
+    beforeAll(() => {
+        patchTypeOrmDeepValue();
+    });
+
+    it('reads a single-segment path', () => {
+        expect(OrmUtils.deepValue({ owner: true }, 'owner')).toBe(true);
+    });
+
+    it('reads a nested path', () => {
+        expect(OrmUtils.deepValue({ customFields: { owner: true } }, 'customFields.owner')).toBe(true);
+    });
+
+    it('returns undefined for a missing leaf segment', () => {
+        expect(OrmUtils.deepValue({ customFields: {} }, 'customFields.owner')).toBeUndefined();
+    });
+
+    // The find options of a query for an entity with an eager relation custom field, where the
+    // query asks for some other relation. Unpatched, TypeORM reads `owner` of `undefined` here.
+    it('returns undefined for a missing intermediate segment', () => {
+        expect(OrmUtils.deepValue({ featuredAsset: true }, 'customFields.owner')).toBeUndefined();
+    });
+
+    it('returns undefined for a null intermediate segment', () => {
+        expect(OrmUtils.deepValue({ customFields: null } as any, 'customFields.owner')).toBeUndefined();
+    });
+});

--- a/packages/core/src/entity/typeorm-deep-value-fix.ts
+++ b/packages/core/src/entity/typeorm-deep-value-fix.ts
@@ -1,0 +1,43 @@
+import { ObjectLiteral } from 'typeorm';
+import { OrmUtils } from 'typeorm/util/OrmUtils';
+
+let patchApplied = false;
+
+/**
+ * Works around a TypeORM bug which throws when find options are resolved for a relation that
+ * lives inside an embedded entity, and the find options do not mention that embedded entity.
+ * Every relation custom field is such a relation, e.g. `customFields.owner` on Product.
+ *
+ * `OrmUtils.deepValue()` walks a dotted property path over an object and returns the value at
+ * the end of it. It reads each segment without checking that the previous one resolved to
+ * anything, so `deepValue({ featuredAsset: true }, 'customFields.owner')` reads `owner` of
+ * `undefined` and throws instead of returning `undefined`.
+ *
+ * `SelectQueryBuilder` calls it in seven places to narrow the `select`, `order` and `relations`
+ * options down to the part that applies to one relation, in each case treating a missing path
+ * as "nothing specified for this relation". The call which brings the throw into an ordinary
+ * query is the one in the `relationLoadStrategy: 'query'` eager loading branch, which runs for
+ * every eager relation of the entity being queried whenever any find options are set. So a
+ * query for a Product with a `relations` object that does not name `customFields` fails
+ * outright once an eager relation custom field is configured.
+ *
+ * The implementation below is the original with a guard added for a nullish intermediate
+ * segment, which is what every call site already expects.
+ */
+export function patchTypeOrmDeepValue() {
+    if (patchApplied) {
+        return;
+    }
+    patchApplied = true;
+
+    OrmUtils.deepValue = function (obj: ObjectLiteral, path: string): any {
+        let value: any = obj;
+        for (const segment of path.split('.')) {
+            if (value == null) {
+                return undefined;
+            }
+            value = value[segment];
+        }
+        return value;
+    };
+}

--- a/packages/core/src/entity/typeorm-deep-value-fix.ts
+++ b/packages/core/src/entity/typeorm-deep-value-fix.ts
@@ -23,6 +23,9 @@ let patchApplied = false;
  *
  * The implementation below is the original with a guard added for a nullish intermediate
  * segment, which is what every call site already expects.
+ *
+ * Reported upstream as https://github.com/typeorm/typeorm/issues/12774. This workaround can be
+ * removed once the minimum supported TypeORM version contains a fix.
  */
 export function patchTypeOrmDeepValue() {
     if (patchApplied) {

--- a/packages/core/src/entity/typeorm-duplicate-eager-load-fix.spec.ts
+++ b/packages/core/src/entity/typeorm-duplicate-eager-load-fix.spec.ts
@@ -1,0 +1,103 @@
+import { RelationMetadata } from 'typeorm/metadata/RelationMetadata';
+import { JoinAttribute } from 'typeorm/query-builder/JoinAttribute';
+import { describe, expect, it } from 'vitest';
+
+import { joinCoversRelation, RelationLoadNarrowingOptions } from './typeorm-duplicate-eager-load-fix';
+
+describe('joinCoversRelation()', () => {
+    function relation(overrides: Partial<RelationMetadata> = {}): RelationMetadata {
+        return {
+            isEager: true,
+            propertyPath: 'productVariantPrices',
+            inverseEntityMetadata: { eagerRelations: [] },
+            ...overrides,
+        } as RelationMetadata;
+    }
+
+    const eagerRelation = relation();
+
+    function join(overrides: Partial<JoinAttribute> = {}): JoinAttribute {
+        return {
+            relation: eagerRelation,
+            parentAlias: 'productvariant',
+            direction: 'LEFT',
+            condition: undefined,
+            isSelected: true,
+            ...overrides,
+        } as JoinAttribute;
+    }
+
+    function covers(
+        target: RelationMetadata,
+        joins: JoinAttribute[],
+        findOptions: RelationLoadNarrowingOptions = {},
+    ) {
+        return joinCoversRelation(target, joins, 'productvariant', findOptions);
+    }
+
+    it('covers a selected, unconditional LEFT join of the relation', () => {
+        expect(covers(eagerRelation, [join()])).toBe(true);
+    });
+
+    it('does not cover when there is no join', () => {
+        expect(covers(eagerRelation, [])).toBe(false);
+    });
+
+    it('does not cover a join of a different relation', () => {
+        expect(covers(eagerRelation, [join({ relation: relation() })])).toBe(false);
+    });
+
+    it('does not cover a join from a different alias', () => {
+        expect(covers(eagerRelation, [join({ parentAlias: 'other' })])).toBe(false);
+    });
+
+    it('does not cover an INNER join', () => {
+        expect(covers(eagerRelation, [join({ direction: 'INNER' })])).toBe(false);
+    });
+
+    // A conditional join hydrates a subset of the relation, so the separate query still has to run.
+    it('does not cover a join carrying an ON condition', () => {
+        expect(covers(eagerRelation, [join({ condition: 'channel.id = :channelId' })])).toBe(false);
+    });
+
+    it('does not cover an unselected join', () => {
+        expect(covers(eagerRelation, [join({ isSelected: false })])).toBe(false);
+    });
+
+    it('does not cover a relation which is not eager', () => {
+        const target = relation({ isEager: false });
+        expect(covers(target, [join({ relation: target })])).toBe(false);
+    });
+
+    // Only the separate query loads the related entity's own eager relations.
+    it('does not cover a relation whose target has eager relations of its own', () => {
+        const target = relation({ inverseEntityMetadata: { eagerRelations: [{}] } as any });
+        expect(covers(target, [join({ relation: target })])).toBe(false);
+    });
+
+    it.each(['select', 'order', 'relations'] as const)(
+        'does not cover a relation the find options narrow through "%s"',
+        key => {
+            expect(
+                covers(eagerRelation, [join()], { [key]: { productVariantPrices: { price: true } } }),
+            ).toBe(false);
+        },
+    );
+
+    it('covers a relation the find options merely name', () => {
+        expect(covers(eagerRelation, [join()], { relations: { productVariantPrices: true } })).toBe(true);
+    });
+
+    it('covers a relation when the find options name an unrelated one', () => {
+        expect(covers(eagerRelation, [join()], { relations: { featuredAsset: true } })).toBe(true);
+    });
+
+    it('reads a dotted property path out of the find options', () => {
+        const nested = relation({ propertyPath: 'customFields.owner' });
+        expect(
+            covers(nested, [join({ relation: nested })], {
+                relations: { customFields: { owner: { roles: true } } },
+            }),
+        ).toBe(false);
+    });
+});

--- a/packages/core/src/entity/typeorm-duplicate-eager-load-fix.ts
+++ b/packages/core/src/entity/typeorm-duplicate-eager-load-fix.ts
@@ -59,10 +59,9 @@ export function patchTypeOrmDuplicateEagerLoad() {
  * would, so that running the query as well only repeats work.
  *
  * The join has to be a LEFT join of that relation from the queried entity, carry no extra ON
- * condition, and be selected. This is the same test TypeORM applies in the `join` strategy when
- * deciding whether an existing join can stand in for an eager one. A join which restricts its
- * rows — as a channel-scoped `INNER JOIN ... ON channel.id = :channelId` does — hydrates a subset
- * of the relation, so it does not cover it.
+ * condition, and be selected. A join which restricts its rows — as a channel-scoped
+ * `INNER JOIN ... ON channel.id = :channelId` does — hydrates a subset of the relation, and the
+ * separate query is what replaces that subset with the whole of it, so it is not covered.
  *
  * Beyond that, the separate query loads the related entity's own eager relations and honours any
  * `select`, `order` or `relations` the find options give for the relation, none of which a join

--- a/packages/core/src/entity/typeorm-duplicate-eager-load-fix.ts
+++ b/packages/core/src/entity/typeorm-duplicate-eager-load-fix.ts
@@ -1,0 +1,109 @@
+import { QueryRunner } from 'typeorm';
+import { RelationMetadata } from 'typeorm/metadata/RelationMetadata';
+import { JoinAttribute } from 'typeorm/query-builder/JoinAttribute';
+import { SelectQueryBuilder } from 'typeorm/query-builder/SelectQueryBuilder';
+
+let patchApplied = false;
+
+/**
+ * Options which narrow what a relation load returns. Only the shape this module inspects is
+ * declared; the find options carry more than this.
+ */
+export interface RelationLoadNarrowingOptions {
+    select?: any;
+    order?: any;
+    relations?: any;
+}
+
+/**
+ * Stops an eager relation from being loaded twice when the query already joins and selects it,
+ * under `relationLoadStrategy: 'query'`.
+ *
+ * Under that strategy each eager relation of the queried entity is fetched by a separate query
+ * after the main one, and the result is assigned over whatever the main query hydrated. A query
+ * which joins and selects an eager relation itself therefore pays for the relation twice: once
+ * in the join and once in the extra query. {@link ListQueryBuilder} does exactly this for the
+ * relations that a `@Calculated()` column's expression refers to, because the expression names
+ * the join alias and so the join has to exist for the SQL to resolve.
+ *
+ * The patch drops such a relation from the separate-query list, on the conditions described by
+ * {@link joinCoversRelation}.
+ */
+export function patchTypeOrmDuplicateEagerLoad() {
+    if (patchApplied) {
+        return;
+    }
+    patchApplied = true;
+
+    const proto = SelectQueryBuilder.prototype as any;
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const originalExecute = proto.executeEntitiesAndRawResults;
+    proto.executeEntitiesAndRawResults = function (this: any, queryRunner: QueryRunner) {
+        if (this.expressionMap.relationLoadStrategy === 'query' && this.relationMetadatas.length) {
+            this.relationMetadatas = this.relationMetadatas.filter(
+                (relation: RelationMetadata) =>
+                    !joinCoversRelation(
+                        relation,
+                        this.expressionMap.joinAttributes,
+                        this.expressionMap.mainAlias?.name,
+                        this.findOptions ?? {},
+                    ),
+            );
+        }
+        return originalExecute.call(this, queryRunner);
+    };
+}
+
+/**
+ * Whether one of the given joins already produces exactly what the separate query for `relation`
+ * would, so that running the query as well only repeats work.
+ *
+ * The join has to be a LEFT join of that relation from the queried entity, carry no extra ON
+ * condition, and be selected. This is the same test TypeORM applies in the `join` strategy when
+ * deciding whether an existing join can stand in for an eager one. A join which restricts its
+ * rows — as a channel-scoped `INNER JOIN ... ON channel.id = :channelId` does — hydrates a subset
+ * of the relation, so it does not cover it.
+ *
+ * Beyond that, the separate query loads the related entity's own eager relations and honours any
+ * `select`, `order` or `relations` the find options give for the relation, none of which a join
+ * of it reproduces. A relation is therefore only covered when neither applies to it.
+ */
+export function joinCoversRelation(
+    relation: RelationMetadata,
+    joinAttributes: JoinAttribute[],
+    mainAliasName: string | undefined,
+    findOptions: RelationLoadNarrowingOptions,
+): boolean {
+    if (!relation.isEager || relation.inverseEntityMetadata.eagerRelations.length > 0) {
+        return false;
+    }
+    const narrowed = [findOptions.select, findOptions.order, findOptions.relations].some(options =>
+        hasOptionsForPath(options, relation.propertyPath),
+    );
+    if (narrowed) {
+        return false;
+    }
+    return joinAttributes.some(
+        join =>
+            join.relation === relation &&
+            join.parentAlias === mainAliasName &&
+            join.direction === 'LEFT' &&
+            join.condition === undefined &&
+            join.isSelected,
+    );
+}
+
+/**
+ * Whether the given find options object holds a nested object at `propertyPath`, i.e. says
+ * something about the contents of the relation rather than merely naming it.
+ */
+function hasOptionsForPath(options: any, propertyPath: string): boolean {
+    let value = options;
+    for (const segment of propertyPath.split('.')) {
+        if (value == null || typeof value !== 'object') {
+            return false;
+        }
+        value = value[segment];
+    }
+    return value != null && typeof value === 'object';
+}

--- a/packages/core/src/entity/typeorm-duplicate-eager-load-fix.ts
+++ b/packages/core/src/entity/typeorm-duplicate-eager-load-fix.ts
@@ -28,6 +28,9 @@ export interface RelationLoadNarrowingOptions {
  *
  * The patch drops such a relation from the separate-query list, on the conditions described by
  * {@link joinCoversRelation}.
+ *
+ * Reported upstream as https://github.com/typeorm/typeorm/issues/12775. This workaround can be
+ * removed once the minimum supported TypeORM version contains a fix.
  */
 export function patchTypeOrmDuplicateEagerLoad() {
     if (patchApplied) {

--- a/packages/core/src/entity/typeorm-relation-id-loader-fix.ts
+++ b/packages/core/src/entity/typeorm-relation-id-loader-fix.ts
@@ -4,6 +4,8 @@ import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata';
 import { RelationMetadata } from 'typeorm/metadata/RelationMetadata';
 import { RelationIdLoader } from 'typeorm/query-builder/RelationIdLoader';
 
+import { DataSourceHolder, getDataSource } from '../connection/get-data-source';
+
 let patchApplied = false;
 
 /**
@@ -51,9 +53,13 @@ export function patchTypeOrmRelationIdLoader() {
     ]) {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         const originalMethod = proto[methodName];
-        proto[methodName] = async function (relation: RelationMetadata, ...rest: any[]) {
+        proto[methodName] = async function (
+            this: DataSourceHolder,
+            relation: RelationMetadata,
+            ...rest: any[]
+        ) {
             const rows = await originalMethod.apply(this, [relation, ...rest]);
-            return normalizeGroupingKeys(this.connection.driver, relation, rows);
+            return normalizeGroupingKeys(getDataSource(this).driver, relation, rows);
         };
     }
 }

--- a/packages/core/src/migrate.ts
+++ b/packages/core/src/migrate.ts
@@ -10,6 +10,7 @@ import { camelCase } from 'typeorm/util/StringUtils';
 import { preBootstrapConfig } from './bootstrap';
 import { resetConfig } from './config/config-helpers';
 import { VendureConfig } from './config/vendure-config';
+import { getDatabaseType } from './connection/database-type';
 
 /**
  * @description
@@ -224,7 +225,7 @@ async function createEmptyDatabaseConnection(
     config: Partial<VendureConfig>,
 ): Promise<EmptyDatabaseConnection> {
     const baseOptions = createDataSourceOptions(config);
-    switch (baseOptions.type) {
+    switch (getDatabaseType(baseOptions)) {
         // aurora-postgres/aurora-mysql are intentionally excluded: they connect over the Aurora
         // Data API, where `CREATE DATABASE` is not supported the same way, and this has not been
         // verified - so they fall through to the clear "unsupported" error below.
@@ -380,7 +381,8 @@ function emptySqliteOptions(baseOptions: DataSourceOptions): DataSourceOptions {
  * See https://github.com/typeorm/typeorm/issues/2576#issuecomment-499506647
  */
 async function disableForeignKeysForSqLite<T>(connection: DataSource, work: () => Promise<T>): Promise<T> {
-    const isSqLite = connection.options.type === 'sqlite' || connection.options.type === 'better-sqlite3';
+    const dbType = getDatabaseType(connection);
+    const isSqLite = dbType === 'sqlite' || dbType === 'better-sqlite3';
     if (isSqLite) {
         await connection.query('PRAGMA foreign_keys=OFF');
     }

--- a/packages/core/src/migrate.ts
+++ b/packages/core/src/migrate.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'crypto';
 import fs from 'fs-extra';
 import path from 'path';
 import pc from 'picocolors';
-import { Connection, createConnection, DataSourceOptions } from 'typeorm';
+import { DataSource, DataSourceOptions } from 'typeorm';
 import { MysqlDriver } from 'typeorm/driver/mysql/MysqlDriver';
 import { camelCase } from 'typeorm/util/StringUtils';
 
@@ -56,7 +56,7 @@ export interface MigrationOptions {
  */
 export async function runMigrations(userConfig: Partial<VendureConfig>): Promise<string[]> {
     const config = await preBootstrapConfig(userConfig);
-    const connection = await createConnection(createConnectionOptions(config));
+    const connection = await createDataSource(createDataSourceOptions(config));
     const migrationsRan: string[] = [];
     try {
         const migrations = await disableForeignKeysForSqLite(connection, () =>
@@ -76,13 +76,13 @@ export async function runMigrations(userConfig: Partial<VendureConfig>): Promise
         }
     } finally {
         await checkMigrationStatus(connection);
-        await connection.close();
+        await connection.destroy();
         resetConfig();
     }
     return migrationsRan;
 }
 
-async function checkMigrationStatus(connection: Connection) {
+async function checkMigrationStatus(connection: DataSource) {
     const builderLog = await connection.driver.createSchemaBuilder().log();
     if (builderLog.upQueries.length) {
         log(
@@ -105,7 +105,7 @@ async function checkMigrationStatus(connection: Connection) {
  */
 export async function revertLastMigration(userConfig: Partial<VendureConfig>) {
     const config = await preBootstrapConfig(userConfig);
-    const connection = await createConnection(createConnectionOptions(config));
+    const connection = await createDataSource(createDataSourceOptions(config));
     try {
         await disableForeignKeysForSqLite(connection, () =>
             connection.undoLastMigration({ transaction: 'each' }),
@@ -119,7 +119,7 @@ export async function revertLastMigration(userConfig: Partial<VendureConfig>) {
             process.exitCode = 1;
         }
     } finally {
-        await connection.close();
+        await connection.destroy();
         resetConfig();
     }
 }
@@ -139,7 +139,7 @@ export async function generateMigration(
     const config = await preBootstrapConfig(userConfig);
     const { connection, cleanup } = options.fromEmpty
         ? await createEmptyDatabaseConnection(config)
-        : { connection: await createConnection(createConnectionOptions(config)), cleanup: undefined };
+        : { connection: await createDataSource(createDataSourceOptions(config)), cleanup: undefined };
 
     let migrationName: string | undefined;
     try {
@@ -173,11 +173,11 @@ export async function generateMigration(
             log(pc.yellow('No changes in database schema were found - cannot generate a migration.'));
         }
     } finally {
-        // Nested so that a failing connection.close() still drops the shadow database (cleanup)
+        // Nested so that a failing connection.destroy() still drops the shadow database (cleanup)
         // and resets the config, rather than orphaning the shadow DB and leaking the admin
         // connection.
         try {
-            await connection.close();
+            await connection.destroy();
         } finally {
             if (cleanup) {
                 await cleanup();
@@ -188,7 +188,7 @@ export async function generateMigration(
     return migrationName;
 }
 
-function createConnectionOptions(userConfig: Partial<VendureConfig>): DataSourceOptions {
+function createDataSourceOptions(userConfig: Partial<VendureConfig>): DataSourceOptions {
     return Object.assign({ logging: ['query', 'error', 'schema'] }, userConfig.dbConnectionOptions, {
         subscribers: [],
         synchronize: false,
@@ -198,11 +198,15 @@ function createConnectionOptions(userConfig: Partial<VendureConfig>): DataSource
     });
 }
 
+function createDataSource(options: DataSourceOptions): Promise<DataSource> {
+    return new DataSource(options).initialize();
+}
+
 interface EmptyDatabaseConnection {
-    connection: Connection;
+    connection: DataSource;
     /**
      * Tears down any temporary database that was provisioned. Must be called *after* the
-     * {@link connection} has been closed.
+     * {@link connection} has been destroyed.
      */
     cleanup?: () => Promise<void>;
 }
@@ -219,7 +223,7 @@ interface EmptyDatabaseConnection {
 async function createEmptyDatabaseConnection(
     config: Partial<VendureConfig>,
 ): Promise<EmptyDatabaseConnection> {
-    const baseOptions = createConnectionOptions(config);
+    const baseOptions = createDataSourceOptions(config);
     switch (baseOptions.type) {
         // aurora-postgres/aurora-mysql are intentionally excluded: they connect over the Aurora
         // Data API, where `CREATE DATABASE` is not supported the same way, and this has not been
@@ -232,7 +236,7 @@ async function createEmptyDatabaseConnection(
         case 'better-sqlite3':
         case 'sqlite':
         case 'sqljs':
-            return { connection: await createConnection(emptySqliteOptions(baseOptions)) };
+            return { connection: await createDataSource(emptySqliteOptions(baseOptions)) };
         default:
             throw new Error(
                 `Generating a migration from an empty database is not supported for the "${baseOptions.type}" ` +
@@ -294,9 +298,8 @@ async function provisionShadowDatabase(
 
     // An admin connection to the *configured* database, used only to create and later drop the
     // temporary shadow database.
-    const admin = await createConnection({
+    const admin = await createDataSource({
         ...master,
-        name: `vendure-shadow-admin-${shadowName}`,
         entities: [],
         migrations: [],
         logging: false,
@@ -314,27 +317,24 @@ async function provisionShadowDatabase(
     try {
         await admin.query(`CREATE DATABASE ${quotedName}${charsetClause}`);
     } catch (e: any) {
-        await admin.close();
+        await admin.destroy();
         throw new Error(
             `Could not create the temporary shadow database ${shadowName}. Ensure the configured database ` +
                 `user has permission to create databases. Original error: ${e.message as string}`,
         );
     }
 
-    let connection: Connection;
+    let connection: DataSource;
     try {
         // `withDatabase` retargets the shadow connection at shadowName, accounting for a database
         // embedded in a connection `url` (which would otherwise override the top-level `database`
         // and point the shadow connection back at the real configured database).
-        connection = await createConnection({
-            ...withDatabase(master, shadowName),
-            name: `vendure-shadow-${shadowName}`,
-        } as DataSourceOptions);
+        connection = await createDataSource(withDatabase(master, shadowName));
     } catch (e) {
         // The shadow database was created but we could not connect to it - drop it so it is not
         // left behind, then surface the original error.
         await admin.query(`DROP DATABASE IF EXISTS ${quotedName}`).catch(() => undefined);
-        await admin.close();
+        await admin.destroy();
         throw e;
     }
 
@@ -352,7 +352,7 @@ async function provisionShadowDatabase(
                 }
                 await admin.query(`DROP DATABASE IF EXISTS ${quotedName}`);
             } finally {
-                await admin.close();
+                await admin.destroy();
             }
         },
     };
@@ -383,7 +383,7 @@ function emptySqliteOptions(baseOptions: DataSourceOptions): DataSourceOptions {
  * is a work-around for the issue.
  * See https://github.com/typeorm/typeorm/issues/2576#issuecomment-499506647
  */
-async function disableForeignKeysForSqLite<T>(connection: Connection, work: () => Promise<T>): Promise<T> {
+async function disableForeignKeysForSqLite<T>(connection: DataSource, work: () => Promise<T>): Promise<T> {
     const isSqLite = connection.options.type === 'sqlite' || connection.options.type === 'better-sqlite3';
     if (isSqLite) {
         await connection.query('PRAGMA foreign_keys=OFF');

--- a/packages/core/src/migrate.ts
+++ b/packages/core/src/migrate.ts
@@ -359,23 +359,19 @@ async function provisionShadowDatabase(
 }
 
 function emptySqliteOptions(baseOptions: DataSourceOptions): DataSourceOptions {
-    const shared = {
-        ...baseOptions,
-        name: `vendure-shadow-${uniqueShadowSuffix()}`,
-    };
     if (baseOptions.type === 'sqljs') {
         // For sqljs the database can be a Uint8Array of saved bytes; unset it (and the save
         // callback/location) so the shadow really is an empty in-memory database, not a restored
         // copy of a populated one.
         return {
-            ...shared,
+            ...baseOptions,
             location: undefined,
             database: undefined,
             autoSave: false,
             autoSaveCallback: undefined,
         } as unknown as DataSourceOptions;
     }
-    return { ...shared, database: ':memory:' } as DataSourceOptions;
+    return { ...baseOptions, database: ':memory:' } as DataSourceOptions;
 }
 
 /**

--- a/packages/core/src/migration-utils/v3_6_asset_translations.ts
+++ b/packages/core/src/migration-utils/v3_6_asset_translations.ts
@@ -5,6 +5,8 @@
 // once the migration has run.
 import { QueryRunner } from 'typeorm';
 
+import { getDataSource } from '../connection/get-data-source';
+
 /**
  * @description
  * Populates the new `asset_translation` table with data from the existing `name`
@@ -49,7 +51,7 @@ export async function migrateAssetTranslationData(queryRunner: QueryRunner): Pro
         return;
     }
 
-    const esc = (name: string) => queryRunner.connection.driver.escape(name);
+    const esc = (name: string) => getDataSource(queryRunner).driver.escape(name);
 
     // 1. If there is no asset data to migrate, skip entirely. This covers the
     // fresh-install case where migrations run against an empty database before

--- a/packages/core/src/migration-utils/v3_6_shared_option_groups.ts
+++ b/packages/core/src/migration-utils/v3_6_shared_option_groups.ts
@@ -5,6 +5,8 @@
 // once the migration has run.
 import { QueryRunner } from 'typeorm';
 
+import { getDataSource } from '../connection/get-data-source';
+
 /**
  * @description
  * Populates the new join tables for shared, channel-aware ProductOptionGroups
@@ -50,7 +52,7 @@ export async function migrateProductOptionGroupData(queryRunner: QueryRunner): P
         return;
     }
 
-    const esc = (name: string) => queryRunner.connection.driver.escape(name);
+    const esc = (name: string) => getDataSource(queryRunner).driver.escape(name);
 
     // 1. Populate Product <-> ProductOptionGroup join table from existing FK
     await queryRunner.query(

--- a/packages/core/src/plugin/default-job-queue-plugin/sql-job-queue-strategy.ts
+++ b/packages/core/src/plugin/default-job-queue-plugin/sql-job-queue-strategy.ts
@@ -5,6 +5,7 @@ import { Brackets, DataSource, EntityManager, FindOptionsWhere, In, LessThan } f
 import { Injector } from '../../common/injector';
 import { InspectableJobQueueStrategy, JobQueueStrategy } from '../../config';
 import { Logger } from '../../config/logger/vendure-logger';
+import { getDatabaseType } from '../../connection/database-type';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { Job, JobData, JobQueueStrategyJobOptions } from '../../job-queue';
 import { PollingJobQueueStrategy } from '../../job-queue/polling-job-queue-strategy';
@@ -84,7 +85,7 @@ export class SqlJobQueueStrategy extends PollingJobQueueStrategy implements Insp
             throw new Error('Connection not available');
         }
         const connection = this.rawConnection;
-        const connectionType = this.rawConnection.options.type;
+        const connectionType = getDatabaseType(this.rawConnection);
         const isSQLite =
             connectionType === 'sqlite' || connectionType === 'sqljs' || connectionType === 'better-sqlite3';
 

--- a/packages/core/src/plugin/default-job-queue-plugin/sql-job-queue-strategy.ts
+++ b/packages/core/src/plugin/default-job-queue-plugin/sql-job-queue-strategy.ts
@@ -54,7 +54,7 @@ export class SqlJobQueueStrategy extends PollingJobQueueStrategy implements Insp
      * In order to try to prevent that, this method will truncate any strings in the `data` object over 2kb in size.
      */
     private constrainDataSize<Data extends JobData<Data> = object>(job: Job<Data>): Data | undefined {
-        const type = this.rawConnection?.options.type;
+        const type = this.rawConnection && getDatabaseType(this.rawConnection);
         if (type === 'mysql' || type === 'mariadb') {
             const stringified = JSON.stringify(job.data);
             if (64 * 1024 <= stringified.length) {

--- a/packages/core/src/plugin/default-job-queue-plugin/sql-job-queue-strategy.ts
+++ b/packages/core/src/plugin/default-job-queue-plugin/sql-job-queue-strategy.ts
@@ -1,6 +1,6 @@
 import { JobListOptions, JobState } from '@vendure/common/lib/generated-types';
 import { ID, PaginatedList } from '@vendure/common/lib/shared-types';
-import { Brackets, Connection, EntityManager, FindOptionsWhere, In, LessThan } from 'typeorm';
+import { Brackets, DataSource, EntityManager, FindOptionsWhere, In, LessThan } from 'typeorm';
 
 import { Injector } from '../../common/injector';
 import { InspectableJobQueueStrategy, JobQueueStrategy } from '../../config';
@@ -20,7 +20,7 @@ import { JobRecord } from './job-record.entity';
  * @docsCategory JobQueue
  */
 export class SqlJobQueueStrategy extends PollingJobQueueStrategy implements InspectableJobQueueStrategy {
-    private rawConnection: Connection | undefined;
+    private rawConnection: DataSource | undefined;
     private connection: TransactionalConnection | undefined;
     private listQueryBuilder: ListQueryBuilder;
 
@@ -222,8 +222,8 @@ export class SqlJobQueueStrategy extends PollingJobQueueStrategy implements Insp
         return deleteCount;
     }
 
-    private connectionAvailable(connection: Connection | undefined): connection is Connection {
-        return !!this.rawConnection && this.rawConnection.isConnected;
+    private connectionAvailable(connection: DataSource | undefined): connection is DataSource {
+        return !!this.rawConnection && this.rawConnection.isInitialized;
     }
 
     private toRecord(job: Job<any>, data?: any, retries?: number): JobRecord {

--- a/packages/core/src/plugin/default-search-plugin/fulltext-search.service.ts
+++ b/packages/core/src/plugin/default-search-plugin/fulltext-search.service.ts
@@ -4,6 +4,7 @@ import { Omit } from '@vendure/common/lib/omit';
 
 import { RequestContext } from '../../api/common/request-context';
 import { InternalServerError } from '../../common/error/errors';
+import { getDatabaseType } from '../../connection/database-type';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { Collection, FacetValue } from '../../entity';
 import { EventBus } from '../../event-bus/event-bus';
@@ -114,7 +115,7 @@ export class FulltextSearchService {
         if (this.options.searchStrategy) {
             this._searchStrategy = this.options.searchStrategy;
         } else {
-            switch (this.connection.rawConnection.options.type) {
+            switch (getDatabaseType(this.connection.rawConnection)) {
                 case 'mysql':
                 case 'mariadb':
                 case 'aurora-mysql':

--- a/packages/core/src/plugin/default-search-plugin/indexer/indexer.controller.ts
+++ b/packages/core/src/plugin/default-search-plugin/indexer/indexer.controller.ts
@@ -36,6 +36,7 @@ import {
     VariantChannelMessageData,
 } from '../types';
 
+import { findOptionsArrayToObject } from '../../../connection/find-options-array-to-object';
 import { dedupeSearchIndexItems } from './index-item-utils';
 import { MutableRequestContext } from './mutable-request-context';
 
@@ -372,7 +373,7 @@ export class IndexerController {
         where.channels = { id: In(channels.map(c => c.id)) };
         const [variants, count] = await this.connection.getRepository(ctx, ProductVariant).findAndCount({
             loadEagerRelations: false,
-            relations: variantRelations,
+            relations: findOptionsArrayToObject<ProductVariant>(variantRelations),
             where,
             take,
             skip,
@@ -396,7 +397,7 @@ export class IndexerController {
 
         const product = await this.connection.getRepository(ctx, Product).findOne({
             loadEagerRelations: false,
-            relations: productRelations,
+            relations: findOptionsArrayToObject<Product>(productRelations),
             relationLoadStrategy: 'query',
             where: { id: Equal(productId), channels: { id: In(channels.map(x => x.id)) } },
         });

--- a/packages/core/src/plugin/default-search-plugin/indexer/indexer.controller.ts
+++ b/packages/core/src/plugin/default-search-plugin/indexer/indexer.controller.ts
@@ -13,6 +13,7 @@ import { Translatable, Translation } from '../../../common/types/locale-types';
 import { asyncObservable, idsAreEqual } from '../../../common/utils';
 import { ConfigService } from '../../../config/config.service';
 import { Logger } from '../../../config/logger/vendure-logger';
+import { findOptionsArrayToObject } from '../../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../../connection/transactional-connection';
 import { Channel } from '../../../entity/channel/channel.entity';
 import { FacetValue } from '../../../entity/facet-value/facet-value.entity';
@@ -36,7 +37,6 @@ import {
     VariantChannelMessageData,
 } from '../types';
 
-import { findOptionsArrayToObject } from '../../../connection/find-options-array-to-object';
 import { dedupeSearchIndexItems } from './index-item-utils';
 import { MutableRequestContext } from './mutable-request-context';
 

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -5,6 +5,7 @@ import { SelectQueryBuilder } from 'typeorm';
 
 import { RequestContext } from '../../../api/common/request-context';
 import { InternalServerError } from '../../../common/error/errors';
+import { findOptionsArrayToObject } from '../../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../../connection/transactional-connection';
 import { VendureEntity } from '../../../entity/base/base.entity';
 import { ProductVariant } from '../../../entity/product-variant/product-variant.entity';
@@ -136,7 +137,9 @@ export class EntityHydrator {
                 hydratedQb.setFindOptions({
                     relationLoadStrategy: 'query',
                     where: { id: target.id },
-                    relations: missingRelations.filter(relationPath => !joinedRelations.has(relationPath)),
+                    relations: findOptionsArrayToObject(
+                        missingRelations.filter(relationPath => !joinedRelations.has(relationPath)),
+                    ),
                 });
                 const hydrated = await hydratedQb.getOne();
                 const propertiesToAdd = unique(missingRelations.map(relation => relation.split('.')[0]));

--- a/packages/core/src/service/helpers/facet-value-checker/facet-value-checker.ts
+++ b/packages/core/src/service/helpers/facet-value-checker/facet-value-checker.ts
@@ -123,7 +123,7 @@ export class FacetValueChecker implements OnModuleInit {
                 .getRepository(ctx, ProductVariant)
                 .findOne({
                     where: { id: orderLine.productVariant.id },
-                    relations: ['product', 'product.facetValues', 'facetValues'],
+                    relations: { product: { facetValues: true }, facetValues: true },
                     loadEagerRelations: false,
                 })
                 .then(result => result ?? undefined);

--- a/packages/core/src/service/helpers/list-query-builder/calculated-column-join.spec.ts
+++ b/packages/core/src/service/helpers/list-query-builder/calculated-column-join.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveCalculatedColumnJoin } from './calculated-column-join';
+
+describe('resolveCalculatedColumnJoin()', () => {
+    describe('when the expression does not reference the eager-join alias', () => {
+        it('joins the relation under its own name', () => {
+            expect(resolveCalculatedColumnJoin('order', 'lines')).toEqual({
+                propertyPath: 'order.lines',
+                alias: 'lines',
+                joinType: 'inner',
+            });
+        });
+
+        it('joins under its own name when the expression names a different relation', () => {
+            expect(resolveCalculatedColumnJoin('order', 'lines', 'shippingLines.listPrice')).toEqual({
+                propertyPath: 'order.lines',
+                alias: 'lines',
+                joinType: 'inner',
+            });
+        });
+
+        it('joins under its own name when the expression uses the plain relation alias', () => {
+            expect(resolveCalculatedColumnJoin('order', 'lines', 'lines.listPrice')).toEqual({
+                propertyPath: 'order.lines',
+                alias: 'lines',
+                joinType: 'inner',
+            });
+        });
+    });
+
+    describe('when the expression references the eager-join alias', () => {
+        it('joins under that alias with a left join', () => {
+            expect(
+                resolveCalculatedColumnJoin(
+                    'productvariant',
+                    'productVariantPrices',
+                    'productvariant__productVariantPrices.price',
+                ),
+            ).toEqual({
+                propertyPath: 'productvariant.productVariantPrices',
+                alias: 'productvariant__productVariantPrices',
+                joinType: 'left',
+            });
+        });
+
+        it('matches the alias regardless of case', () => {
+            expect(
+                resolveCalculatedColumnJoin(
+                    'productVariant',
+                    'productVariantPrices',
+                    'productvariant__productvariantprices.price',
+                ),
+            ).toEqual({
+                propertyPath: 'productVariant.productVariantPrices',
+                alias: 'productvariant__productvariantprices',
+                joinType: 'left',
+            });
+        });
+    });
+
+    describe('nested relation paths', () => {
+        it('uses the path as given and aliases on its last segment', () => {
+            expect(resolveCalculatedColumnJoin('order', 'lines.productVariant')).toEqual({
+                propertyPath: 'lines.productVariant',
+                alias: 'productVariant',
+                joinType: 'inner',
+            });
+        });
+
+        it('builds the eager-style alias from the last segment', () => {
+            expect(
+                resolveCalculatedColumnJoin('order', 'lines.productVariant', 'order__productVariant.sku'),
+            ).toEqual({
+                propertyPath: 'lines.productVariant',
+                alias: 'order__productVariant',
+                joinType: 'left',
+            });
+        });
+    });
+
+    it('ignores an expression which does not start with an alias reference', () => {
+        expect(resolveCalculatedColumnJoin('order', 'lines', 'SUM(order__lines.quantity)')).toEqual({
+            propertyPath: 'order.lines',
+            alias: 'lines',
+            joinType: 'inner',
+        });
+    });
+});

--- a/packages/core/src/service/helpers/list-query-builder/calculated-column-join.ts
+++ b/packages/core/src/service/helpers/list-query-builder/calculated-column-join.ts
@@ -1,0 +1,37 @@
+/**
+ * The join required by a relation listed on a calculated column's `listQuery` instruction.
+ */
+export interface CalculatedColumnJoin {
+    propertyPath: string;
+    alias: string;
+    joinType: 'left' | 'inner';
+}
+
+/**
+ * Resolves the property path, alias and join type for a relation which a calculated column
+ * expression depends on.
+ *
+ * TypeORM joins eager relations under `<entityAlias>__<relation>`. An expression written
+ * against that alias is embedded into the SQL verbatim, so the join has to be created under
+ * that exact name, and with a LEFT JOIN to match how the eager join would have behaved.
+ * Otherwise the relation is joined under its own name with an INNER JOIN.
+ */
+export function resolveCalculatedColumnJoin(
+    entityAlias: string,
+    relation: string,
+    expression?: string,
+): CalculatedColumnJoin {
+    const isNestedPath = relation.includes('.');
+    const propertyPath = isNestedPath ? relation : `${entityAlias}.${relation}`;
+    const baseAlias = isNestedPath ? relation.split('.').reverse()[0] : relation;
+    const expressionAlias = expression?.match(/^(\w+)\.\w+/)?.[1];
+    const eagerStyleAlias = `${entityAlias}__${baseAlias}`;
+    const usesEagerStyleAlias =
+        expressionAlias != null && expressionAlias.toLowerCase() === eagerStyleAlias.toLowerCase();
+
+    return {
+        propertyPath,
+        alias: usesEagerStyleAlias ? expressionAlias : baseAlias,
+        joinType: usesEagerStyleAlias ? 'left' : 'inner',
+    };
+}

--- a/packages/core/src/service/helpers/list-query-builder/connection-utils.ts
+++ b/packages/core/src/service/helpers/list-query-builder/connection-utils.ts
@@ -34,10 +34,6 @@ export function getColumnMetadata<T>(connection: DataSource, entity: Type<T>) {
     return { columns, translationColumns, alias };
 }
 
-export function getEntityAlias<T>(connection: DataSource, entity: Type<T>): string {
-    return connection.getMetadata(entity).name.toLowerCase();
-}
-
 /**
  * @description
  * Escapes identifiers in an expression according to the current database driver.

--- a/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
+++ b/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
@@ -27,6 +27,7 @@ import { TransactionalConnection } from '../../../connection';
 import { VendureEntity } from '../../../entity';
 import { joinTreeRelationsDynamically } from '../utils/tree-relations-qb-joiner';
 
+import { findOptionsArrayToObject } from '../../../connection/find-options-array-to-object';
 import { getColumnMetadata, getEntityAlias } from './connection-utils';
 import { getCalculatedColumns } from './get-calculated-columns';
 import { parseFilterParams, WhereCondition, WhereGroup } from './parse-filter-params';
@@ -287,7 +288,7 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
         relations = relations.filter(relationPath => !processedRelations.has(relationPath));
 
         qb.setFindOptions({
-            relations,
+            relations: findOptionsArrayToObject<T>(relations),
             take,
             skip,
             where: extendedOptions.where || {},

--- a/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
+++ b/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
@@ -29,6 +29,7 @@ import { getDataSource } from '../../../connection/get-data-source';
 import { VendureEntity } from '../../../entity';
 import { joinTreeRelationsDynamically } from '../utils/tree-relations-qb-joiner';
 
+import { resolveCalculatedColumnJoin } from './calculated-column-join';
 import { getColumnMetadata } from './connection-utils';
 import { getCalculatedColumns } from './get-calculated-columns';
 import { parseFilterParams, WhereCondition, WhereGroup } from './parse-filter-params';
@@ -782,26 +783,17 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
             const instruction = calculatedColumnDef?.listQuery;
             if (instruction) {
                 const relations = instruction.relations || [];
-                const expressionAlias = instruction.expression?.match(/^(\w+)\.\w+/)?.[1];
                 for (const relation of relations) {
-                    const propertyPath = relation.includes('.') ? relation : `${alias}.${relation}`;
-                    const baseAlias = relation.includes('.')
-                        ? relation.split('.').reverse()[0]
-                        : relation;
-                    // When the expression references the relation under the alias which TypeORM
-                    // uses for eagerly-joined relations (`<entityAlias>__<relation>`), the join
-                    // must be created under that exact name, since the expression is embedded
-                    // in the SQL as-is.
-                    const eagerStyleAlias = `${alias}__${baseAlias}`;
-                    const usesEagerStyleAlias =
-                        expressionAlias != null &&
-                        expressionAlias.toLowerCase() === eagerStyleAlias.toLowerCase();
-                    const relationAlias = usesEagerStyleAlias ? expressionAlias : baseAlias;
+                    const {
+                        propertyPath,
+                        alias: relationAlias,
+                        joinType,
+                    } = resolveCalculatedColumnJoin(alias, relation, instruction.expression);
                     // The check is on the alias rather than the relation property path, because
                     // the expression references the alias by name. The same relation joined
                     // under a different alias does not satisfy that reference.
                     if (!this.isRelationAlreadyJoined(qb, relationAlias)) {
-                        if (usesEagerStyleAlias) {
+                        if (joinType === 'left') {
                             qb.leftJoinAndSelect(propertyPath, relationAlias);
                         } else {
                             qb.innerJoinAndSelect(propertyPath, relationAlias);
@@ -871,9 +863,7 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
             }
         }
         const filterKeys = this.getFilterFields(filterParams);
-        const filteringOnTranslatableKey = translationColumns.some(c =>
-            filterKeys.includes(c.propertyName),
-        );
+        const filteringOnTranslatableKey = translationColumns.some(c => filterKeys.includes(c.propertyName));
 
         if (translationColumns.length && (sortingOnTranslatableKey || filteringOnTranslatableKey)) {
             const translationsAlias = `${alias}__translations`;

--- a/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
+++ b/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
@@ -24,10 +24,10 @@ import {
 import { Instrument } from '../../../common/instrument-decorator';
 import { ConfigService, CustomFields, Logger } from '../../../config';
 import { TransactionalConnection } from '../../../connection';
+import { findOptionsArrayToObject } from '../../../connection/find-options-array-to-object';
 import { VendureEntity } from '../../../entity';
 import { joinTreeRelationsDynamically } from '../utils/tree-relations-qb-joiner';
 
-import { findOptionsArrayToObject } from '../../../connection/find-options-array-to-object';
 import { getColumnMetadata, getEntityAlias } from './connection-utils';
 import { getCalculatedColumns } from './get-calculated-columns';
 import { parseFilterParams, WhereCondition, WhereGroup } from './parse-filter-params';
@@ -482,7 +482,10 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
         // Helper to escape identifiers for the current database driver (handles PostgreSQL quoting)
         const escapeId = (name: string) => mainQb.connection.driver.escape(name);
         const escapeTablePath = (path: string) =>
-            path.split('.').map(segment => mainQb.connection.driver.escape(segment)).join('.');
+            path
+                .split('.')
+                .map(segment => mainQb.connection.driver.escape(segment))
+                .join('.');
 
         let existsQuery: string;
 

--- a/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
+++ b/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
@@ -29,7 +29,7 @@ import { getDataSource } from '../../../connection/get-data-source';
 import { VendureEntity } from '../../../entity';
 import { joinTreeRelationsDynamically } from '../utils/tree-relations-qb-joiner';
 
-import { getColumnMetadata, getEntityAlias } from './connection-utils';
+import { getColumnMetadata } from './connection-utils';
 import { getCalculatedColumns } from './get-calculated-columns';
 import { parseFilterParams, WhereCondition, WhereGroup } from './parse-filter-params';
 import { parseSortParams } from './parse-sort-params';
@@ -310,7 +310,7 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
 
         const customFieldsForType = this.configService.customFields[entity.name as keyof CustomFields];
         const sortParams = Object.assign({}, options.sort, extendedOptions.orderBy);
-        this.applyTranslationConditions(qb, entity, sortParams, extendedOptions.ctx);
+        this.applyTranslationConditions(qb, entity, sortParams, options.filter, extendedOptions.ctx);
         const dataSource = getDataSource(qb);
         const sort = parseSortParams(
             dataSource,
@@ -776,22 +776,36 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
     ) {
         const calculatedColumns = getCalculatedColumns(entity);
         const filterAndSortFields = this.getFilterAndSortFields(options);
-        const alias = getEntityAlias(this.connection.rawConnection, entity);
+        const alias = qb.alias;
         for (const field of filterAndSortFields) {
             const calculatedColumnDef = calculatedColumns.find(c => c.name === field);
             const instruction = calculatedColumnDef?.listQuery;
             if (instruction) {
                 const relations = instruction.relations || [];
+                const expressionAlias = instruction.expression?.match(/^(\w+)\.\w+/)?.[1];
                 for (const relation of relations) {
-                    const relationIsAlreadyJoined = qb.expressionMap.joinAttributes.find(
-                        ja => ja.entityOrProperty === `${alias}.${relation}`,
-                    );
-                    if (!relationIsAlreadyJoined) {
-                        const propertyPath = relation.includes('.') ? relation : `${alias}.${relation}`;
-                        const relationAlias = relation.includes('.')
-                            ? relation.split('.').reverse()[0]
-                            : relation;
-                        qb.innerJoinAndSelect(propertyPath, relationAlias);
+                    const propertyPath = relation.includes('.') ? relation : `${alias}.${relation}`;
+                    const baseAlias = relation.includes('.')
+                        ? relation.split('.').reverse()[0]
+                        : relation;
+                    // When the expression references the relation under the alias which TypeORM
+                    // uses for eagerly-joined relations (`<entityAlias>__<relation>`), the join
+                    // must be created under that exact name, since the expression is embedded
+                    // in the SQL as-is.
+                    const eagerStyleAlias = `${alias}__${baseAlias}`;
+                    const usesEagerStyleAlias =
+                        expressionAlias != null &&
+                        expressionAlias.toLowerCase() === eagerStyleAlias.toLowerCase();
+                    const relationAlias = usesEagerStyleAlias ? expressionAlias : baseAlias;
+                    // The check is on the alias rather than the relation property path, because
+                    // the expression references the alias by name. The same relation joined
+                    // under a different alias does not satisfy that reference.
+                    if (!this.isRelationAlreadyJoined(qb, relationAlias)) {
+                        if (usesEagerStyleAlias) {
+                            qb.leftJoinAndSelect(propertyPath, relationAlias);
+                        } else {
+                            qb.innerJoinAndSelect(propertyPath, relationAlias);
+                        }
                     }
                 }
                 if (typeof instruction.query === 'function') {
@@ -831,14 +845,16 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
 
     /**
      * @description
-     * If this entity is Translatable, and we are sorting on one of the translatable fields,
-     * then we need to apply appropriate WHERE clauses to limit
-     * the joined translation relations.
+     * If this entity is Translatable, and we are sorting or filtering on one of the translatable
+     * fields, we need to join the translations. When sorting, we additionally apply WHERE clauses
+     * to limit the joined translation relations to a single language, so that the row ordering
+     * is deterministic.
      */
     private applyTranslationConditions<T extends VendureEntity>(
         qb: SelectQueryBuilder<any>,
         entity: Type<T>,
         sortParams: NullOptionals<SortParameter<T>> & FindOneOptions<T>['order'],
+        filterParams?: NullOptionals<FilterParameter<T>> | null,
         ctx?: RequestContext,
     ) {
         const languageCode = ctx?.languageCode || this.configService.defaultLanguageCode;
@@ -854,11 +870,18 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
                 sortingOnTranslatableKey = true;
             }
         }
+        const filterKeys = this.getFilterFields(filterParams);
+        const filteringOnTranslatableKey = translationColumns.some(c =>
+            filterKeys.includes(c.propertyName),
+        );
 
-        if (translationColumns.length && sortingOnTranslatableKey) {
-            const translationsAlias = dataSource.namingStrategy.joinTableName(alias, 'translations', '', '');
+        if (translationColumns.length && (sortingOnTranslatableKey || filteringOnTranslatableKey)) {
+            const translationsAlias = `${alias}__translations`;
             if (!this.isRelationAlreadyJoined(qb, translationsAlias)) {
                 qb.leftJoinAndSelect(`${alias}.translations`, translationsAlias);
+            }
+            if (!sortingOnTranslatableKey) {
+                return;
             }
 
             qb.andWhere(

--- a/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
+++ b/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
@@ -25,6 +25,7 @@ import { Instrument } from '../../../common/instrument-decorator';
 import { ConfigService, CustomFields, Logger } from '../../../config';
 import { TransactionalConnection } from '../../../connection';
 import { findOptionsArrayToObject } from '../../../connection/find-options-array-to-object';
+import { getDataSource } from '../../../connection/get-data-source';
 import { VendureEntity } from '../../../entity';
 import { joinTreeRelationsDynamically } from '../utils/tree-relations-qb-joiner';
 
@@ -310,8 +311,9 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
         const customFieldsForType = this.configService.customFields[entity.name as keyof CustomFields];
         const sortParams = Object.assign({}, options.sort, extendedOptions.orderBy);
         this.applyTranslationConditions(qb, entity, sortParams, extendedOptions.ctx);
+        const dataSource = getDataSource(qb);
         const sort = parseSortParams(
-            qb.connection,
+            dataSource,
             entity,
             sortParams,
             customPropertyMap,
@@ -320,7 +322,7 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
         );
 
         const filter = parseFilterParams({
-            connection: qb.connection,
+            connection: dataSource,
             entity,
             filterParams: options.filter,
             customPropertyMap,
@@ -480,11 +482,12 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
         const newParamKey = `exists_${baseParamKey}`;
 
         // Helper to escape identifiers for the current database driver (handles PostgreSQL quoting)
-        const escapeId = (name: string) => mainQb.connection.driver.escape(name);
+        const { driver } = getDataSource(mainQb);
+        const escapeId = (name: string) => driver.escape(name);
         const escapeTablePath = (path: string) =>
             path
                 .split('.')
-                .map(segment => mainQb.connection.driver.escape(segment))
+                .map(segment => driver.escape(segment))
                 .join('.');
 
         let existsQuery: string;
@@ -840,7 +843,8 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
     ) {
         const languageCode = ctx?.languageCode || this.configService.defaultLanguageCode;
 
-        const { translationColumns } = getColumnMetadata(qb.connection, entity);
+        const dataSource = getDataSource(qb);
+        const { translationColumns } = getColumnMetadata(dataSource, entity);
         const alias = qb.alias;
 
         const sortKeys = Object.keys(sortParams);
@@ -852,12 +856,7 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
         }
 
         if (translationColumns.length && sortingOnTranslatableKey) {
-            const translationsAlias = qb.connection.namingStrategy.joinTableName(
-                alias,
-                'translations',
-                '',
-                '',
-            );
+            const translationsAlias = dataSource.namingStrategy.joinTableName(alias, 'translations', '', '');
             if (!this.isRelationAlreadyJoined(qb, translationsAlias)) {
                 qb.leftJoinAndSelect(`${alias}.translations`, translationsAlias);
             }

--- a/packages/core/src/service/helpers/list-query-builder/parse-channel-param.ts
+++ b/packages/core/src/service/helpers/list-query-builder/parse-channel-param.ts
@@ -1,5 +1,5 @@
 import { ID, Type } from '@vendure/common/lib/shared-types';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 
 import { VendureEntity } from '../../../entity/base/base.entity';
 
@@ -10,7 +10,7 @@ import { WhereCondition } from './parse-filter-params';
  * which are assigned to the channel specified by channelId,
  */
 export function parseChannelParam<T extends VendureEntity>(
-    connection: Connection,
+    connection: DataSource,
     entity: Type<T>,
     channelId: ID,
     entityAlias?: string,

--- a/packages/core/src/service/helpers/list-query-builder/parse-filter-params.ts
+++ b/packages/core/src/service/helpers/list-query-builder/parse-filter-params.ts
@@ -1,7 +1,7 @@
 import { LogicalOperator } from '@vendure/common/lib/generated-types';
 import { Type } from '@vendure/common/lib/shared-types';
 import { assertNever } from '@vendure/common/lib/shared-utils';
-import { DataSource, DataSourceOptions } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { DateUtils } from 'typeorm/util/DateUtils';
 
 import { InternalServerError, UserInputError } from '../../../common/error/errors';
@@ -14,6 +14,7 @@ import {
     NumberOperators,
     StringOperators,
 } from '../../../common/types/common-types';
+import { getDatabaseType, VendureDatabaseType } from '../../../connection/database-type';
 import { VendureEntity } from '../../../entity/base/base.entity';
 
 import { escapeCalculatedColumnExpression, getColumnMetadata } from './connection-utils';
@@ -108,7 +109,7 @@ export function parseFilterParams<T extends VendureEntity>(
     const alias = entityAlias ?? defaultAlias;
     const calculatedColumns = getCalculatedColumns(entity);
 
-    const dbType = connection.options.type;
+    const dbType = getDatabaseType(connection);
     let argIndex = 1;
 
     // Detect which custom property fields map to *-to-Many relations.
@@ -260,7 +261,7 @@ function buildWhereCondition(
     operator: Operator,
     operand: any,
     argIndex: number,
-    dbType: DataSourceOptions['type'],
+    dbType: VendureDatabaseType,
 ): WhereCondition {
     switch (operator) {
         case 'eq':
@@ -385,7 +386,7 @@ function convertDate(input: Date | string | number): string | number {
 /**
  * Returns a valid regexp clause based on the current DB driver type.
  */
-function getRegexpClause(fieldName: string, argIndex: number, dbType: DataSourceOptions['type']): string {
+function getRegexpClause(fieldName: string, argIndex: number, dbType: VendureDatabaseType): string {
     switch (dbType) {
         case 'mariadb':
         case 'mysql':

--- a/packages/core/src/service/helpers/list-query-builder/parse-sort-params.spec.ts
+++ b/packages/core/src/service/helpers/list-query-builder/parse-sort-params.spec.ts
@@ -5,6 +5,7 @@ import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata';
 import { RelationMetadata } from 'typeorm/metadata/RelationMetadata';
 import { describe, expect, it } from 'vitest';
 
+import { Calculated } from '../../../common/calculated-decorator';
 import { SortParameter } from '../../../common/types/common-types';
 import { CustomFieldConfig } from '../../../config/custom-field/custom-field-types';
 import { ProductTranslation } from '../../../entity/product/product-translation.entity';
@@ -12,6 +13,24 @@ import { Product } from '../../../entity/product/product.entity';
 import { I18nError } from '../../../i18n/i18n-error';
 
 import { parseSortParams } from './parse-sort-params';
+
+class EntityWithCalculatedProperty {
+    @Calculated({
+        relations: ['productVariantPrices'],
+        expression: 'productVariantPrices.price',
+    })
+    get price(): number {
+        return 0;
+    }
+
+    @Calculated({
+        relations: ['productVariantPrices'],
+        expression: 'ROUND(productVariantPrices.price * 1.2)',
+    })
+    get priceWithTax(): number {
+        return 0;
+    }
+}
 
 describe('parseSortParams()', () => {
     it('works with no params', () => {
@@ -75,6 +94,52 @@ describe('parseSortParams()', () => {
         expect(result).toEqual({
             'product.id': 'ASC',
             'product__translations.name': 'DESC',
+        });
+    });
+
+    it('works with localized fields and a camelCase entity alias', () => {
+        const connection = new MockConnection();
+        connection.setColumns(Product, [{ propertyName: 'id' }, { propertyName: 'image' }]);
+        connection.setRelations(Product, [{ propertyName: 'translations', type: ProductTranslation }]);
+        connection.setColumns(ProductTranslation, [
+            { propertyName: 'id' },
+            { propertyName: 'name' },
+            { propertyName: 'base', relationMetadata: {} as any },
+        ]);
+
+        const sortParams: SortParameter<Product> = {
+            id: 'ASC',
+            name: 'DESC',
+        };
+
+        const result = parseSortParams(connection as any, Product, sortParams, undefined, 'productVariant');
+        expect(result).toEqual({
+            'productVariant.id': 'ASC',
+            'productVariant__translations.name': 'DESC',
+        });
+    });
+
+    it('leaves a simple property-path expression of a calculated column unescaped', () => {
+        const connection = new MockConnection();
+        connection.setColumns(EntityWithCalculatedProperty, [{ propertyName: 'id' }]);
+
+        const result = parseSortParams(connection as any, EntityWithCalculatedProperty, {
+            price: 'ASC',
+        } as any);
+        expect(result).toEqual({
+            'productVariantPrices.price': 'ASC',
+        });
+    });
+
+    it('escapes identifiers in a complex expression of a calculated column', () => {
+        const connection = new MockConnection();
+        connection.setColumns(EntityWithCalculatedProperty, [{ propertyName: 'id' }]);
+
+        const result = parseSortParams(connection as any, EntityWithCalculatedProperty, {
+            priceWithTax: 'ASC',
+        } as any);
+        expect(result).toEqual({
+            'ROUND("productVariantPrices".price * 1.2)': 'ASC',
         });
     });
 
@@ -160,6 +225,7 @@ export class MockConnection {
         };
     };
     namingStrategy = new DefaultNamingStrategy();
+    driver = { escape: (name: string) => `"${name}"` };
     readonly options = {
         type: 'sqljs',
     };

--- a/packages/core/src/service/helpers/list-query-builder/parse-sort-params.ts
+++ b/packages/core/src/service/helpers/list-query-builder/parse-sort-params.ts
@@ -46,7 +46,7 @@ export function parseSortParams<T extends VendureEntity>(
         if (matchingColumn) {
             output[`${alias}.${matchingColumn.propertyPath}`] = order as any;
         } else if (translationColumns.find(c => c.propertyName === key)) {
-            const translationsAlias = connection.namingStrategy.joinTableName(alias, 'translations', '', '');
+            const translationsAlias = `${alias}__translations`;
 
             const pathParts = [translationsAlias];
             const isLocaleStringCustomField =
@@ -59,7 +59,14 @@ export function parseSortParams<T extends VendureEntity>(
         } else if (calculatedColumnDef) {
             const instruction = calculatedColumnDef.listQuery;
             if (instruction && instruction.expression) {
-                output[escapeCalculatedColumnExpression(connection, instruction.expression)] = order as any;
+                // A simple `alias.property` path is left unescaped so that TypeORM can resolve
+                // the alias and apply its own driver-specific escaping. Pre-escaping it would
+                // prevent that resolution and fail when pagination requires a subquery.
+                const isSimplePropertyPath = /^\w+(\.\w+)+$/.test(instruction.expression);
+                const expression = isSimplePropertyPath
+                    ? instruction.expression
+                    : escapeCalculatedColumnExpression(connection, instruction.expression);
+                output[expression] = order as any;
             }
         } else if (customPropertyMap?.[key]) {
             output[customPropertyMap[key]] = order as any;

--- a/packages/core/src/service/helpers/list-query-builder/sqlite-regexp-function.ts
+++ b/packages/core/src/service/helpers/list-query-builder/sqlite-regexp-function.ts
@@ -1,4 +1,4 @@
-import { DataSourceOptions } from 'typeorm';
+import { VendureDatabaseType } from '../../../connection/database-type';
 
 import { UserInputError } from '../../../common/error/errors';
 import { Logger } from '../../../config/logger/vendure-logger';
@@ -19,7 +19,7 @@ type RegExpEngine = new (pattern: string, flags: string) => CompiledRegExp;
  * The SQLite driver flavours whose `regexp` implementation is a JS function evaluated on the
  * Node.js event loop, and which are therefore exposed to ReDoS via the built-in `RegExp` engine.
  */
-const SQLITE_REGEXP_DB_TYPES: Array<DataSourceOptions['type']> = ['better-sqlite3', 'sqljs'];
+const SQLITE_REGEXP_DB_TYPES: Array<VendureDatabaseType> = ['better-sqlite3', 'sqljs'];
 
 // `undefined` = not yet attempted, `null` = re2 is not installed.
 let re2Engine: RegExpEngine | null | undefined;
@@ -49,7 +49,7 @@ function loadRe2Engine(): RegExpEngine | null {
  * Has no effect when `re2` is not installed (the built-in engine, which supports those features,
  * is used as a fallback) or on non-SQLite backends, where the pattern is evaluated by the database.
  */
-export function assertRegexFilterEngineCompatible(pattern: string, dbType: DataSourceOptions['type']): void {
+export function assertRegexFilterEngineCompatible(pattern: string, dbType: VendureDatabaseType): void {
     if (!SQLITE_REGEXP_DB_TYPES.includes(dbType)) {
         return;
     }

--- a/packages/core/src/service/helpers/list-query-builder/sqlite-regexp-function.ts
+++ b/packages/core/src/service/helpers/list-query-builder/sqlite-regexp-function.ts
@@ -1,7 +1,6 @@
-import { VendureDatabaseType } from '../../../connection/database-type';
-
 import { UserInputError } from '../../../common/error/errors';
 import { Logger } from '../../../config/logger/vendure-logger';
+import { VendureDatabaseType } from '../../../connection/database-type';
 
 const loggerCtx = 'ListQueryBuilder';
 
@@ -19,7 +18,7 @@ type RegExpEngine = new (pattern: string, flags: string) => CompiledRegExp;
  * The SQLite driver flavours whose `regexp` implementation is a JS function evaluated on the
  * Node.js event loop, and which are therefore exposed to ReDoS via the built-in `RegExp` engine.
  */
-const SQLITE_REGEXP_DB_TYPES: Array<VendureDatabaseType> = ['better-sqlite3', 'sqljs'];
+const SQLITE_REGEXP_DB_TYPES: VendureDatabaseType[] = ['better-sqlite3', 'sqljs'];
 
 // `undefined` = not yet attempted, `null` = re2 is not installed.
 let re2Engine: RegExpEngine | null | undefined;

--- a/packages/core/src/service/helpers/order-modifier/order-modifier.ts
+++ b/packages/core/src/service/helpers/order-modifier/order-modifier.ts
@@ -37,6 +37,7 @@ import { Instrument } from '../../../common/instrument-decorator';
 import { idsAreEqual } from '../../../common/utils';
 import { ConfigService } from '../../../config/config.service';
 import { CustomFieldConfig } from '../../../config/custom-field/custom-field-types';
+import { findOptionsArrayToObject } from '../../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../../connection/transactional-connection';
 import { VendureEntity } from '../../../entity/base/base.entity';
 import { FulfillmentLine } from '../../../entity/order-line-reference/fulfillment-line.entity';
@@ -808,7 +809,7 @@ export class OrderModifier {
 
     private getOrderPayments(ctx: RequestContext, orderId: ID): Promise<Payment[]> {
         return this.connection.getRepository(ctx, Payment).find({
-            relations: ['refunds'],
+            relations: { refunds: true },
             where: {
                 order: { id: orderId } as any,
             },
@@ -851,7 +852,9 @@ export class OrderModifier {
                 .getRepository(ctx, OrderLine)
                 .findOne({
                     where: { id: orderLine.id },
-                    relations: customFieldRelations.map(r => `customFields.${r.name}`),
+                    relations: findOptionsArrayToObject<OrderLine>(
+                        customFieldRelations.map(r => `customFields.${r.name}`),
+                    ),
                 })
                 .then(result => result ?? undefined);
         }

--- a/packages/core/src/service/helpers/translatable-saver/translatable-saver.ts
+++ b/packages/core/src/service/helpers/translatable-saver/translatable-saver.ts
@@ -96,7 +96,7 @@ export class TranslatableSaver {
             relationLoadStrategy: 'query',
             loadEagerRelations: false,
             where: { base: { id: input.id } } as Translation<T>,
-            relations: ['base'],
+            relations: { base: true },
         } as FindManyOptions<Translation<T>>);
 
         const differ = new TranslationDiffer(translationType, this.connection);

--- a/packages/core/src/service/helpers/utils/order-utils.ts
+++ b/packages/core/src/service/helpers/utils/order-utils.ts
@@ -145,7 +145,7 @@ export async function getOrdersFromLines(
     const orders = new Map<ID, Order>();
     const lines = await connection.getRepository(ctx, OrderLine).find({
         where: { id: In(orderLinesInput.map(l => l.orderLineId)) },
-        relations: ['order', 'order.channels'],
+        relations: { order: { channels: true } },
         order: { id: 'ASC' },
     });
     for (const line of lines) {

--- a/packages/core/src/service/helpers/utils/tree-relations-qb-joiner.ts
+++ b/packages/core/src/service/helpers/utils/tree-relations-qb-joiner.ts
@@ -3,6 +3,7 @@ import { EntityTarget } from 'typeorm/common/EntityTarget';
 import { DriverUtils } from 'typeorm/driver/DriverUtils';
 
 import { findOptionsObjectToArray } from '../../../connection/find-options-object-to-array';
+import { getDataSource } from '../../../connection/get-data-source';
 import { VendureEntity } from '../../../entity';
 
 /**
@@ -62,7 +63,8 @@ export function joinTreeRelationsDynamically<T extends VendureEntity>(
         return joinedRelations;
     }
 
-    const sourceMetadata = qb.connection.getMetadata(entity);
+    const dataSource = getDataSource(qb);
+    const sourceMetadata = dataSource.getMetadata(entity);
     const sourceMetadataIsTree = isTreeEntityMetadata(sourceMetadata);
 
     const processRelation = (
@@ -112,7 +114,7 @@ export function joinTreeRelationsDynamically<T extends VendureEntity>(
             joinConnector = '__';
         }
         const nextAlias = DriverUtils.buildAlias(
-            qb.connection.driver,
+            dataSource.driver,
             { shorten: false, joiner: joinConnector },
             currentAlias,
             part.replace(/\./g, '_'),

--- a/packages/core/src/service/helpers/utils/tree-relations-qb-joiner.ts
+++ b/packages/core/src/service/helpers/utils/tree-relations-qb-joiner.ts
@@ -1,4 +1,4 @@
-import { EntityMetadata, FindOneOptions, SelectQueryBuilder } from 'typeorm';
+import { EntityMetadata, FindOptionsRelations, SelectQueryBuilder } from 'typeorm';
 import { EntityTarget } from 'typeorm/common/EntityTarget';
 import { DriverUtils } from 'typeorm/driver/DriverUtils';
 
@@ -33,7 +33,8 @@ function isTreeEntityMetadata(metadata: EntityMetadata): boolean {
  *
  * @param {SelectQueryBuilder<T>} qb - The query builder instance for joining relations.
  * @param {EntityTarget<T>} entity - The target entity class or schema name, used to access entity metadata.
- * @param {string[]} [requestedRelations=[]] - An array of relation paths (e.g., 'parent.children') to join dynamically.
+ * @param {FindOptionsRelations<T> | string[]} [requestedRelations={}] - The relations to join dynamically, either in
+ * the TypeORM object form or as an array of dotted paths (e.g., 'parent.children').
  * @param {number} [maxEagerDepth=1] - Limits the depth of eager relation joins to avoid excessively deep joins.
  * @returns {Map<string, string>} - A Map of joined relation paths to their aliases, aiding in tracking and preventing duplicates.
  * @template T - The entity type, extending VendureEntity for compatibility with Vendure's data layer.
@@ -54,7 +55,7 @@ function isTreeEntityMetadata(metadata: EntityMetadata): boolean {
 export function joinTreeRelationsDynamically<T extends VendureEntity>(
     qb: SelectQueryBuilder<T>,
     entity: EntityTarget<T>,
-    requestedRelations: FindOneOptions['relations'] = {},
+    requestedRelations: FindOptionsRelations<T> | string[] = {},
     maxEagerDepth: number = 1,
 ): Map<string, string> {
     const joinedRelations = new Map<string, string>();

--- a/packages/core/src/service/services/administrator.service.ts
+++ b/packages/core/src/service/services/administrator.service.ts
@@ -20,6 +20,7 @@ import {
 import { ListQueryOptions } from '../../common/types/common-types';
 import { assertFound, idsAreEqual, normalizeEmailAddress } from '../../common/utils';
 import { API_KEY_AUTH_STRATEGY_NAME, ConfigService, Logger } from '../../config';
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { Administrator } from '../../entity/administrator/administrator.entity';
 import { ApiKey } from '../../entity/api-key/api-key.entity';
@@ -40,7 +41,6 @@ import { checkSuperadminCredentials } from '../helpers/utils/check-superadmin-cr
 import { getChannelPermissions } from '../helpers/utils/get-user-channels-permissions';
 import { patchEntity } from '../helpers/utils/patch-entity';
 
-import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { AssetService } from './asset.service';
 import { RoleService } from './role.service';
 import { UserService } from './user.service';

--- a/packages/core/src/service/services/administrator.service.ts
+++ b/packages/core/src/service/services/administrator.service.ts
@@ -40,6 +40,7 @@ import { checkSuperadminCredentials } from '../helpers/utils/check-superadmin-cr
 import { getChannelPermissions } from '../helpers/utils/get-user-channels-permissions';
 import { patchEntity } from '../helpers/utils/patch-entity';
 
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { AssetService } from './asset.service';
 import { RoleService } from './role.service';
 import { UserService } from './user.service';
@@ -150,7 +151,9 @@ export class AdministratorService {
         return this.connection
             .getRepository(ctx, Administrator)
             .findOne({
-                relations: relations ?? ['avatar', 'user', 'user.roles'],
+                relations: findOptionsArrayToObject<Administrator>(
+                    relations ?? ['avatar', 'user', 'user.roles'],
+                ),
                 where: {
                     id: administratorId,
                     deletedAt: IsNull(),
@@ -171,7 +174,7 @@ export class AdministratorService {
         return this.connection
             .getRepository(ctx, Administrator)
             .findOne({
-                relations: relations ?? ['avatar'],
+                relations: findOptionsArrayToObject<Administrator>(relations ?? ['avatar']),
                 where: {
                     user: { id: userId },
                     deletedAt: IsNull(),
@@ -497,7 +500,7 @@ export class AdministratorService {
     private async isSoleSuperadmin(ctx: RequestContext, id: ID) {
         const superAdminRole = await this.roleService.getSuperAdminRole(ctx);
         const allAdmins = await this.connection.getRepository(ctx, Administrator).find({
-            relations: ['user', 'user.roles'],
+            relations: { user: { roles: true } },
             where: { deletedAt: IsNull() },
         });
         const superAdmins = allAdmins.filter(

--- a/packages/core/src/service/services/api-key.service.ts
+++ b/packages/core/src/service/services/api-key.service.ts
@@ -22,6 +22,7 @@ import {
 import { API_KEY_AUTH_STRATEGY_NAME, ConfigService, Logger } from '../../config';
 import { ApiKeyStrategy } from '../../config/api-key-strategy/api-key-strategy';
 import { TransactionalConnection } from '../../connection';
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { AuthenticationMethod, Role, User } from '../../entity';
 import { ApiKeyTranslation } from '../../entity/api-key/api-key-translation.entity';
 import { ApiKey } from '../../entity/api-key/api-key.entity';
@@ -33,7 +34,6 @@ import { TranslatableSaver } from '../helpers/translatable-saver/translatable-sa
 import { TranslatorService } from '../helpers/translator/translator.service';
 import { getChannelPermissions } from '../helpers/utils/get-user-channels-permissions';
 
-import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { ChannelService } from './channel.service';
 import { RoleService } from './role.service';
 import { SessionService } from './session.service';

--- a/packages/core/src/service/services/api-key.service.ts
+++ b/packages/core/src/service/services/api-key.service.ts
@@ -33,6 +33,7 @@ import { TranslatableSaver } from '../helpers/translatable-saver/translatable-sa
 import { TranslatorService } from '../helpers/translator/translator.service';
 import { getChannelPermissions } from '../helpers/utils/get-user-channels-permissions';
 
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { ChannelService } from './channel.service';
 import { RoleService } from './role.service';
 import { SessionService } from './session.service';
@@ -353,7 +354,7 @@ export class ApiKeyService {
         relations?: RelationPaths<ApiKey>,
     ): Promise<ApiKey | null> {
         const entity = await this.connection.getRepository(ctx, ApiKey).findOne({
-            relations: [...(relations ?? []), 'channels'],
+            relations: findOptionsArrayToObject<ApiKey>([...(relations ?? []), 'channels']),
             where: {
                 lookupId,
                 deletedAt: IsNull(),

--- a/packages/core/src/service/services/asset.service.ts
+++ b/packages/core/src/service/services/asset.service.ts
@@ -33,6 +33,7 @@ import { ChannelAware } from '../../common/types/common-types';
 import { Translated } from '../../common/types/locale-types';
 import { idsAreEqual } from '../../common/utils';
 import { ConfigService } from '../../config/config.service';
+import { getDataSource } from '../../connection/get-data-source';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { AssetTranslation } from '../../entity/asset/asset-translation.entity';
 import { AssetUsage } from '../../entity/asset/asset-usage';
@@ -135,7 +136,7 @@ export class AssetService {
         const tags = options?.tags;
         if (tags && tags.length) {
             const operator = options?.tagsOperator ?? LogicalOperator.AND;
-            const subquery = qb.connection
+            const subquery = getDataSource(qb)
                 .createQueryBuilder()
                 .select('asset.id')
                 .from(Asset, 'asset')

--- a/packages/core/src/service/services/auth.service.ts
+++ b/packages/core/src/service/services/auth.service.ts
@@ -138,7 +138,7 @@ export class AuthService {
     async destroyAuthenticatedSession(ctx: RequestContext, sessionToken: string): Promise<void> {
         const session = await this.connection.getRepository(ctx, AuthenticatedSession).findOne({
             where: { token: sessionToken },
-            relations: ['user', 'user.authenticationMethods'],
+            relations: { user: { authenticationMethods: true } },
         });
 
         if (session) {

--- a/packages/core/src/service/services/channel.service.ts
+++ b/packages/core/src/service/services/channel.service.ts
@@ -325,7 +325,7 @@ export class ChannelService {
     findOne(ctx: RequestContext, id: ID): Promise<Channel | undefined> {
         return this.connection
             .getRepository(ctx, Channel)
-            .findOne({ where: { id }, relations: ['defaultShippingZone', 'defaultTaxZone'] })
+            .findOne({ where: { id }, relations: { defaultShippingZone: true, defaultTaxZone: true } })
             .then(result => result ?? undefined);
     }
 
@@ -551,7 +551,7 @@ export class ChannelService {
             where: {
                 code: DEFAULT_CHANNEL_CODE,
             },
-            relations: ['seller'],
+            relations: { seller: true },
         });
 
         if (!defaultChannel) {

--- a/packages/core/src/service/services/collection.service.ts
+++ b/packages/core/src/service/services/collection.service.ts
@@ -261,7 +261,7 @@ export class CollectionService implements OnModuleInit {
         relations?: RelationPaths<Collection>,
     ): Promise<Translated<Collection> | undefined> {
         const translations = await this.connection.getRepository(ctx, CollectionTranslation).find({
-            relations: ['base'],
+            relations: { base: true },
             where: {
                 slug,
                 base: {

--- a/packages/core/src/service/services/country.service.ts
+++ b/packages/core/src/service/services/country.service.ts
@@ -14,6 +14,7 @@ import { Instrument } from '../../common/instrument-decorator';
 import { ListQueryOptions } from '../../common/types/common-types';
 import { Translated } from '../../common/types/locale-types';
 import { assertFound } from '../../common/utils';
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { Address } from '../../entity';
 import { Country } from '../../entity/region/country.entity';
@@ -65,7 +66,10 @@ export class CountryService {
     ): Promise<Translated<Country> | undefined> {
         return this.connection
             .getRepository(ctx, Country)
-            .findOne({ where: { id: countryId }, relations })
+            .findOne({
+                where: { id: countryId },
+                relations: findOptionsArrayToObject<Country>(relations ?? []),
+            })
             .then(country => (country && this.translator.translate(country, ctx)) ?? undefined);
     }
 

--- a/packages/core/src/service/services/customer-group.service.ts
+++ b/packages/core/src/service/services/customer-group.service.ts
@@ -27,6 +27,7 @@ import { CustomFieldRelationService } from '../helpers/custom-field-relation/cus
 import { ListQueryBuilder } from '../helpers/list-query-builder/list-query-builder';
 import { patchEntity } from '../helpers/utils/patch-entity';
 
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { HistoryService } from './history.service';
 
 /**
@@ -64,7 +65,10 @@ export class CustomerGroupService {
     ): Promise<CustomerGroup | undefined> {
         return this.connection
             .getRepository(ctx, CustomerGroup)
-            .findOne({ where: { id: customerGroupId }, relations })
+            .findOne({
+                where: { id: customerGroupId },
+                relations: findOptionsArrayToObject<CustomerGroup>(relations ?? []),
+            })
             .then(result => result ?? undefined);
     }
 

--- a/packages/core/src/service/services/customer-group.service.ts
+++ b/packages/core/src/service/services/customer-group.service.ts
@@ -17,6 +17,7 @@ import { RelationPaths } from '../../api/decorators/relations.decorator';
 import { UserInputError } from '../../common/error/errors';
 import { Instrument } from '../../common/instrument-decorator';
 import { assertFound, idsAreEqual } from '../../common/utils';
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { CustomerGroup } from '../../entity/customer-group/customer-group.entity';
 import { Customer } from '../../entity/customer/customer.entity';
@@ -27,7 +28,6 @@ import { CustomFieldRelationService } from '../helpers/custom-field-relation/cus
 import { ListQueryBuilder } from '../helpers/list-query-builder/list-query-builder';
 import { patchEntity } from '../helpers/utils/patch-entity';
 
-import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { HistoryService } from './history.service';
 
 /**

--- a/packages/core/src/service/services/customer.service.ts
+++ b/packages/core/src/service/services/customer.service.ts
@@ -229,7 +229,7 @@ export class CustomerService {
         }
 
         const existingCustomer = await this.connection.getRepository(ctx, Customer).findOne({
-            relations: ['channels'],
+            relations: { channels: true },
             where: {
                 emailAddress: input.emailAddress,
                 deletedAt: IsNull(),
@@ -673,7 +673,7 @@ export class CustomerService {
         input.emailAddress = normalizeEmailAddress(input.emailAddress);
         let customer: Customer;
         const existing = await this.connection.getRepository(ctx, Customer).findOne({
-            relations: ['channels'],
+            relations: { channels: true },
             where: {
                 emailAddress: input.emailAddress,
                 deletedAt: IsNull(),
@@ -909,7 +909,7 @@ export class CustomerService {
     ) {
         const result = await this.connection
             .getRepository(ctx, Address)
-            .findOne({ where: { id: addressId }, relations: ['customer', 'customer.addresses'] });
+            .findOne({ where: { id: addressId }, relations: { customer: { addresses: true } } });
         if (result) {
             const customerAddressIds = result.customer.addresses
                 .map(a => a.id)
@@ -941,7 +941,7 @@ export class CustomerService {
         }
         const result = await this.connection
             .getRepository(ctx, Address)
-            .findOne({ where: { id: addressToDelete.id }, relations: ['customer', 'customer.addresses'] });
+            .findOne({ where: { id: addressToDelete.id }, relations: { customer: { addresses: true } } });
         if (result) {
             const customerAddresses = result.customer.addresses;
             if (1 < customerAddresses.length) {

--- a/packages/core/src/service/services/facet-value.service.ts
+++ b/packages/core/src/service/services/facet-value.service.ts
@@ -72,7 +72,7 @@ export class FacetValueService {
         const globalDefaultLanguageCode = this.configService.defaultLanguageCode;
         return repository
             .find({
-                relations: ['facet'],
+                relations: { facet: true },
             })
             .then(facetValues =>
                 facetValues.map(facetValue =>
@@ -119,7 +119,7 @@ export class FacetValueService {
             .getRepository(ctx, FacetValue)
             .findOne({
                 where: { id },
-                relations: ['facet'],
+                relations: { facet: true },
             })
             .then(
                 facetValue =>

--- a/packages/core/src/service/services/facet.service.ts
+++ b/packages/core/src/service/services/facet.service.ts
@@ -111,7 +111,7 @@ export class FacetService {
         facetCodeOrLang: string | LanguageCode,
         lang?: LanguageCode,
     ): Promise<Translated<Facet> | undefined> {
-        const relations = ['values', 'values.facet'];
+        const relations = { values: { facet: true } };
         const [repository, facetCode, languageCode, channelLanguageCode] =
             ctxOrFacetCode instanceof RequestContext
                 ? [
@@ -295,7 +295,7 @@ export class FacetService {
         }
         const facetsToAssign = await this.connection
             .getRepository(ctx, Facet)
-            .find({ where: { id: In(input.facetIds) }, relations: ['values'] });
+            .find({ where: { id: In(input.facetIds) }, relations: { values: true } });
         const valuesToAssign = facetsToAssign.reduce(
             (values, facet) => [...values, ...facet.values],
             [] as FacetValue[],
@@ -341,7 +341,7 @@ export class FacetService {
         }
         const facetsToRemove = await this.connection
             .getRepository(ctx, Facet)
-            .find({ where: { id: In(input.facetIds) }, relations: ['values'] });
+            .find({ where: { id: In(input.facetIds) }, relations: { values: true } });
 
         const results: Array<ErrorResultUnion<RemoveFacetFromChannelResult, Facet>> = [];
 

--- a/packages/core/src/service/services/fulfillment.service.ts
+++ b/packages/core/src/service/services/fulfillment.service.ts
@@ -14,11 +14,12 @@ import {
 } from '../../common/error/generated-graphql-admin-errors';
 import { Instrument } from '../../common/instrument-decorator';
 import { ConfigService } from '../../config/config.service';
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { Fulfillment } from '../../entity/fulfillment/fulfillment.entity';
-import { Order } from '../../entity/order/order.entity';
-import { OrderLine } from '../../entity/order-line/order-line.entity';
 import { FulfillmentLine } from '../../entity/order-line-reference/fulfillment-line.entity';
+import { OrderLine } from '../../entity/order-line/order-line.entity';
+import { Order } from '../../entity/order/order.entity';
 import { EventBus } from '../../event-bus/event-bus';
 import { FulfillmentEvent } from '../../event-bus/events/fulfillment-event';
 import { FulfillmentStateTransitionEvent } from '../../event-bus/events/fulfillment-state-transition-event';
@@ -136,7 +137,9 @@ export class FulfillmentService {
     ): Promise<FulfillmentLine[]> {
         const defaultRelations = ['fulfillment'];
         return this.connection.getRepository(ctx, FulfillmentLine).find({
-            relations: Array.from(new Set([...defaultRelations, ...relations])),
+            relations: findOptionsArrayToObject<FulfillmentLine>(
+                Array.from(new Set([...defaultRelations, ...relations])),
+            ),
             where: {
                 fulfillment: {
                     state: Not('Cancelled'),
@@ -168,12 +171,9 @@ export class FulfillmentService {
         // are atomic — see the equivalent comment on OrderService.transitionToState.
         // #4686.
         return this.connection.withTransaction(ctx, async txCtx => {
-            const fulfillment = await this.connection.getEntityOrThrow(
-                txCtx,
-                Fulfillment,
-                fulfillmentId,
-                { relations: ['lines'] },
-            );
+            const fulfillment = await this.connection.getEntityOrThrow(txCtx, Fulfillment, fulfillmentId, {
+                relations: ['lines'],
+            });
             const orderLinesIds = unique(fulfillment.lines.map(lines => lines.orderLineId));
             const orders = await this.connection
                 .getRepository(txCtx, Order)

--- a/packages/core/src/service/services/fulfillment.service.ts
+++ b/packages/core/src/service/services/fulfillment.service.ts
@@ -137,9 +137,7 @@ export class FulfillmentService {
     ): Promise<FulfillmentLine[]> {
         const defaultRelations = ['fulfillment'];
         return this.connection.getRepository(ctx, FulfillmentLine).find({
-            relations: findOptionsArrayToObject<FulfillmentLine>(
-                Array.from(new Set([...defaultRelations, ...relations])),
-            ),
+            relations: findOptionsArrayToObject<FulfillmentLine>([...defaultRelations, ...relations]),
             where: {
                 fulfillment: {
                     state: Not('Cancelled'),

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -123,6 +123,7 @@ import { isForeignKeyViolationError } from '../helpers/utils/db-errors';
 import { getOrdersFromLines, totalCoveredByPayments } from '../helpers/utils/order-utils';
 import { patchEntity } from '../helpers/utils/patch-entity';
 
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { ChannelService } from './channel.service';
 import { CountryService } from './country.service';
 import { CustomerService } from './customer.service';
@@ -261,7 +262,7 @@ export class OrderService {
             .map(r => r.replace('lines.', ''));
 
         qb.setFindOptions({
-            relations: orderRelations,
+            relations: findOptionsArrayToObject<Order>(orderRelations),
             relationLoadStrategy: 'query',
         })
             .leftJoin('order.channels', 'channel')
@@ -279,7 +280,7 @@ export class OrderService {
                 const linesQb = this.connection.getRepository(ctx, OrderLine).createQueryBuilder('line');
                 linesQb
                     .setFindOptions({
-                        relations: lineRelations,
+                        relations: findOptionsArrayToObject<OrderLine>(lineRelations),
                     })
                     .where('line.orderId = :orderId', { orderId })
                     .addOrderBy('line.createdAt', 'ASC')
@@ -311,7 +312,7 @@ export class OrderService {
         relations?: RelationPaths<Order>,
     ): Promise<Order | undefined> {
         const order = await this.connection.getRepository(ctx, Order).findOne({
-            relations: ['customer'],
+            relations: { customer: true },
             where: {
                 code: orderCode,
             },
@@ -362,7 +363,7 @@ export class OrderService {
      */
     getOrderPayments(ctx: RequestContext, orderId: ID): Promise<Payment[]> {
         return this.connection.getRepository(ctx, Payment).find({
-            relations: ['refunds'],
+            relations: { refunds: true },
             where: {
                 order: { id: orderId } as any,
             },
@@ -378,7 +379,7 @@ export class OrderService {
             where: {
                 order: { id: orderId },
             },
-            relations: ['lines', 'payment', 'refund', 'surcharges'],
+            relations: { lines: true, payment: true, refund: true, surcharges: true },
         });
     }
 
@@ -399,7 +400,7 @@ export class OrderService {
             where: {
                 aggregateOrderId: order.id,
             },
-            relations: ['channels'],
+            relations: { channels: true },
         });
     }
 
@@ -408,7 +409,10 @@ export class OrderService {
             ? undefined
             : this.connection
                   .getRepository(ctx, Order)
-                  .findOne({ where: { id: order.aggregateOrderId }, relations: ['channels', 'lines'] })
+                  .findOne({
+                      where: { id: order.aggregateOrderId },
+                      relations: { channels: true, lines: true },
+                  })
                   .then(result => result ?? undefined);
     }
 
@@ -1831,7 +1835,7 @@ export class OrderService {
             where: {
                 id: In(input.lines.map(l => l.orderLineId)),
             },
-            relations: ['productVariant'],
+            relations: { productVariant: true },
         });
 
         for (const line of lines) {
@@ -2084,9 +2088,10 @@ export class OrderService {
         const orderToDelete =
             orderOrId instanceof Order
                 ? orderOrId
-                : await this.connection
-                      .getRepository(ctx, Order)
-                      .findOneOrFail({ where: { id: orderOrId }, relations: ['lines', 'shippingLines'] });
+                : await this.connection.getRepository(ctx, Order).findOneOrFail({
+                      where: { id: orderOrId },
+                      relations: { lines: true, shippingLines: true },
+                  });
         // If there is a Session referencing the Order to be deleted, we must first remove that
         // reference in order to avoid a foreign key error. See https://github.com/vendurehq/vendure/issues/1454
         const sessions = await this.connection

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -81,6 +81,7 @@ import { ListQueryOptions } from '../../common/types/common-types';
 import { assertFound, idsAreEqual } from '../../common/utils';
 import { ConfigService } from '../../config/config.service';
 import { Logger } from '../../config/logger/vendure-logger';
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { Channel } from '../../entity/channel/channel.entity';
 import { Customer } from '../../entity/customer/customer.entity';
@@ -123,7 +124,6 @@ import { isForeignKeyViolationError } from '../helpers/utils/db-errors';
 import { getOrdersFromLines, totalCoveredByPayments } from '../helpers/utils/order-utils';
 import { patchEntity } from '../helpers/utils/patch-entity';
 
-import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { ChannelService } from './channel.service';
 import { CountryService } from './country.service';
 import { CustomerService } from './customer.service';

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -2581,13 +2581,11 @@ export class OrderService implements OnApplicationBootstrap {
 
             const orders = await this.connection.getRepository(orderCtx, Order).find({
                 where: { id: In(affectedOrders.map(o => o.id)) },
-                relations: [
-                    'lines',
-                    'lines.productVariant',
-                    'lines.productVariant.productVariantPrices',
-                    'shippingLines',
-                    'surcharges',
-                ],
+                relations: {
+                    lines: { productVariant: { productVariantPrices: true } },
+                    shippingLines: true,
+                    surcharges: true,
+                },
             });
 
             for (const order of orders) {

--- a/packages/core/src/service/services/payment-method.service.ts
+++ b/packages/core/src/service/services/payment-method.service.ts
@@ -273,7 +273,7 @@ export class PaymentMethodService {
     async getEligiblePaymentMethods(ctx: RequestContext, order: Order): Promise<PaymentMethodQuote[]> {
         const paymentMethods = await this.connection
             .getRepository(ctx, PaymentMethod)
-            .find({ where: { enabled: true }, relations: ['channels'] });
+            .find({ where: { enabled: true }, relations: { channels: true } });
         const results: PaymentMethodQuote[] = [];
         const paymentMethodsInChannel = paymentMethods
             .filter(p => p.channels.find(pc => idsAreEqual(pc.id, ctx.channelId)))
@@ -335,7 +335,7 @@ export class PaymentMethodService {
     async getActivePaymentMethods(ctx: RequestContext): Promise<PaymentMethod[]> {
         const paymentMethods = await this.connection.getRepository(ctx, PaymentMethod).find({
             where: { enabled: true, channels: { id: ctx.channelId } },
-            relations: ['channels', 'customFields'],
+            relations: { channels: true, customFields: true },
         });
         return paymentMethods.map(p => this.translator.translate(p, ctx));
     }

--- a/packages/core/src/service/services/product-option-group.service.ts
+++ b/packages/core/src/service/services/product-option-group.service.ts
@@ -294,7 +294,7 @@ export class ProductOptionGroupService {
                 relationLoadStrategy: 'query',
                 loadEagerRelations: false,
                 where: { id: productId },
-                relations: ['optionGroups'],
+                relations: { optionGroups: true },
             });
             if (product) {
                 product.optionGroups = product.optionGroups.filter(og => !idsAreEqual(og.id, id));
@@ -326,7 +326,7 @@ export class ProductOptionGroupService {
         }
         const groupsToAssign = await this.connection
             .getRepository(ctx, ProductOptionGroup)
-            .find({ where: { id: In(input.productOptionGroupIds) }, relations: ['options'] });
+            .find({ where: { id: In(input.productOptionGroupIds) }, relations: { options: true } });
         const optionsToAssign = groupsToAssign.reduce(
             (options, group) => [...options, ...group.options],
             [] as ProductOption[],
@@ -374,7 +374,7 @@ export class ProductOptionGroupService {
         }
         const groupsToRemove = await this.connection
             .getRepository(ctx, ProductOptionGroup)
-            .find({ where: { id: In(input.productOptionGroupIds) }, relations: ['options'] });
+            .find({ where: { id: In(input.productOptionGroupIds) }, relations: { options: true } });
 
         const results: Array<
             ErrorResultUnion<RemoveProductOptionGroupFromChannelResult, Translated<ProductOptionGroup>>

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -187,7 +187,11 @@ export class ProductVariantService {
             .innerJoinAndSelect('productvariant.channels', 'channel', 'channel.id = :channelId', {
                 channelId: ctx.channelId,
             })
-            .innerJoinAndSelect('productvariant.product', 'product', 'product.id = :productId', {
+            // Not selected: the join is only here to constrain the query to one Product. Selecting
+            // it would populate `productvariant.product` with a Product carrying none of its own
+            // relations, which then takes precedence over the fully-loaded one when `product` is
+            // among the requested relations.
+            .innerJoin('productvariant.product', 'product', 'product.id = :productId', {
                 productId,
             });
 

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -487,7 +487,7 @@ export class ProductVariantService {
         // ProductService.assignProductsToChannel().
         const product = await this.connection.getRepository(ctx, Product).findOne({
             where: { id: input.productId },
-            relations: ['channels'],
+            relations: { channels: true },
             relationLoadStrategy: 'query',
             loadEagerRelations: false,
         });
@@ -502,13 +502,11 @@ export class ProductVariantService {
                 const optionIds = input.optionIds || [];
                 let optionGroupIds: ID[] = [];
                 if (optionIds.length) {
-                    const variantOptions = await this.connection
-                        .getRepository(ctx, ProductOption)
-                        .find({
-                            where: { id: In(optionIds) },
-                            relations: ['group'],
-                            loadEagerRelations: false,
-                        });
+                    const variantOptions = await this.connection.getRepository(ctx, ProductOption).find({
+                        where: { id: In(optionIds) },
+                        relations: { group: true },
+                        loadEagerRelations: false,
+                    });
                     optionGroupIds = unique(variantOptions.map(o => o.group.id));
                 }
 
@@ -523,20 +521,14 @@ export class ProductVariantService {
                     if (optionIds.length) {
                         await Promise.all([
                             ...optionGroupIds.map(id =>
-                                this.channelService.assignToChannels(
-                                    ctx,
-                                    ProductOptionGroup,
-                                    id,
-                                    [additionalChannelId],
-                                ),
+                                this.channelService.assignToChannels(ctx, ProductOptionGroup, id, [
+                                    additionalChannelId,
+                                ]),
                             ),
                             ...optionIds.map(id =>
-                                this.channelService.assignToChannels(
-                                    ctx,
-                                    ProductOption,
-                                    id,
-                                    [additionalChannelId],
-                                ),
+                                this.channelService.assignToChannels(ctx, ProductOption, id, [
+                                    additionalChannelId,
+                                ]),
                             ),
                         ]);
                     }
@@ -892,7 +884,7 @@ export class ProductVariantService {
             where: {
                 id: In(input.productVariantIds),
             },
-            relations: ['taxCategory', 'assets'],
+            relations: { taxCategory: true, assets: true },
         });
         const priceFactor = input.priceFactor != null ? input.priceFactor : 1;
         const targetChannel = await this.connection.getEntityOrThrow(ctx, Channel, input.channelId);
@@ -1006,7 +998,7 @@ export class ProductVariantService {
                 where: {
                     productId: variant.productId,
                 },
-                relations: ['channels'],
+                relations: { channels: true },
             });
             const productChannelsFromVariants = ([] as Channel[]).concat(
                 ...productVariants.map(pv => pv.channels),

--- a/packages/core/src/service/services/product.service.ts
+++ b/packages/core/src/service/services/product.service.ts
@@ -22,6 +22,7 @@ import { Instrument } from '../../common/instrument-decorator';
 import { ListQueryOptions } from '../../common/types/common-types';
 import { Translated } from '../../common/types/locale-types';
 import { assertFound, idsAreEqual } from '../../common/utils';
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { Channel } from '../../entity/channel/channel.entity';
 import { FacetValue } from '../../entity/facet-value/facet-value.entity';
@@ -40,7 +41,6 @@ import { SlugValidator } from '../helpers/slug-validator/slug-validator';
 import { TranslatableSaver } from '../helpers/translatable-saver/translatable-saver';
 import { TranslatorService } from '../helpers/translator/translator.service';
 
-import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { AssetService } from './asset.service';
 import { ChannelService } from './channel.service';
 import { FacetValueService } from './facet-value.service';

--- a/packages/core/src/service/services/product.service.ts
+++ b/packages/core/src/service/services/product.service.ts
@@ -40,6 +40,7 @@ import { SlugValidator } from '../helpers/slug-validator/slug-validator';
 import { TranslatableSaver } from '../helpers/translatable-saver/translatable-saver';
 import { TranslatorService } from '../helpers/translator/translator.service';
 
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { AssetService } from './asset.service';
 import { ChannelService } from './channel.service';
 import { FacetValueService } from './facet-value.service';
@@ -155,7 +156,7 @@ export class ProductService {
         const qb = this.connection
             .getRepository(ctx, Product)
             .createQueryBuilder('product')
-            .setFindOptions({ relations: (relations && false) || this.relations });
+            .setFindOptions({ relations: findOptionsArrayToObject<Product>(this.relations) });
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         FindOptionsUtils.joinEagerRelations(qb, qb.alias, qb.expressionMap.mainAlias!.metadata);
         return qb
@@ -188,7 +189,7 @@ export class ProductService {
             .getRepository(ctx, Product)
             .findOne({
                 where: { id: productId },
-                relations: ['facetValues'],
+                relations: { facetValues: true },
             })
             .then(product => {
                 if (!product) {
@@ -330,7 +331,7 @@ export class ProductService {
     ): Promise<Array<Translated<Product>>> {
         const productsWithVariants = await this.connection.getRepository(ctx, Product).find({
             where: { id: In(input.productIds) },
-            relations: ['variants', 'assets', 'optionGroups', 'optionGroups.options'],
+            relations: { variants: true, assets: true, optionGroups: { options: true } },
             relationLoadStrategy: 'query',
             loadEagerRelations: false,
         });
@@ -380,7 +381,7 @@ export class ProductService {
     ): Promise<Array<Translated<Product>>> {
         const productsWithVariants = await this.connection.getRepository(ctx, Product).find({
             where: { id: In(input.productIds) },
-            relations: ['variants', 'optionGroups', 'optionGroups.options'],
+            relations: { variants: true, optionGroups: { options: true } },
             relationLoadStrategy: 'query',
             loadEagerRelations: false,
         });

--- a/packages/core/src/service/services/promotion.service.ts
+++ b/packages/core/src/service/services/promotion.service.ts
@@ -283,7 +283,7 @@ export class PromotionService {
                 deletedAt: IsNull(),
                 channels: { id: ctx.channelId },
             },
-            relations: ['channels'],
+            relations: { channels: true },
         });
         if (!promotion || !promotion.channels.find(c => idsAreEqual(c.id, ctx.channelId))) {
             return new CouponCodeInvalidError({ couponCode });

--- a/packages/core/src/service/services/province.service.ts
+++ b/packages/core/src/service/services/province.service.ts
@@ -13,6 +13,7 @@ import { Instrument } from '../../common/instrument-decorator';
 import { ListQueryOptions } from '../../common/types/common-types';
 import { Translated } from '../../common/types/locale-types';
 import { assertFound } from '../../common/utils';
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { Province } from '../../entity/region/province.entity';
 import { RegionTranslation } from '../../entity/region/region-translation.entity';
@@ -64,7 +65,10 @@ export class ProvinceService {
     ): Promise<Translated<Province> | undefined> {
         return this.connection
             .getRepository(ctx, Province)
-            .findOne({ where: { id: provinceId }, relations })
+            .findOne({
+                where: { id: provinceId },
+                relations: findOptionsArrayToObject<Province>(relations ?? []),
+            })
             .then(province => (province && this.translator.translate(province, ctx)) ?? undefined);
     }
 

--- a/packages/core/src/service/services/role.service.ts
+++ b/packages/core/src/service/services/role.service.ts
@@ -44,6 +44,7 @@ import {
 } from '../helpers/utils/get-user-channels-permissions';
 import { patchEntity } from '../helpers/utils/patch-entity';
 
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { ChannelService } from './channel.service';
 
 /**
@@ -118,7 +119,7 @@ export class RoleService {
             .getRepository(ctx, Role)
             .findOne({
                 where: { id: roleId },
-                relations: unique([...(relations ?? []), 'channels']),
+                relations: findOptionsArrayToObject<Role>(unique([...(relations ?? []), 'channels'])),
             })
             .then(async result => {
                 if (result && (await this.activeUserCanReadRole(ctx, result))) {
@@ -212,7 +213,9 @@ export class RoleService {
 
     private async getAllRolesWithChannels(ctx: RequestContext): Promise<Role[]> {
         const allRolesJson = await this.rolesCache.get(this.rolesCacheKey, async () => {
-            const roles = await this.connection.getRepository(ctx, Role).find({ relations: ['channels'] });
+            const roles = await this.connection
+                .getRepository(ctx, Role)
+                .find({ relations: { channels: true } });
             return JSON.stringify(roles);
         });
 

--- a/packages/core/src/service/services/role.service.ts
+++ b/packages/core/src/service/services/role.service.ts
@@ -31,6 +31,7 @@ import { Instrument } from '../../common/instrument-decorator';
 import { ListQueryOptions } from '../../common/types/common-types';
 import { assertFound, idsAreEqual } from '../../common/utils';
 import { ConfigService } from '../../config/config.service';
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { Channel } from '../../entity/channel/channel.entity';
 import { Role } from '../../entity/role/role.entity';
@@ -44,7 +45,6 @@ import {
 } from '../helpers/utils/get-user-channels-permissions';
 import { patchEntity } from '../helpers/utils/patch-entity';
 
-import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { ChannelService } from './channel.service';
 
 /**

--- a/packages/core/src/service/services/role.service.ts
+++ b/packages/core/src/service/services/role.service.ts
@@ -119,7 +119,7 @@ export class RoleService {
             .getRepository(ctx, Role)
             .findOne({
                 where: { id: roleId },
-                relations: findOptionsArrayToObject<Role>(unique([...(relations ?? []), 'channels'])),
+                relations: findOptionsArrayToObject<Role>([...(relations ?? []), 'channels']),
             })
             .then(async result => {
                 if (result && (await this.activeUserCanReadRole(ctx, result))) {

--- a/packages/core/src/service/services/session.service.ts
+++ b/packages/core/src/service/services/session.service.ts
@@ -39,6 +39,15 @@ export class SessionService implements EntitySubscriberInterface, OnModuleInit {
     private cleanSessionsJobQueue: JobQueue<{ batchSize: number }>;
     private readonly sessionDurationInMs: number;
     private readonly sessionCacheTimeoutMs = 50;
+    /**
+     * `user` is declared on AuthenticatedSession, not the abstract Session queried here, so an
+     * object literal typed against Session does not compile.
+     */
+    private readonly userRelations = findOptionsArrayToObject<Session>([
+        'user',
+        'user.roles',
+        'user.roles.channels',
+    ]);
 
     constructor(
         private connection: TransactionalConnection,
@@ -255,9 +264,7 @@ export class SessionService implements EntitySubscriberInterface, OnModuleInit {
     ): Promise<CachedSession> {
         const session = await this.connection.getRepository(ctx, Session).findOne({
             where: { id: serializedSession.id },
-            // `user` is declared on AuthenticatedSession, not the abstract Session queried
-            // here, so an object literal typed against Session does not compile.
-            relations: findOptionsArrayToObject<Session>(['user', 'user.roles', 'user.roles.channels']),
+            relations: this.userRelations,
         });
         if (session) {
             session.activeOrder = order;
@@ -277,9 +284,7 @@ export class SessionService implements EntitySubscriberInterface, OnModuleInit {
         if (serializedSession.activeOrderId) {
             const session = await this.connection.getRepository(ctx, Session).findOne({
                 where: { id: serializedSession.id },
-                // `user` is declared on AuthenticatedSession, not the abstract Session queried
-                // here, so an object literal typed against Session does not compile.
-                relations: findOptionsArrayToObject<Session>(['user', 'user.roles', 'user.roles.channels']),
+                relations: this.userRelations,
             });
             if (session) {
                 session.activeOrder = null;
@@ -299,9 +304,7 @@ export class SessionService implements EntitySubscriberInterface, OnModuleInit {
     async setActiveChannel(serializedSession: CachedSession, channel: Channel): Promise<CachedSession> {
         const session = await this.connection.rawConnection.getRepository(Session).findOne({
             where: { id: serializedSession.id },
-            // `user` is declared on AuthenticatedSession, not the abstract Session queried
-            // here, so an object literal typed against Session does not compile.
-            relations: findOptionsArrayToObject<Session>(['user', 'user.roles', 'user.roles.channels']),
+            relations: this.userRelations,
         });
         if (session) {
             session.activeChannel = channel;

--- a/packages/core/src/service/services/session.service.ts
+++ b/packages/core/src/service/services/session.service.ts
@@ -255,7 +255,8 @@ export class SessionService implements EntitySubscriberInterface, OnModuleInit {
     ): Promise<CachedSession> {
         const session = await this.connection.getRepository(ctx, Session).findOne({
             where: { id: serializedSession.id },
-            // `user` is declared on AuthenticatedSession, not the abstract Session queried here.
+            // `user` is declared on AuthenticatedSession, not the abstract Session queried
+            // here, so an object literal typed against Session does not compile.
             relations: findOptionsArrayToObject<Session>(['user', 'user.roles', 'user.roles.channels']),
         });
         if (session) {
@@ -276,7 +277,8 @@ export class SessionService implements EntitySubscriberInterface, OnModuleInit {
         if (serializedSession.activeOrderId) {
             const session = await this.connection.getRepository(ctx, Session).findOne({
                 where: { id: serializedSession.id },
-                // `user` is declared on AuthenticatedSession, not the abstract Session queried here.
+                // `user` is declared on AuthenticatedSession, not the abstract Session queried
+                // here, so an object literal typed against Session does not compile.
                 relations: findOptionsArrayToObject<Session>(['user', 'user.roles', 'user.roles.channels']),
             });
             if (session) {
@@ -297,7 +299,8 @@ export class SessionService implements EntitySubscriberInterface, OnModuleInit {
     async setActiveChannel(serializedSession: CachedSession, channel: Channel): Promise<CachedSession> {
         const session = await this.connection.rawConnection.getRepository(Session).findOne({
             where: { id: serializedSession.id },
-            // `user` is declared on AuthenticatedSession, not the abstract Session queried here.
+            // `user` is declared on AuthenticatedSession, not the abstract Session queried
+            // here, so an object literal typed against Session does not compile.
             relations: findOptionsArrayToObject<Session>(['user', 'user.roles', 'user.roles.channels']),
         });
         if (session) {

--- a/packages/core/src/service/services/session.service.ts
+++ b/packages/core/src/service/services/session.service.ts
@@ -9,6 +9,7 @@ import { Instrument } from '../../common/instrument-decorator';
 import { API_KEY_AUTH_STRATEGY_DEFAULT_DURATION_MS, API_KEY_AUTH_STRATEGY_NAME, Logger } from '../../config';
 import { ConfigService } from '../../config/config.service';
 import { CachedSession, SessionCacheStrategy } from '../../config/session-cache/session-cache-strategy';
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { ApiKey } from '../../entity/api-key/api-key.entity';
 import { Channel } from '../../entity/channel/channel.entity';
@@ -23,7 +24,6 @@ import { JobQueueService } from '../../job-queue/job-queue.service';
 import { RequestContextService } from '../helpers/request-context/request-context.service';
 import { getUserChannelsPermissions } from '../helpers/utils/get-user-channels-permissions';
 
-import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { OrderService } from './order.service';
 
 /**

--- a/packages/core/src/service/services/session.service.ts
+++ b/packages/core/src/service/services/session.service.ts
@@ -23,6 +23,7 @@ import { JobQueueService } from '../../job-queue/job-queue.service';
 import { RequestContextService } from '../helpers/request-context/request-context.service';
 import { getUserChannelsPermissions } from '../helpers/utils/get-user-channels-permissions';
 
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { OrderService } from './order.service';
 
 /**
@@ -254,7 +255,8 @@ export class SessionService implements EntitySubscriberInterface, OnModuleInit {
     ): Promise<CachedSession> {
         const session = await this.connection.getRepository(ctx, Session).findOne({
             where: { id: serializedSession.id },
-            relations: ['user', 'user.roles', 'user.roles.channels'],
+            // `user` is declared on AuthenticatedSession, not the abstract Session queried here.
+            relations: findOptionsArrayToObject<Session>(['user', 'user.roles', 'user.roles.channels']),
         });
         if (session) {
             session.activeOrder = order;
@@ -274,7 +276,8 @@ export class SessionService implements EntitySubscriberInterface, OnModuleInit {
         if (serializedSession.activeOrderId) {
             const session = await this.connection.getRepository(ctx, Session).findOne({
                 where: { id: serializedSession.id },
-                relations: ['user', 'user.roles', 'user.roles.channels'],
+                // `user` is declared on AuthenticatedSession, not the abstract Session queried here.
+                relations: findOptionsArrayToObject<Session>(['user', 'user.roles', 'user.roles.channels']),
             });
             if (session) {
                 session.activeOrder = null;
@@ -294,7 +297,8 @@ export class SessionService implements EntitySubscriberInterface, OnModuleInit {
     async setActiveChannel(serializedSession: CachedSession, channel: Channel): Promise<CachedSession> {
         const session = await this.connection.rawConnection.getRepository(Session).findOne({
             where: { id: serializedSession.id },
-            relations: ['user', 'user.roles', 'user.roles.channels'],
+            // `user` is declared on AuthenticatedSession, not the abstract Session queried here.
+            relations: findOptionsArrayToObject<Session>(['user', 'user.roles', 'user.roles.channels']),
         });
         if (session) {
             session.activeChannel = channel;

--- a/packages/core/src/service/services/shipping-method.service.ts
+++ b/packages/core/src/service/services/shipping-method.service.ts
@@ -271,7 +271,7 @@ export class ShippingMethodService {
 
     async getActiveShippingMethods(ctx: RequestContext): Promise<ShippingMethod[]> {
         const shippingMethods = await this.connection.getRepository(ctx, ShippingMethod).find({
-            relations: ['channels', 'customFields'],
+            relations: { channels: true, customFields: true },
             where: { deletedAt: IsNull() },
         });
         return shippingMethods

--- a/packages/core/src/service/services/shipping-method.service.ts
+++ b/packages/core/src/service/services/shipping-method.service.ts
@@ -22,6 +22,7 @@ import { Translated } from '../../common/types/locale-types';
 import { assertFound, idsAreEqual } from '../../common/utils';
 import { ConfigService } from '../../config/config.service';
 import { Logger } from '../../config/logger/vendure-logger';
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { ShippingMethodTranslation } from '../../entity/shipping-method/shipping-method-translation.entity';
 import { ShippingMethod } from '../../entity/shipping-method/shipping-method.entity';
@@ -103,7 +104,7 @@ export class ShippingMethodService {
                     id: shippingMethodId,
                     deletedAt: includeDeleted ? undefined : IsNull(),
                 },
-                relations,
+                relations: findOptionsArrayToObject<ShippingMethod>(relations),
             });
         } else {
             shippingMethod = await this.connection.findOneInChannel(

--- a/packages/core/src/service/services/shipping-method.service.ts
+++ b/packages/core/src/service/services/shipping-method.service.ts
@@ -102,7 +102,7 @@ export class ShippingMethodService {
             shippingMethod = await this.connection.getRepository(ctx, ShippingMethod).findOne({
                 where: {
                     id: shippingMethodId,
-                    deletedAt: includeDeleted ? undefined : IsNull(),
+                    ...(includeDeleted ? {} : { deletedAt: IsNull() }),
                 },
                 relations: findOptionsArrayToObject<ShippingMethod>(relations),
             });

--- a/packages/core/src/service/services/stock-movement.service.ts
+++ b/packages/core/src/service/services/stock-movement.service.ts
@@ -14,8 +14,8 @@ import { idsAreEqual } from '../../common/utils';
 import { ShippingCalculator } from '../../config/shipping-method/shipping-calculator';
 import { ShippingEligibilityChecker } from '../../config/shipping-method/shipping-eligibility-checker';
 import { TransactionalConnection } from '../../connection/transactional-connection';
-import { Order } from '../../entity/order/order.entity';
 import { OrderLine } from '../../entity/order-line/order-line.entity';
+import { Order } from '../../entity/order/order.entity';
 import { ProductVariant } from '../../entity/product-variant/product-variant.entity';
 import { ShippingMethod } from '../../entity/shipping-method/shipping-method.entity';
 import { Allocation } from '../../entity/stock-movement/allocation.entity';
@@ -270,7 +270,7 @@ export class StockMovementService {
             where: {
                 id: In(lineInputs.map(l => l.orderLineId)),
             },
-            relations: ['productVariant'],
+            relations: { productVariant: true },
         });
 
         const cancellations: Cancellation[] = [];
@@ -321,7 +321,7 @@ export class StockMovementService {
         const releases: Release[] = [];
         const orderLines = await this.connection.getRepository(ctx, OrderLine).find({
             where: { id: In(lineInputs.map(l => l.orderLineId)) },
-            relations: ['productVariant'],
+            relations: { productVariant: true },
         });
         const globalTrackInventory = (await this.globalSettingsService.getSettings(ctx)).trackInventory;
         const variantsMap = new Map<ID, ProductVariant>();

--- a/packages/core/src/service/services/tax-rate.service.ts
+++ b/packages/core/src/service/services/tax-rate.service.ts
@@ -16,6 +16,7 @@ import { createSelfRefreshingCache, SelfRefreshingCache } from '../../common/sel
 import { ListQueryOptions } from '../../common/types/common-types';
 import { assertFound } from '../../common/utils';
 import { ConfigService } from '../../config/config.service';
+import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { CustomerGroup } from '../../entity/customer-group/customer-group.entity';
 import { TaxCategory } from '../../entity/tax-category/tax-category.entity';
@@ -106,7 +107,9 @@ export class TaxRateService {
             .getRepository(ctx, TaxRate)
             .findOne({
                 where: { id: taxRateId },
-                relations: relations ?? ['category', 'zone', 'customerGroup'],
+                relations: findOptionsArrayToObject<TaxRate>(
+                    relations ?? ['category', 'zone', 'customerGroup'],
+                ),
             })
             .then(result => result ?? undefined);
     }
@@ -208,7 +211,7 @@ export class TaxRateService {
 
     private async findActiveTaxRates(ctx: RequestContext): Promise<TaxRate[]> {
         return await this.connection.getRepository(ctx, TaxRate).find({
-            relations: ['category', 'zone', 'customerGroup'],
+            relations: { category: true, zone: true, customerGroup: true },
             where: {
                 enabled: true,
             },

--- a/packages/core/src/service/services/zone.service.ts
+++ b/packages/core/src/service/services/zone.service.ts
@@ -68,7 +68,7 @@ export class ZoneService {
             refresh: {
                 fn: ctx =>
                     this.connection.getRepository(ctx, Zone).find({
-                        relations: ['members'],
+                        relations: { members: true },
                     }),
                 defaultArgs: [RequestContext.empty()],
             },
@@ -97,7 +97,7 @@ export class ZoneService {
             .getRepository(ctx, Zone)
             .findOne({
                 where: { id: zoneId },
-                relations: ['members'],
+                relations: { members: true },
             })
             .then(zone => {
                 if (zone) {

--- a/packages/core/src/telemetry/collectors/database.collector.ts
+++ b/packages/core/src/telemetry/collectors/database.collector.ts
@@ -163,12 +163,12 @@ export class DatabaseCollector {
                 return undefined;
             }
             const channels = await rawConnection.getRepository(Channel).find({
-                select: [
-                    'defaultLanguageCode',
-                    'availableLanguageCodes',
-                    'defaultCurrencyCode',
-                    'availableCurrencyCodes',
-                ],
+                select: {
+                    defaultLanguageCode: true,
+                    availableLanguageCodes: true,
+                    defaultCurrencyCode: true,
+                    availableCurrencyCodes: true,
+                },
             });
             const languages = new Set<string>();
             const currencies = new Set<string>();

--- a/packages/core/src/telemetry/collectors/database.collector.ts
+++ b/packages/core/src/telemetry/collectors/database.collector.ts
@@ -3,6 +3,7 @@ import { OrderType } from '@vendure/common/lib/generated-types';
 import { IsNull, MoreThanOrEqual, Not, type Repository } from 'typeorm';
 
 import { ConfigService } from '../../config/config.service';
+import { getDatabaseType as getConfiguredDatabaseType } from '../../connection/database-type';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { Channel } from '../../entity/channel/channel.entity';
 import { coreEntitiesMap } from '../../entity/entities';
@@ -201,7 +202,7 @@ export class DatabaseCollector {
     }
 
     private getDatabaseType(): SupportedDatabaseType {
-        const dbType = this.configService.dbConnectionOptions.type;
+        const dbType = getConfiguredDatabaseType(this.configService.dbConnectionOptions);
         if (dbType === 'better-sqlite3' || dbType === 'sqlite') {
             return 'sqlite';
         }

--- a/packages/core/src/telemetry/telemetry.types.ts
+++ b/packages/core/src/telemetry/telemetry.types.ts
@@ -1,4 +1,4 @@
-import { DataSourceOptions } from 'typeorm';
+import { VendureDatabaseType } from '../connection/database-type';
 
 /**
  * Range buckets for anonymizing entity counts
@@ -30,11 +30,11 @@ export interface TelemetryRuntime {
 
 /**
  * Supported database types for Vendure telemetry.
- * Derived from TypeORM's DataSourceOptions for type safety.
+ * Derived from the driver names Vendure recognises, for type safety.
  * Note: 'better-sqlite3' is normalized to 'sqlite' in the collector.
  */
 export type SupportedDatabaseType =
-    | Extract<DataSourceOptions['type'], 'postgres' | 'mysql' | 'mariadb' | 'sqlite'>
+    | Extract<VendureDatabaseType, 'postgres' | 'mysql' | 'mariadb' | 'sqlite'>
     | 'other';
 
 /**

--- a/packages/dashboard/plugin/service/metrics.service.ts
+++ b/packages/dashboard/plugin/service/metrics.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Logger, Order, RequestContext, TransactionalConnection } from '@vendure/core';
+import { getDatabaseType, Logger, Order, RequestContext, TransactionalConnection } from '@vendure/core';
 import { addDays, differenceInCalendarDays, endOfDay, format, startOfDay } from 'date-fns';
 
 import {
@@ -134,7 +134,7 @@ export class MetricsService {
     }
 
     private getDateExpression(): string {
-        switch (this.connection.rawConnection.options.type) {
+        switch (getDatabaseType(this.connection.rawConnection)) {
             case 'postgres':
                 return `TO_CHAR(order.orderPlacedAt, 'YYYY-MM-DD')`;
             case 'mysql':

--- a/packages/testing/src/data-population/clear-all-tables.ts
+++ b/packages/testing/src/data-population/clear-all-tables.ts
@@ -1,6 +1,6 @@
 import { VendureConfig } from '@vendure/core';
 import { preBootstrapConfig } from '@vendure/core/dist/bootstrap';
-import { createConnection } from 'typeorm';
+import { DataSource } from 'typeorm';
 
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-floating-promises */
@@ -13,14 +13,14 @@ export async function clearAllTables(config: VendureConfig, logging = true) {
     }
     config = await preBootstrapConfig(config);
     const entityIdStrategy = config.entityIdStrategy ?? config.entityOptions?.entityIdStrategy;
-    const connection = await createConnection({ ...config.dbConnectionOptions });
+    const connection = await new DataSource({ ...config.dbConnectionOptions }).initialize();
     try {
         await connection.synchronize(true);
     } catch (err: any) {
         console.error('Error occurred when attempting to clear tables!');
         console.log(err);
     } finally {
-        await connection.close();
+        await connection.destroy();
     }
     if (logging) {
         console.log('Done!');

--- a/packages/testing/src/initializers/mysql-initializer.ts
+++ b/packages/testing/src/initializers/mysql-initializer.ts
@@ -1,15 +1,14 @@
 import path from 'path';
-import { MysqlConnectionOptions } from 'typeorm/driver/mysql/MysqlConnectionOptions';
 
-import { TestDbInitializer } from './test-db-initializer';
+import { DriverOptions, TestDbInitializer } from './test-db-initializer';
 
-export class MysqlInitializer implements TestDbInitializer<MysqlConnectionOptions> {
+export class MysqlInitializer implements TestDbInitializer<DriverOptions<'mysql' | 'mariadb'>> {
     private conn: import('mysql2/promise').Connection;
 
     async init(
         testFileName: string,
-        connectionOptions: MysqlConnectionOptions,
-    ): Promise<MysqlConnectionOptions> {
+        connectionOptions: DriverOptions<'mysql' | 'mariadb'>,
+    ): Promise<DriverOptions<'mysql' | 'mariadb'>> {
         const dbName = this.getDbNameFromFilename(testFileName);
         this.conn = await this.getMysqlConnection(connectionOptions);
         (connectionOptions as any).database = dbName;
@@ -28,7 +27,7 @@ export class MysqlInitializer implements TestDbInitializer<MysqlConnectionOption
     }
 
     private async getMysqlConnection(
-        connectionOptions: MysqlConnectionOptions,
+        connectionOptions: DriverOptions<'mysql' | 'mariadb'>,
     ): Promise<import('mysql2/promise').Connection> {
         const { createConnection } = await import('mysql2/promise');
         const conn = createConnection({

--- a/packages/testing/src/initializers/postgres-initializer.ts
+++ b/packages/testing/src/initializers/postgres-initializer.ts
@@ -1,15 +1,14 @@
 import path from 'path';
-import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 
-import { TestDbInitializer } from './test-db-initializer';
+import { DriverOptions, TestDbInitializer } from './test-db-initializer';
 
-export class PostgresInitializer implements TestDbInitializer<PostgresConnectionOptions> {
+export class PostgresInitializer implements TestDbInitializer<DriverOptions<'postgres'>> {
     private client: import('pg').Client;
 
     async init(
         testFileName: string,
-        connectionOptions: PostgresConnectionOptions,
-    ): Promise<PostgresConnectionOptions> {
+        connectionOptions: DriverOptions<'postgres'>,
+    ): Promise<DriverOptions<'postgres'>> {
         const dbName = this.getDbNameFromFilename(testFileName);
         (connectionOptions as any).database = dbName;
         (connectionOptions as any).synchronize = true;
@@ -28,7 +27,7 @@ export class PostgresInitializer implements TestDbInitializer<PostgresConnection
     }
 
     private async getPostgresConnection(
-        connectionOptions: PostgresConnectionOptions,
+        connectionOptions: DriverOptions<'postgres'>,
     ): Promise<import('pg').Client> {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const { Client } = require('pg');

--- a/packages/testing/src/initializers/sqljs-initializer.ts
+++ b/packages/testing/src/initializers/sqljs-initializer.ts
@@ -1,14 +1,13 @@
 import fs from 'fs';
 import path from 'path';
-import { SqljsConnectionOptions } from 'typeorm/driver/sqljs/SqljsConnectionOptions';
 
 import { Mutable } from '../types';
 
-import { TestDbInitializer } from './test-db-initializer';
+import { DriverOptions, TestDbInitializer } from './test-db-initializer';
 
-export class SqljsInitializer implements TestDbInitializer<SqljsConnectionOptions> {
+export class SqljsInitializer implements TestDbInitializer<DriverOptions<'sqljs'>> {
     private dbFilePath: string;
-    private connectionOptions: SqljsConnectionOptions;
+    private connectionOptions: DriverOptions<'sqljs'>;
 
     /**
      * @param dataDir
@@ -20,11 +19,11 @@ export class SqljsInitializer implements TestDbInitializer<SqljsConnectionOption
 
     async init(
         testFileName: string,
-        connectionOptions: SqljsConnectionOptions,
-    ): Promise<SqljsConnectionOptions> {
+        connectionOptions: DriverOptions<'sqljs'>,
+    ): Promise<DriverOptions<'sqljs'>> {
         this.dbFilePath = this.getDbFilePath(testFileName);
         this.connectionOptions = connectionOptions;
-        (connectionOptions as Mutable<SqljsConnectionOptions>).location = this.dbFilePath;
+        (connectionOptions as Mutable<DriverOptions<'sqljs'>>).location = this.dbFilePath;
         return connectionOptions;
     }
 
@@ -34,12 +33,12 @@ export class SqljsInitializer implements TestDbInitializer<SqljsConnectionOption
             if (!fs.existsSync(dirName)) {
                 fs.mkdirSync(dirName);
             }
-            (this.connectionOptions as Mutable<SqljsConnectionOptions>).autoSave = true;
-            (this.connectionOptions as Mutable<SqljsConnectionOptions>).synchronize = true;
+            (this.connectionOptions as Mutable<DriverOptions<'sqljs'>>).autoSave = true;
+            (this.connectionOptions as Mutable<DriverOptions<'sqljs'>>).synchronize = true;
             await populateFn();
             await new Promise(resolve => setTimeout(resolve, this.postPopulateTimeoutMs));
-            (this.connectionOptions as Mutable<SqljsConnectionOptions>).autoSave = false;
-            (this.connectionOptions as Mutable<SqljsConnectionOptions>).synchronize = false;
+            (this.connectionOptions as Mutable<DriverOptions<'sqljs'>>).autoSave = false;
+            (this.connectionOptions as Mutable<DriverOptions<'sqljs'>>).synchronize = false;
         }
     }
 

--- a/packages/testing/src/initializers/test-db-initializer.ts
+++ b/packages/testing/src/initializers/test-db-initializer.ts
@@ -1,5 +1,14 @@
 import { DataSourceOptions } from 'typeorm';
-import { BaseConnectionOptions } from 'typeorm/connection/BaseConnectionOptions';
+
+/**
+ * @description
+ * The TypeORM options for a particular driver, selected from the `DataSourceOptions` union by
+ * the driver's `type`. Selecting from the union rather than importing the driver's own options
+ * module avoids depending on where TypeORM keeps that module.
+ *
+ * @docsCategory testing
+ */
+export type DriverOptions<T extends DataSourceOptions['type']> = Extract<DataSourceOptions, { type: T }>;
 
 /**
  * @description
@@ -20,7 +29,7 @@ import { BaseConnectionOptions } from 'typeorm/connection/BaseConnectionOptions'
  *
  * @docsCategory testing
  */
-export interface TestDbInitializer<T extends BaseConnectionOptions> {
+export interface TestDbInitializer<T extends DataSourceOptions> {
     /**
      * @description
      * Responsible for creating a database for the current test suite.

--- a/scripts/typeorm/README.md
+++ b/scripts/typeorm/README.md
@@ -33,6 +33,10 @@ bun run typeorm:use --reset
 `bun run typeorm:use` rewrites `package.json` and `bun.lock`. Run `--reset` before committing;
 a stray `typeormProfile` field in the root `package.json` is the tell that you forgot.
 
+Applying a profile saves a copy of `bun.lock` first, and `--reset` puts it back and installs
+frozen. Without that, the reset install would float every dependency to the newest version its
+declared range allows, leaving the workspace on different versions from the ones it started on.
+
 `test:db` verifies the install before running anything. That check matters more than it looks:
 entity metadata is registered against a single `typeorm` module instance, so if a second copy
 ends up nested somewhere in `node_modules`, the suites fail in ways that read like genuine

--- a/scripts/typeorm/README.md
+++ b/scripts/typeorm/README.md
@@ -1,0 +1,74 @@
+# TypeORM version test harness
+
+Vendure is moving towards supporting both TypeORM v0.3 and v1 from the same source, so that
+existing projects can stay on v0.3 while new ones adopt v1. These scripts run the
+database-backed test suites against either version.
+
+## Why the version has to be forced
+
+`typeorm` is a direct dependency of `@vendure/core`, not a peer dependency, so you cannot pick
+the version at install time. Instead, each profile in `profiles.json` is written into the root
+`package.json` as a set of `overrides`, which bun applies to workspace packages' direct
+dependencies. The root already uses the same mechanism to keep `graphql` on one version.
+
+A profile covers more than `typeorm` itself. TypeORM v1 requires `@nestjs/typeorm` 11.0.1 or
+later (earlier releases declare a `typeorm` peer range of `^0.3.0`) and `better-sqlite3` v12.
+
+## Running the suites
+
+```sh
+# Switch the workspace to TypeORM v1 and install
+bun run typeorm:use 1
+
+# Run the unit and e2e suites against whichever profile is active
+bun run test:db                  # sqljs
+DB=postgres bun run test:db      # postgres
+bun run test:db --e2e-only
+bun run test:db --scope @vendure/core
+
+# Go back to the versions declared in the workspace
+bun run typeorm:use --reset
+```
+
+`bun run typeorm:use` rewrites `package.json` and `bun.lock`. Run `--reset` before committing;
+a stray `typeormProfile` field in the root `package.json` is the tell that you forgot.
+
+`test:db` verifies the install before running anything. That check matters more than it looks:
+entity metadata is registered against a single `typeorm` module instance, so if a second copy
+ends up nested somewhere in `node_modules`, the suites fail in ways that read like genuine
+version incompatibilities. `bun run typeorm:verify` runs the same check on its own.
+
+## Building while type errors remain
+
+```sh
+bun run build:for-tests
+```
+
+While the migration is in progress the packages do not typecheck against v1, and `bun run
+build` stops at the first error. `@vendure/core` builds in three stages joined by `&&` — the
+main compile, the CLI compile, and a copy of the static `.graphql` schema files — so one type
+error leaves `dist/` without the schema files and the server then fails to boot with "No type
+definitions were found", which tells you nothing about the actual incompatibility.
+
+`build:for-tests` runs each stage separately and keeps going. `tsc` emits its output even when
+it reports errors, so everything needed to boot a server is produced. Type errors are not
+being hidden: the `build` job in `typeorm_v1.yml` reports those, and the e2e jobs use this
+script to give the second, independent signal of which calls fail once the code is running.
+
+## In CI
+
+The `.github/actions/setup` action takes a `typeorm` input naming a profile. With no input it
+installs the committed lockfile, which is what `build_and_test.yml` does and what gives the
+project its v0.3 coverage.
+
+The v1 runs live in `typeorm_v1.yml`, separate from `build_and_test.yml`, because they are
+expected to fail until the migration is finished and a permanently red job inside the required
+matrix teaches people to ignore the required matrix. It runs nightly, on demand, and on any
+pull request labelled `typeorm-v1`. When every job in it passes, move them into
+`build_and_test.yml` as a `typeorm` matrix axis and delete the separate workflow.
+
+## Adding a version
+
+Add an entry to `profiles.json` naming every package that has to move together with that
+TypeORM version. `use-version.mjs` clears the packages named by _all_ profiles before applying
+the requested one, so switching between profiles never leaves a stale override behind.

--- a/scripts/typeorm/build-for-tests.mjs
+++ b/scripts/typeorm/build-for-tests.mjs
@@ -29,13 +29,13 @@ const repoRoot = path.resolve(scriptDir, '..', '..');
 const order = topologicalPackageOrder();
 const failed = [];
 
-// A package manager puts the local `.bin` directories on PATH before running a
-// script; spawning the commands directly does not, so it is done here.
-const binPath = [
+// The local `.bin` directories, searched in the order a package manager would.
+// Commands are resolved against these to an absolute path rather than being
+// looked up through PATH at spawn time.
+const binDirs = [
     path.join(repoRoot, 'node_modules', '.bin'),
     ...order.map(pkg => path.join(pkg.location, 'node_modules', '.bin')),
-].join(path.delimiter);
-const env = { ...process.env, PATH: `${binPath}${path.delimiter}${process.env.PATH ?? ''}` };
+];
 
 for (const { name, location } of order) {
     const manifest = JSON.parse(fs.readFileSync(path.join(location, 'package.json'), 'utf8'));
@@ -46,7 +46,14 @@ for (const { name, location } of order) {
     console.log(`\n--- ${name}`);
     for (const stage of stages) {
         console.log(`$ ${stage}`);
-        const result = spawnSync(stage, { cwd: location, stdio: 'inherit', shell: true, env });
+        const [command, ...commandArgs] = stage.split(/\s+/);
+        const executable = resolveLocalBin(command);
+        if (!executable) {
+            console.log(`  skipped: no local binary named "${command}"`);
+            failed.push(`${name}: ${stage}`);
+            continue;
+        }
+        const result = spawnSync(executable, commandArgs, { cwd: location, stdio: 'inherit' });
         if (result.status !== 0) {
             failed.push(`${name}: ${stage}`);
         }
@@ -89,16 +96,71 @@ function resolveBuildStages(manifest) {
         .filter(Boolean);
 }
 
-function topologicalPackageOrder() {
-    const result = spawnSync('bunx', ['lerna', 'list', '--toposort', '--json', '--all'], {
-        cwd: repoRoot,
-        encoding: 'utf8',
-    });
-    if (result.status !== 0) {
-        console.error(result.stderr);
-        throw new Error('Could not determine the package build order via lerna.');
+/**
+ * Finds `command` in the workspace's `.bin` directories and returns its absolute
+ * path, or undefined if it is not installed.
+ */
+function resolveLocalBin(command) {
+    const candidates =
+        process.platform === 'win32' ? [`${command}.cmd`, `${command}.exe`, command] : [command];
+    for (const dir of binDirs) {
+        for (const candidate of candidates) {
+            const full = path.join(dir, candidate);
+            if (fs.existsSync(full)) {
+                return full;
+            }
+        }
     }
-    // lerna prints progress on stdout before the JSON payload.
-    const json = result.stdout.slice(result.stdout.indexOf('['));
-    return JSON.parse(json);
+    return undefined;
+}
+
+/**
+ * Orders the workspace packages so that each one is built after the packages it
+ * depends on. Derived from the manifests directly rather than by shelling out to
+ * lerna, which keeps the build order available even when the workspace is in a
+ * half-installed state.
+ */
+function topologicalPackageOrder() {
+    const packagesDir = path.join(repoRoot, 'packages');
+    const packages = fs
+        .readdirSync(packagesDir, { withFileTypes: true })
+        .filter(entry => entry.isDirectory())
+        .map(entry => path.join(packagesDir, entry.name))
+        .filter(location => fs.existsSync(path.join(location, 'package.json')))
+        .map(location => {
+            const manifest = JSON.parse(fs.readFileSync(path.join(location, 'package.json'), 'utf8'));
+            return {
+                name: manifest.name,
+                location,
+                deps: Object.keys({ ...manifest.dependencies, ...manifest.devDependencies }),
+            };
+        });
+
+    const byName = new Map(packages.map(pkg => [pkg.name, pkg]));
+    const ordered = [];
+    const visiting = new Set();
+    const visited = new Set();
+
+    const visit = pkg => {
+        if (visited.has(pkg.name) || visiting.has(pkg.name)) {
+            // A cycle between workspace packages is not something this script can
+            // resolve, so the package is emitted where it was first reached.
+            return;
+        }
+        visiting.add(pkg.name);
+        for (const dep of pkg.deps) {
+            const depPkg = byName.get(dep);
+            if (depPkg) {
+                visit(depPkg);
+            }
+        }
+        visiting.delete(pkg.name);
+        visited.add(pkg.name);
+        ordered.push({ name: pkg.name, location: pkg.location });
+    };
+
+    for (const pkg of packages) {
+        visit(pkg);
+    }
+    return ordered;
 }

--- a/scripts/typeorm/build-for-tests.mjs
+++ b/scripts/typeorm/build-for-tests.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Builds the workspace as far as it will go, without stopping at type errors,
+ * so that the database-backed suites can run and report what breaks at runtime.
+ *
+ * This exists because of how the build scripts are chained. `@vendure/core`'s
+ * build runs three stages joined by `&&`: the main compile, the CLI compile,
+ * and a copy of the static `.graphql` schema files. `tsc` still emits output
+ * when it reports type errors, but its non-zero exit stops the chain, so a
+ * single type error leaves `dist/` without the schema files. The server then
+ * fails to boot with "No type definitions were found", which says nothing about
+ * the actual incompatibility.
+ *
+ * Type errors are not swallowed by doing this — the `build` job in the same
+ * workflow reports them. This script gives the second, independent signal:
+ * which calls fail once the code is actually running.
+ *
+ * Usage:
+ *   node scripts/typeorm/build-for-tests.mjs
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..', '..');
+
+const order = topologicalPackageOrder();
+const failed = [];
+
+// A package manager puts the local `.bin` directories on PATH before running a
+// script; spawning the commands directly does not, so it is done here.
+const binPath = [
+    path.join(repoRoot, 'node_modules', '.bin'),
+    ...order.map(pkg => path.join(pkg.location, 'node_modules', '.bin')),
+].join(path.delimiter);
+const env = { ...process.env, PATH: `${binPath}${path.delimiter}${process.env.PATH ?? ''}` };
+
+for (const { name, location } of order) {
+    const manifest = JSON.parse(fs.readFileSync(path.join(location, 'package.json'), 'utf8'));
+    const stages = resolveBuildStages(manifest);
+    if (stages.length === 0) {
+        continue;
+    }
+    console.log(`\n--- ${name}`);
+    for (const stage of stages) {
+        console.log(`$ ${stage}`);
+        const result = spawnSync(stage, { cwd: location, stdio: 'inherit', shell: true, env });
+        if (result.status !== 0) {
+            failed.push(`${name}: ${stage}`);
+        }
+    }
+}
+
+if (failed.length) {
+    console.log(`\n${failed.length} build stage(s) reported errors; output was still emitted:`);
+    for (const entry of failed) {
+        console.log(`  ${entry}`);
+    }
+} else {
+    console.log('\nAll build stages passed.');
+}
+
+// Always succeeds: reporting build failures is the job of the `build` job, and
+// exiting non-zero here would stop the tests this script exists to enable.
+process.exit(0);
+
+/**
+ * Returns the `ci` script's stages, split on `&&` so each runs regardless of
+ * whether the previous one exited non-zero. One level of `npm run <script>`
+ * indirection is followed, which covers the `ci` -> `build` alias the packages
+ * use. Splitting on `&&` assumes no build command contains `&&` inside a quoted
+ * argument, which holds for every package script in this repo.
+ */
+function resolveBuildStages(manifest) {
+    const scripts = manifest.scripts ?? {};
+    let script = scripts.ci;
+    if (!script) {
+        return [];
+    }
+    const alias = /^(?:npm|bun|yarn) run ([\w:-]+)$/.exec(script.trim());
+    if (alias && scripts[alias[1]]) {
+        script = scripts[alias[1]];
+    }
+    return script
+        .split('&&')
+        .map(stage => stage.trim())
+        .filter(Boolean);
+}
+
+function topologicalPackageOrder() {
+    const result = spawnSync('bunx', ['lerna', 'list', '--toposort', '--json', '--all'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+    });
+    if (result.status !== 0) {
+        console.error(result.stderr);
+        throw new Error('Could not determine the package build order via lerna.');
+    }
+    // lerna prints progress on stdout before the JSON payload.
+    const json = result.stdout.slice(result.stdout.indexOf('['));
+    return JSON.parse(json);
+}

--- a/scripts/typeorm/profiles.json
+++ b/scripts/typeorm/profiles.json
@@ -1,0 +1,15 @@
+{
+    "//": "Dependency sets used to run the database-backed test suites against each supported TypeORM major. Each profile is applied as a set of `overrides` in the root package.json. `@nestjs/typeorm` must be >= 11.0.1 for both profiles, because that is the first release whose `typeorm` peer range admits v1.",
+    "profiles": {
+        "0.3": {
+            "typeorm": "0.3.31",
+            "@nestjs/typeorm": "11.0.3",
+            "better-sqlite3": "11.10.0"
+        },
+        "1": {
+            "typeorm": "1.1.0",
+            "@nestjs/typeorm": "11.0.3",
+            "better-sqlite3": "12.11.1"
+        }
+    }
+}

--- a/scripts/typeorm/run-db-tests.mjs
+++ b/scripts/typeorm/run-db-tests.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Runs the test suites that talk to a database, against whichever TypeORM
+ * profile the workspace is currently set to.
+ *
+ * The suites themselves are the normal `test` and `e2e` scripts. This wrapper
+ * exists so that a run is verified and labelled: it refuses to start against a
+ * broken install, and it states the TypeORM version and database engine that
+ * were actually exercised. Without that, a log full of failures gives no way to
+ * tell a real incompatibility from a mis-resolved dependency.
+ *
+ * Usage:
+ *   node scripts/typeorm/run-db-tests.mjs              # unit + e2e, sqljs
+ *   DB=postgres node scripts/typeorm/run-db-tests.mjs  # unit + e2e, postgres
+ *   node scripts/typeorm/run-db-tests.mjs --e2e-only
+ *   node scripts/typeorm/run-db-tests.mjs --scope @vendure/core
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..', '..');
+
+const args = process.argv.slice(2);
+const e2eOnly = args.includes('--e2e-only');
+const unitOnly = args.includes('--unit-only');
+const scopeIndex = args.indexOf('--scope');
+const scope = scopeIndex === -1 ? undefined : args[scopeIndex + 1];
+
+const verify = spawnSync(process.execPath, [path.join(scriptDir, 'verify.mjs')], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+});
+if (verify.status !== 0) {
+    process.exit(verify.status ?? 1);
+}
+
+const typeormVersion = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'node_modules', 'typeorm', 'package.json'), 'utf8'),
+).version;
+const dbEngine = process.env.DB || 'sqljs';
+
+console.log(`\nRunning database tests against typeorm@${typeormVersion} on ${dbEngine}.\n`);
+
+const scopeArgs = scope ? ['--scope', scope] : [];
+const suites = [
+    ...(e2eOnly ? [] : [{ name: 'unit', args: ['run', 'test', ...scopeArgs, '--stream', '--no-bail'] }]),
+    ...(unitOnly ? [] : [{ name: 'e2e', args: ['run', 'e2e', ...scopeArgs, '--stream', '--no-bail'] }]),
+];
+
+const failed = [];
+for (const suite of suites) {
+    const result = spawnSync('bunx', ['lerna', ...suite.args], {
+        cwd: repoRoot,
+        stdio: 'inherit',
+        env: { ...process.env, DB: dbEngine },
+    });
+    if (result.status !== 0) {
+        failed.push(suite.name);
+    }
+}
+
+console.log(
+    `\ntypeorm@${typeormVersion} on ${dbEngine}: ${failed.length ? `${failed.join(', ')} failed` : 'all suites passed'}`,
+);
+process.exit(failed.length ? 1 : 0);

--- a/scripts/typeorm/run-db-tests.mjs
+++ b/scripts/typeorm/run-db-tests.mjs
@@ -50,9 +50,17 @@ const suites = [
     ...(unitOnly ? [] : [{ name: 'e2e', args: ['run', 'e2e', ...scopeArgs, '--stream', '--no-bail'] }]),
 ];
 
+// Run lerna's entry point under the current Node binary, so neither the
+// executable nor the runtime is resolved through PATH.
+const lernaCli = path.join(repoRoot, 'node_modules', 'lerna', 'dist', 'cli.js');
+if (!fs.existsSync(lernaCli)) {
+    console.error(`Could not find lerna at ${lernaCli}. Run \`bun install\` first.`);
+    process.exit(1);
+}
+
 const failed = [];
 for (const suite of suites) {
-    const result = spawnSync('bunx', ['lerna', ...suite.args], {
+    const result = spawnSync(process.execPath, [lernaCli, ...suite.args], {
         cwd: repoRoot,
         stdio: 'inherit',
         env: { ...process.env, DB: dbEngine },

--- a/scripts/typeorm/use-version.mjs
+++ b/scripts/typeorm/use-version.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Switches the whole workspace onto one of the TypeORM profiles defined in
+ * `profiles.json`, so the database-backed test suites can be run against each
+ * supported TypeORM major.
+ *
+ * `typeorm` is a direct dependency of `@vendure/core` rather than a peer
+ * dependency, so the version cannot be selected per-install. The profile is
+ * applied as a set of root-level `overrides`, which bun honours for workspace
+ * packages' direct dependencies.
+ *
+ * Usage:
+ *   node scripts/typeorm/use-version.mjs 1          # switch to TypeORM v1 and install
+ *   node scripts/typeorm/use-version.mjs 0.3        # switch back to TypeORM v0.3 and install
+ *   node scripts/typeorm/use-version.mjs --reset    # drop the profile and restore the default install
+ *   node scripts/typeorm/use-version.mjs 1 --no-install
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..', '..');
+const rootPackageJsonPath = path.join(repoRoot, 'package.json');
+const PROFILE_FIELD = 'typeormProfile';
+
+const args = process.argv.slice(2);
+const install = !args.includes('--no-install');
+const reset = args.includes('--reset');
+const requested = args.find(arg => !arg.startsWith('--'));
+
+const { profiles } = JSON.parse(fs.readFileSync(path.join(scriptDir, 'profiles.json'), 'utf8'));
+
+if (!reset && !requested) {
+    console.error(
+        `Specify a profile (${Object.keys(profiles).join(', ')}) or --reset.\n` +
+            'See scripts/typeorm/README.md for details.',
+    );
+    process.exit(1);
+}
+if (requested && !profiles[requested]) {
+    console.error(
+        `Unknown TypeORM profile "${requested}". Available profiles: ${Object.keys(profiles).join(', ')}.`,
+    );
+    process.exit(1);
+}
+
+const rootPackageJsonSource = fs.readFileSync(rootPackageJsonPath, 'utf8');
+const rootPackageJson = JSON.parse(rootPackageJsonSource);
+const indent = /\n(\s+)"/.exec(rootPackageJsonSource)?.[1] ?? '  ';
+const overrides = { ...(rootPackageJson.overrides ?? {}) };
+
+// Every package named by any profile is removed first, so switching between
+// profiles never leaves a stale override behind.
+for (const profile of Object.values(profiles)) {
+    for (const name of Object.keys(profile)) {
+        delete overrides[name];
+    }
+}
+
+if (reset) {
+    delete rootPackageJson[PROFILE_FIELD];
+    console.log('Removed the TypeORM profile; the workspace will install its default versions.');
+} else {
+    Object.assign(overrides, profiles[requested]);
+    rootPackageJson[PROFILE_FIELD] = requested;
+    console.log(`Applying TypeORM profile "${requested}":`);
+    for (const [name, version] of Object.entries(profiles[requested])) {
+        console.log(`  ${name}@${version}`);
+    }
+}
+
+rootPackageJson.overrides = overrides;
+fs.writeFileSync(rootPackageJsonPath, `${JSON.stringify(rootPackageJson, null, indent)}\n`);
+
+if (!install) {
+    console.log('\nSkipped install (--no-install). Run `bun install` to apply.');
+    process.exit(0);
+}
+
+if (reset && !args.includes('--keep-lockfile')) {
+    // Without this the reset install floats every dependency to the newest
+    // version its declared range allows, which is not the state the profile was
+    // applied on top of. Pass --keep-lockfile to skip.
+    console.log('\nRestoring bun.lock from git…');
+    try {
+        execFileSync('git', ['checkout', '--', 'bun.lock'], { cwd: repoRoot, stdio: 'inherit' });
+        console.log('Installing…');
+        execFileSync('bun', ['install', '--frozen-lockfile'], { cwd: repoRoot, stdio: 'inherit' });
+        console.log('\nThe workspace is back on its committed dependency versions.');
+        process.exit(0);
+    } catch {
+        console.log('Could not restore bun.lock from git; installing without it.');
+    }
+}
+
+// Applying a profile rewrites the overrides, so the lockfile is expected to
+// change and --frozen-lockfile cannot be used.
+console.log('\nInstalling…');
+execFileSync('bun', ['install'], { cwd: repoRoot, stdio: 'inherit' });
+
+if (!reset) {
+    console.log(
+        '\npackage.json and bun.lock now hold profile-specific versions. ' +
+            'Run `node scripts/typeorm/use-version.mjs --reset` before committing.',
+    );
+}

--- a/scripts/typeorm/use-version.mjs
+++ b/scripts/typeorm/use-version.mjs
@@ -23,6 +23,9 @@ import { fileURLToPath } from 'node:url';
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..', '..');
 const rootPackageJsonPath = path.join(repoRoot, 'package.json');
+const lockfilePath = path.join(repoRoot, 'bun.lock');
+// Gitignored alongside the lockfile it copies; see .gitignore.
+const lockfileBackupPath = path.join(repoRoot, 'bun.lock.typeorm-profile-backup');
 const PROFILE_FIELD = 'typeormProfile';
 
 const args = process.argv.slice(2);
@@ -79,28 +82,38 @@ if (!install) {
     process.exit(0);
 }
 
-if (reset && !args.includes('--keep-lockfile')) {
-    // Without this the reset install floats every dependency to the newest
-    // version its declared range allows, which is not the state the profile was
-    // applied on top of. Pass --keep-lockfile to skip.
-    console.log('\nRestoring bun.lock from git…');
-    try {
-        execFileSync('git', ['checkout', '--', 'bun.lock'], { cwd: repoRoot, stdio: 'inherit' });
-        console.log('Installing…');
-        execFileSync('bun', ['install', '--frozen-lockfile'], { cwd: repoRoot, stdio: 'inherit' });
-        console.log('\nThe workspace is back on its committed dependency versions.');
-        process.exit(0);
-    } catch {
-        console.log('Could not restore bun.lock from git; installing without it.');
+let frozen = false;
+if (reset) {
+    // A plain reset install floats every dependency to the newest version its
+    // declared range allows, which is not the state the profile was applied on
+    // top of. The lockfile saved when the profile was applied is put back so the
+    // workspace returns to exactly the versions it had.
+    if (fs.existsSync(lockfileBackupPath)) {
+        fs.copyFileSync(lockfileBackupPath, lockfilePath);
+        fs.rmSync(lockfileBackupPath);
+        frozen = true;
+        console.log('\nRestored the lockfile saved when the profile was applied.');
+    } else {
+        console.log(
+            '\nNo saved lockfile found, so dependencies will resolve afresh within their ' +
+                'declared ranges. Check bun.lock before committing.',
+        );
     }
+} else if (!fs.existsSync(lockfileBackupPath) && fs.existsSync(lockfilePath)) {
+    fs.copyFileSync(lockfilePath, lockfileBackupPath);
 }
 
-// Applying a profile rewrites the overrides, so the lockfile is expected to
-// change and --frozen-lockfile cannot be used.
 console.log('\nInstalling…');
-execFileSync('bun', ['install'], { cwd: repoRoot, stdio: 'inherit' });
+// Resolved through PATH by necessity: bun is the workspace's package manager and
+// is not installed into the workspace itself. NOSONAR
+execFileSync('bun', frozen ? ['install', '--frozen-lockfile'] : ['install'], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+});
 
-if (!reset) {
+if (reset) {
+    console.log('\nThe workspace is back on its committed dependency versions.');
+} else {
     console.log(
         '\npackage.json and bun.lock now hold profile-specific versions. ' +
             'Run `node scripts/typeorm/use-version.mjs --reset` before committing.',

--- a/scripts/typeorm/verify.mjs
+++ b/scripts/typeorm/verify.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Asserts that the installed TypeORM matches the profile the workspace is set
+ * to, and that exactly one copy of it is installed.
+ *
+ * Both checks are worth making before a test run. A hoisting quirk or a stale
+ * `node_modules` can leave the intended version in the root while a workspace
+ * package resolves a nested copy of the other major, and the resulting test
+ * failures look like genuine incompatibilities rather than a bad install.
+ *
+ * Usage:
+ *   node scripts/typeorm/verify.mjs            # check against the profile in package.json
+ *   node scripts/typeorm/verify.mjs --expect 1 # check against an explicit profile
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..', '..');
+const PROFILE_FIELD = 'typeormProfile';
+
+const args = process.argv.slice(2);
+const expectFlagIndex = args.indexOf('--expect');
+const rootPackageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+const expected = expectFlagIndex === -1 ? rootPackageJson[PROFILE_FIELD] : args[expectFlagIndex + 1];
+
+const installs = findTypeormInstalls();
+
+if (installs.length === 0) {
+    console.error('No installed copy of typeorm found. Run `bun install` first.');
+    process.exit(1);
+}
+
+for (const { version, location } of installs) {
+    console.log(`typeorm@${version}  ${location}`);
+}
+
+const distinctVersions = [...new Set(installs.map(i => i.version))];
+if (distinctVersions.length > 1) {
+    console.error(
+        `\nFound ${distinctVersions.length} different typeorm versions installed (${distinctVersions.join(
+            ', ',
+        )}). Entity metadata is registered against a single typeorm instance, so a split install ` +
+            'produces failures unrelated to version compatibility. Delete node_modules and reinstall.',
+    );
+    process.exit(1);
+}
+
+const [actual] = distinctVersions;
+
+if (!expected) {
+    console.log(`\nNo TypeORM profile is set; using typeorm@${actual}.`);
+    process.exit(0);
+}
+
+const expectedMajor = expected.split('.')[0];
+const actualMajor = actual.split('.')[0];
+if (expectedMajor !== actualMajor) {
+    console.error(
+        `\nProfile "${expected}" was requested but typeorm@${actual} is installed. ` +
+            'Run `node scripts/typeorm/use-version.mjs ' +
+            `${expected}\` to reinstall.`,
+    );
+    process.exit(1);
+}
+
+console.log(`\nTypeORM profile "${expected}" verified: typeorm@${actual}.`);
+
+/**
+ * Looks for typeorm in the root, in each workspace package, and one level of
+ * nesting under the root `node_modules` — the places bun can put a second copy.
+ */
+function findTypeormInstalls() {
+    const candidateRoots = [
+        path.join(repoRoot, 'node_modules'),
+        ...listDirs(path.join(repoRoot, 'packages')).map(dir => path.join(dir, 'node_modules')),
+        ...listDirs(path.join(repoRoot, 'node_modules')).flatMap(dir =>
+            path.basename(dir).startsWith('@')
+                ? listDirs(dir).map(scoped => path.join(scoped, 'node_modules'))
+                : [path.join(dir, 'node_modules')],
+        ),
+    ];
+
+    const found = [];
+    for (const modulesDir of candidateRoots) {
+        const manifest = path.join(modulesDir, 'typeorm', 'package.json');
+        if (fs.existsSync(manifest)) {
+            found.push({
+                version: JSON.parse(fs.readFileSync(manifest, 'utf8')).version,
+                location: path.relative(repoRoot, path.dirname(manifest)),
+            });
+        }
+    }
+    return found;
+}
+
+function listDirs(dir) {
+    if (!fs.existsSync(dir)) {
+        return [];
+    }
+    return fs
+        .readdirSync(dir, { withFileTypes: true })
+        .filter(entry => entry.isDirectory() && entry.name !== 'typeorm')
+        .map(entry => path.join(dir, entry.name));
+}


### PR DESCRIPTION
Moves `@vendure/core` off the TypeORM 0.3 APIs that version 1 removes, so that the same source works against both. Tracked in vendurehq/vendure#5105.

This replaces the previous stack of #5107, #5120 and #5121, which are closed in favour of this branch. The stack was collapsed because `typeorm_v1.yml` and `build_and_test.yml` both filter `pull_request` on the base branch, and only the bottom PR of a stack targets `minor`. Everything above it got no build, no unit tests and no e2e on either TypeORM version, so there was no way to tell whether the later steps were getting closer to working. A single PR against `minor` gets the full matrix on every push. The trigger bug itself is fixed separately, since it will bite the next stacked PR regardless of what happens here.

The commits are unchanged and still atomic, so the three stages can be read individually.

## Find options in object syntax

The string-array form of the find options `relations` and `select` properties is removed in v1. The object form is valid in both versions, so this is an ordinary refactor rather than a compatibility shim, and the existing Build & Test suite proves it.

`RelationPaths<T>` stays as it is. It is public API, plugin authors use it, and the `@Relations()` decorator produces one. `TransactionalConnection` therefore owns its find-options types instead of extending TypeORM's: `VendureFindOneOptions` and `VendureFindManyOptions` accept both forms and normalise to the object form before handing over to TypeORM. That covered 62 call sites without touching any of them. The rest go directly to a TypeORM repository and are converted here, either to an object literal or through `findOptionsArrayToObject`, which is exported for plugins doing the same thing.

The object form is checked against the entity where the array form was an unchecked string list, which turned up two real problems. Three queries in `SessionService` request `user` against the abstract `Session`, where the property is declared on `AuthenticatedSession`; it resolves at runtime through single-table inheritance, which is why it has always worked. Those are left as they are with a comment, because changing which entity a session query targets is a behaviour change that does not belong in a syntax conversion. Separately, `findByIdsInChannel` only applied the tree-relation join filtering when `relations` was an array, so the object form produced duplicate joins for Collection tree relations. It now filters both forms, matching `findOneInChannel`.

## Reading the DataSource

`getDataSource()` returns the `DataSource` that a TypeORM object belongs to, by reading whichever of the `dataSource` and `connection` properties the installed version provides. It is applied at every site in `@vendure/core` that reaches for one.

Of the eighteen sites, exactly one was genuinely broken: the `RelationIdLoader` patch in `packages/core/src/entity/typeorm-relation-id-loader-fix.ts`. That class holds its `DataSource` in a private field which TypeORM renamed without leaving an alias, because nothing outside the class was supposed to read it. That single site produced around 110 `Cannot read properties of undefined (reading 'driver')` failures per database backend. The other seventeen work on v1 today through a deprecated getter, and are converted so they survive its removal.

The accessor prefers `dataSource` and falls back to `connection`, so the fallback stops being used the moment a workspace moves to v1.

The original failure produced no type error, because the patch assigns through `proto[methodName]`, which is `any`. `get-data-source.spec.ts` covers both property shapes, the case where both are present, and the error when neither is. Its last test constructs a real `RelationIdLoader` from whichever TypeORM is installed and asserts the accessor resolves its `DataSource`, which is the check that would have caught the original failure and is meaningful under both profiles.

## The removed connection API

`Connection`, `createConnection`, `isConnected`, `close()` and `DataSourceOptions.name` are all gone in v1. Every replacement already exists in 0.3, so this works on both versions.

The `migrate.ts` "casts that no longer overlap" item on the issue is included here. The cause was `name` being removed from `BaseDataSourceOptions`, not the driver union changing as the issue guessed.

## Measurements

Type errors in `@vendure/core` against TypeORM 1.1.0: **184 at the baseline, 36 after the find options work, 23 after the DataSource and connection API work.** The final commits complete a gap in the find options conversion and remove one further deep import, which I have not re-measured against a real v1 install; the CI run on this PR will give the current figure.

The e2e suite now runs to completion against v1 with no infrastructure failures, where the baseline could not boot. 133 tests passed at the last measurement.

On 0.3: strict `tsc` clean across the workspace, 1277 unit tests pass, and the `entity-hydrator`, `facet`, `list-query-builder`, `collection`, `guest-checkout-strategy`, `custom-field-relations`, `order` and `product` e2e suites pass on sqljs, 536 tests.

## Still outstanding

The v1 jobs on this PR are expected to be red until the remaining items on #5105 are done: tests for the behavioural changes, the renamed deep import paths, the `'sqlite'` driver type cases, `@vendure/cli` and `dev-server`, and the dependency question. Nothing here claims v1 support. That happens in the final change which sets the dependency range and folds the v1 jobs into Build & Test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789029817&installation_model_id=20193&pr_number=5122&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5122&signature=562cf9d583f3b6498883e9792b77eb742cc7ba1f8521d4b61b954533ddbc3df1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->