### PR TITLE
fix(dashboard): Expose relation object to readonly relation custom field components

### DIFF
--- a/docs/docs/guides/extending-the-dashboard/custom-form-components/relation-selectors.mdx
+++ b/docs/docs/guides/extending-the-dashboard/custom-form-components/relation-selectors.mdx
@@ -72,6 +72,17 @@ export function ProductSelectorComponent({ value, onChange, disabled }: Dashboar
 }
 ```
 
+:::info What `props.value` contains for a relation custom field
+For a **writable** single `relation` custom field, `props.value` is the related entity's **id** — the
+form binds to the scalar `<name>Id` field, which is what `SingleRelationInput` consumes via
+`value`/`onChange`.
+
+For a **readonly** single `relation` custom field there is no `<name>Id` in the form (readonly custom
+fields are excluded from the update/create input types), so `props.value` is instead the **related
+entity object**. Read it directly to render the relation (e.g. `value?.id`, `value?.name`); a readonly
+field exists only for display, so there is nothing to wire up to `onChange`.
+:::
+
 ### Multi Selection
 
 ```tsx title="src/plugins/my-plugin/dashboard/components/product-multi-selector.tsx"

--- a/packages/dashboard/e2e/fixtures/e2e-shared-config.ts
+++ b/packages/dashboard/e2e/fixtures/e2e-shared-config.ts
@@ -1,4 +1,4 @@
-import { CollectionFilter, CustomFields, dummyPaymentHandler, LanguageCode } from '@vendure/core';
+import { Asset, CollectionFilter, CustomFields, dummyPaymentHandler, LanguageCode } from '@vendure/core';
 
 /**
  * Custom fields and payment handlers used by global-setup.ts to configure
@@ -59,6 +59,19 @@ export const e2eCustomFields: CustomFields = {
             nullable: true,
             label: [{ languageCode: LanguageCode.en, value: 'Feature Type' }],
             options: [{ value: 'standard' }, { value: 'premium' }],
+        },
+        // Readonly single relation with a custom form component — reproduces OSS-584 (#4902):
+        // the component must receive the related entity object as `value`. Seeded directly in
+        // global-setup.ts because readonly relations cannot be set via the Admin API.
+        {
+            name: 'relatedAsset',
+            type: 'relation',
+            entity: Asset,
+            list: false,
+            nullable: true,
+            readonly: true,
+            label: [{ languageCode: LanguageCode.en, value: 'Related Asset' }],
+            ui: { component: 'relation-cf.related-asset' },
         },
         // ── SEO tab ──
         {

--- a/packages/dashboard/e2e/fixtures/e2e-vendure-config.ts
+++ b/packages/dashboard/e2e/fixtures/e2e-vendure-config.ts
@@ -2,6 +2,7 @@ import { VendureConfig } from '@vendure/core';
 
 import { AlertTestPlugin } from './alert-test-plugin';
 import { FormInputsTestPlugin } from './form-inputs-test-plugin';
+import { RelationCfPlugin } from './relation-cf-plugin';
 
 /**
  * Vendure config for the Vite plugin during E2E tests.
@@ -30,5 +31,5 @@ export const config: VendureConfig = {
     paymentOptions: {
         paymentMethodHandlers: [],
     },
-    plugins: [FormInputsTestPlugin, AlertTestPlugin],
+    plugins: [FormInputsTestPlugin, AlertTestPlugin, RelationCfPlugin],
 };

--- a/packages/dashboard/e2e/fixtures/relation-cf-dashboard/index.tsx
+++ b/packages/dashboard/e2e/fixtures/relation-cf-dashboard/index.tsx
@@ -1,0 +1,26 @@
+import { defineDashboardExtension } from '@vendure/dashboard';
+
+/**
+ * Registers a custom form component for the readonly single `relation` custom field
+ * `Product.relatedAsset` (configured in e2e-shared-config.ts). The component renders the
+ * related entity from `props.value`.
+ *
+ * This exercises OSS-584 (#4902): a custom form component bound to a readonly relation custom
+ * field must receive the related entity *object* as `value`. Before the fix it received
+ * `undefined`, because the form control binds to the scalar `<name>Id` which does not exist for
+ * a readonly relation (readonly custom fields are excluded from the update/create input types).
+ */
+defineDashboardExtension({
+    customFormComponents: {
+        customFields: [
+            {
+                id: 'relation-cf.related-asset',
+                component: ({ value }) => (
+                    <div data-testid="related-asset-cf">
+                        {value?.id ? `asset:${value.id}` : 'none'}
+                    </div>
+                ),
+            },
+        ],
+    },
+});

