### PR TITLE
ci: Scope the TypeORM v1 compatibility runs

### DIFF
--- a/.github/workflows/typeorm_v1.yml
+++ b/.github/workflows/typeorm_v1.yml
@@ -1,24 +1,38 @@
 name: TypeORM v1 compatibility
 
-# Runs the database-backed suites against TypeORM v1 while support for it is being
-# built. These jobs are expected to fail until that work is finished, which is why
-# they are kept out of Build & Test: a job that is always red stops being read.
-# Once they all pass, move them into build_and_test.yml as a `typeorm` matrix axis
-# and delete this file.
+# Runs the database-backed suites against TypeORM v1. Build & Test gives the same
+# suites their v0.3 coverage across the full database matrix; this workflow is the
+# v1 half of that, kept separate so that adding the second TypeORM version does not
+# double the cost of every pull request.
 #
-# Add the `typeorm-v1` label to a pull request to run it against that PR.
+# One database per TypeORM dialect family is enough to expose a version difference,
+# so mysql is left out: it goes through the same TypeORM driver as mariadb. The
+# full four-database matrix stays on v0.3 in build_and_test.yml.
+#
+# Coverage comes from the push trigger, after a change has been merged. Pull
+# requests opt in with the `typeorm-v1` label, which is worth adding to anything
+# touching entities, repositories, migrations or query building.
+#
+# There is deliberately no `schedule` trigger. scripts/typeorm/profiles.json pins
+# exact versions, so a run with no repository change can only repeat the previous
+# result.
 
 on:
     workflow_dispatch:
-    schedule:
-        # Nightly, so regressions in either TypeORM v1 or Vendure surface without
-        # anyone having to remember to trigger a run.
-        - cron: '0 3 * * *'
-    pull_request:
+    push:
         branches:
             - master
-            - major
             - minor
+            - major
+        paths:
+            - 'packages/**'
+            - 'package.json'
+            - 'bun.lock'
+            - 'bunfig.toml'
+    # No base-branch filter: the `typeorm-v1` label is the only gate, applied per job
+    # below. A pull request stacked on another feature branch does not target master,
+    # major or minor, and filtering on the base would silently skip every one of them.
+    pull_request:
         types: [opened, reopened, synchronize, labeled]
 
 env:
@@ -28,9 +42,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
-# NOTE: As in build_and_test.yml, the service definitions are duplicated across
-# the e2e-* jobs because GitHub Actions supports neither YAML anchors nor
-# service reuse. Update all four copies together.
+# NOTE: As in build_and_test.yml, the Redis service definition is duplicated across
+# the e2e-* jobs because GitHub Actions supports neither YAML anchors nor service
+# reuse. Update all three copies together.
 jobs:
     build:
         name: build
@@ -116,38 +130,6 @@ jobs:
                   E2E_MARIADB_PORT: ${{ job.services.mariadb.ports['3306'] }}
                   E2E_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
                   DB: mariadb
-              run: node scripts/typeorm/run-db-tests.mjs --e2e-only
-
-    e2e-mysql:
-        name: e2e (mysql)
-        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'typeorm-v1')
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-        services:
-            mysql:
-                image: vendure/mysql-8-native-auth:latest
-                env:
-                    MYSQL_ROOT_PASSWORD: password
-                ports:
-                    - 3306
-                options: --health-cmd="mysqladmin ping --silent" --health-interval=10s --health-timeout=20s --health-retries=10
-            redis:
-                image: redis:7.4.1
-                ports:
-                    - 6379
-        steps:
-            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-            - uses: ./.github/actions/setup
-              with:
-                  typeorm: '1'
-            - name: Build (continues past type errors)
-              run: node scripts/typeorm/build-for-tests.mjs
-            - name: e2e tests
-              env:
-                  E2E_MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
-                  E2E_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
-                  DB: mysql
               run: node scripts/typeorm/run-db-tests.mjs --e2e-only
 
     e2e-postgres:

--- a/.github/workflows/typeorm_v1.yml
+++ b/.github/workflows/typeorm_v1.yml
@@ -29,6 +29,13 @@ on:
             - 'package.json'
             - 'bun.lock'
             - 'bunfig.toml'
