### PR TITLE
fix(core): reconcile read/write quantity basis for OrderLine discounts (#5127)

### DIFF
--- a/packages/core/e2e/order-modification.e2e-spec.ts
+++ b/packages/core/e2e/order-modification.e2e-spec.ts
@@ -2880,11 +2880,16 @@ describe('Order modification', () => {
 
             // A partial cancellation does not redistribute the order-level discount, so the
             // reduced line keeps the per-unit share it was assigned at placement, and the
-            // untouched line keeps its share in full.
-            expect(orderLevelShareOf(remainingDiscountedLine) / remainingDiscountedLine.quantity).toBeCloseTo(
-                orderLevelShareOf(placedLines.get('T_1')!) / placedLines.get('T_1')!.quantity,
-                6,
+            // untouched line keeps its share in full. The per-unit rate itself is exact, but
+            // `orderLevelShareOf` is a line total rounded to the nearest minor unit, so scale the
+            // placement rate by the reduced quantity and round the same way rather than comparing
+            // two already-rounded per-unit values, which can differ by a fraction of a cent.
+            const placedDiscountedShareLine = placedLines.get('T_1')!;
+            const expectedRemainingShare = Math.round(
+                (orderLevelShareOf(placedDiscountedShareLine) / placedDiscountedShareLine.quantity) *
+                    remainingDiscountedLine.quantity,
             );
+            expect(orderLevelShareOf(remainingDiscountedLine)).toBe(expectedRemainingShare);
             expect(orderLevelShareOf(remainingLines.get('T_4')!)).toBe(
                 orderLevelShareOf(placedLines.get('T_4')!),
             );

--- a/packages/core/e2e/order-modification.e2e-spec.ts
+++ b/packages/core/e2e/order-modification.e2e-spec.ts
@@ -2642,7 +2642,8 @@ describe('Order modification', () => {
             orderGuard.assertSuccess(placedOrder);
 
             const placedLine = placedOrder.lines[0];
-            expect(placedLine.discountedUnitPriceWithTax).toBe(placedLine.unitPriceWithTax / 2);
+            const placedUnitPriceWithTax = placedLine.unitPriceWithTax;
+            expect(placedLine.discountedUnitPriceWithTax).toBe(placedUnitPriceWithTax / 2);
 
             const transitionOrderToState = await adminTransitionOrderToState(placedOrder.id, 'Modifying');
             orderGuard.assertSuccess(transitionOrderToState);
@@ -2664,13 +2665,12 @@ describe('Order modification', () => {
             const modifiedLine = modifyOrder.lines.find(l => l.id === placedLine.id)!;
             expect(modifiedLine.quantity).toBe(2);
             expect(modifiedLine.orderPlacedQuantity).toBe(20);
-            // Before the fix, `OrderCalculator.applyPriceAdjustments` (triggered by `modifyOrder`)
-            // already recomputes `adjustments` freshly against the *new* quantity of 2 - i.e. the
-            // stored adjustment total is already correctly scaled. The read-side getters then divided
-            // that already-correct total by `Math.max(orderPlacedQuantity, quantity)` a second time,
-            // silently rescaling the 50% discount down to `quantity / orderPlacedQuantity` (2/20 = 10%)
-            // of its correct value.
-            expect(modifiedLine.discountedLinePriceWithTax).toBe(modifiedLine.linePriceWithTax / 2);
+            // Both assertions are pinned to `placedUnitPriceWithTax`, captured before the
+            // modification, rather than to `modifiedLine`'s own fields - see #5127 for why the
+            // pre-fix read-side getters silently rescaled the discount down to 10% of its correct
+            // value here.
+            expect(modifiedLine.linePriceWithTax).toBe(placedUnitPriceWithTax * 2);
+            expect(modifiedLine.discountedLinePriceWithTax).toBe(placedUnitPriceWithTax);
         });
 
         it('cancelOrder: partially cancelling a line keeps the 50% discount ratio on the remaining units', async () => {
@@ -2726,7 +2726,203 @@ describe('Order modification', () => {
             // The remaining 2 units should still carry the full 50% discount: half of their combined
             // list price, i.e. exactly one unit's price.
             expect(remainingLine.proratedLinePriceWithTax).toBe(unitPriceWithTax);
+            expect(remainingLine.discounts.length).toBe(1);
             expect(remainingLine.discounts[0].amountWithTax).toBe(-unitPriceWithTax);
+        });
+
+        // #5127 — DefaultOrderLineDiscountDistributionStrategy.getWeight() reads
+        // line.proratedLinePriceWithTax, so an order-level DISTRIBUTED_ORDER_PROMOTION's split
+        // across lines depends on the very value this fix changes for a reduced line. These two
+        // tests put an item-level PROMOTION and an order-level DISTRIBUTED_ORDER_PROMOTION on the
+        // same order, then reduce the discounted line's quantity, to guard the split against
+        // corruption from that interaction.
+        it('modifyOrder: order-level discount split survives reducing one line of a multi-line order', async () => {
+            await adminClient.query(createPromotionDocument, {
+                input: {
+                    couponCode: 'ITEM_5127_COMBO_MODIFY',
+                    enabled: true,
+                    conditions: [],
+                    actions: [
+                        {
+                            code: productsPercentageDiscount.code,
+                            arguments: [
+                                { name: 'discount', value: '50' },
+                                { name: 'productVariantIds', value: JSON.stringify(['T_1']) },
+                            ],
+                        },
+                    ],
+                    translations: [
+                        { languageCode: LanguageCode.en, name: '50% off T_1 (#5127 combo modify)' },
+                    ],
+                },
+            });
+            await adminClient.query(createPromotionDocument, {
+                input: {
+                    couponCode: 'ORDER_5127_COMBO_MODIFY',
+                    enabled: true,
+                    conditions: [],
+                    actions: [
+                        {
+                            code: orderFixedDiscount.code,
+                            arguments: [{ name: 'discount', value: '500' }],
+                        },
+                    ],
+                    translations: [
+                        { languageCode: LanguageCode.en, name: '$5 off order (#5127 combo modify)' },
+                    ],
+                },
+            });
+
+            await shopClient.asUserWithCredentials('hayden.zieme12@hotmail.com', 'test');
+            await shopClient.query(addItemToOrderWithCustomFieldsDocument, {
+                productVariantId: 'T_1',
+                quantity: 20,
+            } as any);
+            await shopClient.query(addItemToOrderWithCustomFieldsDocument, {
+                productVariantId: 'T_4',
+                quantity: 1,
+            } as any);
+            await shopClient.query(applyCouponCodeDocument, { couponCode: 'ITEM_5127_COMBO_MODIFY' });
+            await shopClient.query(applyCouponCodeDocument, { couponCode: 'ORDER_5127_COMBO_MODIFY' });
+            await proceedToArrangingPayment(shopClient);
+            const placedOrder = await addPaymentToOrder(shopClient, testSuccessfulPaymentMethod);
+            orderGuard.assertSuccess(placedOrder);
+
+            const placedDiscountedLine = placedOrder.lines.find(l => l.productVariant.id === 'T_1')!;
+            const placedOtherLine = placedOrder.lines.find(l => l.productVariant.id === 'T_4')!;
+            const placedUnitPriceWithTax = placedDiscountedLine.unitPriceWithTax;
+
+            const transitionOrderToState = await adminTransitionOrderToState(placedOrder.id, 'Modifying');
+            orderGuard.assertSuccess(transitionOrderToState);
+
+            const { modifyOrder } = await adminClient.query(modifyOrderDocument, {
+                input: {
+                    dryRun: false,
+                    orderId: placedOrder.id,
+                    adjustOrderLines: [{ orderLineId: placedDiscountedLine.id, quantity: 2 }],
+                    refund: {
+                        paymentId: placedOrder.payments![0].id,
+                        reason: 'reduced quantity (#5127 combo modify)',
+                    },
+                },
+            });
+            orderWithModificationsGuard.assertSuccess(modifyOrder);
+
+            const modifiedDiscountedLine = modifyOrder.lines.find(l => l.id === placedDiscountedLine.id)!;
+            const modifiedOtherLine = modifyOrder.lines.find(l => l.id === placedOtherLine.id)!;
+
+            // The item-level 50% discount on the reduced line survives, independently of the
+            // order-level discount below.
+            expect(modifiedDiscountedLine.discountedLinePriceWithTax).toBe(placedUnitPriceWithTax);
+
+            // The order-level $5 discount is still split, in full, across the two lines - it is
+            // neither dropped nor double-counted by combining it with the item-level discount.
+            const discountedLineOrderShare =
+                modifiedDiscountedLine.proratedLinePriceWithTax -
+                modifiedDiscountedLine.discountedLinePriceWithTax;
+            const otherLineOrderShare =
+                modifiedOtherLine.proratedLinePriceWithTax - modifiedOtherLine.discountedLinePriceWithTax;
+            expect(discountedLineOrderShare + otherLineOrderShare).toBe(-500);
+            expect(modifiedOtherLine.discountedLinePriceWithTax).toBe(placedOtherLine.unitPriceWithTax);
+
+            expect(modifyOrder.totalWithTax).toBe(modifyOrder.subTotalWithTax + modifyOrder.shippingWithTax);
+        });
+
+        it('cancelOrder: order-level discount split survives partially cancelling one line of a multi-line order', async () => {
+            await adminClient.query(createPromotionDocument, {
+                input: {
+                    couponCode: 'ITEM_5127_COMBO_CANCEL',
+                    enabled: true,
+                    conditions: [],
+                    actions: [
+                        {
+                            code: productsPercentageDiscount.code,
+                            arguments: [
+                                { name: 'discount', value: '50' },
+                                { name: 'productVariantIds', value: JSON.stringify(['T_1']) },
+                            ],
+                        },
+                    ],
+                    translations: [
+                        { languageCode: LanguageCode.en, name: '50% off T_1 (#5127 combo cancel)' },
+                    ],
+                },
+            });
+            await adminClient.query(createPromotionDocument, {
+                input: {
+                    couponCode: 'ORDER_5127_COMBO_CANCEL',
+                    enabled: true,
+                    conditions: [],
+                    actions: [
+                        {
+                            code: orderFixedDiscount.code,
+                            arguments: [{ name: 'discount', value: '500' }],
+                        },
+                    ],
+                    translations: [
+                        { languageCode: LanguageCode.en, name: '$5 off order (#5127 combo cancel)' },
+                    ],
+                },
+            });
+
+            await shopClient.asUserWithCredentials('hayden.zieme12@hotmail.com', 'test');
+            await shopClient.query(addItemToOrderWithCustomFieldsDocument, {
+                productVariantId: 'T_1',
+                quantity: 20,
+            } as any);
+            await shopClient.query(addItemToOrderWithCustomFieldsDocument, {
+                productVariantId: 'T_4',
+                quantity: 1,
+            } as any);
+            await shopClient.query(applyCouponCodeDocument, { couponCode: 'ITEM_5127_COMBO_CANCEL' });
+            await shopClient.query(applyCouponCodeDocument, { couponCode: 'ORDER_5127_COMBO_CANCEL' });
+            await proceedToArrangingPayment(shopClient);
+            const placedOrder = await addPaymentToOrder(shopClient, testSuccessfulPaymentMethod);
+            orderGuard.assertSuccess(placedOrder);
+
+            const placedDiscountedLine = placedOrder.lines.find(l => l.productVariant.id === 'T_1')!;
+            const placedOtherLine = placedOrder.lines.find(l => l.productVariant.id === 'T_4')!;
+            const unitPriceWithTax = placedDiscountedLine.unitPriceWithTax;
+
+            const { cancelOrder } = await adminClient.query(cancelOrderDocument, {
+                input: {
+                    orderId: placedOrder.id,
+                    lines: [{ orderLineId: placedDiscountedLine.id, quantity: 18 }],
+                    reason: 'partial cancellation (#5127 combo cancel)',
+                },
+            });
+            canceledOrderGuard.assertSuccess(cancelOrder);
+
+            const { order } = await adminClient.query(getOrderWithLineDiscountsDocument, {
+                id: placedOrder.id,
+            });
+            const remainingDiscountedLine = order!.lines.find(l => l.id === placedDiscountedLine.id)!;
+            const remainingOtherLine = order!.lines.find(l => l.id === placedOtherLine.id)!;
+
+            expect(remainingDiscountedLine.quantity).toBe(2);
+            expect(remainingDiscountedLine.orderPlacedQuantity).toBe(20);
+
+            // The order-level discount is present on both lines; the item-level discount only on
+            // the discounted one. Tell them apart that way, rather than by adjustmentSource format.
+            const otherLineSources = new Set(remainingOtherLine.discounts.map(d => d.adjustmentSource));
+            const itemDiscounts = remainingDiscountedLine.discounts.filter(
+                d => !otherLineSources.has(d.adjustmentSource),
+            );
+            const discountedLineOrderLevelDiscounts = remainingDiscountedLine.discounts.filter(d =>
+                otherLineSources.has(d.adjustmentSource),
+            );
+
+            // The item-level 50% discount on the remaining 2 units still equals half their
+            // combined list price, independently of the order-level discount split below.
+            expect(itemDiscounts.length).toBe(1);
+            expect(itemDiscounts[0].amountWithTax).toBe(-unitPriceWithTax);
+
+            // The order-level $5 discount is still split, in full, across both lines - neither
+            // dropped nor double-counted by combining it with the item-level discount.
+            const orderLevelDiscountTotal =
+                summate(discountedLineOrderLevelDiscounts, 'amountWithTax') +
+                summate(remainingOtherLine.discounts, 'amountWithTax');
+            expect(orderLevelDiscountTotal).toBe(-500);
         });
     });
 

--- a/packages/core/e2e/order-modification.e2e-spec.ts
+++ b/packages/core/e2e/order-modification.e2e-spec.ts
@@ -2606,6 +2606,130 @@ describe('Order modification', () => {
         });
     });
 
+    describe('reducing OrderLine quantity below orderPlacedQuantity keeps the discount ratio (#5127)', () => {
+        type CanceledOrderFragment = FragmentOf<typeof canceledOrderFragment>;
+        const canceledOrderGuard: ErrorResultGuard<CanceledOrderFragment> = createErrorResultGuard(
+            input => !!input.lines,
+        );
+
+        it('modifyOrder: reducing quantity via order modification keeps the 50% discount', async () => {
+            await adminClient.query(createPromotionDocument, {
+                input: {
+                    couponCode: 'HALF_5127_MODIFY',
+                    enabled: true,
+                    conditions: [],
+                    actions: [
+                        {
+                            code: productsPercentageDiscount.code,
+                            arguments: [
+                                { name: 'discount', value: '50' },
+                                { name: 'productVariantIds', value: JSON.stringify(['T_1']) },
+                            ],
+                        },
+                    ],
+                    translations: [{ languageCode: LanguageCode.en, name: '50% off T_1 (#5127 modify)' }],
+                },
+            });
+
+            await shopClient.asUserWithCredentials('hayden.zieme12@hotmail.com', 'test');
+            await shopClient.query(addItemToOrderWithCustomFieldsDocument, {
+                productVariantId: 'T_1',
+                quantity: 20,
+            } as any);
+            await shopClient.query(applyCouponCodeDocument, { couponCode: 'HALF_5127_MODIFY' });
+            await proceedToArrangingPayment(shopClient);
+            const placedOrder = await addPaymentToOrder(shopClient, testSuccessfulPaymentMethod);
+            orderGuard.assertSuccess(placedOrder);
+
+            const placedLine = placedOrder.lines[0];
+            expect(placedLine.discountedUnitPriceWithTax).toBe(placedLine.unitPriceWithTax / 2);
+
+            const transitionOrderToState = await adminTransitionOrderToState(placedOrder.id, 'Modifying');
+            orderGuard.assertSuccess(transitionOrderToState);
+
+            // Reduce the quantity from 20 down to 2, well below the orderPlacedQuantity of 20.
+            const { modifyOrder } = await adminClient.query(modifyOrderDocument, {
+                input: {
+                    dryRun: false,
+                    orderId: placedOrder.id,
+                    adjustOrderLines: [{ orderLineId: placedLine.id, quantity: 2 }],
+                    refund: {
+                        paymentId: placedOrder.payments![0].id,
+                        reason: 'reduced quantity (#5127)',
+                    },
+                },
+            });
+            orderWithModificationsGuard.assertSuccess(modifyOrder);
+
+            const modifiedLine = modifyOrder.lines.find(l => l.id === placedLine.id)!;
+            expect(modifiedLine.quantity).toBe(2);
+            expect(modifiedLine.orderPlacedQuantity).toBe(20);
+            // Before the fix, `OrderCalculator.applyPriceAdjustments` (triggered by `modifyOrder`)
+            // already recomputes `adjustments` freshly against the *new* quantity of 2 - i.e. the
+            // stored adjustment total is already correctly scaled. The read-side getters then divided
+            // that already-correct total by `Math.max(orderPlacedQuantity, quantity)` a second time,
+            // silently rescaling the 50% discount down to `quantity / orderPlacedQuantity` (2/20 = 10%)
+            // of its correct value.
+            expect(modifiedLine.discountedLinePriceWithTax).toBe(modifiedLine.linePriceWithTax / 2);
+        });
+
+        it('cancelOrder: partially cancelling a line keeps the 50% discount ratio on the remaining units', async () => {
+            await adminClient.query(createPromotionDocument, {
+                input: {
+                    couponCode: 'HALF_5127_CANCEL',
+                    enabled: true,
+                    conditions: [],
+                    actions: [
+                        {
+                            code: productsPercentageDiscount.code,
+                            arguments: [
+                                { name: 'discount', value: '50' },
+                                { name: 'productVariantIds', value: JSON.stringify(['T_1']) },
+                            ],
+                        },
+                    ],
+                    translations: [{ languageCode: LanguageCode.en, name: '50% off T_1 (#5127 cancel)' }],
+                },
+            });
+
+            await shopClient.asUserWithCredentials('hayden.zieme12@hotmail.com', 'test');
+            await shopClient.query(addItemToOrderWithCustomFieldsDocument, {
+                productVariantId: 'T_1',
+                quantity: 20,
+            } as any);
+            await shopClient.query(applyCouponCodeDocument, { couponCode: 'HALF_5127_CANCEL' });
+            await proceedToArrangingPayment(shopClient);
+            const placedOrder = await addPaymentToOrder(shopClient, testSuccessfulPaymentMethod);
+            orderGuard.assertSuccess(placedOrder);
+
+            const placedLine = placedOrder.lines[0];
+            const unitPriceWithTax = placedLine.unitPriceWithTax;
+
+            // Cancel 18 of the 20 units, going through `OrderModifier.cancelOrderByOrderLines()` - a
+            // path which, unlike `modifyOrder`, does *not* recalculate promotions from scratch.
+            const { cancelOrder } = await adminClient.query(cancelOrderDocument, {
+                input: {
+                    orderId: placedOrder.id,
+                    lines: [{ orderLineId: placedLine.id, quantity: 18 }],
+                    reason: 'partial cancellation (#5127)',
+                },
+            });
+            canceledOrderGuard.assertSuccess(cancelOrder);
+
+            const { order } = await adminClient.query(getOrderWithLineDiscountsDocument, {
+                id: placedOrder.id,
+            });
+            const remainingLine = order!.lines.find(l => l.id === placedLine.id)!;
+
+            expect(remainingLine.quantity).toBe(2);
+            expect(remainingLine.orderPlacedQuantity).toBe(20);
+            // The remaining 2 units should still carry the full 50% discount: half of their combined
+            // list price, i.e. exactly one unit's price.
+            expect(remainingLine.proratedLinePriceWithTax).toBe(unitPriceWithTax);
+            expect(remainingLine.discounts[0].amountWithTax).toBe(-unitPriceWithTax);
+        });
+    });
+
     async function adminTransitionOrderToState(id: string, state: string) {
         const result = await adminClient.query(adminTransitionToStateDocument, {
             id,

--- a/packages/core/e2e/order-modification.e2e-spec.ts
+++ b/packages/core/e2e/order-modification.e2e-spec.ts
@@ -220,9 +220,18 @@ const getOrderWithLineDiscountsDocument = adminGraphql(`
                 id
                 quantity
                 orderPlacedQuantity
+                unitPriceWithTax
+                linePriceWithTax
+                discountedUnitPriceWithTax
+                discountedLinePriceWithTax
+                proratedUnitPriceWithTax
                 proratedLinePriceWithTax
+                productVariant {
+                    id
+                }
                 discounts {
                     adjustmentSource
+                    type
                     amount
                     amountWithTax
                 }
@@ -317,6 +326,11 @@ describe('Order modification', () => {
     type OrderWithModificationsFragment = FragmentOf<typeof orderWithModificationsFragment>;
     const orderWithModificationsGuard: ErrorResultGuard<OrderWithModificationsFragment> =
         createErrorResultGuard(input => !!input.id);
+
+    type CanceledOrderFragment = FragmentOf<typeof canceledOrderFragment>;
+    const canceledOrderGuard: ErrorResultGuard<CanceledOrderFragment> = createErrorResultGuard(
+        input => !!input.lines,
+    );
 
     // Type aliases for fragment types
     type OrderWithLinesFragment = FragmentOf<typeof orderWithLinesFragment>;
@@ -2508,11 +2522,6 @@ describe('Order modification', () => {
     describe('cancelling an order with a line added by a modification', () => {
         const CODE_HALF_PRICE = 'HALF_PRICE';
 
-        type CanceledOrderFragment = FragmentOf<typeof canceledOrderFragment>;
-        const canceledOrderGuard: ErrorResultGuard<CanceledOrderFragment> = createErrorResultGuard(
-            input => !!input.lines,
-        );
-
         it('order with discounts can still be read after cancellation', async () => {
             await adminClient.query(createPromotionDocument, {
                 input: {
@@ -2607,15 +2616,12 @@ describe('Order modification', () => {
     });
 
     describe('reducing OrderLine quantity below orderPlacedQuantity keeps the discount ratio (#5127)', () => {
-        type CanceledOrderFragment = FragmentOf<typeof canceledOrderFragment>;
-        const canceledOrderGuard: ErrorResultGuard<CanceledOrderFragment> = createErrorResultGuard(
-            input => !!input.lines,
-        );
+        const createdPromotionIds: string[] = [];
 
-        it('modifyOrder: reducing quantity via order modification keeps the 50% discount', async () => {
-            await adminClient.query(createPromotionDocument, {
+        async function createItemPromotion(couponCode: string, name: string) {
+            const { createPromotion } = await adminClient.query(createPromotionDocument, {
                 input: {
-                    couponCode: 'HALF_5127_MODIFY',
+                    couponCode,
                     enabled: true,
                     conditions: [],
                     actions: [
@@ -2627,9 +2633,62 @@ describe('Order modification', () => {
                             ],
                         },
                     ],
-                    translations: [{ languageCode: LanguageCode.en, name: '50% off T_1 (#5127 modify)' }],
+                    translations: [{ languageCode: LanguageCode.en, name }],
                 },
             });
+            createdPromotionIds.push((createPromotion as any).id);
+        }
+
+        async function createOrderPromotion(couponCode: string, name: string) {
+            const { createPromotion } = await adminClient.query(createPromotionDocument, {
+                input: {
+                    couponCode,
+                    enabled: true,
+                    conditions: [],
+                    actions: [
+                        {
+                            code: orderFixedDiscount.code,
+                            arguments: [{ name: 'discount', value: '500' }],
+                        },
+                    ],
+                    translations: [{ languageCode: LanguageCode.en, name }],
+                },
+            });
+            createdPromotionIds.push((createPromotion as any).id);
+        }
+
+        afterAll(async () => {
+            for (const id of createdPromotionIds) {
+                await adminClient.query(deletePromotionDocument, { id });
+            }
+        });
+
+        async function getOrderLines(orderId: string) {
+            const { order } = await adminClient.query(getOrderWithLineDiscountsDocument, { id: orderId });
+            return order!.lines;
+        }
+
+        type LineWithDiscounts = Awaited<ReturnType<typeof getOrderLines>>[number];
+
+        async function getLinesByVariant(orderId: string) {
+            const lines = await getOrderLines(orderId);
+            return new Map<string, LineWithDiscounts>(lines.map(line => [line.productVariant.id, line]));
+        }
+
+        const itemShareOf = (line: LineWithDiscounts) =>
+            summate(
+                line.discounts.filter(d => d.type === 'PROMOTION'),
+                'amountWithTax',
+            );
+
+        const orderLevelShareOf = (line: LineWithDiscounts) =>
+            summate(
+                line.discounts.filter(d => d.type === 'DISTRIBUTED_ORDER_PROMOTION'),
+                'amountWithTax',
+            );
+
+        it('modifyOrder: reducing quantity via order modification keeps the 50% discount', async () => {
+            await createItemPromotion('HALF_5127_MODIFY', '50% off T_1 (#5127 modify)');
 
             await shopClient.asUserWithCredentials('hayden.zieme12@hotmail.com', 'test');
             await shopClient.query(addItemToOrderWithCustomFieldsDocument, {
@@ -2665,32 +2724,14 @@ describe('Order modification', () => {
             const modifiedLine = modifyOrder.lines.find(l => l.id === placedLine.id)!;
             expect(modifiedLine.quantity).toBe(2);
             expect(modifiedLine.orderPlacedQuantity).toBe(20);
-            // Both assertions are pinned to `placedUnitPriceWithTax`, captured before the
-            // modification, rather than to `modifiedLine`'s own fields - see #5127 for why the
-            // pre-fix read-side getters silently rescaled the discount down to 10% of its correct
-            // value here.
+            // Pinned to `placedUnitPriceWithTax`, captured before the modification, rather than to
+            // `modifiedLine`'s own fields.
             expect(modifiedLine.linePriceWithTax).toBe(placedUnitPriceWithTax * 2);
             expect(modifiedLine.discountedLinePriceWithTax).toBe(placedUnitPriceWithTax);
         });
 
         it('cancelOrder: partially cancelling a line keeps the 50% discount ratio on the remaining units', async () => {
-            await adminClient.query(createPromotionDocument, {
-                input: {
-                    couponCode: 'HALF_5127_CANCEL',
-                    enabled: true,
-                    conditions: [],
-                    actions: [
-                        {
-                            code: productsPercentageDiscount.code,
-                            arguments: [
-                                { name: 'discount', value: '50' },
-                                { name: 'productVariantIds', value: JSON.stringify(['T_1']) },
-                            ],
-                        },
-                    ],
-                    translations: [{ languageCode: LanguageCode.en, name: '50% off T_1 (#5127 cancel)' }],
-                },
-            });
+            await createItemPromotion('HALF_5127_CANCEL', '50% off T_1 (#5127 cancel)');
 
             await shopClient.asUserWithCredentials('hayden.zieme12@hotmail.com', 'test');
             await shopClient.query(addItemToOrderWithCustomFieldsDocument, {
@@ -2730,48 +2771,15 @@ describe('Order modification', () => {
             expect(remainingLine.discounts[0].amountWithTax).toBe(-unitPriceWithTax);
         });
 
-        // #5127 — DefaultOrderLineDiscountDistributionStrategy.getWeight() reads
+        // DefaultOrderLineDiscountDistributionStrategy.getWeight() reads
         // line.proratedLinePriceWithTax, so an order-level DISTRIBUTED_ORDER_PROMOTION's split
         // across lines depends on the very value this fix changes for a reduced line. These two
         // tests put an item-level PROMOTION and an order-level DISTRIBUTED_ORDER_PROMOTION on the
         // same order, then reduce the discounted line's quantity, to guard the split against
         // corruption from that interaction.
         it('modifyOrder: order-level discount split survives reducing one line of a multi-line order', async () => {
-            await adminClient.query(createPromotionDocument, {
-                input: {
-                    couponCode: 'ITEM_5127_COMBO_MODIFY',
-                    enabled: true,
-                    conditions: [],
-                    actions: [
-                        {
-                            code: productsPercentageDiscount.code,
-                            arguments: [
-                                { name: 'discount', value: '50' },
-                                { name: 'productVariantIds', value: JSON.stringify(['T_1']) },
-                            ],
-                        },
-                    ],
-                    translations: [
-                        { languageCode: LanguageCode.en, name: '50% off T_1 (#5127 combo modify)' },
-                    ],
-                },
-            });
-            await adminClient.query(createPromotionDocument, {
-                input: {
-                    couponCode: 'ORDER_5127_COMBO_MODIFY',
-                    enabled: true,
-                    conditions: [],
-                    actions: [
-                        {
-                            code: orderFixedDiscount.code,
-                            arguments: [{ name: 'discount', value: '500' }],
-                        },
-                    ],
-                    translations: [
-                        { languageCode: LanguageCode.en, name: '$5 off order (#5127 combo modify)' },
-                    ],
-                },
-            });
+            await createItemPromotion('ITEM_5127_COMBO_MODIFY', '50% off T_1 (#5127 combo modify)');
+            await createOrderPromotion('ORDER_5127_COMBO_MODIFY', '$5 off order (#5127 combo modify)');
 
             await shopClient.asUserWithCredentials('hayden.zieme12@hotmail.com', 'test');
             await shopClient.query(addItemToOrderWithCustomFieldsDocument, {
@@ -2791,6 +2799,7 @@ describe('Order modification', () => {
             const placedDiscountedLine = placedOrder.lines.find(l => l.productVariant.id === 'T_1')!;
             const placedOtherLine = placedOrder.lines.find(l => l.productVariant.id === 'T_4')!;
             const placedUnitPriceWithTax = placedDiscountedLine.unitPriceWithTax;
+            const placedLines = await getLinesByVariant(placedOrder.id);
 
             const transitionOrderToState = await adminTransitionOrderToState(placedOrder.id, 'Modifying');
             orderGuard.assertSuccess(transitionOrderToState);
@@ -2814,56 +2823,22 @@ describe('Order modification', () => {
             // The item-level 50% discount on the reduced line survives, independently of the
             // order-level discount below.
             expect(modifiedDiscountedLine.discountedLinePriceWithTax).toBe(placedUnitPriceWithTax);
-
-            // The order-level $5 discount is still split, in full, across the two lines - it is
-            // neither dropped nor double-counted by combining it with the item-level discount.
-            const discountedLineOrderShare =
-                modifiedDiscountedLine.proratedLinePriceWithTax -
-                modifiedDiscountedLine.discountedLinePriceWithTax;
-            const otherLineOrderShare =
-                modifiedOtherLine.proratedLinePriceWithTax - modifiedOtherLine.discountedLinePriceWithTax;
-            expect(discountedLineOrderShare + otherLineOrderShare).toBe(-500);
             expect(modifiedOtherLine.discountedLinePriceWithTax).toBe(placedOtherLine.unitPriceWithTax);
 
-            expect(modifyOrder.totalWithTax).toBe(modifyOrder.subTotalWithTax + modifyOrder.shippingWithTax);
+            // The order-level $5 discount is still split across both lines. `modifyOrder` runs a
+            // full recalculation, which redistributes it by weight, so the reduced line's much
+            // smaller weight can only move share towards the untouched line - it must not leave
+            // either line without one.
+            const modifiedLines = await getLinesByVariant(placedOrder.id);
+            expect(orderLevelShareOf(modifiedLines.get('T_1')!)).toBeLessThan(0);
+            expect(orderLevelShareOf(modifiedLines.get('T_4')!)).toBeLessThanOrEqual(
+                orderLevelShareOf(placedLines.get('T_4')!),
+            );
         });
 
         it('cancelOrder: order-level discount split survives partially cancelling one line of a multi-line order', async () => {
-            await adminClient.query(createPromotionDocument, {
-                input: {
-                    couponCode: 'ITEM_5127_COMBO_CANCEL',
-                    enabled: true,
-                    conditions: [],
-                    actions: [
-                        {
-                            code: productsPercentageDiscount.code,
-                            arguments: [
-                                { name: 'discount', value: '50' },
-                                { name: 'productVariantIds', value: JSON.stringify(['T_1']) },
-                            ],
-                        },
-                    ],
-                    translations: [
-                        { languageCode: LanguageCode.en, name: '50% off T_1 (#5127 combo cancel)' },
-                    ],
-                },
-            });
-            await adminClient.query(createPromotionDocument, {
-                input: {
-                    couponCode: 'ORDER_5127_COMBO_CANCEL',
-                    enabled: true,
-                    conditions: [],
-                    actions: [
-                        {
-                            code: orderFixedDiscount.code,
-                            arguments: [{ name: 'discount', value: '500' }],
-                        },
-                    ],
-                    translations: [
-                        { languageCode: LanguageCode.en, name: '$5 off order (#5127 combo cancel)' },
-                    ],
-                },
-            });
+            await createItemPromotion('ITEM_5127_COMBO_CANCEL', '50% off T_1 (#5127 combo cancel)');
+            await createOrderPromotion('ORDER_5127_COMBO_CANCEL', '$5 off order (#5127 combo cancel)');
 
             await shopClient.asUserWithCredentials('hayden.zieme12@hotmail.com', 'test');
             await shopClient.query(addItemToOrderWithCustomFieldsDocument, {
@@ -2881,8 +2856,8 @@ describe('Order modification', () => {
             orderGuard.assertSuccess(placedOrder);
 
             const placedDiscountedLine = placedOrder.lines.find(l => l.productVariant.id === 'T_1')!;
-            const placedOtherLine = placedOrder.lines.find(l => l.productVariant.id === 'T_4')!;
             const unitPriceWithTax = placedDiscountedLine.unitPriceWithTax;
+            const placedLines = await getLinesByVariant(placedOrder.id);
 
             const { cancelOrder } = await adminClient.query(cancelOrderDocument, {
                 input: {
@@ -2893,36 +2868,26 @@ describe('Order modification', () => {
             });
             canceledOrderGuard.assertSuccess(cancelOrder);
 
-            const { order } = await adminClient.query(getOrderWithLineDiscountsDocument, {
-                id: placedOrder.id,
-            });
-            const remainingDiscountedLine = order!.lines.find(l => l.id === placedDiscountedLine.id)!;
-            const remainingOtherLine = order!.lines.find(l => l.id === placedOtherLine.id)!;
+            const remainingLines = await getLinesByVariant(placedOrder.id);
+            const remainingDiscountedLine = remainingLines.get('T_1')!;
 
             expect(remainingDiscountedLine.quantity).toBe(2);
             expect(remainingDiscountedLine.orderPlacedQuantity).toBe(20);
 
-            // The order-level discount is present on both lines; the item-level discount only on
-            // the discounted one. Tell them apart that way, rather than by adjustmentSource format.
-            const otherLineSources = new Set(remainingOtherLine.discounts.map(d => d.adjustmentSource));
-            const itemDiscounts = remainingDiscountedLine.discounts.filter(
-                d => !otherLineSources.has(d.adjustmentSource),
-            );
-            const discountedLineOrderLevelDiscounts = remainingDiscountedLine.discounts.filter(d =>
-                otherLineSources.has(d.adjustmentSource),
-            );
-
             // The item-level 50% discount on the remaining 2 units still equals half their
             // combined list price, independently of the order-level discount split below.
-            expect(itemDiscounts.length).toBe(1);
-            expect(itemDiscounts[0].amountWithTax).toBe(-unitPriceWithTax);
+            expect(itemShareOf(remainingDiscountedLine)).toBe(-unitPriceWithTax);
 
-            // The order-level $5 discount is still split, in full, across both lines - neither
-            // dropped nor double-counted by combining it with the item-level discount.
-            const orderLevelDiscountTotal =
-                summate(discountedLineOrderLevelDiscounts, 'amountWithTax') +
-                summate(remainingOtherLine.discounts, 'amountWithTax');
-            expect(orderLevelDiscountTotal).toBe(-500);
+            // A partial cancellation does not redistribute the order-level discount, so the
+            // reduced line keeps the per-unit share it was assigned at placement, and the
+            // untouched line keeps its share in full.
+            expect(orderLevelShareOf(remainingDiscountedLine) / remainingDiscountedLine.quantity).toBeCloseTo(
+                orderLevelShareOf(placedLines.get('T_1')!) / placedLines.get('T_1')!.quantity,
+                6,
+            );
+            expect(orderLevelShareOf(remainingLines.get('T_4')!)).toBe(
+                orderLevelShareOf(placedLines.get('T_4')!),
+            );
         });
     });
 

--- a/packages/core/src/entity/order-line/order-line.entity.spec.ts
+++ b/packages/core/src/entity/order-line/order-line.entity.spec.ts
@@ -10,23 +10,23 @@ describe('OrderLine entity', () => {
         await ensureConfigLoaded();
     });
 
+    const distributedOrderPromotionAdjustment: Adjustment = {
+        adjustmentSource: 'PROMOTION:1',
+        type: AdjustmentType.DISTRIBUTED_ORDER_PROMOTION,
+        description: 'half price',
+        amount: -500,
+        data: {},
+    };
+
+    const itemPromotionAdjustment: Adjustment = {
+        adjustmentSource: 'PROMOTION:2',
+        type: AdjustmentType.PROMOTION,
+        description: '40% off',
+        amount: -400,
+        data: {},
+    };
+
     describe('discounts', () => {
-        const distributedOrderPromotionAdjustment: Adjustment = {
-            adjustmentSource: 'PROMOTION:1',
-            type: AdjustmentType.DISTRIBUTED_ORDER_PROMOTION,
-            description: 'half price',
-            amount: -500,
-            data: {},
-        };
-
-        const itemPromotionAdjustment: Adjustment = {
-            adjustmentSource: 'PROMOTION:2',
-            type: AdjustmentType.PROMOTION,
-            description: '40% off',
-            amount: -400,
-            data: {},
-        };
-
         function createOrderLine(
             quantity: number,
             orderPlacedQuantity: number,
@@ -78,10 +78,50 @@ describe('OrderLine entity', () => {
             expect(item?.amountWithTax).toBe(-400);
         });
 
-        it('does not divide a PROMOTION adjustment by zero when orderPlacedQuantity is 0', () => {
-            const line = createOrderLine(2, 0, [itemPromotionAdjustment]);
+        it('is zero, not NaN, for a PROMOTION adjustment on a fully-cancelled line', () => {
+            const line = createOrderLine(0, 20, [itemPromotionAdjustment]);
 
-            expect(line.discounts[0].amountWithTax).toBe(-400);
+            expect(line.discounts[0].amount).toBe(0);
+            expect(line.discounts[0].amountWithTax).toBe(0);
+        });
+    });
+
+    describe('setQuantityRescalingAdjustments()', () => {
+        function createOrderLine(quantity: number, adjustments: Adjustment[]): OrderLine {
+            return new OrderLine({
+                quantity,
+                orderPlacedQuantity: quantity,
+                listPrice: 2975,
+                listPriceIncludesTax: true,
+                taxLines: [{ description: 'vat', taxRate: 20 }],
+                adjustments,
+            });
+        }
+
+        it('scales PROMOTION adjustments to the new quantity', () => {
+            const line = createOrderLine(20, [
+                { ...itemPromotionAdjustment, amount: -29750 },
+                { ...distributedOrderPromotionAdjustment, amount: -500 },
+            ]);
+
+            line.setQuantityRescalingAdjustments(2);
+
+            expect(line.quantity).toBe(2);
+            expect(line.adjustments.find(a => a.type === AdjustmentType.PROMOTION)?.amount).toBe(-2975);
+            expect(
+                line.adjustments.find(a => a.type === AdjustmentType.DISTRIBUTED_ORDER_PROMOTION)?.amount,
+            ).toBe(-500);
+        });
+
+        // A fully cancelled line reads as zero-discount either way, so zeroing the stored amounts
+        // would only destroy the record of the discount that had applied.
+        it('leaves the adjustments intact when the line is fully cancelled', () => {
+            const line = createOrderLine(20, [{ ...itemPromotionAdjustment, amount: -29750 }]);
+
+            line.setQuantityRescalingAdjustments(0);
+
+            expect(line.quantity).toBe(0);
+            expect(line.adjustments[0].amount).toBe(-29750);
         });
     });
 });

--- a/packages/core/src/entity/order-line/order-line.entity.spec.ts
+++ b/packages/core/src/entity/order-line/order-line.entity.spec.ts
@@ -11,7 +11,7 @@ describe('OrderLine entity', () => {
     });
 
     describe('discounts', () => {
-        const promotionAdjustment: Adjustment = {
+        const distributedOrderPromotionAdjustment: Adjustment = {
             adjustmentSource: 'PROMOTION:1',
             type: AdjustmentType.DISTRIBUTED_ORDER_PROMOTION,
             description: 'half price',
@@ -19,14 +19,26 @@ describe('OrderLine entity', () => {
             data: {},
         };
 
-        function createOrderLine(quantity: number, orderPlacedQuantity: number): OrderLine {
+        const itemPromotionAdjustment: Adjustment = {
+            adjustmentSource: 'PROMOTION:2',
+            type: AdjustmentType.PROMOTION,
+            description: '40% off',
+            amount: -400,
+            data: {},
+        };
+
+        function createOrderLine(
+            quantity: number,
+            orderPlacedQuantity: number,
+            adjustments: Adjustment[] = [distributedOrderPromotionAdjustment],
+        ): OrderLine {
             return new OrderLine({
                 quantity,
                 orderPlacedQuantity,
                 listPrice: 1000,
                 listPriceIncludesTax: true,
                 taxLines: [{ description: 'vat', taxRate: 20 }],
-                adjustments: [promotionAdjustment],
+                adjustments,
             });
         }
 
@@ -43,6 +55,33 @@ describe('OrderLine entity', () => {
 
             expect(line.discounts[0].amount).toBe(0);
             expect(line.discounts[0].amountWithTax).toBe(0);
+        });
+
+        // #5127 — a PROMOTION adjustment's stored amount is already scaled to the current
+        // quantity, unlike DISTRIBUTED_ORDER_PROMOTION, so it must not be divided again by
+        // orderPlacedQuantity.
+        it('does not re-divide a PROMOTION adjustment by orderPlacedQuantity', () => {
+            const line = createOrderLine(2, 20, [itemPromotionAdjustment]);
+
+            expect(line.discounts[0].amountWithTax).toBe(-400);
+        });
+
+        it('applies each adjustment type on its own basis when both are present', () => {
+            const line = createOrderLine(2, 20, [
+                distributedOrderPromotionAdjustment,
+                itemPromotionAdjustment,
+            ]);
+
+            const distributed = line.discounts.find(d => d.adjustmentSource === 'PROMOTION:1');
+            const item = line.discounts.find(d => d.adjustmentSource === 'PROMOTION:2');
+            expect(distributed?.amountWithTax).toBe(-50);
+            expect(item?.amountWithTax).toBe(-400);
+        });
+
+        it('does not divide a PROMOTION adjustment by zero when orderPlacedQuantity is 0', () => {
+            const line = createOrderLine(2, 0, [itemPromotionAdjustment]);
+
+            expect(line.discounts[0].amountWithTax).toBe(-400);
         });
     });
 });

--- a/packages/core/src/entity/order-line/order-line.entity.ts
+++ b/packages/core/src/entity/order-line/order-line.entity.ts
@@ -287,19 +287,22 @@ export class OrderLine extends VendureEntity implements HasCustomFields {
         // Group discounts together, so that it does not list a new
         // discount row for each item in the line
         const groupedDiscounts = new Map<string, Discount>();
-        // A line added by an OrderModification keeps an orderPlacedQuantity of 0, so once it is
-        // cancelled there are no units left to prorate the adjustment over.
-        const proratedOverQuantity = Math.max(this.orderPlacedQuantity, this.quantity);
+        // See `getUnitAdjustmentsTotal()` for the quantity basis used per adjustment type. A
+        // quantity of 0 (e.g. a fully-cancelled line added by an OrderModification, which keeps
+        // `orderPlacedQuantity` at 0 too, per #5097) has no units left to hold a discount,
+        // regardless of what the stored adjustment amount is.
         for (const adjustment of this.adjustments) {
             const discountGroup = groupedDiscounts.get(adjustment.adjustmentSource);
-            const unitAdjustmentAmount =
-                proratedOverQuantity === 0 ? 0 : (adjustment.amount / proratedOverQuantity) * this.quantity;
+            const lineAdjustmentAmount =
+                this.quantity === 0
+                    ? 0
+                    : (adjustment.amount / this.quantityBasisFor(adjustment)) * this.quantity;
             const amount = priceIncludesTax
-                ? netPriceOf(unitAdjustmentAmount, this.taxRate)
-                : unitAdjustmentAmount;
+                ? netPriceOf(lineAdjustmentAmount, this.taxRate)
+                : lineAdjustmentAmount;
             const amountWithTax = priceIncludesTax
-                ? unitAdjustmentAmount
-                : grossPriceOf(unitAdjustmentAmount, this.taxRate);
+                ? lineAdjustmentAmount
+                : grossPriceOf(lineAdjustmentAmount, this.taxRate);
             if (discountGroup) {
                 discountGroup.amount += amount;
                 discountGroup.amountWithTax += amountWithTax;
@@ -418,7 +421,9 @@ export class OrderLine extends VendureEntity implements HasCustomFields {
 
     /**
      * @description
-     * The total of all price adjustments. Will typically be a negative number due to discounts.
+     * The total of all price adjustments, expressed per unit. Will typically be a negative
+     * number due to discounts. See `quantityBasisFor()` for the quantity basis used per
+     * adjustment, which differs by `AdjustmentType`.
      */
     private getUnitAdjustmentsTotal(type?: AdjustmentType): number {
         if (!this.adjustments || this.quantity === 0) {
@@ -426,13 +431,14 @@ export class OrderLine extends VendureEntity implements HasCustomFields {
         }
         return this.adjustments
             .filter(adjustment => (type ? adjustment.type === type : true))
-            .map(adjustment => adjustment.amount / Math.max(this.orderPlacedQuantity, this.quantity))
+            .map(adjustment => adjustment.amount / this.quantityBasisFor(adjustment))
             .reduce((total, a) => total + a, 0);
     }
 
     /**
      * @description
-     * The total of all price adjustments. Will typically be a negative number due to discounts.
+     * The total of all price adjustments for the whole line. Will typically be a negative number
+     * due to discounts. See `quantityBasisFor()` for the quantity basis used per adjustment.
      */
     private getLineAdjustmentsTotal(withTax: boolean, type?: AdjustmentType): number {
         if (!this.adjustments || this.quantity === 0) {
@@ -440,18 +446,41 @@ export class OrderLine extends VendureEntity implements HasCustomFields {
         }
         const sum = this.adjustments
             .filter(adjustment => (type ? adjustment.type === type : true))
-            .map(adjustment => adjustment.amount)
+            .map(adjustment => (adjustment.amount / this.quantityBasisFor(adjustment)) * this.quantity)
             .reduce((total, a) => total + a, 0);
-        const adjustedForQuantityChanges =
-            sum * (this.quantity / Math.max(this.orderPlacedQuantity, this.quantity));
         if (withTax) {
-            return this.listPriceIncludesTax
-                ? adjustedForQuantityChanges
-                : grossPriceOf(adjustedForQuantityChanges, this.taxRate);
+            return this.listPriceIncludesTax ? sum : grossPriceOf(sum, this.taxRate);
         } else {
-            return this.listPriceIncludesTax
-                ? netPriceOf(adjustedForQuantityChanges, this.taxRate)
-                : adjustedForQuantityChanges;
+            return this.listPriceIncludesTax ? netPriceOf(sum, this.taxRate) : sum;
         }
+    }
+
+    /**
+     * @description
+     * Returns the quantity that `adjustment.amount` (a line total) should be divided by to get a
+     * correct per-unit share, given how that adjustment's total is (re-)computed:
+     *
+     * - `PROMOTION` adjustments (item- and line-level `PromotionAction`s) are always freshly
+     *   computed against `this.quantity` on every recalculation -
+     *   `OrderCalculator.applyOrderItemPromotions()` clears and rebuilds them via `addAdjustment()`
+     *   with the current quantity every time - so `this.quantity` is the correct, already-matching
+     *   basis. A quantity reduction that bypasses recalculation entirely (a partial cancellation via
+     *   `OrderModifier.cancelOrderByOrderLines()`) explicitly rescales these adjustments to the new
+     *   quantity for the same reason (see #5127).
+     * - `DISTRIBUTED_ORDER_PROMOTION` adjustments are a per-line *share* of an order-level
+     *   promotion, redistributed by weight across lines on every recalculation - reducing this
+     *   line's quantity does not proportionally shrink its freshly-computed share (a single
+     *   remaining line can still be assigned the *entire* order-level discount). Dividing by the
+     *   quantity as it stood when the order was placed keeps this line's per-unit share of the
+     *   discount fixed, rather than letting the surviving units of a partially cancelled/refunded
+     *   line absorb a share meant for units that no longer exist. `OTHER`-type adjustments use the
+     *   same conservative basis, since core never adds this type to an `OrderLine` and a plugin that
+     *   does so has no documented scaling contract to assume otherwise.
+     */
+    private quantityBasisFor(adjustment: Adjustment): number {
+        if (adjustment.type === AdjustmentType.PROMOTION) {
+            return this.quantity;
+        }
+        return Math.max(this.orderPlacedQuantity, this.quantity);
     }
 }

--- a/packages/core/src/entity/order-line/order-line.entity.ts
+++ b/packages/core/src/entity/order-line/order-line.entity.ts
@@ -1,7 +1,7 @@
 import { Adjustment, AdjustmentType, Discount, TaxLine } from '@vendure/common/lib/generated-types';
 import { DeepPartial, ID } from '@vendure/common/lib/shared-types';
 import { summate } from '@vendure/common/lib/shared-utils';
-import { Column, Entity, Index, ManyToOne, OneToMany, OneToOne } from 'typeorm';
+import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
 
 import { Calculated } from '../../common/calculated-decorator';
 import { roundMoney } from '../../common/round-money';
@@ -13,8 +13,8 @@ import { Channel } from '../channel/channel.entity';
 import { CustomOrderLineFields } from '../custom-entity-fields';
 import { EntityId } from '../entity-id.decorator';
 import { Money } from '../money.decorator';
-import { Order } from '../order/order.entity';
 import { OrderLineReference } from '../order-line-reference/order-line-reference.entity';
+import { Order } from '../order/order.entity';
 import { ProductVariant } from '../product-variant/product-variant.entity';
 import { ShippingLine } from '../shipping-line/shipping-line.entity';
 import { Allocation } from '../stock-movement/allocation.entity';
@@ -368,6 +368,26 @@ export class OrderLine extends VendureEntity implements HasCustomFields {
     }
 
     /**
+     * @description
+     * Rescales this line's `PROMOTION`-type adjustments from `this.quantity` to `newQuantity`,
+     * mutating `this.adjustments` in place. Used where a quantity reduction bypasses
+     * `OrderCalculator` recalculation (see `OrderModifier.cancelOrderByOrderLines()`), to keep
+     * those adjustments matching the "already scaled to `this.quantity`" basis that
+     * `quantityBasisFor()` assumes for `PROMOTION` (see #5127). Does not touch `this.quantity`
+     * itself - callers are expected to assign that separately, after rescaling.
+     */
+    rescaleAdjustmentsForQuantity(newQuantity: number) {
+        // Guards a lineInput requesting a no-op (0-quantity) cancellation on a line that is
+        // already fully cancelled (quantity 0), which would otherwise divide 0 / 0.
+        const scaleFactor = this.quantity > 0 ? newQuantity / this.quantity : 0;
+        this.adjustments = (this.adjustments ?? []).map(adjustment =>
+            adjustment.type === AdjustmentType.PROMOTION
+                ? { ...adjustment, amount: roundMoney(adjustment.amount * scaleFactor) }
+                : adjustment,
+        );
+    }
+
+    /**
      * Clears Adjustments from all OrderItems of the given type. If no type
      * is specified, then all adjustments are removed.
      */
@@ -457,30 +477,22 @@ export class OrderLine extends VendureEntity implements HasCustomFields {
 
     /**
      * @description
-     * Returns the quantity that `adjustment.amount` (a line total) should be divided by to get a
-     * correct per-unit share, given how that adjustment's total is (re-)computed:
-     *
-     * - `PROMOTION` adjustments (item- and line-level `PromotionAction`s) are always freshly
-     *   computed against `this.quantity` on every recalculation -
-     *   `OrderCalculator.applyOrderItemPromotions()` clears and rebuilds them via `addAdjustment()`
-     *   with the current quantity every time - so `this.quantity` is the correct, already-matching
-     *   basis. A quantity reduction that bypasses recalculation entirely (a partial cancellation via
-     *   `OrderModifier.cancelOrderByOrderLines()`) explicitly rescales these adjustments to the new
-     *   quantity for the same reason (see #5127).
-     * - `DISTRIBUTED_ORDER_PROMOTION` adjustments are a per-line *share* of an order-level
-     *   promotion, redistributed by weight across lines on every recalculation - reducing this
-     *   line's quantity does not proportionally shrink its freshly-computed share (a single
-     *   remaining line can still be assigned the *entire* order-level discount). Dividing by the
-     *   quantity as it stood when the order was placed keeps this line's per-unit share of the
-     *   discount fixed, rather than letting the surviving units of a partially cancelled/refunded
-     *   line absorb a share meant for units that no longer exist. `OTHER`-type adjustments use the
-     *   same conservative basis, since core never adds this type to an `OrderLine` and a plugin that
-     *   does so has no documented scaling contract to assume otherwise.
+     * The quantity that `adjustment.amount` (a line total) should be divided by to get a correct
+     * per-unit share. `PROMOTION` adjustments are always freshly recomputed against the current
+     * `this.quantity`, so that is their basis. Other types (`DISTRIBUTED_ORDER_PROMOTION`, `OTHER`)
+     * are a per-line share of an order-level amount that is redistributed by weight on every
+     * recalculation, so their basis is pinned to `orderPlacedQuantity` - otherwise a partially
+     * cancelled/refunded line's surviving units could absorb a bigger share than they're due. See
+     * #5127 for the full reasoning.
      */
     private quantityBasisFor(adjustment: Adjustment): number {
-        if (adjustment.type === AdjustmentType.PROMOTION) {
-            return this.quantity;
+        switch (adjustment.type) {
+            case AdjustmentType.PROMOTION:
+                return this.quantity;
+            case AdjustmentType.DISTRIBUTED_ORDER_PROMOTION:
+            case AdjustmentType.OTHER:
+            default:
+                return Math.max(this.orderPlacedQuantity, this.quantity);
         }
-        return Math.max(this.orderPlacedQuantity, this.quantity);
     }
 }

--- a/packages/core/src/entity/order-line/order-line.entity.ts
+++ b/packages/core/src/entity/order-line/order-line.entity.ts
@@ -369,22 +369,25 @@ export class OrderLine extends VendureEntity implements HasCustomFields {
 
     /**
      * @description
-     * Rescales this line's `PROMOTION`-type adjustments from `this.quantity` to `newQuantity`,
-     * mutating `this.adjustments` in place. Used where a quantity reduction bypasses
-     * `OrderCalculator` recalculation (see `OrderModifier.cancelOrderByOrderLines()`), to keep
-     * those adjustments matching the "already scaled to `this.quantity`" basis that
-     * `quantityBasisFor()` assumes for `PROMOTION` (see #5127). Does not touch `this.quantity`
-     * itself - callers are expected to assign that separately, after rescaling.
+     * Sets this line's quantity to `newQuantity`, rescaling its `PROMOTION`-type adjustments to
+     * match. Used where a quantity reduction bypasses `OrderCalculator` recalculation (see
+     * `OrderModifier.cancelOrderByOrderLines()`), to preserve the invariant that `PROMOTION`
+     * amounts are stored scaled to the current quantity.
+     *
+     * A `newQuantity` of 0 sets the quantity but leaves the adjustments untouched: the getters
+     * short-circuit on an empty line either way, so scaling them to zero would only erase the
+     * record of the discount that had applied, which plugins and accounting exports read back.
      */
-    rescaleAdjustmentsForQuantity(newQuantity: number) {
-        // Guards a lineInput requesting a no-op (0-quantity) cancellation on a line that is
-        // already fully cancelled (quantity 0), which would otherwise divide 0 / 0.
-        const scaleFactor = this.quantity > 0 ? newQuantity / this.quantity : 0;
-        this.adjustments = (this.adjustments ?? []).map(adjustment =>
-            adjustment.type === AdjustmentType.PROMOTION
-                ? { ...adjustment, amount: roundMoney(adjustment.amount * scaleFactor) }
-                : adjustment,
-        );
+    setQuantityRescalingAdjustments(newQuantity: number) {
+        if (0 < newQuantity) {
+            const scaleFactor = newQuantity / this.quantity;
+            this.adjustments = (this.adjustments ?? []).map(adjustment =>
+                adjustment.type === AdjustmentType.PROMOTION
+                    ? { ...adjustment, amount: roundMoney(adjustment.amount * scaleFactor) }
+                    : adjustment,
+            );
+        }
+        this.quantity = newQuantity;
     }
 
     /**
@@ -486,13 +489,18 @@ export class OrderLine extends VendureEntity implements HasCustomFields {
      * #5127 for the full reasoning.
      */
     private quantityBasisFor(adjustment: Adjustment): number {
-        switch (adjustment.type) {
-            case AdjustmentType.PROMOTION:
-                return this.quantity;
-            case AdjustmentType.DISTRIBUTED_ORDER_PROMOTION:
-            case AdjustmentType.OTHER:
-            default:
-                return Math.max(this.orderPlacedQuantity, this.quantity);
-        }
+        const basis = (() => {
+            switch (adjustment.type) {
+                case AdjustmentType.PROMOTION:
+                    return this.quantity;
+                case AdjustmentType.DISTRIBUTED_ORDER_PROMOTION:
+                case AdjustmentType.OTHER:
+                default:
+                    return Math.max(this.orderPlacedQuantity, this.quantity);
+            }
+        })();
+        // An empty line has no units to divide across; every caller discards the result in that
+        // case, and 1 keeps a future caller that forgets from producing NaN (cf. #5101).
+        return basis === 0 ? 1 : basis;
     }
 }

--- a/packages/core/src/migration-utils/index.ts
+++ b/packages/core/src/migration-utils/index.ts
@@ -1,2 +1,3 @@
 export { migrateAssetTranslationData } from './v3_6_asset_translations';
 export { migrateProductOptionGroupData } from './v3_6_shared_option_groups';
+export { rescaleOrderLinePromotionAdjustments } from './v3_8_orderline_promotion_rescale';

--- a/packages/core/src/migration-utils/index.ts
+++ b/packages/core/src/migration-utils/index.ts
@@ -1,3 +1,6 @@
 export { migrateAssetTranslationData } from './v3_6_asset_translations';
 export { migrateProductOptionGroupData } from './v3_6_shared_option_groups';
-export { rescaleOrderLinePromotionAdjustments } from './v3_8_orderline_promotion_rescale';
+export {
+    RescaleOrderLinePromotionAdjustmentsOptions,
+    rescaleOrderLinePromotionAdjustments,
+} from './v3_8_orderline_promotion_rescale';

--- a/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.spec.ts
+++ b/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.spec.ts
@@ -5,13 +5,14 @@ import { rescaleOrderLinePromotionAdjustments } from './v3_8_orderline_promotion
 
 interface Row {
     id: number;
+    orderId?: number;
     quantity: number;
     orderPlacedQuantity: number;
     adjustments: string | null;
 }
 
 interface ModificationRow {
-    orderLineId: number;
+    orderId: number;
     createdAt: string;
 }
 
@@ -42,14 +43,10 @@ const defaultMetadata: Record<string, MetadataNames> = {
         },
         relations: { order: 'orderId' },
     },
-    OrderModificationLine: {
-        tablePath: 'order_line_reference',
-        columns: {},
-        relations: { orderLine: 'orderLineId', modification: 'modificationId' },
-    },
     OrderModification: {
         tablePath: 'order_modification',
-        columns: { id: 'id', createdAt: 'createdAt' },
+        columns: { createdAt: 'createdAt' },
+        relations: { order: 'orderId' },
     },
     OrderHistoryEntry: {
         tablePath: 'history_entry',
@@ -78,7 +75,11 @@ function createQueryRunner(
     metadataOverrides: Partial<Record<string, MetadataNames>> = {},
 ) {
     const executed: ExecutedQuery[] = [];
-    const selectResults = [rows, history.modifications ?? [], history.cancellations ?? []];
+    const selectResults = [
+        rows.map(row => ({ orderId: 1, ...row })),
+        history.modifications ?? [],
+        history.cancellations ?? [],
+    ];
     let selectIndex = 0;
     const metadata = { ...defaultMetadata, ...metadataOverrides };
     const queryRunner = {
@@ -200,7 +201,47 @@ describe('rescaleOrderLinePromotionAdjustments()', () => {
                 },
             ],
             {
-                modifications: [{ orderLineId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
+                modifications: [{ orderId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
+            },
+        );
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner);
+
+        expect(updatesFrom(executed)).toEqual([]);
+    });
+
+    it("leaves a cancelled line alone when another line's later modification recalculated the order", async () => {
+        // B was cancelled first. Reducing A in modifyOrder records A's cancellation before the
+        // order-level modification, whose promotion pass then rewrites both lines.
+        const { queryRunner, executed } = createQueryRunner(
+            [
+                {
+                    id: 1,
+                    orderId: 42,
+                    quantity: 10,
+                    orderPlacedQuantity: 20,
+                    adjustments: JSON.stringify([promotion(-10000)]),
+                },
+                {
+                    id: 2,
+                    orderId: 42,
+                    quantity: 10,
+                    orderPlacedQuantity: 20,
+                    adjustments: JSON.stringify([promotion(-10000)]),
+                },
+            ],
+            {
+                modifications: [{ orderId: 42, createdAt: '2026-01-03T00:00:00.000Z' }],
+                cancellations: [
+                    {
+                        createdAt: '2026-01-01T00:00:00.000Z',
+                        data: JSON.stringify({ lines: [{ orderLineId: 2, quantity: 10 }] }),
+                    },
+                    {
+                        createdAt: '2026-01-02T00:00:00.000Z',
+                        data: JSON.stringify({ lines: [{ orderLineId: 1, quantity: 10 }] }),
+                    },
+                ],
             },
         );
 
@@ -220,7 +261,7 @@ describe('rescaleOrderLinePromotionAdjustments()', () => {
                 },
             ],
             {
-                modifications: [{ orderLineId: 1, createdAt: '2026-01-03T00:00:00.000Z' }],
+                modifications: [{ orderId: 1, createdAt: '2026-01-03T00:00:00.000Z' }],
                 cancellations: [
                     {
                         createdAt: '2026-01-02T00:00:00.000Z',
@@ -246,7 +287,7 @@ describe('rescaleOrderLinePromotionAdjustments()', () => {
                 },
             ],
             {
-                modifications: [{ orderLineId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
+                modifications: [{ orderId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
                 cancellations: [
                     {
                         createdAt: '2026-01-02T00:00:00.000Z',
@@ -274,7 +315,7 @@ describe('rescaleOrderLinePromotionAdjustments()', () => {
                 },
             ],
             {
-                modifications: [{ orderLineId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
+                modifications: [{ orderId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
                 cancellations: [
                     {
                         createdAt: '2026-01-02T00:00:00.000Z',
@@ -302,7 +343,7 @@ describe('rescaleOrderLinePromotionAdjustments()', () => {
                 },
             ],
             {
-                modifications: [{ orderLineId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
+                modifications: [{ orderId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
                 cancellations: [
                     {
                         createdAt: '2026-01-02T00:00:00.000Z',
@@ -332,7 +373,7 @@ describe('rescaleOrderLinePromotionAdjustments()', () => {
                 },
             ],
             {
-                modifications: [{ orderLineId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
+                modifications: [{ orderId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
                 cancellations: [
                     {
                         createdAt: '2026-01-03T00:00:00.000Z',
@@ -361,7 +402,7 @@ describe('rescaleOrderLinePromotionAdjustments()', () => {
                 },
             ],
             {
-                modifications: [{ orderLineId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
+                modifications: [{ orderId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
                 cancellations: [
                     {
                         createdAt: '2026-01-01T00:00:00.000Z',
@@ -434,14 +475,10 @@ describe('rescaleOrderLinePromotionAdjustments()', () => {
                     },
                     relations: { order: 'order_fk' },
                 },
-                OrderModificationLine: {
-                    tablePath: 'tenant.pref_line_refs',
-                    columns: {},
-                    relations: { orderLine: 'line_fk', modification: 'modification_fk' },
-                },
                 OrderModification: {
                     tablePath: 'tenant.pref_modifications',
-                    columns: { id: 'modification_pk', createdAt: 'created_on' },
+                    columns: { createdAt: 'created_on' },
+                    relations: { order: 'modification_order_fk' },
                 },
                 OrderHistoryEntry: {
                     tablePath: 'tenant.pref_history',
@@ -455,7 +492,6 @@ describe('rescaleOrderLinePromotionAdjustments()', () => {
 
         const sql = executed.map(query => query.sql).join('\n');
         expect(sql).toContain('"tenant"."pref_order_lines"');
-        expect(sql).toContain('"tenant"."pref_line_refs"');
         expect(sql).toContain('"tenant"."pref_modifications"');
         expect(sql).toContain('"tenant"."pref_history"');
         for (const name of [
@@ -464,9 +500,7 @@ describe('rescaleOrderLinePromotionAdjustments()', () => {
             'placed_qty',
             'price_adjustments',
             'order_fk',
-            'line_fk',
-            'modification_fk',
-            'modification_pk',
+            'modification_order_fk',
             'created_on',
             'event_type',
             'payload',

--- a/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.spec.ts
+++ b/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.spec.ts
@@ -150,6 +150,24 @@ describe('rescaleOrderLinePromotionAdjustments()', () => {
         expect(updatesFrom(executed)).toEqual([]);
     });
 
+    it('leaves a line untouched when the modification and cancellation have equal timestamps', async () => {
+        const { queryRunner, executed } = createQueryRunner([
+            {
+                id: 1,
+                quantity: 8,
+                orderPlacedQuantity: 20,
+                adjustments: JSON.stringify([promotion(-11900)]),
+                lastCancelledAt: '2026-01-02T00:00:00.000Z',
+                lastModifiedAt: '2026-01-02T00:00:00.000Z',
+                modificationDelta: -2,
+            },
+        ]);
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner);
+
+        expect(updatesFrom(executed)).toEqual([]);
+    });
+
     it('rescales a modified-then-cancelled line from its post-modification quantity', async () => {
         // Placed at 20, modified down to 10 (which rewrote the amount to -14875), then 8 units
         // cancelled. The basis is 10, not the placement quantity of 20.

--- a/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.spec.ts
+++ b/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.spec.ts
@@ -1,0 +1,222 @@
+import { QueryRunner } from 'typeorm';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { rescaleOrderLinePromotionAdjustments } from './v3_8_orderline_promotion_rescale';
+
+interface Row {
+    id: number;
+    quantity: number;
+    orderPlacedQuantity: number;
+    adjustments: string | null;
+    lastCancelledAt?: string | null;
+    lastModifiedAt?: string | null;
+    modificationDelta?: number | null;
+}
+
+interface ExecutedQuery {
+    sql: string;
+    params: any[];
+}
+
+function promotion(amount: number) {
+    return { adjustmentSource: 'PROMOTION:1', type: 'PROMOTION', description: '50% off', amount, data: {} };
+}
+
+function distributed(amount: number) {
+    return {
+        adjustmentSource: 'PROMOTION:2',
+        type: 'DISTRIBUTED_ORDER_PROMOTION',
+        description: '£5 off order',
+        amount,
+        data: {},
+    };
+}
+
+function createQueryRunner(rows: Row[]) {
+    const executed: ExecutedQuery[] = [];
+    const queryRunner = {
+        connection: {
+            driver: {
+                escape: (name: string) => `"${name}"`,
+                createParameter: (_name: string, index: number) => `$${index + 1}`,
+            },
+        },
+        query: vi.fn(async (sql: string, params: any[] = []) => {
+            executed.push({ sql, params });
+            if (sql.trim().startsWith('SELECT')) {
+                return rows.map(row => ({
+                    lastCancelledAt: null,
+                    lastModifiedAt: null,
+                    modificationDelta: null,
+                    ...row,
+                }));
+            }
+            return [];
+        }),
+    } as unknown as QueryRunner;
+    return { queryRunner, executed };
+}
+
+function updatesFrom(executed: ExecutedQuery[]) {
+    return executed.filter(q => q.sql.trim().startsWith('UPDATE'));
+}
+
+/**
+ * Reads back the adjustments the migration would have written for the given order_line id, by
+ * pairing up the parameters of the `CASE "id" WHEN ? THEN ?` update.
+ */
+function writtenAdjustmentsFor(executed: ExecutedQuery[], id: number): any[] | undefined {
+    for (const query of updatesFrom(executed)) {
+        const whenCount = (query.sql.match(/WHEN/g) ?? []).length;
+        for (let i = 0; i < whenCount; i++) {
+            if (query.params[i * 2] === id) {
+                return JSON.parse(query.params[i * 2 + 1]);
+            }
+        }
+    }
+    return undefined;
+}
+
+describe('rescaleOrderLinePromotionAdjustments()', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    });
+
+    it('rescales a partially-cancelled line to its current quantity', async () => {
+        // 20 units at 2975 with a 50% item promotion, 18 units cancelled by pre-#5127 code.
+        const { queryRunner, executed } = createQueryRunner([
+            {
+                id: 1,
+                quantity: 2,
+                orderPlacedQuantity: 20,
+                adjustments: JSON.stringify([promotion(-29750)]),
+            },
+        ]);
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner);
+
+        expect(writtenAdjustmentsFor(executed, 1)).toEqual([promotion(-2975)]);
+    });
+
+    it('leaves non-PROMOTION adjustments untouched', async () => {
+        const { queryRunner, executed } = createQueryRunner([
+            {
+                id: 1,
+                quantity: 2,
+                orderPlacedQuantity: 20,
+                adjustments: JSON.stringify([promotion(-29750), distributed(-500)]),
+            },
+        ]);
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner);
+
+        expect(writtenAdjustmentsFor(executed, 1)).toEqual([promotion(-2975), distributed(-500)]);
+    });
+
+    it('leaves a line reduced by an OrderModification untouched', async () => {
+        // modifyOrder() ends in applyPriceAdjustments(), so -2975 is already the correct amount
+        // for the 2 remaining units. Rescaling it again would give -297.
+        const { queryRunner, executed } = createQueryRunner([
+            {
+                id: 1,
+                quantity: 2,
+                orderPlacedQuantity: 20,
+                adjustments: JSON.stringify([promotion(-2975)]),
+                lastModifiedAt: '2026-01-02T00:00:00.000Z',
+                modificationDelta: -18,
+            },
+        ]);
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner);
+
+        expect(updatesFrom(executed)).toEqual([]);
+    });
+
+    it('leaves a line untouched when the modification is more recent than the cancellation', async () => {
+        const { queryRunner, executed } = createQueryRunner([
+            {
+                id: 1,
+                quantity: 8,
+                orderPlacedQuantity: 20,
+                adjustments: JSON.stringify([promotion(-11900)]),
+                lastCancelledAt: '2026-01-02T00:00:00.000Z',
+                lastModifiedAt: '2026-01-03T00:00:00.000Z',
+                modificationDelta: -2,
+            },
+        ]);
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner);
+
+        expect(updatesFrom(executed)).toEqual([]);
+    });
+
+    it('rescales a modified-then-cancelled line from its post-modification quantity', async () => {
+        // Placed at 20, modified down to 10 (which rewrote the amount to -14875), then 8 units
+        // cancelled. The basis is 10, not the placement quantity of 20.
+        const { queryRunner, executed } = createQueryRunner([
+            {
+                id: 1,
+                quantity: 2,
+                orderPlacedQuantity: 20,
+                adjustments: JSON.stringify([promotion(-14875)]),
+                lastCancelledAt: '2026-01-03T00:00:00.000Z',
+                lastModifiedAt: '2026-01-02T00:00:00.000Z',
+                modificationDelta: -10,
+            },
+        ]);
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner);
+
+        expect(writtenAdjustmentsFor(executed, 1)).toEqual([promotion(-2975)]);
+    });
+
+    it('skips lines with no PROMOTION adjustment', async () => {
+        const { queryRunner, executed } = createQueryRunner([
+            { id: 1, quantity: 2, orderPlacedQuantity: 20, adjustments: JSON.stringify([distributed(-500)]) },
+            { id: 2, quantity: 2, orderPlacedQuantity: 20, adjustments: null },
+            { id: 3, quantity: 2, orderPlacedQuantity: 20, adjustments: JSON.stringify([]) },
+        ]);
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner);
+
+        expect(updatesFrom(executed)).toEqual([]);
+    });
+
+    it('passes values as bound parameters rather than SQL literals', async () => {
+        const { queryRunner, executed } = createQueryRunner([
+            {
+                id: 1,
+                quantity: 2,
+                orderPlacedQuantity: 20,
+                // A description carrying a quote and a backslash, which literal-escaping mangles.
+                adjustments: JSON.stringify([{ ...promotion(-29750), description: `Bob's 50\\% off` }]),
+            },
+        ]);
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner);
+
+        const [update] = updatesFrom(executed);
+        expect(update.sql).not.toContain('Bob');
+        expect(update.sql).not.toContain('-2975');
+        expect(update.params[0]).toBe(1);
+        expect(JSON.parse(update.params[1])[0].description).toBe(`Bob's 50\\% off`);
+    });
+
+    it('updates all affected rows in a single statement', async () => {
+        const { queryRunner, executed } = createQueryRunner(
+            [1, 2, 3].map(id => ({
+                id,
+                quantity: 2,
+                orderPlacedQuantity: 20,
+                adjustments: JSON.stringify([promotion(-29750)]),
+            })),
+        );
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner);
+
+        expect(updatesFrom(executed).length).toBe(1);
+        for (const id of [1, 2, 3]) {
+            expect(writtenAdjustmentsFor(executed, id)).toEqual([promotion(-2975)]);
+        }
+    });
+});

