### PR TITLE
fix(dashboard): working interpolation and plurals in dashboard extension

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -77,6 +77,7 @@
         "@lingui/cli": "^5.9.3",
         "@lingui/core": "^5.9.3",
         "@lingui/format-po": "^5.9.3",
+        "@lingui/message-utils": "^5.9.3",
         "@lingui/react": "^5.9.3",
         "@lingui/vite-plugin": "^5.9.3",
         "@tailwindcss/vite": "^4.2.2",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -77,7 +77,6 @@
         "@lingui/cli": "^5.9.3",
         "@lingui/core": "^5.9.3",
         "@lingui/format-po": "^5.9.3",
-        "@lingui/message-utils": "^5.9.3",
         "@lingui/react": "^5.9.3",
         "@lingui/vite-plugin": "^5.9.3",
         "@tailwindcss/vite": "^4.2.2",

--- a/packages/dashboard/src/lib/virtual.d.ts
+++ b/packages/dashboard/src/lib/virtual.d.ts
@@ -6,7 +6,11 @@ declare module 'virtual:dashboard-extensions' {
     export const runDashboardExtensions: () => Promise<void>;
 }
 declare module 'virtual:plugin-translations' {
-    export default translations = Record<string, any>;
+    import { Messages } from '@lingui/core';
+
+    // Keyed by locale with `-` replaced by `_`, as emitted by `translationsPlugin`.
+    const translations: Record<string, Messages>;
+    export default translations;
 }
 
 declare module 'virtual:vendure-ui-config' {

--- a/packages/dashboard/vite/tests/fixtures-plugin-translations-malformed/src/dashboard/i18n/en.po
+++ b/packages/dashboard/vite/tests/fixtures-plugin-translations-malformed/src/dashboard/i18n/en.po
@@ -1,0 +1,11 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+msgid "extension.broken"
+msgstr "Hello {name"

--- a/packages/dashboard/vite/tests/fixtures-plugin-translations/src/dashboard/i18n/en.po
+++ b/packages/dashboard/vite/tests/fixtures-plugin-translations/src/dashboard/i18n/en.po
@@ -1,0 +1,15 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+msgid "extension.greeting"
+msgstr "Hello {name}"
+
+#. js-lingui-explicit-id
+msgid "extension.itemCount"
+msgstr "{count, plural, one {# item} other {# items}}"

--- a/packages/dashboard/vite/tests/with-translations.spec.ts
+++ b/packages/dashboard/vite/tests/with-translations.spec.ts
@@ -35,7 +35,7 @@ describe('plugin translation catalogs in virtual:plugin-translations', () => {
     const packageRoot = join(__dirname, '..', '..');
     const fixtureRoot = join(__dirname, 'fixtures-plugin-translations');
 
-    async function loadVirtualModule(): Promise<string> {
+    async function loadVirtualModule(root: string = fixtureRoot): Promise<string> {
         const plugin = translationsPlugin({ packageRoot }) as any;
         const configLoaderStub = {
             name: 'vendure:config-loader',
@@ -46,7 +46,7 @@ describe('plugin translation catalogs in virtual:plugin-translations', () => {
                         pluginInfo: [
                             {
                                 name: 'TranslatedPlugin',
-                                pluginPath: join(fixtureRoot, 'src', 'my.plugin.js'),
+                                pluginPath: join(root, 'src', 'my.plugin.js'),
                                 dashboardEntryPath: './dashboard/index.tsx',
                             },
                         ],
@@ -54,7 +54,15 @@ describe('plugin translation catalogs in virtual:plugin-translations', () => {
             },
         };
         plugin.configResolved.call({}, { plugins: [configLoaderStub] });
-        const ctx = { debug: () => undefined, info: () => undefined, warn: () => undefined };
+        const ctx = {
+            debug: () => undefined,
+            info: () => undefined,
+            warn: () => undefined,
+            // Rollup's `PluginContext.error` throws; the plugin relies on that to abort.
+            error: (message: string) => {
+                throw new Error(message);
+            },
+        };
         const result = await plugin.load.call(ctx, '\0virtual:plugin-translations');
         expect(typeof result).toBe('string');
         return result as string;
@@ -92,5 +100,11 @@ describe('plugin translation catalogs in virtual:plugin-translations', () => {
         } finally {
             process.env.NODE_ENV = previousNodeEnv;
         }
+    });
+
+    it('fails the build on malformed plugin ICU instead of emitting it silently', async () => {
+        await expect(
+            loadVirtualModule(join(__dirname, 'fixtures-plugin-translations-malformed')),
+        ).rejects.toThrow(/extension\.broken/);
     });
 });

--- a/packages/dashboard/vite/tests/with-translations.spec.ts
+++ b/packages/dashboard/vite/tests/with-translations.spec.ts
@@ -1,9 +1,11 @@
+import { setupI18n } from '@lingui/core';
 import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { compile } from '../utils/compiler.js';
 import { debugLogger, noopLogger } from '../utils/logger.js';
+import { translationsPlugin } from '../vite-plugin-translations.js';
 
 describe('detecting plugins with translations', () => {
     it('should detect plugins with translations', { timeout: 60_000 }, async () => {
@@ -22,5 +24,73 @@ describe('detecting plugins with translations', () => {
             join(__dirname, 'fixtures-with-translations', 'src', 'my.plugin.ts'),
         );
         expect(result.pluginInfo[0].pluginPath).toBe(join(tempDir, 'src', 'my.plugin.js'));
+    });
+});
+
+// #5131 — plugin (extension) catalogs assembled into `virtual:plugin-translations` must be
+// compiled to Lingui's runtime message format. `@lingui/core` only registers a message
+// compiler when `NODE_ENV !== 'production'`, so raw ICU source in that virtual module
+// renders literally in a production dashboard build: `Hello {name}` instead of `Hello Bob`.
+describe('plugin translation catalogs in virtual:plugin-translations', () => {
+    const packageRoot = join(__dirname, '..', '..');
+    const fixtureRoot = join(__dirname, 'fixtures-plugin-translations');
+
+    async function loadVirtualModule(): Promise<string> {
+        const plugin = translationsPlugin({ packageRoot }) as any;
+        const configLoaderStub = {
+            name: 'vendure:config-loader',
+            api: {
+                getVendureConfig: () =>
+                    Promise.resolve({
+                        vendureConfig: {},
+                        pluginInfo: [
+                            {
+                                name: 'TranslatedPlugin',
+                                pluginPath: join(fixtureRoot, 'src', 'my.plugin.js'),
+                                dashboardEntryPath: './dashboard/index.tsx',
+                            },
+                        ],
+                    }),
+            },
+        };
+        plugin.configResolved.call({}, { plugins: [configLoaderStub] });
+        const ctx = { debug: () => undefined, info: () => undefined, warn: () => undefined };
+        const result = await plugin.load.call(ctx, '\0virtual:plugin-translations');
+        expect(typeof result).toBe('string');
+        return result as string;
+    }
+
+    function evaluateVirtualModule(code: string): Record<string, Record<string, unknown>> {
+        // eslint-disable-next-line @typescript-eslint/no-implied-eval
+        return new Function(code.replace('export default translations;', 'return translations;'))();
+    }
+
+    it('emits messages in the compiled Lingui format, not raw ICU source', async () => {
+        const translations = evaluateVirtualModule(await loadVirtualModule());
+
+        expect(translations.en['extension.greeting']).not.toBe('Hello {name}');
+        expect(translations.en['extension.greeting']).toEqual(['Hello ', ['name']]);
+        expect(translations.en['extension.itemCount']).toEqual([
+            ['count', 'plural', { one: ['#', ' item'], other: ['#', ' items'] }],
+        ]);
+    });
+
+    it('interpolates and pluralises in a production @lingui/core runtime', async () => {
+        const translations = evaluateVirtualModule(await loadVirtualModule());
+
+        const previousNodeEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'production';
+        try {
+            // Constructed under NODE_ENV=production, so no runtime message compiler is
+            // registered — exactly the state of a built dashboard bundle.
+            const i18n = setupI18n();
+            i18n.loadAndActivate({ locale: 'en', messages: translations.en as any });
+
+            expect(i18n._('extension.greeting', { name: 'Bob' })).toBe('Hello Bob');
+            expect(i18n._('extension.itemCount', { count: 1 })).toBe('1 item');
+            expect(i18n._('extension.itemCount', { count: 3 })).toBe('3 items');
+        } finally {
+            process.env.NODE_ENV = previousNodeEnv;
+        }
     });
 });

--- a/packages/dashboard/vite/vite-plugin-translations.ts
+++ b/packages/dashboard/vite/vite-plugin-translations.ts
@@ -5,6 +5,7 @@ import {
     getCatalogs,
 } from '@lingui/cli/api';
 import { getConfig, LinguiConfigNormalized } from '@lingui/conf';
+import { compileMessage, type CompiledMessage } from '@lingui/message-utils/compileMessage';
 import glob from 'fast-glob';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -102,7 +103,7 @@ export function translationsPlugin(options: TranslationsPluginOptions): Plugin {
                         ${[...mergedMessageMap.entries()]
                             .map(([locale, messages]) => {
                                 const safeLocale = locale.replace(/-/g, '_');
-                                return `${safeLocale}: ${JSON.stringify(messages)}`;
+                                return `${safeLocale}: ${JSON.stringify(compileMessages(messages))}`;
                             })
                             .join(',\n')}
                     };
@@ -266,4 +267,17 @@ async function createMergedMessageMap({
     }
 
     return mergedMessageMap;
+}
+
+/**
+ * Built-in catalogs are compiled by `@lingui/vite-plugin` when their `.po` files are imported;
+ * plugin catalogs are assembled here into `virtual:plugin-translations` and would otherwise reach
+ * `@lingui/core` as raw ICU source strings, which disables interpolation and plurals at runtime.
+ */
+function compileMessages(messages: Record<string, string>): Record<string, CompiledMessage> {
+    const compiled: Record<string, CompiledMessage> = {};
+    for (const [id, message] of Object.entries(messages)) {
+        compiled[id] = compileMessage(message);
+    }
+    return compiled;
 }

--- a/packages/dashboard/vite/vite-plugin-translations.ts
+++ b/packages/dashboard/vite/vite-plugin-translations.ts
@@ -5,7 +5,6 @@ import {
     getCatalogs,
 } from '@lingui/cli/api';
 import { getConfig, LinguiConfigNormalized } from '@lingui/conf';
-import { compileMessage, type CompiledMessage } from '@lingui/message-utils/compileMessage';
 import glob from 'fast-glob';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -49,11 +48,11 @@ const resolvedVirtualModuleId = `\0${virtualModuleId}`;
  *
  * It handles 2 modes: dev and build.
  *
- * - The dev case is handled in the `load` function using Vite virtual
- * modules to compile and return translations from plugins _only_, which then get merged with the built-in
+ * - The `load` function serves the `virtual:plugin-translations` module in both dev and build. It
+ * compiles and returns translations from plugins _only_, which then get merged with the built-in
  * translations in the `loadI18nMessages` function
- * - The build case loads both built-in and plugin translations, merges them, and outputs the compiled
- * files as .js files that can be statically consumed by the built app.
+ * - The `generateBundle` function additionally emits the merged built-in and plugin catalogs as .js
+ * files under the `outputPath` directory. Nothing in the dashboard reads those files today.
  *
  * @param options
  */
@@ -103,7 +102,21 @@ export function translationsPlugin(options: TranslationsPluginOptions): Plugin {
                         ${[...mergedMessageMap.entries()]
                             .map(([locale, messages]) => {
                                 const safeLocale = locale.replace(/-/g, '_');
-                                return `${safeLocale}: ${JSON.stringify(compileMessages(messages))}`;
+                                // `@lingui/core` interpolates compiled token arrays, not ICU source
+                                // strings. It registers a runtime compiler of its own only when
+                                // `NODE_ENV !== 'production'`, so an uncompiled catalog here renders
+                                // literally in a built dashboard: `Hello {name}` instead of `Hello Bob`.
+                                const { source, errors } = createCompiledCatalog(locale, messages, {
+                                    namespace: 'json',
+                                    pseudoLocale: cachedLinguiConfig.pseudoLocale,
+                                });
+                                if (errors.length) {
+                                    this.error(createCompilationErrorMessage(locale, errors));
+                                }
+                                const { messages: compiledMessages } = JSON.parse(source) as {
+                                    messages: Record<string, unknown>;
+                                };
+                                return `${safeLocale}: ${JSON.stringify(compiledMessages)}`;
                             })
                             .join(',\n')}
                     };
@@ -267,17 +280,4 @@ async function createMergedMessageMap({
     }
 
     return mergedMessageMap;
-}
-
-/**
- * Built-in catalogs are compiled by `@lingui/vite-plugin` when their `.po` files are imported;
- * plugin catalogs are assembled here into `virtual:plugin-translations` and would otherwise reach
- * `@lingui/core` as raw ICU source strings, which disables interpolation and plurals at runtime.
- */
-function compileMessages(messages: Record<string, string>): Record<string, CompiledMessage> {
-    const compiled: Record<string, CompiledMessage> = {};
-    for (const [id, message] of Object.entries(messages)) {
-        compiled[id] = compileMessage(message);
-    }
-    return compiled;
 }


### PR DESCRIPTION
Fix i18n interpolation for vendure plugins

# Description

Lingui’s i18n messages do not appear to be compiled when loaded from a Vendure plugin.
This prevents variable interpolation in production.

This commit fixes this bug.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789121916&installation_model_id=20193&pr_number=5131&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5131&signature=880099910e02cb0bb99cb49f76f8315b555d55819e226a2eb7a2907dcbaca109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->