+            # The harness these jobs run through. Without it a change to the version
+            # profiles or the test runner reaches a release branch untested, and the
+            # first run against it is whenever some unrelated change to packages/
+            # happens to land.
+            - 'scripts/typeorm/**'
+            - '.github/actions/setup/**'
+            - '.github/workflows/typeorm_v1.yml'
     # `labeled` only. Actions has no workflow-level `if`, so the label gate below can
     # only skip jobs once a run already exists, and any other type would put a skipped
     # run in the checks list of every pull request in the repository. The cost is that

--- a/.github/workflows/typeorm_v1.yml
+++ b/.github/workflows/typeorm_v1.yml
@@ -29,11 +29,17 @@ on:
             - 'package.json'
             - 'bun.lock'
             - 'bunfig.toml'
-    # No base-branch filter: the `typeorm-v1` label is the only gate, applied per job
-    # below. A pull request stacked on another feature branch does not target master,
-    # major or minor, and filtering on the base would silently skip every one of them.
+    # `labeled` only. Actions has no workflow-level `if`, so the label gate below can
+    # only skip jobs once a run already exists, and any other type would put a skipped
+    # run in the checks list of every pull request in the repository. The cost is that
+    # pushing to an already-labelled pull request does not re-run these jobs; remove
+    # and re-add the label to get a result for the new commits.
     pull_request:
-        types: [opened, reopened, synchronize, labeled]
+        branches:
+            - master
+            - major
+            - minor
+        types: [labeled]
 
 env:
     CI: true

--- a/scripts/typeorm/README.md
+++ b/scripts/typeorm/README.md
@@ -1,8 +1,8 @@
 # TypeORM version test harness
 
-Vendure is moving towards supporting both TypeORM v0.3 and v1 from the same source, so that
-existing projects can stay on v0.3 while new ones adopt v1. These scripts run the
-database-backed test suites against either version.
+Vendure supports both TypeORM v0.3 and v1 from the same source, so that existing projects can
+stay on v0.3 while new ones adopt v1. These scripts run the database-backed test suites against
+either version.
 
 ## Why the version has to be forced
 