--- a/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.spec.ts
+++ b/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.spec.ts
@@ -8,15 +8,55 @@ interface Row {
     quantity: number;
     orderPlacedQuantity: number;
     adjustments: string | null;
-    lastCancelledAt?: string | null;
-    lastModifiedAt?: string | null;
-    modificationDelta?: number | null;
+}
+
+interface ModificationRow {
+    orderLineId: number;
+    createdAt: string;
+}
+
+interface CancellationRow {
+    createdAt: string;
+    data: string;
 }
 
 interface ExecutedQuery {
     sql: string;
     params: any[];
 }
+
+interface MetadataNames {
+    tablePath: string;
+    columns: Record<string, string>;
+    relations?: Record<string, string>;
+}
+
+const defaultMetadata: Record<string, MetadataNames> = {
+    OrderLine: {
+        tablePath: 'order_line',
+        columns: {
+            id: 'id',
+            quantity: 'quantity',
+            orderPlacedQuantity: 'orderPlacedQuantity',
+            adjustments: 'adjustments',
+        },
+        relations: { order: 'orderId' },
+    },
+    OrderModificationLine: {
+        tablePath: 'order_line_reference',
+        columns: {},
+        relations: { orderLine: 'orderLineId', modification: 'modificationId' },
+    },
+    OrderModification: {
+        tablePath: 'order_modification',
+        columns: { id: 'id', createdAt: 'createdAt' },
+    },
+    OrderHistoryEntry: {
+        tablePath: 'history_entry',
+        columns: { createdAt: 'createdAt', type: 'type', data: 'data' },
+        relations: { order: 'orderId' },
+    },
+};
 
 function promotion(amount: number) {
     return { adjustmentSource: 'PROMOTION:1', type: 'PROMOTION', description: '50% off', amount, data: {} };
@@ -32,26 +72,45 @@ function distributed(amount: number) {
     };
 }
 
