### PR TITLE
ci: Run the TypeORM v1 jobs on stacked pull requests

### DIFF
--- a/.github/workflows/typeorm_v1.yml
+++ b/.github/workflows/typeorm_v1.yml
@@ -14,11 +14,10 @@ on:
         # Nightly, so regressions in either TypeORM v1 or Vendure surface without
         # anyone having to remember to trigger a run.
         - cron: '0 3 * * *'
+    # No base-branch filter: the `typeorm-v1` label is the only gate, applied per job
+    # below. A pull request stacked on another feature branch does not target master,
+    # major or minor, and filtering on the base would silently skip every one of them.
     pull_request:
-        branches:
-            - master
-            - major
-            - minor
         types: [opened, reopened, synchronize, labeled]
 
 env:


### PR DESCRIPTION
`typeorm_v1.yml` filters `pull_request` on the base branch:

```yaml
pull_request:
    branches: [master, major, minor]
```

That is the base branch, not the head. Only the bottom pull request of a stack targets `minor`; everything above it targets the branch below. So a stacked pull request never triggers the workflow at all, no matter what labels it carries.

This was not theoretical. PRs 5120 and 5121 both had the `typeorm-v1` label and neither had ever produced a single run. Every run in the workflow's history came from the one branch at the bottom of the stack. An absent check looks exactly like a check nobody has added yet, so there was no signal that anything was wrong.

The `typeorm-v1` label is already the gate, applied per job. The base-branch filter was redundant at best, so it is removed.

The cost is that every pull request in the repository now produces a run with all six jobs skipped, which shows as grey entries in the checks list. No runner time is consumed. This goes away when the v1 jobs fold into Build & Test and this file is deleted.

Note that `build_and_test.yml` has the same filter and therefore the same behaviour, which is left alone here: it is the required check set, and broadening it would run the full matrix on every pull request targeting any branch, including forks.

Relates to vendurehq/vendure#5105.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789029832&installation_model_id=20193&pr_number=5123&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5123&signature=fe224989f4c82970a68bf8529816cfbec6a0a3318ce43d1978cfc36d5caad6ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->