--- a/packages/dashboard/e2e/fixtures/relation-cf-plugin.ts
+++ b/packages/dashboard/e2e/fixtures/relation-cf-plugin.ts
@@ -1,0 +1,14 @@
+import { VendurePlugin } from '@vendure/core';
+
+/**
+ * E2E-only plugin whose dashboard extension registers a custom form component for the readonly
+ * `Product.relatedAsset` relation custom field. Used to verify OSS-584 (#4902): the component
+ * must receive the related entity object as `value`.
+ *
+ * The dashboard extension is discovered by the Vite plugin's config introspection and dynamically
+ * imported at build time.
+ */
+@VendurePlugin({
+    dashboard: './relation-cf-dashboard/index.tsx',
+})
+export class RelationCfPlugin {}

--- a/packages/dashboard/e2e/global-setup.ts
+++ b/packages/dashboard/e2e/global-setup.ts
@@ -130,5 +130,26 @@ export default async function globalSetup() {
         productsCsvPath: path.join(__dirname, '../../core/e2e/fixtures/e2e-products-full.csv'),
         customerCount: 5,
     });
+
+    // Seed a value for the readonly `relatedAsset` relation custom field on the first product
+    // (Laptop). Readonly relation custom fields are excluded from the GraphQL input types, so they
+    // cannot be set via the Admin API — set it directly here so OSS-584 (a custom form component
+    // reading the relation object) can be exercised on the product detail page.
+    const { Asset, Product, TransactionalConnection } = await import('@vendure/core');
+    const dataSource = server.app.get(TransactionalConnection).rawConnection;
+    const [firstAsset] = await dataSource.getRepository(Asset).find({ take: 1, order: { id: 'ASC' } });
+    // Target the same product the e2e test opens (slug "laptop"), so seeding and assertion never
+    // drift apart if the fixture CSV order changes.
+    const laptop = await dataSource
+        .getRepository(Product)
+        .createQueryBuilder('product')
+        .leftJoin('product.translations', 'translation')
+        .where('translation.slug = :slug', { slug: 'laptop' })
+        .getOne();
+    if (firstAsset && laptop) {
+        (laptop.customFields as Record<string, unknown>).relatedAsset = firstAsset;
+        await dataSource.getRepository(Product).save(laptop);
+    }
+
     (globalThis as any).__VENDURE_SERVER__ = server;
 }

--- a/packages/dashboard/e2e/tests/catalog/custom-fields.spec.ts
+++ b/packages/dashboard/e2e/tests/catalog/custom-fields.spec.ts
@@ -515,4 +515,29 @@ test.describe('Custom Fields', () => {
         await expect(popover).not.toBeVisible();
         await expect(triggerButton).not.toContainText('MM/DD/YYYY');
     });
+
+    // OSS-584 (#4902) — a custom form component registered for a readonly single `relation`
+    // custom field must receive the related entity *object* as `value` (previously `undefined`,
+    // because the form control binds to the scalar `<name>Id` which is absent for a readonly
+    // relation). `relatedAsset` is seeded on the first product in global-setup.ts.
+    test('readonly relation custom field exposes the relation object to its custom component', async ({
+        page,
+    }) => {
+        await goToFirstProduct(page);
+        const dp = detailPage(page);
+
+        // Read path: the component renders `asset:<id>` from the relation object, not `none`.
+        const badge = page.getByTestId('related-asset-cf');
+        await expect(badge).toBeVisible();
+        await expect(badge).toHaveText(/^asset:T_\d+$/);
+
+        // Write path: saving an unrelated change must still succeed — the readonly relation object
+        // must not leak into the update mutation input (it is not a writeable field).
+        await dp.formItem('Info URL').getByRole('textbox').fill('https://example.com/oss-584');
+        await dp.clickUpdate();
+        await dp.expectSuccessToast(/Successfully updated product/);
+
+        // The relation object is still exposed after the save.
+        await expect(badge).toHaveText(/^asset:T_\d+$/);
+    });
 });

