### PR TITLE
chore(repo): Back-merge master into minor

### DIFF
--- a/docs/docs/reference/dashboard/list-views/list-page.mdx
+++ b/docs/docs/reference/dashboard/list-views/list-page.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## ListPage
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/list-page.tsx" sourceLine="503" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/list-page.tsx" sourceLine="524" packageName="@vendure/dashboard" since="3.3.0" />
 
 Auto-generates a list page with columns generated based on the provided query document fields.
 
@@ -129,6 +129,9 @@ interface ListPageProps<T extends TypedDocumentNode<U, V>, U extends ListQuerySh
     facetedFilters?: FacetedFilterConfig<T>;
     rowActions?: RowAction<ListQueryFields<T>>[];
     transformData?: (data: any[]) => any[];
+    transformQueryKey?: (queryKey: any[]) => any[];
+    disableViewOptions?: boolean;
+    includeSelectionColumn?: boolean;
     setTableOptions?: (table: TableOptions<any>) => TableOptions<any>;
     bulkActions?: BulkActionsInput;
     registerRefresher?: PaginatedListRefresherRegisterFn;
@@ -444,6 +447,25 @@ By default, the actions column includes all bulk actions defined in the `bulkAct
 
 Allows the returned list query data to be transformed in some way. This is an advanced feature
 that is not often required.
+### transformQueryKey
+
+<MemberInfo kind="property" type={`(queryKey: any[]) => any[]`}   />
+
+Allows the react-query cache key to be transformed. Use this together with the
+`transformVariables` prop when a page injects extra state into the query
+(e.g. a language selector or a status filter): the default key only reflects page, sorting,
+column filters and the search term, so without transforming the key too, changing the injected
+state serves a stale cached result instead of refetching.
+### disableViewOptions
+
+<MemberInfo kind="property" type={`boolean`}   />
+
+When true, disables the view options (column visibility) control in the table toolbar.
+### includeSelectionColumn
+
+<MemberInfo kind="property" type={`boolean`} default={`true`}   />
+
+When false, the row selection checkbox column will not be included.
 ### setTableOptions
 
 <MemberInfo kind="property" type={`(table: TableOptions<any>) => TableOptions<any>`}   />

--- a/docs/docs/reference/typescript-api/services/promotion-service.mdx
+++ b/docs/docs/reference/typescript-api/services/promotion-service.mdx
@@ -2,7 +2,7 @@
 title: "PromotionService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/promotion.service.ts" sourceLine="58" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/promotion.service.ts" sourceLine="60" packageName="@vendure/core" />
 
 Contains methods relating to [Promotion](/reference/typescript-api/entities/promotion#promotion) entities.
 
@@ -10,7 +10,7 @@ Contains methods relating to [Promotion](/reference/typescript-api/entities/prom
 class PromotionService {
     availableConditions: PromotionCondition[] = [];
     availableActions: PromotionAction[] = [];
-    constructor(connection: TransactionalConnection, configService: ConfigService, channelService: ChannelService, listQueryBuilder: ListQueryBuilder, configArgService: ConfigArgService, customFieldRelationService: CustomFieldRelationService, eventBus: EventBus, translatableSaver: TranslatableSaver, translator: TranslatorService)
+    constructor(connection: TransactionalConnection, configService: ConfigService, channelService: ChannelService, listQueryBuilder: ListQueryBuilder, configArgService: ConfigArgService, customFieldRelationService: CustomFieldRelationService, eventBus: EventBus, translatableSaver: TranslatableSaver, translator: TranslatorService, roleService: RoleService)
     findAll(ctx: RequestContext, options?: ListQueryOptions<Promotion>, relations: RelationPaths<Promotion> = []) => Promise<PaginatedList<Promotion>>;
     findOne(ctx: RequestContext, adjustmentSourceId: ID, relations: RelationPaths<Promotion> = []) => Promise<Promotion | undefined>;
     getPromotionConditions(ctx: RequestContext) => ConfigurableOperationDefinition[];

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3078,7 +3078,7 @@
                   "title": "PromotionService",
                   "slug": "promotion-service",
                   "file": "docs/reference/typescript-api/services/promotion-service.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-11T13:32:38Z"
                 },
                 {
                   "title": "ProvinceService",
@@ -4285,7 +4285,7 @@
                   "title": "ListPage",
                   "slug": "list-page",
                   "file": "docs/reference/dashboard/list-views/list-page.mdx",
-                  "lastModified": "2026-07-16T14:41:21+02:00"
+                  "lastModified": "2026-08-11T13:32:38Z"
                 },
                 {
                   "title": "PaginatedListDataTable",

--- a/packages/core/e2e/entity-hydrator.e2e-spec.ts
+++ b/packages/core/e2e/entity-hydrator.e2e-spec.ts
@@ -10,6 +10,7 @@ import {
     OrderLine,
     OrderService,
     Product,
+    ProductVariant,
     RequestContext,
     RequestContextService,
     TransactionalConnection,
@@ -522,6 +523,56 @@ describe('Entity hydration', () => {
         const child = entity.childrenPropertyWithAVeryLongNameThatExceedsPostgresLimitsEasilyByItself[0];
         expect(child.image1).toBeDefined();
         expect(child.image2).toBeDefined();
+    });
+
+    // Follow-up to #4986: isTranslatable() decided from element [0] whether an entire relation
+    // array was translatable. With a null featuredAsset at [0], nothing in the array was
+    // translated (Asset.name is a LocaleString, so it stayed undefined); with the asset at [0],
+    // translation ran but every other element's null featuredAsset was rewritten to undefined.
+    // The assertions below fail under either ordering, so the test does not depend on DB row
+    // order or on the id strategy.
+    it('translates a relation reached past a null array element', async () => {
+        const ctx = await server.app.get(RequestContextService).create({ apiType: 'admin' });
+        const connection = server.app.get(TransactionalConnection).rawConnection;
+        // The expected name is the known fixture literal (also asserted near the top of this
+        // file), so the expectation is independent of the data the translation path reads
+        const assetName = 'derick-david-409858-unsplash.jpg';
+        const assets = await connection.getRepository(Asset).find();
+        const asset = assets.find(a => a.translations.some(t => t.name === assetName));
+
+        // Raw-connection queries take the numeric DB id; 'T_1' exists only at the API layer
+        const laptop = await connection
+            .getRepository(Product)
+            .findOne({ where: { id: 1 }, relations: ['variants'] });
+        const variantWithAssetId = laptop!.variants[laptop!.variants.length - 1].id;
+        const nullAssetVariantCount = laptop!.variants.length - 1;
+        // Give exactly one of the variants a featuredAsset; the others keep the
+        // featuredAsset that is null in the database.
+        await connection.getRepository(ProductVariant).update(variantWithAssetId, { featuredAsset: asset! });
+        try {
+            const product = await connection
+                .getRepository(Product)
+                .findOne({ where: { id: 1 }, relations: ['variants'] });
+
+            await server.app.get(EntityHydrator).hydrate(ctx, product!, {
+                relations: ['variants.featuredAsset'],
+            });
+
+            const withAsset = product!.variants.filter(v => v.featuredAsset != null);
+            expect(withAsset.length).toBe(1);
+            expect(withAsset[0].featuredAsset.name).toBe(assetName);
+            // The others were null in the database and must still be null, not undefined:
+            // getMissingRelations() treats undefined as never-fetched, so hydrate() would
+            // re-query them on every subsequent call.
+            expect(product!.variants.filter(v => v.featuredAsset === null).length).toBe(
+                nullAssetVariantCount,
+            );
+        } finally {
+            // Restore the shared fixture so tests added after this one do not inherit it
+            await connection
+                .getRepository(ProductVariant)
+                .update(variantWithAssetId, { featuredAsset: null });
+        }
     });
 });
 

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
@@ -242,4 +242,33 @@ describe('EntityHydrator', () => {
             expect(result).toEqual([translation, undefined]);
         });
     });
+
+    describe('isTranslatable()', () => {
+        function isTranslatable(input: any): boolean {
+            const hydrator = new EntityHydrator(undefined as any, undefined as any, undefined as any);
+            return (hydrator as any).isTranslatable(input);
+        }
+        const translatable = { translations: [{ languageCode: 'en', name: 'Laptop' }] };
+
+        // A relation array can contain `null` (fetched but null on that element) or `undefined`
+        // (never fetched) entries — getRelationEntityAtPath() pushes both deliberately — so
+        // whether the relation is translatable cannot be decided from element [0] alone.
+        it('detects a translatable entity after a null leading element', () => {
+            expect(isTranslatable([null, translatable])).toBe(true);
+        });
+
+        it('detects a translatable entity after an undefined leading hole', () => {
+            expect(isTranslatable([undefined, translatable])).toBe(true);
+        });
+
+        // The falsy side: an array with nothing translatable must report false
+        it('reports false for an empty array', () => {
+            expect(isTranslatable([])).toBe(false);
+        });
+
+        it('reports false when no element is translatable', () => {
+            expect(isTranslatable([null, null])).toBe(false);
+            expect(isTranslatable([{ id: 1 }, null])).toBe(false);
+        });
+    });
 });

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import { Asset } from '../../../entity/asset/asset.entity';
+import { ProductVariant } from '../../../entity/product-variant/product-variant.entity';
+import { ProductPriceApplicator } from '../product-price-applicator/product-price-applicator';
+
 import { EntityHydrator } from './entity-hydrator.service';
 
 describe('EntityHydrator', () => {
@@ -216,9 +220,13 @@ describe('EntityHydrator', () => {
     });
 
     describe('getRelationEntityAtPath()', () => {
+        function getRelationEntityAtPath(target: any, path: string[]): any {
+            const hydrator = new EntityHydrator(undefined as any, undefined as any, undefined as any);
+            return (hydrator as any).getRelationEntityAtPath(target, path);
+        }
+
         // https://github.com/vendurehq/vendure/issues/4661
         it('treats undefined intermediate relations as terminal values', () => {
-            const hydrator = new EntityHydrator(undefined as any, undefined as any, undefined as any);
             const translation = { languageCode: 'en', name: 'Laptop' };
             const order = {
                 lines: [
@@ -233,13 +241,190 @@ describe('EntityHydrator', () => {
                 ],
             };
 
-            const result = (hydrator as any).getRelationEntityAtPath(order, [
-                'lines',
-                'productVariant',
-                'translations',
-            ]);
+            const result = getRelationEntityAtPath(order, ['lines', 'productVariant', 'translations']);
 
             expect(result).toEqual([translation, undefined]);
+        });
+
+        it('does not crash when a terminal relation array is very large', () => {
+            // A relation at the end of the path is collected element by element. `push(...target)`
+            // expands the array into call arguments, which exceeds V8's stack budget and throws a
+            // RangeError — the same failure fixed in getMissingRelations() in #4986. Reproduces
+            // e.g. `collection.productVariants` on a big catalog.
+            //
+            // The limit is a stack budget rather than a fixed count, so it moves with the Node
+            // version and the vitest pool (measured on Node 22: ~110k in a process, ~495k in a
+            // worker thread). The fixture is sized well above both. The hole is deliberate:
+            // `target.forEach(...)` would also avoid the RangeError but silently skips holes, and
+            // the walk must preserve them.
+            const variant = { id: 1 };
+            const productVariants = new Array(1_000_000).fill(variant);
+            delete productVariants[5];
+
+            const result = getRelationEntityAtPath({ productVariants }, ['productVariants']);
+
+            expect(result).toHaveLength(1_000_000);
+            expect(result[5]).toBeUndefined();
+        });
+    });
+
+    describe('getProductVariantsToPrice()', () => {
+        function getProductVariantsToPrice(entity: any): ProductVariant[] {
+            const hydrator = new EntityHydrator(undefined as any, undefined as any, undefined as any);
+            return (hydrator as any).getProductVariantsToPrice(entity);
+        }
+
+        // These pin the semantics of the helper rather than guard a regression: they are also
+        // satisfied by the pre-helper code, which skipped all three shapes by other means.
+        it('returns an empty array for an empty array', () => {
+            expect(getProductVariantsToPrice([])).toEqual([]);
+        });
+
+        it('returns an empty array when the array contains only holes', () => {
+            expect(getProductVariantsToPrice([null, undefined])).toEqual([]);
+        });
+
+        it('returns an empty array for non-ProductVariant entities', () => {
+            const assets = [new Asset({ id: 1 }), new Asset({ id: 2 })];
+            expect(getProductVariantsToPrice(assets)).toEqual([]);
+        });
+
+        it('wraps a bare ProductVariant in an array', () => {
+            const variant = new ProductVariant({ id: 1 });
+            expect(getProductVariantsToPrice(variant)).toEqual([variant]);
+        });
+
+        it('returns an empty array for undefined', () => {
+            expect(getProductVariantsToPrice(undefined)).toEqual([]);
+        });
+    });
+
+    describe('hydrate() with applyProductVariantPrices', () => {
+        class TestOrder {
+            id = 1;
+            children?: any[];
+        }
+        class TestChild {}
+
+        /**
+         * Drives the real hydrate() against a stubbed query builder that returns a fixed
+         * hydrated result. The ProductPriceApplicator is the real implementation with stubbed
+         * strategies, so a crash in applyChannelPriceAndTax() is a real crash, not a mock
+         * artefact. A relation array can contain `null`/`undefined` elements —
+         * getRelationEntityAtPath() pushes them deliberately — and the price application at the
+         * hydrate() call site must neither skip the whole array because of one (the `[0]` sample
+         * did) nor pass one to applyChannelPriceAndTax(), which dereferences its argument.
+         */
+        function createHydrator(children: any[]) {
+            const variantMetadata = {
+                target: ProductVariant,
+                findRelationWithPropertyPath: () => undefined,
+            };
+            const childMetadata = {
+                target: TestChild,
+                findRelationWithPropertyPath: (path: string) =>
+                    path === 'variant' ? { inverseEntityMetadata: variantMetadata } : undefined,
+            };
+            const orderMetadata = {
+                target: TestOrder,
+                treeType: undefined,
+                relations: [],
+                findRelationWithPropertyPath: (path: string) =>
+                    path === 'children' ? { inverseEntityMetadata: childMetadata } : undefined,
+            };
+            const queryBuilder = {
+                alias: 'TestOrder',
+                connection: { getMetadata: () => orderMetadata },
+                expressionMap: { joinAttributes: [] },
+                setFindOptions: () => queryBuilder,
+                getOne: () => Promise.resolve({ children }),
+            };
+            const connection = {
+                rawConnection: { entityMetadatas: [orderMetadata] },
+                getRepository: () => ({ createQueryBuilder: () => queryBuilder }),
+            };
+            const configService = {
+                catalogOptions: {
+                    productVariantPriceSelectionStrategy: {
+                        selectPrice: (_ctx: any, prices: any[]) => Promise.resolve(prices[0]),
+                    },
+                    productVariantPriceCalculationStrategy: {
+                        calculate: ({ inputPrice }: any) =>
+                            Promise.resolve({ price: inputPrice, priceIncludesTax: false }),
+                    },
+                },
+                taxOptions: {
+                    taxZoneStrategy: { determineTaxZone: () => ({ id: 1 }) },
+                },
+            };
+            const priceApplicator = new ProductPriceApplicator(
+                configService as any,
+                { getApplicableTaxRate: () => Promise.resolve({ id: 1 }) } as any,
+                { getAllWithMembers: () => Promise.resolve([]) } as any,
+                { get: (_ctx: any, _key: any, getValue: () => any) => getValue() } as any,
+            );
+            const translator = { translate: (entity: any) => entity };
+            const hydrator = new EntityHydrator(connection as any, priceApplicator, translator as any);
+            const ctx = { channelId: 1, currencyCode: 'USD' } as any;
+            return { hydrator, ctx, target: new TestOrder() };
+        }
+
+        function createVariant(id: number): ProductVariant {
+            return new ProductVariant({
+                id,
+                productVariantPrices: [{ price: 4200, currencyCode: 'USD' }] as any,
+                taxCategory: { id: 1 } as any,
+            });
+        }
+
+        it('prices a variant that sits behind a null array element', async () => {
+            const variant = createVariant(1);
+            const { hydrator, ctx, target } = createHydrator([{ variant: null }, { variant }]);
+
+            await hydrator.hydrate(
+                ctx,
+                target as any,
+                {
+                    relations: ['children.variant'],
+                    applyProductVariantPrices: true,
+                } as any,
+            );
+
+            expect(variant.listPrice).toBe(4200);
+        });
+
+        it('does not pass a null array element to the price applicator', async () => {
+            const variant = createVariant(1);
+            const { hydrator, ctx, target } = createHydrator([{ variant }, { variant: null }]);
+
+            await hydrator.hydrate(
+                ctx,
+                target as any,
+                {
+                    relations: ['children.variant'],
+                    applyProductVariantPrices: true,
+                } as any,
+            );
+
+            expect(variant.listPrice).toBe(4200);
+        });
+
+        it('prices every element when the array is fully populated', async () => {
+            const variant1 = createVariant(1);
+            const variant2 = createVariant(2);
+            const { hydrator, ctx, target } = createHydrator([{ variant: variant1 }, { variant: variant2 }]);
+
+            await hydrator.hydrate(
+                ctx,
+                target as any,
+                {
+                    relations: ['children.variant'],
+                    applyProductVariantPrices: true,
+                } as any,
+            );
+
+            expect(variant1.listPrice).toBe(4200);
+            expect(variant2.listPrice).toBe(4200);
         });
     });
 

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -153,21 +153,11 @@ export class EntityHydrator {
 
                 if (options.applyProductVariantPrices === true) {
                     for (const relationWithEntities of relationsWithEntities) {
-                        const entity = relationWithEntities.entity;
-                        if (entity) {
-                            if (Array.isArray(entity)) {
-                                if (entity[0] instanceof ProductVariant) {
-                                    await Promise.all(
-                                        entity.map((e: any) =>
-                                            this.productPriceApplicator.applyChannelPriceAndTax(e, ctx),
-                                        ),
-                                    );
-                                }
-                            } else {
-                                if (entity instanceof ProductVariant) {
-                                    await this.productPriceApplicator.applyChannelPriceAndTax(entity, ctx);
-                                }
-                            }
+                        // Applied sequentially rather than with Promise.all: relation arrays are
+                        // unbounded in size, and applyChannelPriceAndTax() is applied per variant
+                        // the same way in ProductVariantService.assignProductVariantsToChannel()
+                        for (const variant of this.getProductVariantsToPrice(relationWithEntities.entity)) {
+                            await this.productPriceApplicator.applyChannelPriceAndTax(variant, ctx);
                         }
                     }
                 }
@@ -316,7 +306,13 @@ export class EntityHydrator {
             if (Array.isArray(target)) {
                 isArrayResult = true;
                 if (parts.length === 0) {
-                    result.push(...target);
+                    // Use a plain loop rather than push(...target): spreading a very large array
+                    // (e.g. `collection.productVariants` on a big catalog) expands it into call
+                    // arguments, which exceeds V8's stack budget and throws a RangeError. Same
+                    // fix as in getMissingRelations() above.
+                    for (const item of target) {
+                        result.push(item);
+                    }
                 } else {
                     for (const item of target) {
                         visit(item, parts.slice());
@@ -334,6 +330,20 @@ export class EntityHydrator {
         }
         visit(entity, path.slice());
         return isArrayResult ? result : result[0];
+    }
+
+    /**
+     * Returns the ProductVariants found at a relation path, to which Channel prices should be
+     * applied. A relation array can contain `null`/`undefined` entries — getRelationEntityAtPath()
+     * pushes them deliberately — and only some of its elements may be ProductVariants, so the type
+     * is tested per element rather than sampled from element [0]. Sampling [0] was wrong in both
+     * directions: a hole at [0] suppressed pricing for every real ProductVariant in the array, and
+     * a ProductVariant at [0] passed the holes behind it straight into applyChannelPriceAndTax(),
+     * which dereferences `variant.productVariantPrices` and throws.
+     */
+    private getProductVariantsToPrice(entity: VendureEntity | VendureEntity[] | undefined): ProductVariant[] {
+        const candidates = Array.isArray(entity) ? entity : [entity];
+        return candidates.filter((e): e is ProductVariant => e instanceof ProductVariant);
     }
 
     private getRelationEntityTypeAtPath(entity: VendureEntity, path: string): Type<VendureEntity> {

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -386,9 +386,15 @@ export class EntityHydrator {
         return translationRelations;
     }
 
+    /**
+     * Whether the entity, or any entity of an array-valued relation, is translatable. An array
+     * relation can contain `null` (the relation was fetched but is null on that element) or
+     * `undefined` (never fetched) entries — getRelationEntityAtPath() deliberately pushes both
+     * into its result — so every element must be considered rather than just the first.
+     */
     private isTranslatable<T extends VendureEntity>(input: T | T[] | undefined): boolean {
-        return Array.isArray(input)
-            ? (input[0]?.hasOwnProperty('translations') ?? false)
-            : (input?.hasOwnProperty('translations') ?? false);
+        const hasTranslations = (entity: T | undefined): boolean =>
+            entity?.hasOwnProperty('translations') ?? false;
+        return Array.isArray(input) ? input.some(hasTranslations) : hasTranslations(input);
     }
 }

--- a/packages/core/src/service/helpers/utils/translate-entity.spec.ts
+++ b/packages/core/src/service/helpers/utils/translate-entity.spec.ts
@@ -2,6 +2,8 @@ import { LanguageCode } from '@vendure/common/lib/generated-types';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Translatable, Translation } from '../../../common/types/locale-types';
+import { AssetTranslation } from '../../../entity/asset/asset-translation.entity';
+import { Asset } from '../../../entity/asset/asset.entity';
 import { VendureEntity } from '../../../entity/base/base.entity';
 import { CollectionTranslation } from '../../../entity/collection/collection-translation.entity';
 import { Collection } from '../../../entity/collection/collection.entity';
@@ -448,6 +450,103 @@ describe('translateDeep()', () => {
                 [['singleRealVariant', 'options']],
             ),
         ).not.toThrow();
+    });
+
+    // A relation array can contain `undefined` (an element that was never fetched) or `null`
+    // (fetched, but null in the database) entries — EntityHydrator's getRelationEntityAtPath()
+    // produces both deliberately. Translation must skip such elements rather than dereference
+    // them, and must not rewrite a `null` into `undefined`, because getMissingRelations()
+    // relies on that distinction to decide whether a relation still needs to be fetched.
+    it('preserves an undefined hole and translates the real elements of a relation array', () => {
+        product.variants = [productVariant, undefined] as any;
+
+        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], ['variants']);
+
+        expect(result.variants).toHaveLength(2);
+        expect(result.variants[0]).toHaveProperty('name', VARIANT_NAME_EN);
+        expect(result.variants[1]).toBeUndefined();
+    });
+
+    it('preserves a null element and translates the real elements of a relation array', () => {
+        product.variants = [null, productVariant] as any;
+
+        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], ['variants']);
+
+        expect(result.variants).toHaveLength(2);
+        expect(result.variants[0]).toBeNull();
+        expect(result.variants[1]).toHaveProperty('name', VARIANT_NAME_EN);
+    });
+
+    it('preserves a first-level hole and translates nested relations of later elements', () => {
+        product.variants = [undefined, productVariant] as any;
+
+        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], [['variants', 'options']]);
+
+        expect(result.variants[0]).toBeUndefined();
+        expect(result.variants[1].options[0]).toHaveProperty('name', OPTION_NAME_EN);
+    });
+
+    it('leaves a null nested relation as null', () => {
+        const ASSET_NAME_EN = 'English Asset';
+        const assetTranslation = new AssetTranslation();
+        assetTranslation.id = '51';
+        assetTranslation.languageCode = LANGUAGE_CODE;
+        assetTranslation.name = ASSET_NAME_EN;
+        const asset = new Asset();
+        asset.id = '5';
+        asset.translations = [assetTranslation];
+
+        const secondVariant = new ProductVariant();
+        secondVariant.id = '4';
+        secondVariant.translations = [productVariantTranslation];
+        (productVariant as any).featuredAsset = null;
+        secondVariant.featuredAsset = asset;
+        product.variants = [productVariant, secondVariant];
+
+        const result = translateDeep(
+            product,
+            [LanguageCode.en, LanguageCode.en],
+            [['variants', 'featuredAsset']],
+        );
+
+        expect(result.variants[0].featuredAsset).toBeNull();
+        expect(result.variants[1].featuredAsset).toHaveProperty('name', ASSET_NAME_EN);
+    });
+
+    // The single-segment and two-segment non-array branches feed the shared
+    // `object[property] = value` assignment at the end of the loop, so they must preserve a
+    // null relation for the same reason as the array branch above — e.g.
+    // translate(collection, ctx, ['parent']) reaches the single-segment branch with a null
+    // parent on the root collection.
+    it('leaves a null relation as null for a single-segment path', () => {
+        (product as any).featuredAsset = null;
+
+        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], ['featuredAsset']);
+
+        expect((result as any).featuredAsset).toBeNull();
+    });
+
+    it('leaves a null nested relation as null when the first level is not an array', () => {
+        (productVariant as any).featuredAsset = null;
+        testProduct.singleRealVariant = productVariant;
+
+        const result = translateDeep(
+            testProduct,
+            [LanguageCode.en, LanguageCode.en],
+            [['singleRealVariant', 'featuredAsset']],
+        );
+
+        expect((result.singleRealVariant as any).featuredAsset).toBeNull();
+    });
+
+    // A path deeper than two segments is outside what translateDeep() handles; it must fall
+    // through without creating a junk own-property from the stringified path array
+    it('does not create a junk own-property for a three-segment path', () => {
+        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], [
+            ['variants', 'featuredAsset', 'x'],
+        ] as any);
+
+        expect(Object.keys(result)).not.toContain('variants,featuredAsset,x');
     });
 
     it('should translate a first-level nested non-array entity', () => {

--- a/packages/core/src/service/helpers/utils/translate-entity.ts
+++ b/packages/core/src/service/helpers/utils/translate-entity.ts
@@ -215,8 +215,21 @@ export function translateDeep<T extends Translatable & VendureEntity>(
             if (Array.isArray(valueLevel0)) {
                 valueLevel0.forEach((nested1, index) => {
                     object = (translatedEntity as any)[path0][index];
+                    // An array-valued relation can contain `null`/`undefined` entries, so there
+                    // may be no entity here to assign to.
+                    if (object == null) {
+                        return;
+                    }
                     property = path1;
-                    object[property] = translateLeaf(object, property, languageCode);
+                    const translated = translateLeaf(object, property, languageCode);
+                    // translateLeaf() returns undefined when the relation is null. Assigning that
+                    // unconditionally would rewrite a relation that is null in the database into
+                    // one that looks like it was never fetched — a distinction
+                    // getMissingRelations() relies on, so hydrate() would stop being idempotent
+                    // and re-query the relation on every subsequent call.
+                    if (translated !== undefined) {
+                        object[property] = translated;
+                    }
                 });
                 property = '';
                 object = null;
@@ -231,7 +244,9 @@ export function translateDeep<T extends Translatable & VendureEntity>(
             value = translateLeaf(object, property, languageCode);
         }
 
-        if (object && property) {
+        // Shared by the non-array branches above: skip the assignment when there is nothing
+        // to translate, preserving null relations for the same reason as in the array branch.
+        if (object && property && value !== undefined) {
             object[property] = value;
         }
     }
@@ -247,6 +262,14 @@ function translateLeaf(
     if (object && object[property]) {
         if (Array.isArray(object[property])) {
             return object[property].map((nested2: any) => {
+                // A relation array can contain `null`/`undefined` entries: an element that was
+                // never fetched, or a relation that is null on that element. translateEntity()
+                // dereferences `.translations`, so a hole throws a TypeError — which would be
+                // re-thrown below rather than swallowed like InternalServerError. Leave holes
+                // untouched.
+                if (nested2 == null) {
+                    return nested2;
+                }
                 try {
                     return translateEntity(nested2, languageCode);
                 } catch (e: any) {


### PR DESCRIPTION
Resolves the conflicts that blocked the automatic back-merge in #5124.

`master` and `minor` each appended a test to the end of the same `describe` block in `packages/core/e2e/entity-hydrator.e2e-spec.ts`, so both hunks ended at the same closing `});` and git could not attribute it. The conflict is textual, not semantic: the two tests use different fixtures and do not interact.

Both tests are kept:

- from `minor`: `hydrates a relation custom field with a very long name` (#5030)
- from `master`: `translates a relation reached past a null array element` (#5059)

The only edit made while resolving was inserting the missing `});` between them.

## What this brings into `minor`

- #5058 — Price every ProductVariant in relation arrays, avoid spread RangeError
- #5059 — Check every element in isTranslatable, harden translateDeep against holes

## Verification

- No conflict markers and no unmerged paths remain.
- `it()` count: 21 at the merge base, 22 on each side, 23 after resolution.
- `git diff` of the resolved file against each parent shows zero deleted lines, so it is a strict superset of both sides.
- The file parses (note it carries a pre-existing `// @ts-nocheck` on both branches, so this confirms syntax only, not type-checking).
- The e2e suite has not been run locally; CI covers it here.

Merging this closes #5124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789047048&installation_model_id=20193&pr_number=5125&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5125&signature=4c132a64b6afb8ffb08d3e2b83c6db10a13bb69b0397d4b0a3df2e3fddb8c6ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->