-function createQueryRunner(rows: Row[]) {
+function createQueryRunner(
+    rows: Row[],
+    history: { modifications?: ModificationRow[]; cancellations?: CancellationRow[] } = {},
+    metadataOverrides: Partial<Record<string, MetadataNames>> = {},
+) {
     const executed: ExecutedQuery[] = [];
+    const selectResults = [rows, history.modifications ?? [], history.cancellations ?? []];
+    let selectIndex = 0;
+    const metadata = { ...defaultMetadata, ...metadataOverrides };
     const queryRunner = {
         connection: {
             driver: {
                 escape: (name: string) => `"${name}"`,
                 createParameter: (_name: string, index: number) => `$${index + 1}`,
             },
+            getMetadata: (target: { name: string }) => {
+                const names = metadata[target.name];
+                if (!names) {
+                    throw new Error(`Missing metadata for ${target.name}`);
+                }
+                return {
+                    tablePath: names.tablePath,
+                    findColumnWithPropertyName: (propertyName: string) => {
+                        const databaseName = names.columns[propertyName];
+                        return databaseName ? { databaseName } : undefined;
+                    },
+                    findRelationWithPropertyPath: (propertyPath: string) => {
+                        const databaseName = names.relations?.[propertyPath];
+                        return databaseName ? { joinColumns: [{ databaseName }] } : undefined;
+                    },
+                };
+            },
         },
-        query: vi.fn(async (sql: string, params: any[] = []) => {
+        query: vi.fn((sql: string, params: any[] = []) => {
             executed.push({ sql, params });
             if (sql.trim().startsWith('SELECT')) {
-                return rows.map(row => ({
-                    lastCancelledAt: null,
-                    lastModifiedAt: null,
-                    modificationDelta: null,
-                    ...row,
-                }));
+                return Promise.resolve(selectResults[selectIndex++]);
             }
-            return [];
+            return Promise.resolve([]);
         }),
     } as unknown as QueryRunner;
     return { queryRunner, executed };
@@ -113,19 +172,37 @@ describe('rescaleOrderLinePromotionAdjustments()', () => {
         expect(writtenAdjustmentsFor(executed, 1)).toEqual([promotion(-2975), distributed(-500)]);
     });
 
-    it('leaves a line reduced by an OrderModification untouched', async () => {
-        // modifyOrder() ends in applyPriceAdjustments(), so -2975 is already the correct amount
-        // for the 2 remaining units. Rescaling it again would give -297.
+    it('leaves fully-cancelled lines untouched', async () => {
         const { queryRunner, executed } = createQueryRunner([
             {
                 id: 1,
-                quantity: 2,
+                quantity: 0,
                 orderPlacedQuantity: 20,
-                adjustments: JSON.stringify([promotion(-2975)]),
-                lastModifiedAt: '2026-01-02T00:00:00.000Z',
-                modificationDelta: -18,
+                adjustments: JSON.stringify([promotion(-29750)]),
             },
         ]);
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner);
+
+        expect(updatesFrom(executed)).toEqual([]);
+    });
+
+    it('leaves a line reduced by an OrderModification untouched', async () => {
+        // modifyOrder() ends in applyPriceAdjustments(), so -2975 is already the correct amount
+        // for the 2 remaining units. Rescaling it again would give -297.
+        const { queryRunner, executed } = createQueryRunner(
+            [
+                {
+                    id: 1,
+                    quantity: 2,
+                    orderPlacedQuantity: 20,
+                    adjustments: JSON.stringify([promotion(-2975)]),
+                },
+            ],
+            {
+                modifications: [{ orderLineId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
+            },
+        );
 
         await rescaleOrderLinePromotionAdjustments(queryRunner);
 
@@ -133,59 +210,174 @@ describe('rescaleOrderLinePromotionAdjustments()', () => {
     });
 
     it('leaves a line untouched when the modification is more recent than the cancellation', async () => {
-        const { queryRunner, executed } = createQueryRunner([
+        const { queryRunner, executed } = createQueryRunner(
+            [
+                {
+                    id: 1,
+                    quantity: 8,
+                    orderPlacedQuantity: 20,
+                    adjustments: JSON.stringify([promotion(-11900)]),
+                },
+            ],
             {
-                id: 1,
-                quantity: 8,
-                orderPlacedQuantity: 20,
-                adjustments: JSON.stringify([promotion(-11900)]),
-                lastCancelledAt: '2026-01-02T00:00:00.000Z',
-                lastModifiedAt: '2026-01-03T00:00:00.000Z',
-                modificationDelta: -2,
+                modifications: [{ orderLineId: 1, createdAt: '2026-01-03T00:00:00.000Z' }],
+                cancellations: [
+                    {
+                        createdAt: '2026-01-02T00:00:00.000Z',
+                        data: JSON.stringify({ lines: [{ orderLineId: 1, quantity: 10 }] }),
+                    },
+                ],
             },
-        ]);
+        );
 
         await rescaleOrderLinePromotionAdjustments(queryRunner);
 
         expect(updatesFrom(executed)).toEqual([]);
     });
 
-    it('leaves a line untouched when the modification and cancellation have equal timestamps', async () => {
-        const { queryRunner, executed } = createQueryRunner([
+    it('rejects an ambiguous equal-timestamp history before writing', async () => {
+        const { queryRunner, executed } = createQueryRunner(
+            [
+                {
+                    id: 1,
+                    quantity: 8,
+                    orderPlacedQuantity: 20,
+                    adjustments: JSON.stringify([promotion(-11900)]),
+                },
+            ],
             {
-                id: 1,
-                quantity: 8,
-                orderPlacedQuantity: 20,
-                adjustments: JSON.stringify([promotion(-11900)]),
-                lastCancelledAt: '2026-01-02T00:00:00.000Z',
-                lastModifiedAt: '2026-01-02T00:00:00.000Z',
-                modificationDelta: -2,
+                modifications: [{ orderLineId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
+                cancellations: [
+                    {
+                        createdAt: '2026-01-02T00:00:00.000Z',
+                        data: JSON.stringify({ lines: [{ orderLineId: 1, quantity: 2 }] }),
+                    },
+                ],
             },
-        ]);
+        );
 
-        await rescaleOrderLinePromotionAdjustments(queryRunner);
+        await expect(rescaleOrderLinePromotionAdjustments(queryRunner)).rejects.toThrow(
+            'Cannot safely determine the stored quantity basis for OrderLine IDs: 1',
+        );
 
         expect(updatesFrom(executed)).toEqual([]);
+    });
+
+    it('accepts an explicit current-quantity basis for an equal-timestamp modify-after-cancel line', async () => {
+        const { queryRunner, executed } = createQueryRunner(
+            [
+                {
+                    id: 1,
+                    quantity: 8,
+                    orderPlacedQuantity: 20,
+                    adjustments: JSON.stringify([promotion(-8000)]),
+                },
+            ],
+            {
+                modifications: [{ orderLineId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
+                cancellations: [
+                    {
+                        createdAt: '2026-01-02T00:00:00.000Z',
+                        data: JSON.stringify({ lines: [{ orderLineId: 1, quantity: 2 }] }),
+                    },
+                ],
+            },
+        );
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner, {
+            ambiguousOrderLineQuantityBases: { 1: 8 },
+        });
+
+        expect(updatesFrom(executed)).toEqual([]);
+    });
+
+    it('accepts an explicit pre-cancellation basis for an equal-timestamp cancel-after-modify line', async () => {
+        const { queryRunner, executed } = createQueryRunner(
+            [
+                {
+                    id: 1,
+                    quantity: 8,
+                    orderPlacedQuantity: 20,
+                    adjustments: JSON.stringify([promotion(-10000)]),
+                },
+            ],
+            {
+                modifications: [{ orderLineId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
+                cancellations: [
+                    {
+                        createdAt: '2026-01-02T00:00:00.000Z',
+                        data: JSON.stringify({ lines: [{ orderLineId: 1, quantity: 2 }] }),
+                    },
+                ],
+            },
+        );
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner, {
+            ambiguousOrderLineQuantityBases: { 1: 10 },
+        });
+
+        expect(writtenAdjustmentsFor(executed, 1)).toEqual([promotion(-8000)]);
     });
 
     it('rescales a modified-then-cancelled line from its post-modification quantity', async () => {
         // Placed at 20, modified down to 10 (which rewrote the amount to -14875), then 8 units
         // cancelled. The basis is 10, not the placement quantity of 20.
-        const { queryRunner, executed } = createQueryRunner([
+        const { queryRunner, executed } = createQueryRunner(
+            [
+                {
+                    id: 1,
+                    quantity: 2,
+                    orderPlacedQuantity: 20,
+                    adjustments: JSON.stringify([promotion(-14875)]),
+                },
+            ],
             {
-                id: 1,
-                quantity: 2,
-                orderPlacedQuantity: 20,
-                adjustments: JSON.stringify([promotion(-14875)]),
-                lastCancelledAt: '2026-01-03T00:00:00.000Z',
-                lastModifiedAt: '2026-01-02T00:00:00.000Z',
-                modificationDelta: -10,
+                modifications: [{ orderLineId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
+                cancellations: [
+                    {
+                        createdAt: '2026-01-03T00:00:00.000Z',
+                        data: JSON.stringify({ lines: [{ orderLineId: 1, quantity: 8 }] }),
+                    },
+                ],
             },
-        ]);
+        );
 
         await rescaleOrderLinePromotionAdjustments(queryRunner);
 
         expect(writtenAdjustmentsFor(executed, 1)).toEqual([promotion(-2975)]);
+    });
+
+    it('uses the latest modification basis after earlier and later standalone cancellations', async () => {
+        // Placed at 20, cancelled to 15, modified to 10, then cancelled to 5. The latest
+        // modification rewrote the amount on a basis of 10; summing its -5 delta from placement
+        // would incorrectly produce a basis of 15 by ignoring the first standalone cancellation.
+        const { queryRunner, executed } = createQueryRunner(
+            [
+                {
+                    id: 1,
+                    quantity: 5,
+                    orderPlacedQuantity: 20,
+                    adjustments: JSON.stringify([promotion(-10000)]),
+                },
+            ],
+            {
+                modifications: [{ orderLineId: 1, createdAt: '2026-01-02T00:00:00.000Z' }],
+                cancellations: [
+                    {
+                        createdAt: '2026-01-01T00:00:00.000Z',
+                        data: JSON.stringify({ lines: [{ orderLineId: 1, quantity: 5 }] }),
+                    },
+                    {
+                        createdAt: '2026-01-03T00:00:00.000Z',
+                        data: JSON.stringify({ lines: [{ orderLineId: 1, quantity: 5 }] }),
+                    },
+                ],
+            },
+        );
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner);
+
+        expect(writtenAdjustmentsFor(executed, 1)).toEqual([promotion(-5000)]);
     });
 
     it('skips lines with no PROMOTION adjustment', async () => {
@@ -218,6 +410,70 @@ describe('rescaleOrderLinePromotionAdjustments()', () => {
         expect(update.sql).not.toContain('-2975');
         expect(update.params[0]).toBe(1);
         expect(JSON.parse(update.params[1])[0].description).toBe(`Bob's 50\\% off`);
+    });
+
+    it('uses entity metadata for schema-qualified table paths and physical column names', async () => {
+        const { queryRunner, executed } = createQueryRunner(
+            [
+                {
+                    id: 1,
+                    quantity: 2,
+                    orderPlacedQuantity: 20,
+                    adjustments: JSON.stringify([promotion(-29750)]),
+                },
+            ],
+            {},
+            {
+                OrderLine: {
+                    tablePath: 'tenant.pref_order_lines',
+                    columns: {
+                        id: 'line_pk',
+                        quantity: 'current_qty',
+                        orderPlacedQuantity: 'placed_qty',
+                        adjustments: 'price_adjustments',
+                    },
+                    relations: { order: 'order_fk' },
+                },
+                OrderModificationLine: {
+                    tablePath: 'tenant.pref_line_refs',
+                    columns: {},
+                    relations: { orderLine: 'line_fk', modification: 'modification_fk' },
+                },
+                OrderModification: {
+                    tablePath: 'tenant.pref_modifications',
+                    columns: { id: 'modification_pk', createdAt: 'created_on' },
+                },
+                OrderHistoryEntry: {
+                    tablePath: 'tenant.pref_history',
+                    columns: { createdAt: 'created_on', type: 'event_type', data: 'payload' },
+                    relations: { order: 'order_fk' },
+                },
+            },
+        );
+
+        await rescaleOrderLinePromotionAdjustments(queryRunner);
+
+        const sql = executed.map(query => query.sql).join('\n');
+        expect(sql).toContain('"tenant"."pref_order_lines"');
+        expect(sql).toContain('"tenant"."pref_line_refs"');
+        expect(sql).toContain('"tenant"."pref_modifications"');
+        expect(sql).toContain('"tenant"."pref_history"');
+        for (const name of [
+            'line_pk',
+            'current_qty',
+            'placed_qty',
+            'price_adjustments',
+            'order_fk',
+            'line_fk',
+            'modification_fk',
+            'modification_pk',
+            'created_on',
+            'event_type',
+            'payload',
+        ]) {
+            expect(sql).toContain(`"${name}"`);
+        }
+        expect(sql).not.toContain('"order_line"');
     });
 
     it('updates all affected rows in a single statement', async () => {

--- a/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.ts
+++ b/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.ts
@@ -3,19 +3,19 @@ import { HistoryEntryType } from '@vendure/common/lib/generated-types';
 import { EntityMetadata, QueryRunner } from 'typeorm';
 
 import { OrderHistoryEntry } from '../entity/history-entry/order-history-entry.entity';
-import { OrderModificationLine } from '../entity/order-line-reference/order-modification-line.entity';
 import { OrderLine } from '../entity/order-line/order-line.entity';
 import { OrderModification } from '../entity/order-modification/order-modification.entity';
 
 interface CandidateRow {
     id: string | number;
+    orderId: string | number;
     quantity: number;
     orderPlacedQuantity: number;
     adjustments: string | null;
 }
 
 interface ModificationRow {
-    orderLineId: string | number;
+    orderId: string | number;
     createdAt: Date | string;
 }
 
@@ -39,9 +39,10 @@ const AMBIGUOUS_BASIS = Symbol('AMBIGUOUS_BASIS');
 export interface RescaleOrderLinePromotionAdjustmentsOptions {
     /**
      * @description
-     * The quantity basis for each OrderLine whose latest modification and cancellation have the
-     * same timestamp. Use the current quantity when the modification happened last, or the
-     * quantity before the later cancellation when the cancellation happened last.
+     * The quantity basis for each OrderLine whose cancellation and containing Order's latest
+     * modification have the same timestamp. Use the current quantity when the modification
+     * happened last, or the quantity before the later cancellation when the cancellation happened
+     * last.
      */
     ambiguousOrderLineQuantityBases?: Readonly<Record<string, number>>;
 }
@@ -59,9 +60,9 @@ function toTime(value: Date | string | null): number | null {
  * if they are already scaled to the current quantity and must be left alone.
  *
  * `PROMOTION` amounts are rewritten in full whenever `OrderCalculator` runs, which is what
- * `OrderModifier.modifyOrder()` ends in. A pre-#5127 `cancelOrderByOrderLines()` is the only
- * thing that reduced `quantity` without rewriting them, so only a line whose most recent
- * quantity change came from a cancellation is stale.
+ * `OrderModifier.modifyOrder()` ends in for every line in the order. A pre-#5127
+ * `cancelOrderByOrderLines()` is the only thing that reduced `quantity` without rewriting them,
+ * so only a line whose most recent order-wide recalculation predates its cancellation is stale.
  */
 function getStoredQuantityBasis(
     row: CandidateRow,
@@ -119,11 +120,10 @@ function getRelationColumnName(metadata: EntityMetadata, propertyName: string): 
  * getters (which divide a `PROMOTION` adjustment by the *current* `quantity`,
  * instead of `orderPlacedQuantity`) would otherwise inflate their discount.
  *
- * Lines whose quantity was reduced by an `OrderModification` are left alone:
  * `OrderModifier.modifyOrder()` ends in `applyPriceAdjustments()`, which recomputes the
- * `PROMOTION` amounts against the new quantity, so they are already correct and rescaling
- * them again would shrink them. For a subsequently-cancelled line, the stored basis is its
- * current quantity plus the quantities in order-cancellation history after its latest
+ * `PROMOTION` amounts for every line in the order, including lines not referenced by the
+ * `OrderModification`. For a subsequently-cancelled line, the stored basis is its current
+ * quantity plus the quantities in order-cancellation history after the order's latest
  * `OrderModification`.
  *
  * Some databases can store a modification and cancellation with the same timestamp. Their
@@ -161,7 +161,6 @@ export async function rescaleOrderLinePromotionAdjustments(
     const escTable = (tablePath: string) => tablePath.split('.').map(esc).join('.');
     const param = (index: number) => queryRunner.connection.driver.createParameter('p', index);
     const orderLineMetadata = queryRunner.connection.getMetadata(OrderLine);
-    const modificationLineMetadata = queryRunner.connection.getMetadata(OrderModificationLine);
     const modificationMetadata = queryRunner.connection.getMetadata(OrderModification);
     const historyMetadata = queryRunner.connection.getMetadata(OrderHistoryEntry);
 
@@ -171,13 +170,8 @@ export async function rescaleOrderLinePromotionAdjustments(
     const orderLineQuantity = esc(getColumnName(orderLineMetadata, 'quantity'));
     const orderLinePlacedQuantity = esc(getColumnName(orderLineMetadata, 'orderPlacedQuantity'));
     const orderLineAdjustments = esc(getColumnName(orderLineMetadata, 'adjustments'));
-    const modificationLineTable = escTable(modificationLineMetadata.tablePath);
-    const modificationLineOrderLineId = esc(getRelationColumnName(modificationLineMetadata, 'orderLine'));
-    const modificationLineModificationId = esc(
-        getRelationColumnName(modificationLineMetadata, 'modification'),
-    );
     const modificationTable = escTable(modificationMetadata.tablePath);
-    const modificationId = esc(getColumnName(modificationMetadata, 'id'));
+    const modificationOrderId = esc(getRelationColumnName(modificationMetadata, 'order'));
     const modificationCreatedAt = esc(getColumnName(modificationMetadata, 'createdAt'));
     const historyTable = escTable(historyMetadata.tablePath);
     const historyOrderId = esc(getRelationColumnName(historyMetadata, 'order'));
@@ -187,6 +181,7 @@ export async function rescaleOrderLinePromotionAdjustments(
 
     const rows: CandidateRow[] = await queryRunner.query(
         `SELECT ol.${orderLineId} AS ${esc('id')},
+                ol.${orderLineOrderId} AS ${esc('orderId')},
                 ol.${orderLineQuantity} AS ${esc('quantity')},
                 ol.${orderLinePlacedQuantity} AS ${esc('orderPlacedQuantity')},
                 ol.${orderLineAdjustments} AS ${esc('adjustments')}
@@ -197,16 +192,16 @@ export async function rescaleOrderLinePromotionAdjustments(
     );
 
     const modifications: ModificationRow[] = await queryRunner.query(
-        `SELECT olr.${modificationLineOrderLineId} AS ${esc('orderLineId')},
+        `SELECT om.${modificationOrderId} AS ${esc('orderId')},
                 om.${modificationCreatedAt} AS ${esc('createdAt')}
-         FROM ${modificationLineTable} olr
-         INNER JOIN ${modificationTable} om
-           ON om.${modificationId} = olr.${modificationLineModificationId}
-         INNER JOIN ${orderLineTable} ol
-           ON ol.${orderLineId} = olr.${modificationLineOrderLineId}
-         WHERE ol.${orderLineQuantity} < ol.${orderLinePlacedQuantity}
-           AND ol.${orderLineQuantity} > 0
-           AND ol.${orderLinePlacedQuantity} > 0`,
+         FROM ${modificationTable} om
+         WHERE EXISTS (
+             SELECT 1 FROM ${orderLineTable} ol
+             WHERE ol.${orderLineOrderId} = om.${modificationOrderId}
+               AND ol.${orderLineQuantity} < ol.${orderLinePlacedQuantity}
+               AND ol.${orderLineQuantity} > 0
+               AND ol.${orderLinePlacedQuantity} > 0
+         )`,
     );
     const cancellationHistory: CancellationHistoryRow[] = await queryRunner.query(
         `SELECT h.${historyCreatedAt} AS ${esc('createdAt')},
@@ -223,10 +218,10 @@ export async function rescaleOrderLinePromotionAdjustments(
         [HistoryEntryType.ORDER_CANCELLATION],
     );
 
-    const modificationsByLineId = new Map<string, ModificationRow[]>();
+    const modificationsByOrderId = new Map<string, ModificationRow[]>();
     for (const modification of modifications) {
-        const lineId = String(modification.orderLineId);
-        modificationsByLineId.set(lineId, [...(modificationsByLineId.get(lineId) ?? []), modification]);
+        const orderId = String(modification.orderId);
+        modificationsByOrderId.set(orderId, [...(modificationsByOrderId.get(orderId) ?? []), modification]);
     }
     const cancellationsByLineId = new Map<string, CancellationEvent[]>();
     for (const historyRow of cancellationHistory) {
@@ -252,7 +247,7 @@ export async function rescaleOrderLinePromotionAdjustments(
         const lineId = String(row.id);
         const inferredBasis = getStoredQuantityBasis(
             row,
-            modificationsByLineId.get(lineId) ?? [],
+            modificationsByOrderId.get(String(row.orderId)) ?? [],
             cancellationsByLineId.get(lineId) ?? [],
         );
         let basis: number | undefined;

--- a/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.ts
+++ b/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.ts
@@ -1,6 +1,54 @@
 /* eslint-disable no-console */
 import { QueryRunner } from 'typeorm';
 
+interface CandidateRow {
+    id: string | number;
+    quantity: number;
+    orderPlacedQuantity: number;
+    adjustments: string | null;
+    lastCancelledAt: Date | string | null;
+    lastModifiedAt: Date | string | null;
+    modificationDelta: number | string | null;
+}
+
+const UPDATE_CHUNK_SIZE = 100;
+
+function toTime(value: Date | string | null): number | null {
+    if (value == null) {
+        return null;
+    }
+    const time = value instanceof Date ? value.getTime() : new Date(value).getTime();
+    return Number.isNaN(time) ? null : time;
+}
+
+/**
+ * Returns the quantity that the row's stored `PROMOTION` amounts are scaled to, or `undefined`
+ * if they are already scaled to the current quantity and must be left alone.
+ *
+ * `PROMOTION` amounts are rewritten in full whenever `OrderCalculator` runs, which is what
+ * `OrderModifier.modifyOrder()` ends in. A pre-#5127 `cancelOrderByOrderLines()` is the only
+ * thing that reduced `quantity` without rewriting them, so only a line whose most recent
+ * quantity change came from a cancellation is stale.
+ */
+function getStoredQuantityBasis(row: CandidateRow): number | undefined {
+    const lastModifiedAt = toTime(row.lastModifiedAt);
+    if (lastModifiedAt == null) {
+        // Never modified, so the whole reduction came from cancellations and the amounts are
+        // still on the placement basis.
+        return row.orderPlacedQuantity;
+    }
+    const lastCancelledAt = toTime(row.lastCancelledAt);
+    if (lastCancelledAt == null || lastCancelledAt < lastModifiedAt) {
+        // The modification wrote the amounts after any cancellation, so they already match the
+        // current quantity.
+        return undefined;
+    }
+    // Modified, then cancelled: the amounts are on the basis the last modification left the line
+    // at, which is the placement quantity plus every modification's quantity delta.
+    const basis = row.orderPlacedQuantity + Number(row.modificationDelta ?? 0);
+    return row.quantity < basis ? basis : undefined;
+}
+
 /**
  * @description
  * Rescales `PROMOTION`-type `Adjustment`s on `order_line` rows that were partially
@@ -9,16 +57,17 @@ import { QueryRunner } from 'typeorm';
  * getters (which divide a `PROMOTION` adjustment by the *current* `quantity`,
  * instead of `orderPlacedQuantity`) would otherwise inflate their discount.
  *
- * For each affected row, this multiplies each `PROMOTION` adjustment's `amount` by
- * `quantity / orderPlacedQuantity`, matching what `cancelOrderByOrderLines()` itself
- * now does on write.
+ * Lines whose quantity was reduced by an `OrderModification` are left alone:
+ * `OrderModifier.modifyOrder()` ends in `applyPriceAdjustments()`, which recomputes the
+ * `PROMOTION` amounts against the new quantity, so they are already correct and rescaling
+ * them again would shrink them. Such a line is identified by the `OrderModificationLine` rows
+ * joining it to its `OrderModification`s, compared per line against the most recent
+ * `Cancellation` on the same line.
  *
- * **Limitation:** this assumes the stored amount is still on the `orderPlacedQuantity`
- * basis, i.e. the line hasn't gone through a `modifyOrder` recalculation *since* its
- * last quantity reduction (which would already have rescaled it to that
- * then-current quantity). There is no stored field that distinguishes the two cases.
- * If some of your affected orders have a modification history, spot-check a sample
- * of their `OrderLine.discounts` after migrating before relying on it broadly.
+ * The one case this cannot see is a cancellation of stock that was allocated but never
+ * fulfilled, on a line that was also modified: that records a `Release` rather than a
+ * `Cancellation`, and a `Release` is written by modification and cancellation alike, so it
+ * carries no signal. Such a line keeps its pre-migration amounts.
  *
  * Call this from your migration's `up()` method - it needs no schema change, so it
  * can run at any point in the migration.
@@ -43,22 +92,28 @@ import { QueryRunner } from 'typeorm';
  */
 export async function rescaleOrderLinePromotionAdjustments(queryRunner: QueryRunner): Promise<void> {
     const esc = (name: string) => queryRunner.connection.driver.escape(name);
-    // Standard ANSI SQL literal escaping (doubling embedded single quotes), supported by
-    // sqlite, mysql/mariadb and postgres alike.
-    const escLiteral = (value: string) => `'${value.replace(/'/g, "''")}'`;
+    const param = (index: number) => queryRunner.connection.driver.createParameter('p', index);
 
-    const rows: Array<{
-        id: string | number;
-        quantity: number;
-        orderPlacedQuantity: number;
-        adjustments: string | null;
-    }> = await queryRunner.query(
-        `SELECT ${esc('id')}, ${esc('quantity')}, ${esc('orderPlacedQuantity')}, ${esc('adjustments')}
-         FROM ${esc('order_line')}
-         WHERE ${esc('quantity')} < ${esc('orderPlacedQuantity')} AND ${esc('orderPlacedQuantity')} > 0`,
+    const rows: CandidateRow[] = await queryRunner.query(
+        `SELECT ol.${esc('id')} AS ${esc('id')},
+                ol.${esc('quantity')} AS ${esc('quantity')},
+                ol.${esc('orderPlacedQuantity')} AS ${esc('orderPlacedQuantity')},
+                ol.${esc('adjustments')} AS ${esc('adjustments')},
+                (SELECT MAX(sm.${esc('createdAt')}) FROM ${esc('stock_movement')} sm
+                  WHERE sm.${esc('orderLineId')} = ol.${esc('id')}
+                    AND sm.${esc('type')} = 'CANCELLATION') AS ${esc('lastCancelledAt')},
+                (SELECT MAX(om.${esc('createdAt')}) FROM ${esc('order_line_reference')} olr
+                  INNER JOIN ${esc('order_modification')} om ON om.${esc('id')} = olr.${esc('modificationId')}
+                  WHERE olr.${esc('orderLineId')} = ol.${esc('id')}) AS ${esc('lastModifiedAt')},
+                (SELECT SUM(olr.${esc('quantity')}) FROM ${esc('order_line_reference')} olr
+                  WHERE olr.${esc('orderLineId')} = ol.${esc('id')}
+                    AND olr.${esc('modificationId')} IS NOT NULL) AS ${esc('modificationDelta')}
+         FROM ${esc('order_line')} ol
+         WHERE ol.${esc('quantity')} < ol.${esc('orderPlacedQuantity')}
+           AND ol.${esc('orderPlacedQuantity')} > 0`,
     );
 
-    let migratedCount = 0;
+    const updates: Array<{ id: string | number; adjustments: string }> = [];
     for (const row of rows) {
         if (!row.adjustments) {
             continue;
@@ -67,17 +122,37 @@ export async function rescaleOrderLinePromotionAdjustments(queryRunner: QueryRun
         if (!Array.isArray(adjustments) || !adjustments.some((a: any) => a.type === 'PROMOTION')) {
             continue;
         }
-        const scaleFactor = row.quantity / row.orderPlacedQuantity;
+        const basis = getStoredQuantityBasis(row);
+        if (!basis) {
+            continue;
+        }
+        const scaleFactor = row.quantity / basis;
         const rescaledAdjustments = adjustments.map((adjustment: any) =>
             adjustment.type === 'PROMOTION'
                 ? { ...adjustment, amount: Math.round(adjustment.amount * scaleFactor) }
                 : adjustment,
         );
-        await queryRunner.query(
-            `UPDATE ${esc('order_line')} SET ${esc('adjustments')} = ${escLiteral(JSON.stringify(rescaledAdjustments))} WHERE ${esc('id')} = ${escLiteral(String(row.id))}`,
-        );
-        migratedCount++;
+        updates.push({ id: row.id, adjustments: JSON.stringify(rescaledAdjustments) });
     }
 
-    console.log(`Rescaled PROMOTION adjustments on ${migratedCount} partially-cancelled OrderLine row(s).`);
+    for (let offset = 0; offset < updates.length; offset += UPDATE_CHUNK_SIZE) {
+        const chunk = updates.slice(offset, offset + UPDATE_CHUNK_SIZE);
+        const params: Array<string | number> = [];
+        const whenClauses = chunk
+            .map(update => {
+                const idParam = param(params.push(update.id) - 1);
+                const adjustmentsParam = param(params.push(update.adjustments) - 1);
+                return `WHEN ${idParam} THEN ${adjustmentsParam}`;
+            })
+            .join(' ');
+        const idParams = chunk.map(update => param(params.push(update.id) - 1)).join(', ');
+        await queryRunner.query(
+            `UPDATE ${esc('order_line')}
+             SET ${esc('adjustments')} = CASE ${esc('id')} ${whenClauses} END
+             WHERE ${esc('id')} IN (${idParams})`,
+            params,
+        );
+    }
+
+    console.log(`Rescaled PROMOTION adjustments on ${updates.length} partially-cancelled OrderLine row(s).`);
 }

--- a/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.ts
+++ b/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.ts
@@ -38,7 +38,7 @@ function getStoredQuantityBasis(row: CandidateRow): number | undefined {
         return row.orderPlacedQuantity;
     }
     const lastCancelledAt = toTime(row.lastCancelledAt);
-    if (lastCancelledAt == null || lastCancelledAt < lastModifiedAt) {
+    if (lastCancelledAt == null || lastCancelledAt <= lastModifiedAt) {
         // The modification wrote the amounts after any cancellation, so they already match the
         // current quantity.
         return undefined;

--- a/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.ts
+++ b/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.ts
@@ -1,17 +1,50 @@
 /* eslint-disable no-console */
-import { QueryRunner } from 'typeorm';
+import { HistoryEntryType } from '@vendure/common/lib/generated-types';
+import { EntityMetadata, QueryRunner } from 'typeorm';
+
+import { OrderHistoryEntry } from '../entity/history-entry/order-history-entry.entity';
+import { OrderModificationLine } from '../entity/order-line-reference/order-modification-line.entity';
+import { OrderLine } from '../entity/order-line/order-line.entity';
+import { OrderModification } from '../entity/order-modification/order-modification.entity';
 
 interface CandidateRow {
     id: string | number;
     quantity: number;
     orderPlacedQuantity: number;
     adjustments: string | null;
-    lastCancelledAt: Date | string | null;
-    lastModifiedAt: Date | string | null;
-    modificationDelta: number | string | null;
+}
+
+interface ModificationRow {
+    orderLineId: string | number;
+    createdAt: Date | string;
+}
+
+interface CancellationHistoryRow {
+    createdAt: Date | string;
+    data: string | { lines?: Array<{ orderLineId: string | number; quantity: number }> };
+}
+
+interface CancellationEvent {
+    createdAt: Date | string;
+    quantity: number;
 }
 
 const UPDATE_CHUNK_SIZE = 100;
+const AMBIGUOUS_BASIS = Symbol('AMBIGUOUS_BASIS');
+
+/**
+ * @description
+ * Options for {@link rescaleOrderLinePromotionAdjustments}.
+ */
+export interface RescaleOrderLinePromotionAdjustmentsOptions {
+    /**
+     * @description
+     * The quantity basis for each OrderLine whose latest modification and cancellation have the
+     * same timestamp. Use the current quantity when the modification happened last, or the
+     * quantity before the later cancellation when the cancellation happened last.
+     */
+    ambiguousOrderLineQuantityBases?: Readonly<Record<string, number>>;
+}
 
 function toTime(value: Date | string | null): number | null {
     if (value == null) {
@@ -30,23 +63,52 @@ function toTime(value: Date | string | null): number | null {
  * thing that reduced `quantity` without rewriting them, so only a line whose most recent
  * quantity change came from a cancellation is stale.
  */
-function getStoredQuantityBasis(row: CandidateRow): number | undefined {
-    const lastModifiedAt = toTime(row.lastModifiedAt);
-    if (lastModifiedAt == null) {
+function getStoredQuantityBasis(
+    row: CandidateRow,
+    modifications: ModificationRow[],
+    cancellations: CancellationEvent[],
+): number | typeof AMBIGUOUS_BASIS | undefined {
+    if (modifications.length === 0) {
         // Never modified, so the whole reduction came from cancellations and the amounts are
         // still on the placement basis.
         return row.orderPlacedQuantity;
     }
-    const lastCancelledAt = toTime(row.lastCancelledAt);
-    if (lastCancelledAt == null || lastCancelledAt <= lastModifiedAt) {
-        // The modification wrote the amounts after any cancellation, so they already match the
-        // current quantity.
-        return undefined;
+    const modificationTimes = modifications.map(modification => toTime(modification.createdAt));
+    const cancellationTimes = cancellations.map(cancellation => toTime(cancellation.createdAt));
+    if (modificationTimes.some(time => time == null) || cancellationTimes.some(time => time == null)) {
+        return AMBIGUOUS_BASIS;
     }
-    // Modified, then cancelled: the amounts are on the basis the last modification left the line
-    // at, which is the placement quantity plus every modification's quantity delta.
-    const basis = row.orderPlacedQuantity + Number(row.modificationDelta ?? 0);
-    return row.quantity < basis ? basis : undefined;
+    const lastModifiedAt = Math.max(...(modificationTimes as number[]));
+    if (cancellationTimes.includes(lastModifiedAt)) {
+        return AMBIGUOUS_BASIS;
+    }
+    const quantityCancelledAfterModification = cancellations
+        .filter((_cancellation, index) => (cancellationTimes[index] as number) > lastModifiedAt)
+        .reduce((total, cancellation) => total + cancellation.quantity, 0);
+    return quantityCancelledAfterModification > 0
+        ? row.quantity + quantityCancelledAfterModification
+        : undefined;
+}
+
+function parseCancellationLines(row: CancellationHistoryRow) {
+    const data = typeof row.data === 'string' ? JSON.parse(row.data) : row.data;
+    return Array.isArray(data?.lines) ? data.lines : [];
+}
+
+function getColumnName(metadata: EntityMetadata, propertyName: string): string {
+    const column = metadata.findColumnWithPropertyName(propertyName);
+    if (!column) {
+        throw new Error(`Could not find ${metadata.name}.${propertyName} column metadata.`);
+    }
+    return column.databaseName;
+}
+
+function getRelationColumnName(metadata: EntityMetadata, propertyName: string): string {
+    const column = metadata.findRelationWithPropertyPath(propertyName)?.joinColumns[0];
+    if (!column) {
+        throw new Error(`Could not find ${metadata.name}.${propertyName} relation column metadata.`);
+    }
+    return column.databaseName;
 }
 
 /**
@@ -60,14 +122,15 @@ function getStoredQuantityBasis(row: CandidateRow): number | undefined {
  * Lines whose quantity was reduced by an `OrderModification` are left alone:
  * `OrderModifier.modifyOrder()` ends in `applyPriceAdjustments()`, which recomputes the
  * `PROMOTION` amounts against the new quantity, so they are already correct and rescaling
- * them again would shrink them. Such a line is identified by the `OrderModificationLine` rows
- * joining it to its `OrderModification`s, compared per line against the most recent
- * `Cancellation` on the same line.
+ * them again would shrink them. For a subsequently-cancelled line, the stored basis is its
+ * current quantity plus the quantities in order-cancellation history after its latest
+ * `OrderModification`.
  *
- * The one case this cannot see is a cancellation of stock that was allocated but never
- * fulfilled, on a line that was also modified: that records a `Release` rather than a
- * `Cancellation`, and a `Release` is written by modification and cancellation alike, so it
- * carries no signal. Such a line keeps its pre-migration amounts.
+ * Some databases can store a modification and cancellation with the same timestamp. Their
+ * order is then unknowable from persisted data, so the helper throws before writing anything.
+ * Inspect those lines and pass `ambiguousOrderLineQuantityBases`: use the current quantity if
+ * the modification happened last, or the quantity before cancellation if cancellation happened
+ * last.
  *
  * Call this from your migration's `up()` method - it needs no schema change, so it
  * can run at any point in the migration.
@@ -90,40 +153,125 @@ function getStoredQuantityBasis(row: CandidateRow): number | undefined {
  * @since 3.8.0
  * @docsCategory migration
  */
-export async function rescaleOrderLinePromotionAdjustments(queryRunner: QueryRunner): Promise<void> {
+export async function rescaleOrderLinePromotionAdjustments(
+    queryRunner: QueryRunner,
+    options: RescaleOrderLinePromotionAdjustmentsOptions = {},
+): Promise<void> {
     const esc = (name: string) => queryRunner.connection.driver.escape(name);
+    const escTable = (tablePath: string) => tablePath.split('.').map(esc).join('.');
     const param = (index: number) => queryRunner.connection.driver.createParameter('p', index);
+    const orderLineMetadata = queryRunner.connection.getMetadata(OrderLine);
+    const modificationLineMetadata = queryRunner.connection.getMetadata(OrderModificationLine);
+    const modificationMetadata = queryRunner.connection.getMetadata(OrderModification);
+    const historyMetadata = queryRunner.connection.getMetadata(OrderHistoryEntry);
+
+    const orderLineTable = escTable(orderLineMetadata.tablePath);
+    const orderLineId = esc(getColumnName(orderLineMetadata, 'id'));
+    const orderLineOrderId = esc(getRelationColumnName(orderLineMetadata, 'order'));
+    const orderLineQuantity = esc(getColumnName(orderLineMetadata, 'quantity'));
+    const orderLinePlacedQuantity = esc(getColumnName(orderLineMetadata, 'orderPlacedQuantity'));
+    const orderLineAdjustments = esc(getColumnName(orderLineMetadata, 'adjustments'));
+    const modificationLineTable = escTable(modificationLineMetadata.tablePath);
+    const modificationLineOrderLineId = esc(getRelationColumnName(modificationLineMetadata, 'orderLine'));
+    const modificationLineModificationId = esc(
+        getRelationColumnName(modificationLineMetadata, 'modification'),
+    );
+    const modificationTable = escTable(modificationMetadata.tablePath);
+    const modificationId = esc(getColumnName(modificationMetadata, 'id'));
+    const modificationCreatedAt = esc(getColumnName(modificationMetadata, 'createdAt'));
+    const historyTable = escTable(historyMetadata.tablePath);
+    const historyOrderId = esc(getRelationColumnName(historyMetadata, 'order'));
+    const historyCreatedAt = esc(getColumnName(historyMetadata, 'createdAt'));
+    const historyData = esc(getColumnName(historyMetadata, 'data'));
+    const historyType = esc(getColumnName(historyMetadata, 'type'));
 
     const rows: CandidateRow[] = await queryRunner.query(
-        `SELECT ol.${esc('id')} AS ${esc('id')},
-                ol.${esc('quantity')} AS ${esc('quantity')},
-                ol.${esc('orderPlacedQuantity')} AS ${esc('orderPlacedQuantity')},
-                ol.${esc('adjustments')} AS ${esc('adjustments')},
-                (SELECT MAX(sm.${esc('createdAt')}) FROM ${esc('stock_movement')} sm
-                  WHERE sm.${esc('orderLineId')} = ol.${esc('id')}
-                    AND sm.${esc('type')} = 'CANCELLATION') AS ${esc('lastCancelledAt')},
-                (SELECT MAX(om.${esc('createdAt')}) FROM ${esc('order_line_reference')} olr
-                  INNER JOIN ${esc('order_modification')} om ON om.${esc('id')} = olr.${esc('modificationId')}
-                  WHERE olr.${esc('orderLineId')} = ol.${esc('id')}) AS ${esc('lastModifiedAt')},
-                (SELECT SUM(olr.${esc('quantity')}) FROM ${esc('order_line_reference')} olr
-                  WHERE olr.${esc('orderLineId')} = ol.${esc('id')}
-                    AND olr.${esc('modificationId')} IS NOT NULL) AS ${esc('modificationDelta')}
-         FROM ${esc('order_line')} ol
-         WHERE ol.${esc('quantity')} < ol.${esc('orderPlacedQuantity')}
-           AND ol.${esc('orderPlacedQuantity')} > 0`,
+        `SELECT ol.${orderLineId} AS ${esc('id')},
+                ol.${orderLineQuantity} AS ${esc('quantity')},
+                ol.${orderLinePlacedQuantity} AS ${esc('orderPlacedQuantity')},
+                ol.${orderLineAdjustments} AS ${esc('adjustments')}
+         FROM ${orderLineTable} ol
+         WHERE ol.${orderLineQuantity} < ol.${orderLinePlacedQuantity}
+           AND ol.${orderLineQuantity} > 0
+           AND ol.${orderLinePlacedQuantity} > 0`,
     );
 
+    const modifications: ModificationRow[] = await queryRunner.query(
+        `SELECT olr.${modificationLineOrderLineId} AS ${esc('orderLineId')},
+                om.${modificationCreatedAt} AS ${esc('createdAt')}
+         FROM ${modificationLineTable} olr
+         INNER JOIN ${modificationTable} om
+           ON om.${modificationId} = olr.${modificationLineModificationId}
+         INNER JOIN ${orderLineTable} ol
+           ON ol.${orderLineId} = olr.${modificationLineOrderLineId}
+         WHERE ol.${orderLineQuantity} < ol.${orderLinePlacedQuantity}
+           AND ol.${orderLineQuantity} > 0
+           AND ol.${orderLinePlacedQuantity} > 0`,
+    );
+    const cancellationHistory: CancellationHistoryRow[] = await queryRunner.query(
+        `SELECT h.${historyCreatedAt} AS ${esc('createdAt')},
+                h.${historyData} AS ${esc('data')}
+         FROM ${historyTable} h
+         WHERE h.${historyType} = ${param(0)}
+           AND EXISTS (
+               SELECT 1 FROM ${orderLineTable} ol
+               WHERE ol.${orderLineOrderId} = h.${historyOrderId}
+                 AND ol.${orderLineQuantity} < ol.${orderLinePlacedQuantity}
+                 AND ol.${orderLineQuantity} > 0
+                 AND ol.${orderLinePlacedQuantity} > 0
+           )`,
+        [HistoryEntryType.ORDER_CANCELLATION],
+    );
+
+    const modificationsByLineId = new Map<string, ModificationRow[]>();
+    for (const modification of modifications) {
+        const lineId = String(modification.orderLineId);
+        modificationsByLineId.set(lineId, [...(modificationsByLineId.get(lineId) ?? []), modification]);
+    }
+    const cancellationsByLineId = new Map<string, CancellationEvent[]>();
+    for (const historyRow of cancellationHistory) {
+        for (const line of parseCancellationLines(historyRow)) {
+            const lineId = String(line.orderLineId);
+            cancellationsByLineId.set(lineId, [
+                ...(cancellationsByLineId.get(lineId) ?? []),
+                { createdAt: historyRow.createdAt, quantity: Number(line.quantity) },
+            ]);
+        }
+    }
+
     const updates: Array<{ id: string | number; adjustments: string }> = [];
+    const unresolvedLineIds: Array<string | number> = [];
     for (const row of rows) {
-        if (!row.adjustments) {
+        if (row.quantity <= 0 || !row.adjustments) {
             continue;
         }
         const adjustments = JSON.parse(row.adjustments);
         if (!Array.isArray(adjustments) || !adjustments.some((a: any) => a.type === 'PROMOTION')) {
             continue;
         }
-        const basis = getStoredQuantityBasis(row);
-        if (!basis) {
+        const lineId = String(row.id);
+        const inferredBasis = getStoredQuantityBasis(
+            row,
+            modificationsByLineId.get(lineId) ?? [],
+            cancellationsByLineId.get(lineId) ?? [],
+        );
+        let basis: number | undefined;
+        if (inferredBasis === AMBIGUOUS_BASIS) {
+            const configuredBasis = options.ambiguousOrderLineQuantityBases?.[lineId];
+            if (configuredBasis == null) {
+                unresolvedLineIds.push(row.id);
+                continue;
+            }
+            if (!Number.isInteger(configuredBasis) || configuredBasis < row.quantity) {
+                throw new Error(
+                    `The configured quantity basis for OrderLine ${row.id} must be an integer greater than or equal to its current quantity (${row.quantity}).`,
+                );
+            }
+            basis = configuredBasis;
+        } else {
+            basis = inferredBasis;
+        }
+        if (!basis || basis === row.quantity) {
             continue;
         }
         const scaleFactor = row.quantity / basis;
@@ -133,6 +281,13 @@ export async function rescaleOrderLinePromotionAdjustments(queryRunner: QueryRun
                 : adjustment,
         );
         updates.push({ id: row.id, adjustments: JSON.stringify(rescaledAdjustments) });
+    }
+
+    if (unresolvedLineIds.length > 0) {
+        throw new Error(
+            `Cannot safely determine the stored quantity basis for OrderLine IDs: ${unresolvedLineIds.join(', ')}. ` +
+                'Pass ambiguousOrderLineQuantityBases for each listed ID before rerunning this migration.',
+        );
     }
 
     for (let offset = 0; offset < updates.length; offset += UPDATE_CHUNK_SIZE) {
@@ -147,9 +302,9 @@ export async function rescaleOrderLinePromotionAdjustments(queryRunner: QueryRun
             .join(' ');
         const idParams = chunk.map(update => param(params.push(update.id) - 1)).join(', ');
         await queryRunner.query(
-            `UPDATE ${esc('order_line')}
-             SET ${esc('adjustments')} = CASE ${esc('id')} ${whenClauses} END
-             WHERE ${esc('id')} IN (${idParams})`,
+            `UPDATE ${orderLineTable}
+             SET ${orderLineAdjustments} = CASE ${orderLineId} ${whenClauses} END
+             WHERE ${orderLineId} IN (${idParams})`,
             params,
         );
     }

--- a/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.ts
+++ b/packages/core/src/migration-utils/v3_8_orderline_promotion_rescale.ts
@@ -1,0 +1,83 @@
+/* eslint-disable no-console */
+import { QueryRunner } from 'typeorm';
+
+/**
+ * @description
+ * Rescales `PROMOTION`-type `Adjustment`s on `order_line` rows that were partially
+ * cancelled by a pre-#5127 `cancelOrderByOrderLines()`, which reduced `quantity`
+ * without rescaling `adjustments`. Reading those rows with the fixed `OrderLine`
+ * getters (which divide a `PROMOTION` adjustment by the *current* `quantity`,
+ * instead of `orderPlacedQuantity`) would otherwise inflate their discount.
+ *
+ * For each affected row, this multiplies each `PROMOTION` adjustment's `amount` by
+ * `quantity / orderPlacedQuantity`, matching what `cancelOrderByOrderLines()` itself
+ * now does on write.
+ *
+ * **Limitation:** this assumes the stored amount is still on the `orderPlacedQuantity`
+ * basis, i.e. the line hasn't gone through a `modifyOrder` recalculation *since* its
+ * last quantity reduction (which would already have rescaled it to that
+ * then-current quantity). There is no stored field that distinguishes the two cases.
+ * If some of your affected orders have a modification history, spot-check a sample
+ * of their `OrderLine.discounts` after migrating before relying on it broadly.
+ *
+ * Call this from your migration's `up()` method - it needs no schema change, so it
+ * can run at any point in the migration.
+ *
+ * ```ts
+ * import { MigrationInterface, QueryRunner } from 'typeorm';
+ * import { rescaleOrderLinePromotionAdjustments } from '\@vendure/core';
+ *
+ * export class RescaleOrderLinePromotionAdjustments1234567890 implements MigrationInterface {
+ *     public async up(queryRunner: QueryRunner): Promise<any> {
+ *         await rescaleOrderLinePromotionAdjustments(queryRunner);
+ *     }
+ *
+ *     public async down(queryRunner: QueryRunner): Promise<any> {
+ *         // This is a one-way data migration - the pre-migration amounts are not recoverable.
+ *     }
+ * }
+ * ```
+ *
+ * @since 3.8.0
+ * @docsCategory migration
+ */
+export async function rescaleOrderLinePromotionAdjustments(queryRunner: QueryRunner): Promise<void> {
+    const esc = (name: string) => queryRunner.connection.driver.escape(name);
+    // Standard ANSI SQL literal escaping (doubling embedded single quotes), supported by
+    // sqlite, mysql/mariadb and postgres alike.
+    const escLiteral = (value: string) => `'${value.replace(/'/g, "''")}'`;
+
+    const rows: Array<{
+        id: string | number;
+        quantity: number;
+        orderPlacedQuantity: number;
+        adjustments: string | null;
+    }> = await queryRunner.query(
+        `SELECT ${esc('id')}, ${esc('quantity')}, ${esc('orderPlacedQuantity')}, ${esc('adjustments')}
+         FROM ${esc('order_line')}
+         WHERE ${esc('quantity')} < ${esc('orderPlacedQuantity')} AND ${esc('orderPlacedQuantity')} > 0`,
+    );
+
+    let migratedCount = 0;
+    for (const row of rows) {
+        if (!row.adjustments) {
+            continue;
+        }
+        const adjustments = JSON.parse(row.adjustments);
+        if (!Array.isArray(adjustments) || !adjustments.some((a: any) => a.type === 'PROMOTION')) {
+            continue;
+        }
+        const scaleFactor = row.quantity / row.orderPlacedQuantity;
+        const rescaledAdjustments = adjustments.map((adjustment: any) =>
+            adjustment.type === 'PROMOTION'
+                ? { ...adjustment, amount: Math.round(adjustment.amount * scaleFactor) }
+                : adjustment,
+        );
+        await queryRunner.query(
+            `UPDATE ${esc('order_line')} SET ${esc('adjustments')} = ${escLiteral(JSON.stringify(rescaledAdjustments))} WHERE ${esc('id')} = ${escLiteral(String(row.id))}`,
+        );
+        migratedCount++;
+    }
+
+    console.log(`Rescaled PROMOTION adjustments on ${migratedCount} partially-cancelled OrderLine row(s).`);
+}

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.spec.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.spec.ts
@@ -21,8 +21,8 @@ import {
     TaxLineCalculationStrategy,
 } from '../../../config/tax/tax-line-calculation-strategy';
 import { Promotion } from '../../../entity';
-import { OrderLine } from '../../../entity/order-line/order-line.entity';
 import { Order } from '../../../entity/order/order.entity';
+import { OrderLine } from '../../../entity/order-line/order-line.entity';
 import { ShippingLine } from '../../../entity/shipping-line/shipping-line.entity';
 import { Surcharge } from '../../../entity/surcharge/surcharge.entity';
 import { EventBus } from '../../../event-bus/event-bus';
@@ -445,6 +445,62 @@ describe('OrderCalculator', () => {
                     expect(order.lines[0].adjustments.length).toBe(1);
                     expect(order.lines[0].adjustments[0].description).toBe('50% off each item');
                     expect(order.totalWithTax).toBe(1350);
+                    assertOrderTotalsAddUp(order);
+                });
+            });
+
+            // https://github.com/vendurehq/vendure/issues/5127 (continuation of #3098)
+            describe('quantity reduced below orderPlacedQuantity after recalculation (#5127)', () => {
+                const promotion = new Promotion({
+                    id: 1,
+                    name: '40% off each item',
+                    conditions: [{ code: alwaysTrueCondition.code, args: [] }],
+                    promotionConditions: [alwaysTrueCondition],
+                    actions: [
+                        {
+                            code: percentageItemAction.code,
+                            args: [{ name: 'discount', value: '40' }],
+                        },
+                    ],
+                    promotionActions: [percentageItemAction],
+                });
+
+                it('keeps the 40% discount after a modifyOrder-style recalculation at a reduced quantity', async () => {
+                    const ctx = createRequestContext({ pricesIncludeTax: true });
+                    const order = createOrder({
+                        ctx,
+                        lines: [
+                            {
+                                listPrice: 2975,
+                                taxCategory: taxCategoryZero,
+                                quantity: 20,
+                            },
+                        ],
+                    });
+                    await orderCalculator.applyPriceAdjustments(ctx, order, [promotion], [order.lines[0]]);
+
+                    // simulate order placement: the line's orderPlacedQuantity is fixed at 20
+                    order.lines[0].orderPlacedQuantity = 20;
+                    expect(order.lines[0].proratedLinePriceWithTax).toBe(
+                        Math.round(order.lines[0].linePriceWithTax * 0.6),
+                    );
+
+                    // Simulate `modifyOrder` reducing the quantity from 20 to 2 - the same
+                    // `OrderCalculator.applyPriceAdjustments()` call that a real `modifyOrder`
+                    // mutation makes, which clears and freshly recomputes `adjustments` against the
+                    // *new* (already-reduced) quantity.
+                    order.lines[0].quantity = 2;
+                    await orderCalculator.applyPriceAdjustments(ctx, order, [promotion], [order.lines[0]]);
+
+                    expect(order.lines[0].quantity).toBe(2);
+                    expect(order.lines[0].orderPlacedQuantity).toBe(20);
+                    // Before the fix, dividing the already-current-quantity-scaled adjustment total by
+                    // `Math.max(orderPlacedQuantity, quantity)` a second time silently rescaled this
+                    // down to a ~4% discount (quantity / orderPlacedQuantity = 2 / 20 = 10% of the
+                    // correct 40%).
+                    expect(order.lines[0].proratedLinePriceWithTax).toBe(
+                        Math.round(order.lines[0].linePriceWithTax * 0.6),
+                    );
                     assertOrderTotalsAddUp(order);
                 });
             });

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.spec.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.spec.ts
@@ -21,8 +21,8 @@ import {
     TaxLineCalculationStrategy,
 } from '../../../config/tax/tax-line-calculation-strategy';
 import { Promotion } from '../../../entity';
-import { Order } from '../../../entity/order/order.entity';
 import { OrderLine } from '../../../entity/order-line/order-line.entity';
+import { Order } from '../../../entity/order/order.entity';
 import { ShippingLine } from '../../../entity/shipping-line/shipping-line.entity';
 import { Surcharge } from '../../../entity/surcharge/surcharge.entity';
 import { EventBus } from '../../../event-bus/event-bus';
@@ -481,26 +481,22 @@ describe('OrderCalculator', () => {
 
                     // simulate order placement: the line's orderPlacedQuantity is fixed at 20
                     order.lines[0].orderPlacedQuantity = 20;
-                    expect(order.lines[0].proratedLinePriceWithTax).toBe(
-                        Math.round(order.lines[0].linePriceWithTax * 0.6),
-                    );
+                    // listPrice 2975 * 20 = 59500, 60% of that (i.e. after a 40% discount) is 35700
+                    expect(order.lines[0].proratedLinePriceWithTax).toBe(35700);
 
                     // Simulate `modifyOrder` reducing the quantity from 20 to 2 - the same
                     // `OrderCalculator.applyPriceAdjustments()` call that a real `modifyOrder`
                     // mutation makes, which clears and freshly recomputes `adjustments` against the
-                    // *new* (already-reduced) quantity.
+                    // *new* (already-reduced) quantity. See #5127 for why, pre-fix, this silently
+                    // rescaled the discount down to quantity / orderPlacedQuantity (2 / 20 = 10%) of
+                    // its correct value.
                     order.lines[0].quantity = 2;
                     await orderCalculator.applyPriceAdjustments(ctx, order, [promotion], [order.lines[0]]);
 
                     expect(order.lines[0].quantity).toBe(2);
                     expect(order.lines[0].orderPlacedQuantity).toBe(20);
-                    // Before the fix, dividing the already-current-quantity-scaled adjustment total by
-                    // `Math.max(orderPlacedQuantity, quantity)` a second time silently rescaled this
-                    // down to a ~4% discount (quantity / orderPlacedQuantity = 2 / 20 = 10% of the
-                    // correct 40%).
-                    expect(order.lines[0].proratedLinePriceWithTax).toBe(
-                        Math.round(order.lines[0].linePriceWithTax * 0.6),
-                    );
+                    // listPrice 2975 * 2 = 5950, 60% of that is 3570
+                    expect(order.lines[0].proratedLinePriceWithTax).toBe(3570);
                     assertOrderTotalsAddUp(order);
                 });
             });

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.spec.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.spec.ts
@@ -487,9 +487,7 @@ describe('OrderCalculator', () => {
                     // Simulate `modifyOrder` reducing the quantity from 20 to 2 - the same
                     // `OrderCalculator.applyPriceAdjustments()` call that a real `modifyOrder`
                     // mutation makes, which clears and freshly recomputes `adjustments` against the
-                    // *new* (already-reduced) quantity. See #5127 for why, pre-fix, this silently
-                    // rescaled the discount down to quantity / orderPlacedQuantity (2 / 20 = 10%) of
-                    // its correct value.
+                    // new, already-reduced quantity.
                     order.lines[0].quantity = 2;
                     await orderCalculator.applyPriceAdjustments(ctx, order, [promotion], [order.lines[0]]);
 

--- a/packages/core/src/service/helpers/order-modifier/order-modifier.ts
+++ b/packages/core/src/service/helpers/order-modifier/order-modifier.ts
@@ -333,12 +333,10 @@ export class OrderModifier {
         for (const line of lineInputs) {
             const orderLine = fullOrder.lines.find(l => idsAreEqual(l.id, line.orderLineId));
             if (orderLine) {
-                const newQuantity = orderLine.quantity - line.quantity;
-                // A partial cancellation bypasses `OrderCalculator` recalculation entirely, so
-                // `PROMOTION`-type adjustments must be rescaled to the new quantity here to keep
-                // the invariant `OrderLine.quantityBasisFor()` relies on (see #5127).
-                orderLine.rescaleAdjustmentsForQuantity(newQuantity);
-                orderLine.quantity = newQuantity;
+                // A partial cancellation bypasses `OrderCalculator` recalculation entirely, so the
+                // `PROMOTION` adjustments are rescaled here to preserve the invariant that they are
+                // stored scaled to the current quantity.
+                orderLine.setQuantityRescalingAdjustments(orderLine.quantity - line.quantity);
                 await this.connection.getRepository(ctx, OrderLine).update(line.orderLineId, {
                     quantity: orderLine.quantity,
                     adjustments: orderLine.adjustments,
@@ -590,7 +588,9 @@ export class OrderModifier {
                 );
                 if (isGraphQlErrorResult(validationResult)) {
                     return validationResult as
-                        CouponCodeExpiredError | CouponCodeInvalidError | CouponCodeLimitError;
+                        | CouponCodeExpiredError
+                        | CouponCodeInvalidError
+                        | CouponCodeLimitError;
                 }
                 const canonicalCode = validationResult.couponCode;
                 if (!canonicalCouponCodes.some(cc => couponCodesMatch(cc, canonicalCode))) {

--- a/packages/core/src/service/helpers/order-modifier/order-modifier.ts
+++ b/packages/core/src/service/helpers/order-modifier/order-modifier.ts
@@ -34,16 +34,17 @@ import {
     OrderLimitError,
 } from '../../../common/error/generated-graphql-shop-errors';
 import { Instrument } from '../../../common/instrument-decorator';
+import { roundMoney } from '../../../common/round-money';
 import { idsAreEqual } from '../../../common/utils';
 import { ConfigService } from '../../../config/config.service';
 import { CustomFieldConfig } from '../../../config/custom-field/custom-field-types';
 import { TransactionalConnection } from '../../../connection/transactional-connection';
 import { VendureEntity } from '../../../entity/base/base.entity';
+import { Order } from '../../../entity/order/order.entity';
+import { OrderLine } from '../../../entity/order-line/order-line.entity';
 import { FulfillmentLine } from '../../../entity/order-line-reference/fulfillment-line.entity';
 import { OrderModificationLine } from '../../../entity/order-line-reference/order-modification-line.entity';
-import { OrderLine } from '../../../entity/order-line/order-line.entity';
 import { OrderModification } from '../../../entity/order-modification/order-modification.entity';
-import { Order } from '../../../entity/order/order.entity';
 import { Payment } from '../../../entity/payment/payment.entity';
 import { ProductVariant } from '../../../entity/product-variant/product-variant.entity';
 import { ShippingLine } from '../../../entity/shipping-line/shipping-line.entity';
@@ -333,8 +334,26 @@ export class OrderModifier {
         for (const line of lineInputs) {
             const orderLine = fullOrder.lines.find(l => idsAreEqual(l.id, line.orderLineId));
             if (orderLine) {
+                const newQuantity = orderLine.quantity - line.quantity;
+                // `OrderLine.getUnitAdjustmentsTotal()` treats a `PROMOTION`-type adjustment's
+                // amount as the total discount for the line's *current* quantity, since
+                // `OrderCalculator.applyOrderItemPromotions()` always (re)computes it that way via
+                // `addAdjustment()`. Reducing the quantity here bypasses that recalculation
+                // entirely, so without rescaling, a `PROMOTION` adjustment's stored total would stay
+                // pinned to the pre-cancellation quantity while `OrderLine.quantity` moves on - the
+                // exact mismatch reported in #5127. `DISTRIBUTED_ORDER_PROMOTION` (and any other)
+                // adjustments are left untouched: their per-unit share is always read relative to
+                // `orderPlacedQuantity`, by design, so that cancelling part of a line does not let
+                // its surviving units absorb a bigger share of an order-level discount.
+                const adjustmentScaleFactor = orderLine.quantity > 0 ? newQuantity / orderLine.quantity : 0;
+                const rescaledAdjustments = (orderLine.adjustments ?? []).map(adjustment =>
+                    adjustment.type === AdjustmentType.PROMOTION
+                        ? { ...adjustment, amount: roundMoney(adjustment.amount * adjustmentScaleFactor) }
+                        : adjustment,
+                );
                 await this.connection.getRepository(ctx, OrderLine).update(line.orderLineId, {
-                    quantity: orderLine.quantity - line.quantity,
+                    quantity: newQuantity,
+                    adjustments: rescaledAdjustments,
                 });
 
                 await this.eventBus.publish(new OrderLineEvent(ctx, order, orderLine, 'cancelled'));

--- a/packages/core/src/service/helpers/order-modifier/order-modifier.ts
+++ b/packages/core/src/service/helpers/order-modifier/order-modifier.ts
@@ -34,17 +34,16 @@ import {
     OrderLimitError,
 } from '../../../common/error/generated-graphql-shop-errors';
 import { Instrument } from '../../../common/instrument-decorator';
-import { roundMoney } from '../../../common/round-money';
 import { idsAreEqual } from '../../../common/utils';
 import { ConfigService } from '../../../config/config.service';
 import { CustomFieldConfig } from '../../../config/custom-field/custom-field-types';
 import { TransactionalConnection } from '../../../connection/transactional-connection';
 import { VendureEntity } from '../../../entity/base/base.entity';
-import { Order } from '../../../entity/order/order.entity';
-import { OrderLine } from '../../../entity/order-line/order-line.entity';
 import { FulfillmentLine } from '../../../entity/order-line-reference/fulfillment-line.entity';
 import { OrderModificationLine } from '../../../entity/order-line-reference/order-modification-line.entity';
+import { OrderLine } from '../../../entity/order-line/order-line.entity';
 import { OrderModification } from '../../../entity/order-modification/order-modification.entity';
+import { Order } from '../../../entity/order/order.entity';
 import { Payment } from '../../../entity/payment/payment.entity';
 import { ProductVariant } from '../../../entity/product-variant/product-variant.entity';
 import { ShippingLine } from '../../../entity/shipping-line/shipping-line.entity';
@@ -335,25 +334,14 @@ export class OrderModifier {
             const orderLine = fullOrder.lines.find(l => idsAreEqual(l.id, line.orderLineId));
             if (orderLine) {
                 const newQuantity = orderLine.quantity - line.quantity;
-                // `OrderLine.getUnitAdjustmentsTotal()` treats a `PROMOTION`-type adjustment's
-                // amount as the total discount for the line's *current* quantity, since
-                // `OrderCalculator.applyOrderItemPromotions()` always (re)computes it that way via
-                // `addAdjustment()`. Reducing the quantity here bypasses that recalculation
-                // entirely, so without rescaling, a `PROMOTION` adjustment's stored total would stay
-                // pinned to the pre-cancellation quantity while `OrderLine.quantity` moves on - the
-                // exact mismatch reported in #5127. `DISTRIBUTED_ORDER_PROMOTION` (and any other)
-                // adjustments are left untouched: their per-unit share is always read relative to
-                // `orderPlacedQuantity`, by design, so that cancelling part of a line does not let
-                // its surviving units absorb a bigger share of an order-level discount.
-                const adjustmentScaleFactor = orderLine.quantity > 0 ? newQuantity / orderLine.quantity : 0;
-                const rescaledAdjustments = (orderLine.adjustments ?? []).map(adjustment =>
-                    adjustment.type === AdjustmentType.PROMOTION
-                        ? { ...adjustment, amount: roundMoney(adjustment.amount * adjustmentScaleFactor) }
-                        : adjustment,
-                );
+                // A partial cancellation bypasses `OrderCalculator` recalculation entirely, so
+                // `PROMOTION`-type adjustments must be rescaled to the new quantity here to keep
+                // the invariant `OrderLine.quantityBasisFor()` relies on (see #5127).
+                orderLine.rescaleAdjustmentsForQuantity(newQuantity);
+                orderLine.quantity = newQuantity;
                 await this.connection.getRepository(ctx, OrderLine).update(line.orderLineId, {
-                    quantity: newQuantity,
-                    adjustments: rescaledAdjustments,
+                    quantity: orderLine.quantity,
+                    adjustments: orderLine.adjustments,
                 });
 
                 await this.eventBus.publish(new OrderLineEvent(ctx, order, orderLine, 'cancelled'));
@@ -602,9 +590,7 @@ export class OrderModifier {
                 );
                 if (isGraphQlErrorResult(validationResult)) {
                     return validationResult as
-                        | CouponCodeExpiredError
-                        | CouponCodeInvalidError
-                        | CouponCodeLimitError;
+                        CouponCodeExpiredError | CouponCodeInvalidError | CouponCodeLimitError;
                 }
                 const canonicalCode = validationResult.couponCode;
                 if (!canonicalCouponCodes.some(cc => couponCodesMatch(cc, canonicalCode))) {


### PR DESCRIPTION
# Description

Fixes #5127. Continuation of #3098.

## The bug

When an `OrderLine`'s quantity is reduced below `orderPlacedQuantity` (a partial
cancellation, or reducing a line's quantity via a `modifyOrder` order
modification), the applied promotion discount was silently rescaled — a 40%
discount could collapse to ~4% after cutting quantity from 20 to 2, exactly as
described in #5127 and, for the order-level case, in #3098.

## Root cause: two mismatched quantity bases for the same `adjustment.amount`

`OrderLine.addAdjustment()` (write side) and `getUnitAdjustmentsTotal()` /
`getLineAdjustmentsTotal()` (read side) assumed the same `Adjustment.amount`
meant different things depending on *which* code path last touched the
line's quantity, but the getters didn't know which:

- **`PROMOTION` adjustments** (item- and line-level `PromotionAction`s) are
  always freshly recomputed against the `OrderLine`'s **current** quantity —
  `OrderCalculator.applyOrderItemPromotions()` calls `line.clearAdjustments()`
  and rebuilds them via `addAdjustment()` on every recalculation
  (`order-calculator.ts:196-217`). So the stored total is already correctly
  scaled to the current quantity. Reading it back by dividing by
  `Math.max(orderPlacedQuantity, quantity)` (the pre-fix code) **double-scaled**
  it whenever a quantity reduction triggered a fresh recalculation (e.g. via
  `modifyOrder`), on top of the correct scaling already baked into the stored
  amount — this is the exact bug reported in #5127.

- **`DISTRIBUTED_ORDER_PROMOTION` adjustments** (an order-level promotion's
  per-line share, from `applyOrderPromotions`) are redistributed by *weight*
  across lines on every recalculation, and a single remaining line can end up
  freshly assigned the *entire* order-level discount regardless of its own
  quantity. Dividing by `orderPlacedQuantity` here is a **deliberate,
  pre-existing mechanism** that keeps a partially cancelled/refunded line's
  per-unit share pinned to what it was at placement, so its surviving units
  don't absorb a windfall meant for units that no longer exist. I confirmed
  this is intentional (not part of the bug) by initially "fixing" it uniformly
  and immediately breaking the existing `refunds correct amount when
  order-level promotion applied` e2e test — this behaviour is now explicitly
  preserved and left untouched.

- **`OrderModifier.cancelOrderByOrderLines()`** reduces `quantity` directly via
  a raw repository `.update()`, without going through `OrderCalculator` at
  all — so `PROMOTION`-type adjustments were left stale at the
  pre-cancellation total after a partial cancellation. This method now
  rescales `PROMOTION`-type adjustments (only) proportionally to the new
  quantity when cancelling, so the same "already current-quantity-scaled"
  invariant holds after a partial cancellation as it does after a
  `modifyOrder`-triggered recalculation.

## The fix

`getUnitAdjustmentsTotal()`, `getLineAdjustmentsTotal()` and the `discounts`
getter now pick the quantity basis **per adjustment**, based on its `type`:
`this.quantity` for `PROMOTION`, `Math.max(orderPlacedQuantity, quantity)` for
everything else (`DISTRIBUTED_ORDER_PROMOTION` and `OTHER`) — via a new
`quantityBasisFor()` helper. This makes the read side always match whichever
basis the write side actually used for that adjustment type, instead of
assuming one basis for all adjustments.

`OrderModifier.cancelOrderByOrderLines()` now rescales `PROMOTION`-type
adjustments to the new quantity, matching what a full recalculation would
have produced. `DISTRIBUTED_ORDER_PROMOTION`/`OTHER` adjustments are left
untouched there, consistent with their read-side basis.

I considered instead moving *all* proration to write time (rescale
everything on cancellation, always divide by current quantity on read), which
would have been a smaller code diff, but it collapses the deliberate
order-level "pinned to placement" behaviour above and breaks that existing,
passing e2e test — so I ruled it out in favour of the type-aware fix, which
is a few more lines but changes zero externally-observed behaviour outside of
the actual bug.

## Tests

- `order-calculator.spec.ts`: new unit test reproducing the reported 40% → ~4%
  discount decay after a `modifyOrder`-style recalculation at a reduced
  quantity (fails without the fix, passes with it).
- `order-modification.e2e-spec.ts`: two new e2e tests — one going through
  `modifyOrder` (adjustOrderLines + refund), one through a partial
  `cancelOrder({ lines: [...] })` — both reducing quantity from 20 to 2 under
  a 50% item promotion and asserting the discount ratio survives. The
  `modifyOrder` test fails on the pre-fix code (`expected 296172 to be
  155880`); the `cancelOrder` test happens to already pass on both old and
  new code (the pre-existing read-side formula already handled that specific
  path correctly) but guards the new write-side rescale against regression.
- Confirmed the existing `refunds correct amount when order-level promotion
  applied` e2e test (order-level/`DISTRIBUTED_ORDER_PROMOTION` case) still
  passes unchanged, and the `order-line.entity.spec.ts` #5101 NaN-regression
  unit test still passes unchanged.
- Full run of `order-modification.e2e-spec.ts` (73/73), `order-promotion.e2e-spec.ts`
  (66/67, 1 pre-existing skip), `order.e2e-spec.ts` (93/93),
  `order-cancel-shipping.e2e-spec.ts` (2/2), `order-multi-vendor-promotion.e2e-spec.ts`
  (6/6) and `shop-order.e2e-spec.ts` (104/104) — all green.

# Breaking changes

Yes - for existing data. `OrderLine.discounts`, `discountedLinePrice(WithTax)`,
`proratedLinePrice(WithTax)` etc. now return the *correct* discount amount in
the specific case (quantity reduced below `orderPlacedQuantity`) where they
previously returned an incorrectly rescaled (too small) discount for lines
recalculated via `modifyOrder`. Any code relying on the previous, incorrect
numbers in that narrow case would see different (larger, correct) output.

For lines that were **partially cancelled via `cancelOrder` and never
subsequently went through a `modifyOrder` recalculation**, this PR also
changes what `PROMOTION`-type adjustments are read against (see review
discussion below), so their stored `adjustment.amount` needs rescaling to
match. A `rescaleOrderLinePromotionAdjustments()` migration helper is now
exported from `\@vendure/core` (`migration-utils`) to run as part of your
upgrade migration - see its docblock for usage. The helper skips lines whose
`PROMOTION` amounts were last written by a `modifyOrder` recalculation, which
are already correct.

# Update, addressing review

- Added `rescaleOrderLinePromotionAdjustments()` (in `migration-utils`) and corrected the
  breaking-changes note above for existing partially-cancelled orders.
- Added an e2e test (through both `modifyOrder` and `cancelOrder`) covering an order that
  carries both a `PROMOTION` and a `DISTRIBUTED_ORDER_PROMOTION` at once, since
  `DefaultOrderLineDiscountDistributionStrategy.getWeight()` reads the exact value this PR
  changes for a reduced line.
- Moved the write-side rescale onto the entity (now `OrderLine.setQuantityRescalingAdjustments()`),
  next to `quantityBasisFor()`, and had `cancelOrderByOrderLines()` assign the rescaled
  quantity/adjustments onto the in-memory `OrderLine` before publishing its `OrderLineEvent`,
  so a subscriber no longer sees stale pre-cancellation values.
- Added `order-line.entity.spec.ts` unit tests for `PROMOTION` alone, both types together, and
  `orderPlacedQuantity: 0`.
- Trimmed the `quantityBasisFor()` docblock and de-duplicated the "before the fix..." narration
  that had been repeated across three files down to one explanation, with the others pointing at
  #5127.
- Reworked the flagged assertions in `order-calculator.spec.ts` and
  `order-modification.e2e-spec.ts` to pin expected values to a baseline captured independently
  of the code path under test, rather than deriving them from another getter on the same object.
  Added a length check before indexing `discounts[0]` in the e2e test.
- `quantityBasisFor()` is now a `switch` over `AdjustmentType`.
- Reverted the unrelated import-order changes in `order-modifier.ts` and
  `order-calculator.spec.ts`.
- Left the `orderLine.quantity > 0` guard in the rescale in place, since a lineInput requesting a
  no-op cancellation on an already-fully-cancelled line does reach it; added a comment explaining
  why.
- On the rounding-drift point: agreed it's real and bounded (confirmed by the same brute-force
  check across quantities 2-30), but fixing it needs either extra stored precision or reworking
  cancellation to route through a full recalculation, which felt like a larger change than this
  fix warranted - happy to follow up separately if you'd rather not carry it even at that bound.

# Update, addressing the migration review

- `rescaleOrderLinePromotionAdjustments()` no longer rescales every row matching
  `quantity < orderPlacedQuantity`. It reconstructs each candidate line's history from two further
  queries: every `order_modification.createdAt` belonging to an order that holds a candidate line,
  and every `ORDER_CANCELLATION` history entry for those orders, whose `data.lines` carries the
  quantity cancelled per line. The modification side is grouped per *order* and the cancellation
  side per *line*, because `modifyOrder()` ends in `applyPriceAdjustments()`, which rewrites
  `PROMOTION` amounts for every line in the order rather than only the ones the `OrderModification`
  references - so cancelling line B and then modifying line A still leaves B's amounts correct.
  A line with no modification at all is scaled from `orderPlacedQuantity` as before; a line whose
  order's latest modification is more recent than every one of its cancellations is skipped, since
  those amounts were already rewritten; a line cancelled after that modification is scaled from its
  current quantity plus the quantities cancelled since. Where a modification and a cancellation
  share a timestamp their order is unknowable from stored data, so the helper throws before writing
  anything and names the lines needing an explicit basis via `ambiguousOrderLineQuantityBases`.
- Table and column names come from `queryRunner.connection.getMetadata()` rather than being
  hardcoded, so `entityPrefix`, a schema or a custom naming strategy no longer break the queries.
- Added `v3_8_orderline_promotion_rescale.spec.ts`: 15 tests covering each of those branches, the
  equal-timestamp refusal and the two explicit-basis overrides, the metadata-resolved names, the
  parameter binding and the chunked update.
- `cancelOrderByOrderLines()` no longer zeroes a fully-cancelled line's `PROMOTION` amounts:
  `setQuantityRescalingAdjustments()` assigns the new quantity but leaves the adjustments alone
  when that quantity is 0, so the record of the applied discount survives for plugins and exports.
- Dropped `escLiteral()`. Both migration statements now use
  `queryRunner.connection.driver.createParameter()` with bound values, and the per-row loop is
  replaced by a chunked `UPDATE ... SET adjustments = CASE id WHEN ? THEN ? ... END WHERE id IN (...)`.
- Moved the `quantity === 0` guard into `quantityBasisFor()`, replaced the `orderPlacedQuantity: 0`
  unit test with a `PROMOTION` adjustment on a `quantity === 0` line, and had
  `setQuantityRescalingAdjustments()` assign `this.quantity` itself.
- Combo e2e tests: dropped the total-based assertion and the derived `totalWithTax` check, capture
  each line's order-level share before the change, and tell the two discount types apart with
  `discount.type`. The promotions they create are deleted in an `afterAll`, and the duplicated
  `CanceledOrderFragment`/guard now live once at the top-level describe.
- Reverted the last prettier hunk in `order-modifier.ts`. Note the repo's `bun.lock` pins prettier
  3.7.4 while a bare `npx prettier` resolves 3.9.6, which formats that union the other way -
  `npx prettier@3.7.4 --check` is clean on every file touched here.

_The description of the migration's behaviour above was brought in line with the current
implementation by @biggamesmallworld while reviewing; no code was changed._

# Screenshots

N/A — logic fix, no UI changes.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789483559&installation_model_id=20193&pr_number=5143&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5143&signature=af7742817b22bf7bbe3b845504e75b89e749a58a095dde14a4f53026b1baa2ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