--- a/packages/dashboard/src/lib/components/shared/custom-fields-form.tsx
+++ b/packages/dashboard/src/lib/components/shared/custom-fields-form.tsx
@@ -219,6 +219,20 @@ function CustomFieldItem({ fieldDef, control, fieldName, disabled }: Readonly<Cu
     const containerClassName = shouldBeFullWidth ? 'col-span-2' : '';
     const isReadonly = (fieldDef as CustomFieldConfig).readonly ?? false;
 
+    // A single (non-list) `relation` custom field binds its form control to the scalar `<name>Id`
+    // (see `getCustomFieldBaseName`). For a `readonly` relation that key does not exist in the form
+    // values — readonly custom fields are excluded from the update/create input types (see
+    // graphql-custom-fields.ts) — so a custom form component bound to it receives `value ===
+    // undefined`. The related entity object is still present at `customFields.<name>` (the relation
+    // transform leaves it untouched when there is no matching input field), so surface that object
+    // to the component as `value`. The Controller binding is left unchanged, so the submit payload
+    // is unaffected. See OSS-584 / #4902.
+    const readonlyRelationObjectName =
+        fieldDef.type === 'relation' && isReadonly && !fieldDef.list
+            ? fieldName.replace(/Id$/, '')
+            : undefined;
+    const readonlyRelationValue = readonlyRelationObjectName ? watch(readonlyRelationObjectName) : undefined;
+
     const localeFallbackPlaceholder = useMemo(
         () =>
             isLocaleField
@@ -278,7 +292,13 @@ function CustomFieldItem({ fieldDef, control, fieldName, disabled }: Readonly<Cu
                             fieldName={field.name}
                             fieldState={fieldState}
                         >
-                            <CustomFormComponent fieldDef={fieldDef} {...field} />
+                            <CustomFormComponent
+                                fieldDef={fieldDef}
+                                {...field}
+                                {...(readonlyRelationObjectName !== undefined
+                                    ? { value: readonlyRelationValue }
+                                    : {})}
+                            />
                         </CustomFieldFormItem>
                     )}
                 />


### PR DESCRIPTION
A custom form component registered for a single **readonly** `relation` custom field received `props.value === undefined`, making it impossible to render the related entity.

## Root cause

A relation custom field binds its form control to the scalar `<name>Id` (via `getCustomFieldBaseName`). For a **readonly** relation that key never exists in the form values — readonly custom fields are excluded from the update/create GraphQL input types (`graphql-custom-fields.ts`), so `transformRelationFields` never synthesizes `<name>Id` and the related entity object survives untouched at `customFields.<name>`. The Controller bound to the absent `<name>Id` therefore yields `value === undefined`.

## Fix

For a readonly single relation with a custom form component, surface the related entity object (read from `customFields.<name>`) to the component as `value`. The Controller binding is left unchanged, so the submit payload is unaffected — the fix is purely on the read/display side.

Scoped to single (non-list) relations, matching the reported case; list relations are unchanged.

## Docs

Documents the `props.value` shape contract for relation custom fields (scalar id when writable, entity object when readonly) in the relation-selectors guide.

## Testing

- New e2e (`catalog/custom-fields.spec.ts`): a readonly `relatedAsset` relation custom field with a custom form component renders the relation object (`asset:<id>`), and an unrelated save still succeeds (proving the object does not leak into the update mutation). Verified red without the fix (renders `none`), green with it.
- Full `custom-fields` suite (22/22), `products` + `product-list` (33/33), and dashboard typecheck all pass.

Fixes #4902

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789116693&installation_model_id=20193&pr_number=5130&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5130&signature=45db7ce8d4c3b5d2aeaf1735796b664807201b0066cf674d5a420cdaba29026c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->