@@ -48,11 +48,11 @@ runs the same check on its own.
 bun run build:for-tests
 ```
 
-While the migration is in progress the packages do not typecheck against v1, and `bun run
-build` stops at the first error. `@vendure/core` builds in three stages joined by `&&` — the
-main compile, the CLI compile, and a copy of the static `.graphql` schema files — so one type
-error leaves `dist/` without the schema files and the server then fails to boot with "No type
-definitions were found", which tells you nothing about the actual incompatibility.
+When a package stops typechecking against a TypeORM version, `bun run build` stops at the first
+error. `@vendure/core` builds in three stages joined by `&&` — the main compile, the CLI
+compile, and a copy of the static `.graphql` schema files — so one type error leaves `dist/`
+without the schema files and the server then fails to boot with "No type definitions were
+found", which tells you nothing about the actual incompatibility.
 
 `build:for-tests` runs each stage separately and keeps going. `tsc` emits its output even when
 it reports errors, so everything needed to boot a server is produced. The `build` job in
@@ -65,11 +65,16 @@ The `.github/actions/setup` action takes a `typeorm` input naming a profile. Wit
 installs the committed lockfile, which is what `build_and_test.yml` does and what gives the
 project its v0.3 coverage.
 
-The v1 runs live in `typeorm_v1.yml`, separate from `build_and_test.yml`, because they are
-expected to fail until the migration is finished and a job that is always red stops being read.
-It runs nightly, on demand, and on any pull request labelled `typeorm-v1`. When every job in it
-passes, move them into `build_and_test.yml` as a `typeorm` matrix axis and delete the separate
-workflow.
+The v1 runs live in `typeorm_v1.yml`, kept separate from `build_and_test.yml` so that the
+second TypeORM version does not double the cost of every pull request. They run after a merge
+to `master`, `minor` or `major`, on demand, and on any pull request carrying the `typeorm-v1`
+label. Add that label to work touching entities, repositories, migrations or query building,
+where a version difference is most likely to show.
+
+The v1 jobs cover one database per TypeORM dialect family — postgres, mariadb and sqljs. mysql
+is left out because it goes through the same TypeORM driver as mariadb, so it would repeat that
+coverage rather than add to it. The full four-database matrix stays on v0.3 in
+`build_and_test.yml`.
 
 ## Adding a version
 

--- a/scripts/typeorm/README.md
+++ b/scripts/typeorm/README.md
@@ -67,9 +67,11 @@ project its v0.3 coverage.
 
 The v1 runs live in `typeorm_v1.yml`, kept separate from `build_and_test.yml` so that the
 second TypeORM version does not double the cost of every pull request. They run after a merge
-to `master`, `minor` or `major`, on demand, and on any pull request carrying the `typeorm-v1`
-label. Add that label to work touching entities, repositories, migrations or query building,
-where a version difference is most likely to show.
+to `master`, `minor` or `major`, on demand, and when the `typeorm-v1` label is added to a pull
+request. Add that label to work touching entities, repositories, migrations or query building,
+where a version difference is most likely to show. Adding the label is the only pull request
+trigger, so pushing further commits does not produce a new result; remove and re-add the label
+when you want one.
 
 The v1 jobs cover one database per TypeORM dialect family — postgres, mariadb and sqljs. mysql
 is left out because it goes through the same TypeORM driver as mariadb, so it would repeat that


### PR DESCRIPTION
Makes the TypeORM v1 compatibility workflow actually run, and scopes it so that covering a second TypeORM version does not double the cost of every pull request.

## Why

The workflow has never provided the coverage it was written for. Three separate things stopped it:

1. The `pull_request` trigger filtered on the PR's **base** branch (`master`, `major`, `minor`). A pull request stacked on a feature branch does not target a release branch, so the workflow never triggered and the `typeorm-v1` label did nothing on it.
2. The nightly `schedule` has never fired once. GitHub only schedules workflows that exist on the **default branch**, and `typeorm_v1.yml` only exists on `minor`. `gh run list --workflow=typeorm_v1.yml --event=schedule` returns zero rows.
3. `workflow_dispatch` was dead for the same reason — also zero runs.

The only path that has ever worked is labelling a pull request that targets a release branch, which is why the run history is a handful of real `oss-696` runs and a tail of one-second skips.

Now that TypeORM v1 support has landed (#5122) and the suite is green, the workflow needs to earn its place continuously rather than on demand.

## What changed

**Runs after a merge instead of on a schedule.** Push events resolve the workflow file from the pushed ref, so this works from `minor` today with no default-branch problem, and it names the merge that broke things. `schedule` is removed: `scripts/typeorm/profiles.json` pins exact versions, so a run with no repository change can only repeat the previous result.

`master` and `major` are in the push branch list even though the file is not on those branches yet. Back-merge automation only flows `master → minor`, so the only route to `master` is the minor release merge — which carries #5122 with it. The workflow and the code that makes it green arrive together.

**One database per TypeORM dialect family.** `mysql` is dropped from the v1 axis: it goes through the same TypeORM driver as `mariadb`, so it repeats that coverage rather than adding to it. postgres, mariadb and sqljs remain. The full four-database matrix stays on v0.3 in `build_and_test.yml`.

**Pull request runs are triggered by the label alone.** Actions has no workflow-level `if`, so the per-job label gate can only skip jobs once a run already exists — which put a skipped check on every pull request in the repository. With `types: [labeled]`, opening or pushing to a pull request produces nothing at all.

The trade-off is that pushing further commits to an already-labelled pull request does not produce a new result; remove and re-add the label when you want one. The post-merge run is the safety net, so a stale pre-merge result is caught within one merge rather than shipping.

## Cost

Per-PR e2e cost stays at zero unless a pull request is deliberately opted in. Each merge to a release branch touching `packages/**` adds build, unit tests and three e2e jobs. Folding the v1 axis into `build_and_test.yml` as a matrix, which the old comment in the file recommended, would instead have added four e2e jobs to every pull request.

## Trigger behaviour

| Event | Result |
| --- | --- |
| Pull request opened or pushed to | Nothing — no run, no skipped check |
| `typeorm-v1` label added to a PR targeting a release branch | build, unit tests, e2e on sqljs/mariadb/postgres |
| Any other label added to such a PR | One skipped run |
| Merge to `master`/`minor`/`major` touching `packages/**` | build, unit tests, e2e on sqljs/mariadb/postgres |

`scripts/typeorm/README.md` is updated to match, and its description of the migration as in progress is corrected now that the packages typecheck against v1.

Relates to OSS-696

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789229453&installation_model_id=20193&pr_number=5137&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5137&signature=96cc5c88376d2585458c80374c0dd975179566314a05f2be3e7cb2bbfdd01254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->