### PR TITLE
feat(create): add TanStack Start storefront option

### DIFF
--- a/docs/docs/reference/typescript-api/products-stock/multi-channel-stock-location-strategy.mdx
+++ b/docs/docs/reference/typescript-api/products-stock/multi-channel-stock-location-strategy.mdx
@@ -2,7 +2,7 @@
 title: "MultiChannelStockLocationStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/catalog/multi-channel-stock-location-strategy.ts" sourceLine="32" packageName="@vendure/core" since="3.1.0" />
+<GenerationInfo sourceFile="packages/core/src/config/catalog/multi-channel-stock-location-strategy.ts" sourceLine="35" packageName="@vendure/core" since="3.1.0" />
 
 The MultiChannelStockLocationStrategy is an implementation of the [StockLocationStrategy](/reference/typescript-api/products-stock/stock-location-strategy#stocklocationstrategy).
 which is suitable for both single- and multichannel setups. It takes into account the active

--- a/docs/docs/reference/typescript-api/products-stock/multi-channel-stock-location-strategy.mdx
+++ b/docs/docs/reference/typescript-api/products-stock/multi-channel-stock-location-strategy.mdx
@@ -2,7 +2,7 @@
 title: "MultiChannelStockLocationStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/catalog/multi-channel-stock-location-strategy.ts" sourceLine="35" packageName="@vendure/core" since="3.1.0" />
+<GenerationInfo sourceFile="packages/core/src/config/catalog/multi-channel-stock-location-strategy.ts" sourceLine="32" packageName="@vendure/core" since="3.1.0" />
 
 The MultiChannelStockLocationStrategy is an implementation of the [StockLocationStrategy](/reference/typescript-api/products-stock/stock-location-strategy#stocklocationstrategy).
 which is suitable for both single- and multichannel setups. It takes into account the active

--- a/docs/docs/reference/typescript-api/request/request-context.mdx
+++ b/docs/docs/reference/typescript-api/request/request-context.mdx
@@ -45,7 +45,7 @@ class RequestContext {
     userHasPermissions(permissions: Permission[]) => boolean;
     userHasAllPermissions(permissions: Permission[]) => boolean;
     serialize() => SerializedRequestContext;
-    copy() => RequestContext;
+    copy(channel?: Channel) => RequestContext;
     req: Request | undefined
     apiType: ApiType
     channel: Channel
@@ -120,11 +120,14 @@ This is useful when you need to send a RequestContext object to another
 process, e.g. to pass it to the Job Queue via the [JobQueueService](/reference/typescript-api/job-queue/job-queue-service#jobqueueservice).
 ### copy
 
-<MemberInfo kind="method" type={`() => <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>`}   />
+<MemberInfo kind="method" type={`(channel?: <a href='/reference/typescript-api/entities/channel#channel'>Channel</a>) => <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>`}   />
 
 Creates a shallow copy of the RequestContext instance. This means that
 mutations to the copy itself will not affect the original, but deep mutations
 (e.g. copy.channel.code = 'new') *will* also affect the original.
+
+Passing a `channel` re-scopes the copy to it, switching language and currency
+to the channel's defaults so downstream logic runs in the target channel.
 ### req
 
 <MemberInfo kind="property" type={`Request | undefined`}   />

--- a/docs/docs/reference/typescript-api/request/request-context.mdx
+++ b/docs/docs/reference/typescript-api/request/request-context.mdx
@@ -45,7 +45,7 @@ class RequestContext {
     userHasPermissions(permissions: Permission[]) => boolean;
     userHasAllPermissions(permissions: Permission[]) => boolean;
     serialize() => SerializedRequestContext;
-    copy(channel?: Channel) => RequestContext;
+    copy() => RequestContext;
     req: Request | undefined
     apiType: ApiType
     channel: Channel
@@ -120,14 +120,11 @@ This is useful when you need to send a RequestContext object to another
 process, e.g. to pass it to the Job Queue via the [JobQueueService](/reference/typescript-api/job-queue/job-queue-service#jobqueueservice).
 ### copy
 
-<MemberInfo kind="method" type={`(channel?: <a href='/reference/typescript-api/entities/channel#channel'>Channel</a>) => <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>`}   />
+<MemberInfo kind="method" type={`() => <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>`}   />
 
 Creates a shallow copy of the RequestContext instance. This means that
 mutations to the copy itself will not affect the original, but deep mutations
 (e.g. copy.channel.code = 'new') *will* also affect the original.
-
-Passing a `channel` re-scopes the copy to it, switching language and currency
-to the channel's defaults so downstream logic runs in the target channel.
 ### req
 
 <MemberInfo kind="property" type={`Request | undefined`}   />

--- a/docs/docs/reference/typescript-api/services/order-service.mdx
+++ b/docs/docs/reference/typescript-api/services/order-service.mdx
@@ -2,12 +2,12 @@
 title: "OrderService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/order.service.ts" sourceLine="145" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/order.service.ts" sourceLine="143" packageName="@vendure/core" />
 
 Contains methods relating to [Order](/reference/typescript-api/entities/order#order) entities.
 
 ```ts title="Signature"
-class OrderService implements OnApplicationBootstrap {
+class OrderService {
     constructor(connection: TransactionalConnection, configService: ConfigService, productVariantService: ProductVariantService, customerService: CustomerService, countryService: CountryService, orderCalculator: OrderCalculator, shippingCalculator: ShippingCalculator, orderStateMachine: OrderStateMachine, orderMerger: OrderMerger, paymentService: PaymentService, paymentMethodService: PaymentMethodService, fulfillmentService: FulfillmentService, listQueryBuilder: ListQueryBuilder, refundStateMachine: RefundStateMachine, historyService: HistoryService, promotionService: PromotionService, eventBus: EventBus, channelService: ChannelService, orderModifier: OrderModifier, customFieldRelationService: CustomFieldRelationService, requestCache: RequestContextCacheService, translator: TranslatorService, stockLevelService: StockLevelService)
     getOrderProcessStates() => OrderProcessState[];
     findAll(ctx: RequestContext, options?: OrderListOptions, relations?: RelationPaths<Order>) => Promise<PaginatedList<Order>>;
@@ -75,9 +75,6 @@ class OrderService implements OnApplicationBootstrap {
     applyPriceAdjustments(ctx: RequestContext, order: Order, updatedOrderLines?: OrderLine[], relations?: RelationPaths<Order>, options?: { recalculateShipping?: boolean; recalculateShippingPromotions?: boolean }) => Promise<Order>;
 }
 ```
-* Implements: OnApplicationBootstrap
-
-
 
 <div className="members-wrapper">
 

--- a/docs/docs/reference/typescript-api/services/order-service.mdx
+++ b/docs/docs/reference/typescript-api/services/order-service.mdx
@@ -2,12 +2,12 @@
 title: "OrderService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/order.service.ts" sourceLine="143" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/order.service.ts" sourceLine="145" packageName="@vendure/core" />
 
 Contains methods relating to [Order](/reference/typescript-api/entities/order#order) entities.
 
 ```ts title="Signature"
-class OrderService {
+class OrderService implements OnApplicationBootstrap {
     constructor(connection: TransactionalConnection, configService: ConfigService, productVariantService: ProductVariantService, customerService: CustomerService, countryService: CountryService, orderCalculator: OrderCalculator, shippingCalculator: ShippingCalculator, orderStateMachine: OrderStateMachine, orderMerger: OrderMerger, paymentService: PaymentService, paymentMethodService: PaymentMethodService, fulfillmentService: FulfillmentService, listQueryBuilder: ListQueryBuilder, refundStateMachine: RefundStateMachine, historyService: HistoryService, promotionService: PromotionService, eventBus: EventBus, channelService: ChannelService, orderModifier: OrderModifier, customFieldRelationService: CustomFieldRelationService, requestCache: RequestContextCacheService, translator: TranslatorService, stockLevelService: StockLevelService)
     getOrderProcessStates() => OrderProcessState[];
     findAll(ctx: RequestContext, options?: OrderListOptions, relations?: RelationPaths<Order>) => Promise<PaginatedList<Order>>;
@@ -75,6 +75,9 @@ class OrderService {
     applyPriceAdjustments(ctx: RequestContext, order: Order, updatedOrderLines?: OrderLine[], relations?: RelationPaths<Order>, options?: { recalculateShipping?: boolean; recalculateShippingPromotions?: boolean }) => Promise<Order>;
 }
 ```
+* Implements: OnApplicationBootstrap
+
+
 
 <div className="members-wrapper">
 

--- a/docs/docs/reference/typescript-api/services/shipping-method-service.mdx
+++ b/docs/docs/reference/typescript-api/services/shipping-method-service.mdx
@@ -10,7 +10,7 @@ Contains methods relating to [ShippingMethod](/reference/typescript-api/entities
 class ShippingMethodService {
     constructor(connection: TransactionalConnection, configService: ConfigService, roleService: RoleService, listQueryBuilder: ListQueryBuilder, channelService: ChannelService, configArgService: ConfigArgService, translatableSaver: TranslatableSaver, customFieldRelationService: CustomFieldRelationService, eventBus: EventBus, translator: TranslatorService)
     findAll(ctx: RequestContext, options?: ListQueryOptions<ShippingMethod>, relations: RelationPaths<ShippingMethod> = []) => Promise<PaginatedList<Translated<ShippingMethod>>>;
-    findOne(ctx: RequestContext, shippingMethodId: ID, includeDeleted:  = false, relations: RelationPaths<ShippingMethod> = []) => Promise<Translated<ShippingMethod> | undefined>;
+    findOne(ctx: RequestContext, shippingMethodId: ID, includeDeleted:  = false, relations: RelationPaths<ShippingMethod> = [], filterOnChannel:  = true) => Promise<Translated<ShippingMethod> | undefined>;
     create(ctx: RequestContext, input: CreateShippingMethodInput) => Promise<Translated<ShippingMethod>>;
     update(ctx: RequestContext, input: UpdateShippingMethodInput) => Promise<Translated<ShippingMethod>>;
     softDelete(ctx: RequestContext, id: ID) => Promise<DeletionResponse>;
@@ -32,7 +32,7 @@ class ShippingMethodService {
 
 ### findOne
 
-<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, shippingMethodId: <a href='/reference/typescript-api/common/id#id'>ID</a>, includeDeleted:  = false, relations: RelationPaths<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> = []) => Promise<Translated<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> | undefined>`}   />
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, shippingMethodId: <a href='/reference/typescript-api/common/id#id'>ID</a>, includeDeleted:  = false, relations: RelationPaths<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> = [], filterOnChannel:  = true) => Promise<Translated<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> | undefined>`}   />
 
 
 ### create

--- a/docs/docs/reference/typescript-api/services/shipping-method-service.mdx
+++ b/docs/docs/reference/typescript-api/services/shipping-method-service.mdx
@@ -10,7 +10,7 @@ Contains methods relating to [ShippingMethod](/reference/typescript-api/entities
 class ShippingMethodService {
     constructor(connection: TransactionalConnection, configService: ConfigService, roleService: RoleService, listQueryBuilder: ListQueryBuilder, channelService: ChannelService, configArgService: ConfigArgService, translatableSaver: TranslatableSaver, customFieldRelationService: CustomFieldRelationService, eventBus: EventBus, translator: TranslatorService)
     findAll(ctx: RequestContext, options?: ListQueryOptions<ShippingMethod>, relations: RelationPaths<ShippingMethod> = []) => Promise<PaginatedList<Translated<ShippingMethod>>>;
-    findOne(ctx: RequestContext, shippingMethodId: ID, includeDeleted:  = false, relations: RelationPaths<ShippingMethod> = [], filterOnChannel:  = true) => Promise<Translated<ShippingMethod> | undefined>;
+    findOne(ctx: RequestContext, shippingMethodId: ID, includeDeleted: boolean = false, relations: RelationPaths<ShippingMethod> = [], filterOnChannel: boolean = true) => Promise<Translated<ShippingMethod> | undefined>;
     create(ctx: RequestContext, input: CreateShippingMethodInput) => Promise<Translated<ShippingMethod>>;
     update(ctx: RequestContext, input: UpdateShippingMethodInput) => Promise<Translated<ShippingMethod>>;
     softDelete(ctx: RequestContext, id: ID) => Promise<DeletionResponse>;
@@ -32,7 +32,7 @@ class ShippingMethodService {
 
 ### findOne
 
-<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, shippingMethodId: <a href='/reference/typescript-api/common/id#id'>ID</a>, includeDeleted:  = false, relations: RelationPaths<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> = [], filterOnChannel:  = true) => Promise<Translated<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> | undefined>`}   />
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, shippingMethodId: <a href='/reference/typescript-api/common/id#id'>ID</a>, includeDeleted: boolean = false, relations: RelationPaths<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> = [], filterOnChannel: boolean = true) => Promise<Translated<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> | undefined>`}   />
 
 
 ### create

--- a/docs/docs/reference/typescript-api/services/shipping-method-service.mdx
+++ b/docs/docs/reference/typescript-api/services/shipping-method-service.mdx
@@ -10,7 +10,7 @@ Contains methods relating to [ShippingMethod](/reference/typescript-api/entities
 class ShippingMethodService {
     constructor(connection: TransactionalConnection, configService: ConfigService, roleService: RoleService, listQueryBuilder: ListQueryBuilder, channelService: ChannelService, configArgService: ConfigArgService, translatableSaver: TranslatableSaver, customFieldRelationService: CustomFieldRelationService, eventBus: EventBus, translator: TranslatorService)
     findAll(ctx: RequestContext, options?: ListQueryOptions<ShippingMethod>, relations: RelationPaths<ShippingMethod> = []) => Promise<PaginatedList<Translated<ShippingMethod>>>;
-    findOne(ctx: RequestContext, shippingMethodId: ID, includeDeleted: boolean = false, relations: RelationPaths<ShippingMethod> = [], filterOnChannel: boolean = true) => Promise<Translated<ShippingMethod> | undefined>;
+    findOne(ctx: RequestContext, shippingMethodId: ID, includeDeleted:  = false, relations: RelationPaths<ShippingMethod> = []) => Promise<Translated<ShippingMethod> | undefined>;
     create(ctx: RequestContext, input: CreateShippingMethodInput) => Promise<Translated<ShippingMethod>>;
     update(ctx: RequestContext, input: UpdateShippingMethodInput) => Promise<Translated<ShippingMethod>>;
     softDelete(ctx: RequestContext, id: ID) => Promise<DeletionResponse>;
@@ -32,7 +32,7 @@ class ShippingMethodService {
 
 ### findOne
 
-<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, shippingMethodId: <a href='/reference/typescript-api/common/id#id'>ID</a>, includeDeleted: boolean = false, relations: RelationPaths<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> = [], filterOnChannel: boolean = true) => Promise<Translated<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> | undefined>`}   />
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, shippingMethodId: <a href='/reference/typescript-api/common/id#id'>ID</a>, includeDeleted:  = false, relations: RelationPaths<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> = []) => Promise<Translated<<a href='/reference/typescript-api/entities/shipping-method#shippingmethod'>ShippingMethod</a>> | undefined>`}   />
 
 
 ### create

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2672,7 +2672,7 @@
                   "title": "MultiChannelStockLocationStrategy",
                   "slug": "multi-channel-stock-location-strategy",
                   "file": "docs/reference/typescript-api/products-stock/multi-channel-stock-location-strategy.mdx",
-                  "lastModified": "2026-01-28T14:49:21+01:00"
+                  "lastModified": "2026-08-17T07:04:46Z"
                 },
                 {
                   "title": "ProductVariantPriceCalculationStrategy",
@@ -2766,7 +2766,7 @@
                   "title": "RequestContext",
                   "slug": "request-context",
                   "file": "docs/reference/typescript-api/request/request-context.mdx",
-                  "lastModified": "2026-01-28T14:49:21+01:00"
+                  "lastModified": "2026-08-17T07:04:46Z"
                 },
                 {
                   "title": "RequestContextService",
@@ -2988,7 +2988,7 @@
                   "title": "OrderService",
                   "slug": "order-service",
                   "file": "docs/reference/typescript-api/services/order-service.mdx",
-                  "lastModified": "2026-08-12T11:39:10+02:00"
+                  "lastModified": "2026-08-17T07:04:46Z"
                 },
                 {
                   "title": "OrderTestingService",
@@ -3078,7 +3078,7 @@
                   "title": "ShippingMethodService",
                   "slug": "shipping-method-service",
                   "file": "docs/reference/typescript-api/services/shipping-method-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-17T07:04:46Z"
                 },
                 {
                   "title": "SlugService",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3078,7 +3078,7 @@
                   "title": "ShippingMethodService",
                   "slug": "shipping-method-service",
                   "file": "docs/reference/typescript-api/services/shipping-method-service.mdx",
-                  "lastModified": "2026-08-17T07:04:46Z"
+                  "lastModified": "2026-08-17T09:21:20+02:00"
                 },
                 {
                   "title": "SlugService",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2672,7 +2672,7 @@
                   "title": "MultiChannelStockLocationStrategy",
                   "slug": "multi-channel-stock-location-strategy",
                   "file": "docs/reference/typescript-api/products-stock/multi-channel-stock-location-strategy.mdx",
-                  "lastModified": "2026-01-28T14:49:21+01:00"
+                  "lastModified": "2026-08-17T09:42:19Z"
                 },
                 {
                   "title": "ProductVariantPriceCalculationStrategy",
@@ -2766,7 +2766,7 @@
                   "title": "RequestContext",
                   "slug": "request-context",
                   "file": "docs/reference/typescript-api/request/request-context.mdx",
-                  "lastModified": "2026-01-28T14:49:21+01:00"
+                  "lastModified": "2026-08-17T09:42:19Z"
                 },
                 {
                   "title": "RequestContextService",
@@ -2988,7 +2988,7 @@
                   "title": "OrderService",
                   "slug": "order-service",
                   "file": "docs/reference/typescript-api/services/order-service.mdx",
-                  "lastModified": "2026-08-12T11:39:10+02:00"
+                  "lastModified": "2026-08-17T09:42:19Z"
                 },
                 {
                   "title": "OrderTestingService",
@@ -3078,7 +3078,7 @@
                   "title": "ShippingMethodService",
                   "slug": "shipping-method-service",
                   "file": "docs/reference/typescript-api/services/shipping-method-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-17T09:42:19Z"
                 },
                 {
                   "title": "SlugService",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2672,7 +2672,7 @@
                   "title": "MultiChannelStockLocationStrategy",
                   "slug": "multi-channel-stock-location-strategy",
                   "file": "docs/reference/typescript-api/products-stock/multi-channel-stock-location-strategy.mdx",
-                  "lastModified": "2026-08-17T07:04:46Z"
+                  "lastModified": "2026-01-28T14:49:21+01:00"
                 },
                 {
                   "title": "ProductVariantPriceCalculationStrategy",
@@ -2766,7 +2766,7 @@
                   "title": "RequestContext",
                   "slug": "request-context",
                   "file": "docs/reference/typescript-api/request/request-context.mdx",
-                  "lastModified": "2026-08-17T07:04:46Z"
+                  "lastModified": "2026-01-28T14:49:21+01:00"
                 },
                 {
                   "title": "RequestContextService",
@@ -2988,7 +2988,7 @@
                   "title": "OrderService",
                   "slug": "order-service",
                   "file": "docs/reference/typescript-api/services/order-service.mdx",
-                  "lastModified": "2026-08-17T07:04:46Z"
+                  "lastModified": "2026-08-12T11:39:10+02:00"
                 },
                 {
                   "title": "OrderTestingService",
@@ -3078,7 +3078,7 @@
                   "title": "ShippingMethodService",
                   "slug": "shipping-method-service",
                   "file": "docs/reference/typescript-api/services/shipping-method-service.mdx",
-                  "lastModified": "2026-08-17T09:21:20+02:00"
+                  "lastModified": "2026-04-20T16:08:16+02:00"
                 },
                 {
                   "title": "SlugService",

--- a/packages/core/src/service/services/shipping-method.service.ts
+++ b/packages/core/src/service/services/shipping-method.service.ts
@@ -91,9 +91,9 @@ export class ShippingMethodService {
     async findOne(
         ctx: RequestContext,
         shippingMethodId: ID,
-        includeDeleted: boolean = false,
+        includeDeleted = false,
         relations: RelationPaths<ShippingMethod> = [],
-        filterOnChannel: boolean = true,
+        filterOnChannel = true,
     ): Promise<Translated<ShippingMethod> | undefined> {
         let shippingMethod: ShippingMethod | undefined | null;
 

--- a/packages/core/src/service/services/shipping-method.service.ts
+++ b/packages/core/src/service/services/shipping-method.service.ts
@@ -91,9 +91,9 @@ export class ShippingMethodService {
     async findOne(
         ctx: RequestContext,
         shippingMethodId: ID,
-        includeDeleted = false,
+        includeDeleted: boolean = false,
         relations: RelationPaths<ShippingMethod> = [],
-        filterOnChannel = true,
+        filterOnChannel: boolean = true,
     ): Promise<Translated<ShippingMethod> | undefined> {
         let shippingMethod: ShippingMethod | undefined | null;
 

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -4,7 +4,7 @@ A CLI tool for rapidly scaffolding a new Vendure server application. Heavily ins
 
 ## Usage
 
-Vendure Create requires [Node.js](https://nodejs.org/en/) v18+ to be installed.
+Vendure Create requires [Node.js](https://nodejs.org/en/) `^20.19.0 || >=22.12.0` to be installed.
 
 ```sh
 npx @vendure/create my-app
@@ -14,13 +14,13 @@ npx @vendure/create my-app
 
 ### `--storefront`
 
-In CI mode, include one of the available storefront starters. Currently supported values are `tanstack` and `nextjs`.
+Selects the storefront to scaffold in CI mode. Supported values are `tanstack` and `nextjs`.
 
 ```sh
 npx @vendure/create my-app --ci --storefront tanstack
 ```
 
-The legacy `--with-storefront` flag continues to select the Next.js starter.
+`--with-storefront` also selects the Next.js starter. Use `--storefront nextjs` instead.
 
 ### `--log-level`
 

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -12,13 +12,22 @@ npx @vendure/create my-app
 
 ## Options
 
+### `--storefront`
+
+In CI mode, include one of the available storefront starters. Currently supported values are `tanstack` and `nextjs`.
+
+```sh
+npx @vendure/create my-app --ci --storefront tanstack
+```
+
+The legacy `--with-storefront` flag continues to select the Next.js starter.
+
 ### `--log-level`
 
 You can control how much output is generated during the installation and setup with this flag. Valid options are `silent`, `info` and `verbose`. The default is `info`
 
 Example:
 
-```sh 
+```sh
 npx @vendure/create my-app --log-level verbose
 ```
-

--- a/packages/create/src/constants.ts
+++ b/packages/create/src/constants.ts
@@ -7,8 +7,6 @@ export const REQUIRED_NODE_VERSION = '>=20.0.0';
 export const OLDEST_NON_EOL_NODE_MAJOR = 22;
 export const SERVER_PORT = 3000;
 export const STOREFRONT_PORT = 3001;
-export const STOREFRONT_REPO = 'vendure-ecommerce/nextjs-starter-vendure';
-export const STOREFRONT_BRANCH = 'main';
 /**
  * The TypeScript version needs to pinned because minor versions often
  * introduce breaking changes.

--- a/packages/create/src/constants.ts
+++ b/packages/create/src/constants.ts
@@ -1,4 +1,4 @@
-export const REQUIRED_NODE_VERSION = '>=20.0.0';
+export const REQUIRED_NODE_VERSION = '^20.19.0 || >=22.12.0';
 /**
  * Oldest Node.js major release that has not reached end-of-life. Used to warn (not block)
  * users on EOL versions, for which native deps often stop publishing prebuilt binaries.

--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -54,6 +54,15 @@ import {
     startPostgresDatabase,
 } from './helpers';
 import { log, setLogLevel } from './logger';
+import {
+    configureStorefrontPackageJson,
+    getStorefrontStarter,
+    parseStorefrontId,
+    renderStorefrontEnvironment,
+    STOREFRONT_STARTERS,
+    StorefrontId,
+    StorefrontStarter,
+} from './storefront-starters';
 import { CliLogLevel, PackageManager } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -84,7 +93,12 @@ program
     .option('--verbose', 'Alias for --log-level verbose', false)
     .option('--use-npm', 'Force npm, overriding auto-detection of the package manager that invoked the CLI')
     .option('--ci', 'Runs without prompts for use in CI scenarios', false)
-    .option('--with-storefront', 'Include Next.js storefront (only used with --ci)', false)
+    .option(
+        '--storefront <starter>',
+        `Storefront to include with --ci: ${STOREFRONT_STARTERS.map(starter => starter.id).join(', ')}`,
+        parseStorefrontId,
+    )
+    .option('--with-storefront', 'Include Next.js storefront with --ci (deprecated)', false)
     .option(
         '--db <database>',
         "Database to use with --ci: 'sqlite' or 'postgres' (postgres is started via Docker)",
@@ -94,12 +108,13 @@ program
     .parse(process.argv);
 
 const options = program.opts();
+const selectedCiStorefront = options.storefront ?? (options.withStorefront ? 'nextjs' : undefined);
 void createVendureApp(
     projectName,
     options.useNpm,
     options.verbose ? 'verbose' : options.logLevel || 'info',
     options.ci,
-    options.withStorefront,
+    selectedCiStorefront,
     // The --db regex validates case-insensitively, but the comparisons downstream
     // are against the lowercase literals.
     options.db?.toLowerCase(),
@@ -113,7 +128,7 @@ export async function createVendureApp(
     _useNpm: boolean, // Legacy flag: forces npm, overriding package-manager auto-detection
     logLevel: CliLogLevel,
     isCi: boolean = false,
-    withStorefront: boolean = false,
+    ciStorefront?: StorefrontId,
     ciDbType: 'sqlite' | 'postgres' = 'sqlite',
 ) {
     setLogLevel(logLevel);
@@ -191,13 +206,15 @@ export async function createVendureApp(
         viteConfigSource,
         agentsSource,
         populateProducts,
-        includeStorefront,
-    } =
-        mode === 'ci'
-            ? await getCiConfiguration(root, packageManager, port, withStorefront, ciDbType)
-            : mode === 'manual'
-              ? await getManualConfiguration(root, packageManager, port)
-              : await getQuickStartConfiguration(root, packageManager, port);
+        storefront: storefrontId,
+    } = mode === 'ci'
+        ? await getCiConfiguration(root, packageManager, port, ciStorefront, ciDbType)
+        : mode === 'manual'
+          ? await getManualConfiguration(root, packageManager, port)
+          : await getQuickStartConfiguration(root, packageManager, port);
+    const storefront = storefrontId ? getStorefrontStarter(storefrontId) : undefined;
+    const includeStorefront = storefront != null;
+
     // Determine the server root directory (either root or apps/server for monorepo)
     const serverRoot = includeStorefront ? path.join(root, 'apps', 'server') : root;
     const storefrontRoot = path.join(root, 'apps', 'storefront');
@@ -264,6 +281,8 @@ export async function createVendureApp(
         const rootReadmeContent = Handlebars.compile(rootReadmeTemplate)({
             name: appName,
             packageManager,
+            storefrontName: storefront?.frameworkName,
+            storefrontDocumentationUrl: storefront?.documentationUrl,
             serverPort: port,
             storefrontPort,
             superadminIdentifier: SUPER_ADMIN_USER_IDENTIFIER,
@@ -307,29 +326,29 @@ export async function createVendureApp(
     // Download storefront if needed
     if (includeStorefront) {
         const storefrontSpinner = spinner();
-        storefrontSpinner.start(`Downloading Next.js storefront...`);
+        storefrontSpinner.start(`Downloading ${storefront.name} storefront...`);
         try {
-            await downloadAndExtractStorefront(storefrontRoot);
-            // Update storefront package.json name and dev script port
-            const storefrontPackageJsonPath = path.join(storefrontRoot, 'package.json');
-            const storefrontPackageJson = await fs.readJson(storefrontPackageJsonPath);
-            storefrontPackageJson.name = 'storefront';
-            if (storefrontPackageJson.scripts?.dev) {
-                storefrontPackageJson.scripts.dev = `next dev --port ${storefrontPort}`;
-            }
-            await fs.writeJson(storefrontPackageJsonPath, storefrontPackageJson, { spaces: 2 });
+            await downloadAndExtractStorefront(storefrontRoot, storefront);
 
-            // Generate storefront .env.local from template
-            const storefrontEnvTemplate = await fs.readFile(templatePath('storefront-env.hbs'), 'utf-8');
-            const storefrontEnvContent = Handlebars.compile(storefrontEnvTemplate)({
+            const storefrontSetupContext = {
+                projectName: appName,
                 serverPort: port,
                 storefrontPort,
-                name: appName,
                 revalidationSecret: randomBytes(32).toString('base64'),
-            });
-            fs.writeFileSync(path.join(storefrontRoot, '.env.local'), storefrontEnvContent);
+            };
+            const storefrontPackageJsonPath = path.join(storefrontRoot, 'package.json');
+            const storefrontPackageJson = await fs.readJson(storefrontPackageJsonPath);
+            await fs.writeJson(
+                storefrontPackageJsonPath,
+                configureStorefrontPackageJson(storefrontPackageJson, storefront, storefrontSetupContext),
+                { spaces: 2 },
+            );
+            fs.writeFileSync(
+                path.join(storefrontRoot, storefront.envFile),
+                renderStorefrontEnvironment(storefront, storefrontSetupContext),
+            );
 
-            storefrontSpinner.stop(`Downloaded Next.js storefront`);
+            storefrontSpinner.stop(`Downloaded ${storefront.name} storefront`);
         } catch (e: any) {
             storefrontSpinner.stop(pc.red(`Failed to download storefront`));
             log(e.message, { level: 'verbose' });
@@ -596,7 +615,7 @@ export async function createVendureApp(
                         name,
                         packageManager,
                         superAdminCredentials,
-                        includeStorefront,
+                        storefront,
                         serverPort: port,
                         storefrontPort,
                     });
@@ -627,7 +646,7 @@ export async function createVendureApp(
                 name,
                 packageManager,
                 superAdminCredentials,
-                includeStorefront,
+                storefront,
                 serverPort: port,
                 storefrontPort,
             });
@@ -696,7 +715,7 @@ interface OutroOptions {
     name: string;
     packageManager: PackageManager;
     superAdminCredentials?: { identifier: string; password: string };
-    includeStorefront?: boolean;
+    storefront?: StorefrontStarter;
     serverPort?: number;
     storefrontPort?: number;
 }
@@ -708,7 +727,7 @@ function displayOutro(outroOptions: OutroOptions) {
         name,
         packageManager,
         superAdminCredentials,
-        includeStorefront,
+        storefront,
         serverPort = SERVER_PORT,
         storefrontPort = STOREFRONT_PORT,
     } = outroOptions;
@@ -731,14 +750,14 @@ function displayOutro(outroOptions: OutroOptions) {
 
     let nextSteps: string[];
 
-    if (includeStorefront) {
+    if (storefront) {
         nextSteps = [
             `Your new Vendure project was created!`,
             pc.gray(root),
             `\n`,
             `This is a monorepo with the following apps:`,
             `  ${pc.cyan('apps/server')}     - Vendure backend`,
-            `  ${pc.cyan('apps/storefront')} - Next.js frontend`,
+            `  ${pc.cyan('apps/storefront')} - ${storefront.frameworkName} frontend`,
             `\n`,
             `Next, run:`,
             pc.gray('$ ') + pc.blue(pc.bold(`cd ${name}`)),

--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -59,6 +59,7 @@ import {
     getStorefrontStarter,
     parseStorefrontId,
     renderStorefrontEnvironment,
+    resolveCiStorefront,
     STOREFRONT_STARTERS,
     StorefrontId,
     StorefrontStarter,
@@ -98,7 +99,11 @@ program
         `Storefront to include with --ci: ${STOREFRONT_STARTERS.map(starter => starter.id).join(', ')}`,
         parseStorefrontId,
     )
-    .option('--with-storefront', 'Include Next.js storefront with --ci (deprecated)', false)
+    .option(
+        '--with-storefront',
+        'Include the Next.js storefront with --ci. Deprecated: use --storefront nextjs',
+        false,
+    )
     .option(
         '--db <database>',
         "Database to use with --ci: 'sqlite' or 'postgres' (postgres is started via Docker)",
@@ -108,7 +113,7 @@ program
     .parse(process.argv);
 
 const options = program.opts();
-const selectedCiStorefront = options.storefront ?? (options.withStorefront ? 'nextjs' : undefined);
+const selectedCiStorefront = resolveCiStorefront(options);
 void createVendureApp(
     projectName,
     options.useNpm,

--- a/packages/create/src/gather-user-responses.ts
+++ b/packages/create/src/gather-user-responses.ts
@@ -6,6 +6,7 @@ import Handlebars from 'handlebars';
 import path from 'path';
 
 import { checkCancel, isDockerAvailable, toComposeProjectName } from './helpers';
+import { getStorefrontStarter, STOREFRONT_STARTERS, StorefrontId } from './storefront-starters';
 import { DbType, FileSources, PackageManager, UserResponses } from './types';
 
 interface PromptAnswers {
@@ -20,7 +21,24 @@ interface PromptAnswers {
     superadminIdentifier: string | symbol;
     superadminPassword: string | symbol;
     populateProducts: boolean | symbol;
-    includeStorefront: boolean | symbol;
+    storefront?: StorefrontId;
+}
+
+async function selectStorefront(): Promise<StorefrontId | undefined> {
+    const selected = await select({
+        message: 'Would you like to include a storefront?',
+        options: [
+            { label: 'None', value: 'none' },
+            ...STOREFRONT_STARTERS.map(storefront => ({
+                label: storefront.name,
+                value: storefront.id,
+                hint: storefront.description,
+            })),
+        ],
+        initialValue: 'none' as const,
+    });
+    checkCancel(selected);
+    return selected === 'none' ? undefined : (selected as StorefrontId);
 }
 
 /* eslint-disable no-console */
@@ -64,19 +82,7 @@ export async function getQuickStartConfiguration(
         }
     }
 
-    const includeStorefront = await select({
-        message: 'Would you like to include the Next.js storefront?',
-        options: [
-            { label: 'No', value: false },
-            {
-                label: 'Yes',
-                value: true,
-                hint: 'Adds a ready-to-use Next.js storefront connected to your Vendure server',
-            },
-        ],
-        initialValue: false,
-    });
-    checkCancel(includeStorefront);
+    const storefront = await selectStorefront();
 
     const quickStartAnswers: PromptAnswers = {
         dbType: usePostgres ? 'postgres' : 'sqlite',
@@ -89,7 +95,7 @@ export async function getQuickStartConfiguration(
         populateProducts: true,
         superadminIdentifier: SUPER_ADMIN_USER_IDENTIFIER,
         superadminPassword: SUPER_ADMIN_USER_PASSWORD,
-        includeStorefront,
+        storefront,
     };
 
     const responses = {
@@ -98,7 +104,7 @@ export async function getQuickStartConfiguration(
         populateProducts: quickStartAnswers.populateProducts as boolean,
         superadminIdentifier: quickStartAnswers.superadminIdentifier as string,
         superadminPassword: quickStartAnswers.superadminPassword as string,
-        includeStorefront: includeStorefront as boolean,
+        storefront,
     };
 
     return responses;
@@ -200,19 +206,7 @@ export async function getManualConfiguration(
     });
     checkCancel(populateProducts);
 
-    const includeStorefront = await select({
-        message: 'Would you like to include the Next.js storefront?',
-        options: [
-            { label: 'No', value: false },
-            {
-                label: 'Yes',
-                value: true,
-                hint: 'Adds a ready-to-use Next.js storefront connected to your Vendure server',
-            },
-        ],
-        initialValue: false,
-    });
-    checkCancel(includeStorefront);
+    const storefront = await selectStorefront();
 
     const answers: PromptAnswers = {
         dbType,
@@ -226,7 +220,7 @@ export async function getManualConfiguration(
         superadminIdentifier,
         superadminPassword,
         populateProducts,
-        includeStorefront,
+        storefront,
     };
 
     return {
@@ -235,7 +229,7 @@ export async function getManualConfiguration(
         populateProducts: answers.populateProducts as boolean,
         superadminIdentifier: answers.superadminIdentifier as string,
         superadminPassword: answers.superadminPassword as string,
-        includeStorefront: includeStorefront as boolean,
+        storefront,
     };
 }
 
@@ -246,7 +240,7 @@ export async function getCiConfiguration(
     root: string,
     packageManager: PackageManager,
     port: number,
-    includeStorefront: boolean = false,
+    storefront?: StorefrontId,
     dbType: 'sqlite' | 'postgres' = 'sqlite',
 ): Promise<UserResponses> {
     // The postgres answers mirror the Quick Start flow, which starts the database
@@ -263,7 +257,7 @@ export async function getCiConfiguration(
         populateProducts: true,
         superadminIdentifier: SUPER_ADMIN_USER_IDENTIFIER,
         superadminPassword: SUPER_ADMIN_USER_PASSWORD,
-        includeStorefront,
+        storefront,
     };
 
     return {
@@ -272,7 +266,7 @@ export async function getCiConfiguration(
         populateProducts: ciAnswers.populateProducts,
         superadminIdentifier: ciAnswers.superadminIdentifier,
         superadminPassword: ciAnswers.superadminPassword,
-        includeStorefront,
+        storefront,
     };
 }
 
@@ -298,7 +292,10 @@ async function generateSources(
         requiresConnection: answers.dbType !== 'sqlite',
         cookieSecret: randomBytes(16).toString('base64url'),
         port,
-        isMonorepo: answers.includeStorefront,
+        isMonorepo: answers.storefront != null,
+        storefrontName: answers.storefront
+            ? getStorefrontStarter(answers.storefront).frameworkName
+            : undefined,
         packageManager,
         isBun: packageManager === 'bun',
         needsCorepack: packageManager === 'pnpm' || packageManager === 'yarn',

--- a/packages/create/src/helpers.spec.ts
+++ b/packages/create/src/helpers.spec.ts
@@ -618,6 +618,8 @@ describe('checkNodeVersion', () => {
     it('enforces the Node.js versions supported by the storefront toolchain', () => {
         expect(semver.satisfies('20.18.0', REQUIRED_NODE_VERSION)).toBe(false);
         expect(semver.satisfies('20.19.0', REQUIRED_NODE_VERSION)).toBe(true);
+        expect(semver.satisfies('21.0.0', REQUIRED_NODE_VERSION)).toBe(false);
+        expect(semver.satisfies('22.11.0', REQUIRED_NODE_VERSION)).toBe(false);
         expect(semver.satisfies('22.12.0', REQUIRED_NODE_VERSION)).toBe(true);
     });
 });

--- a/packages/create/src/helpers.spec.ts
+++ b/packages/create/src/helpers.spec.ts
@@ -4,8 +4,10 @@ import Handlebars from 'handlebars';
 import { EventEmitter } from 'node:events';
 import { Socket, createServer, type Server } from 'node:net';
 import path from 'node:path';
+import semver from 'semver';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { REQUIRED_NODE_VERSION } from './constants';
 import { registerEscapeSingleHelper } from './gather-user-responses';
 import {
     checkNodeVersion,
@@ -611,6 +613,12 @@ describe('checkNodeVersion', () => {
     it('does not warn on a maintained Node version', () => {
         checkNodeVersion('>=20.0.0', 'v22.15.0');
         expect(log).not.toHaveBeenCalled();
+    });
+
+    it('enforces the Node.js versions supported by the storefront toolchain', () => {
+        expect(semver.satisfies('20.18.0', REQUIRED_NODE_VERSION)).toBe(false);
+        expect(semver.satisfies('20.19.0', REQUIRED_NODE_VERSION)).toBe(true);
+        expect(semver.satisfies('22.12.0', REQUIRED_NODE_VERSION)).toBe(true);
     });
 });
 

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -22,12 +22,11 @@ import {
     PG_READY_MAX_ATTEMPTS,
     PG_READY_POLL_INTERVAL_MS,
     SOCKET_TIMEOUT_MS,
-    STOREFRONT_BRANCH,
-    STOREFRONT_REPO,
     TYPESCRIPT_VERSION,
     VITE_VERSION,
 } from './constants';
 import { log } from './logger';
+import { StorefrontStarter } from './storefront-starters';
 import { CliLogLevel, DbType, PackageManager } from './types';
 
 /**
@@ -1015,11 +1014,14 @@ export function resolvePackageRootDir(packageName: string, rootDir: string) {
 }
 
 /**
- * Downloads the Next.js storefront starter from GitHub and extracts it to the target directory.
+ * Downloads a storefront starter from GitHub and extracts it to the target directory.
  * Uses the GitHub API tarball endpoint to avoid requiring git.
  */
-export async function downloadAndExtractStorefront(targetDir: string): Promise<void> {
-    const tarballUrl = `https://api.github.com/repos/${STOREFRONT_REPO}/tarball/${STOREFRONT_BRANCH}`;
+export async function downloadAndExtractStorefront(
+    targetDir: string,
+    storefront: StorefrontStarter,
+): Promise<void> {
+    const tarballUrl = `https://api.github.com/repos/${storefront.repository}/tarball/${storefront.ref}`;
     const tempTarPath = path.join(targetDir, '..', 'storefront-temp.tar.gz');
 
     try {

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -112,8 +112,8 @@ export function checkNodeVersion(requiredVersion: string, currentVersion: string
         log(
             pc.red(
                 `You are running Node ${currentVersion}.` +
-                    `Vendure requires Node ${requiredVersion} or higher.` +
-                    'Please update your version of Node.',
+                    `Vendure requires Node ${requiredVersion}.` +
+                    ' Please update your version of Node.',
             ),
         );
         process.exit(1);

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -1015,7 +1015,8 @@ export function resolvePackageRootDir(packageName: string, rootDir: string) {
 
 /**
  * Downloads a storefront starter from GitHub and extracts it to the target directory.
- * Uses the GitHub API tarball endpoint to avoid requiring git.
+ * Uses the starter's main branch intentionally, so improvements and fixes are available to newly
+ * scaffolded projects without requiring a matching @vendure/create release.
  */
 export async function downloadAndExtractStorefront(
     targetDir: string,

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -111,7 +111,7 @@ export function checkNodeVersion(requiredVersion: string, currentVersion: string
     if (!semver.satisfies(currentVersion, requiredVersion)) {
         log(
             pc.red(
-                `You are running Node ${currentVersion}.` +
+                `You are running Node ${currentVersion}. ` +
                     `Vendure requires Node ${requiredVersion}.` +
                     ' Please update your version of Node.',
             ),

--- a/packages/create/src/storefront-starters.spec.ts
+++ b/packages/create/src/storefront-starters.spec.ts
@@ -5,6 +5,7 @@ import {
     getStorefrontStarter,
     parseStorefrontId,
     renderStorefrontEnvironment,
+    resolveCiStorefront,
     STOREFRONT_STARTERS,
 } from './storefront-starters';
 
@@ -28,6 +29,13 @@ describe('storefront starters', () => {
     it('rejects unknown storefront ids from the CLI', () => {
         expect(parseStorefrontId('TANSTACK')).toBe('tanstack');
         expect(() => parseStorefrontId('tansack')).toThrow('Allowed choices are: tanstack, nextjs.');
+    });
+
+    it('resolves the legacy CI storefront flag while preferring an explicit starter', () => {
+        expect(resolveCiStorefront({})).toBeUndefined();
+        expect(resolveCiStorefront({ withStorefront: true })).toBe('nextjs');
+        expect(resolveCiStorefront({ storefront: 'tanstack' })).toBe('tanstack');
+        expect(resolveCiStorefront({ storefront: 'tanstack', withStorefront: true })).toBe('tanstack');
     });
 
     it('configures the TanStack Start scripts for the generated workspace', () => {
@@ -93,4 +101,26 @@ describe('storefront starters', () => {
             expect(environment).toContain(`${siteNameKey}='shop#"demo"'`);
         },
     );
+
+    it('uses backticks when an environment value contains both other quote characters', () => {
+        const environment = renderStorefrontEnvironment(getStorefrontStarter('tanstack'), {
+            ...setupContext,
+            projectName: `shop'"demo`,
+        });
+
+        expect(environment).toContain('SITE_NAME=`shop\'"demo`');
+    });
+
+    it('identifies an environment key whose value cannot be quoted', () => {
+        expect(() =>
+            renderStorefrontEnvironment(getStorefrontStarter('nextjs'), {
+                ...setupContext,
+                projectName: `shop'"\`demo`,
+            }),
+        ).toThrow(
+            'Cannot write NEXT_PUBLIC_SITE_NAME to the storefront env file: the value contains a single quote, ' +
+                'a double quote and a backtick, leaving no character to quote it with. ' +
+                'Choose a project name without one of those characters.',
+        );
+    });
 });

--- a/packages/create/src/storefront-starters.spec.ts
+++ b/packages/create/src/storefront-starters.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    configureStorefrontPackageJson,
+    getStorefrontStarter,
+    parseStorefrontId,
+    renderStorefrontEnvironment,
+    STOREFRONT_STARTERS,
+} from './storefront-starters';
+
+const setupContext = {
+    projectName: 'my-shop',
+    serverPort: 3000,
+    storefrontPort: 3001,
+    revalidationSecret: 'secret',
+};
+
+describe('storefront starters', () => {
+    it('uses unique ids and resolves every registered starter', () => {
+        const ids = STOREFRONT_STARTERS.map(storefront => storefront.id);
+
+        expect(new Set(ids).size).toBe(ids.length);
+        for (const id of ids) {
+            expect(getStorefrontStarter(id)).toMatchObject({ id });
+        }
+    });
+
+    it('rejects unknown storefront ids from the CLI', () => {
+        expect(parseStorefrontId('TANSTACK')).toBe('tanstack');
+        expect(() => parseStorefrontId('tansack')).toThrow('Allowed choices are: tanstack, nextjs.');
+    });
+
+    it('configures the TanStack Start scripts for the generated workspace', () => {
+        const storefront = getStorefrontStarter('tanstack');
+        const packageJson = configureStorefrontPackageJson(
+            { name: 'tanstack-starter-vendure', scripts: { build: 'vite build' } },
+            storefront,
+            setupContext,
+        );
+
+        expect(packageJson.name).toBe('storefront');
+        expect(packageJson.scripts).toEqual({
+            build: 'vite build',
+            dev: 'vite dev --port 3001',
+            start: 'node .output/server/index.mjs',
+        });
+    });
+
+    it('renders the environment contract expected by TanStack Start', () => {
+        const storefront = getStorefrontStarter('tanstack');
+
+        expect(storefront.envFile).toBe('.env');
+        expect(renderStorefrontEnvironment(storefront, setupContext)).toBe(
+            [
+                'VENDURE_SHOP_API_URL=http://localhost:3000/shop-api',
+                'VENDURE_CHANNEL_TOKEN=__default_channel__',
+                'SITE_URL=http://localhost:3001',
+                'SITE_NAME=my-shop',
+                'REVALIDATION_SECRET=secret',
+                '',
+            ].join('\n'),
+        );
+    });
+
+    it('keeps the Next.js environment and scripts starter-specific', () => {
+        const storefront = getStorefrontStarter('nextjs');
+        const packageJson = configureStorefrontPackageJson(
+            { scripts: { start: 'next start' } },
+            storefront,
+            setupContext,
+        );
+        const environment = renderStorefrontEnvironment(storefront, setupContext);
+
+        expect(storefront.envFile).toBe('.env.local');
+        expect(packageJson.scripts).toMatchObject({
+            dev: 'next dev --port 3001',
+            start: 'next start',
+        });
+        expect(environment).toContain('NEXT_PUBLIC_SITE_URL=http://localhost:3001');
+        expect(environment).not.toContain('\nSITE_URL=');
+    });
+});

--- a/packages/create/src/storefront-starters.spec.ts
+++ b/packages/create/src/storefront-starters.spec.ts
@@ -52,11 +52,11 @@ describe('storefront starters', () => {
         expect(storefront.envFile).toBe('.env');
         expect(renderStorefrontEnvironment(storefront, setupContext)).toBe(
             [
-                'VENDURE_SHOP_API_URL=http://localhost:3000/shop-api',
-                'VENDURE_CHANNEL_TOKEN=__default_channel__',
-                'SITE_URL=http://localhost:3001',
-                'SITE_NAME=my-shop',
-                'REVALIDATION_SECRET=secret',
+                "VENDURE_SHOP_API_URL='http://localhost:3000/shop-api'",
+                "VENDURE_CHANNEL_TOKEN='__default_channel__'",
+                "SITE_URL='http://localhost:3001'",
+                "SITE_NAME='my-shop'",
+                "REVALIDATION_SECRET='secret'",
                 '',
             ].join('\n'),
         );
@@ -76,7 +76,21 @@ describe('storefront starters', () => {
             dev: 'next dev --port 3001',
             start: 'next start',
         });
-        expect(environment).toContain('NEXT_PUBLIC_SITE_URL=http://localhost:3001');
+        expect(environment).toContain("NEXT_PUBLIC_SITE_URL='http://localhost:3001'");
         expect(environment).not.toContain('\nSITE_URL=');
     });
+
+    it.each(['tanstack', 'nextjs'] as const)(
+        'preserves comment and quote characters in the %s environment file',
+        storefrontId => {
+            const storefront = getStorefrontStarter(storefrontId);
+            const environment = renderStorefrontEnvironment(storefront, {
+                ...setupContext,
+                projectName: 'shop#"demo"',
+            });
+            const siteNameKey = storefrontId === 'nextjs' ? 'NEXT_PUBLIC_SITE_NAME' : 'SITE_NAME';
+
+            expect(environment).toContain(`${siteNameKey}='shop#"demo"'`);
+        },
+    );
 });

--- a/packages/create/src/storefront-starters.ts
+++ b/packages/create/src/storefront-starters.ts
@@ -28,7 +28,7 @@ export const STOREFRONT_STARTERS = [
     {
         id: 'tanstack',
         name: 'TanStack Start',
-        description: 'A TanStack Start storefront with routing, internationalization, and checkout',
+        description: 'Vite-powered routing with TanStack Router and Paraglide internationalization',
         frameworkName: 'TanStack Start',
         documentationUrl: 'https://tanstack.com/start/latest/docs/framework/react/overview',
         repository: 'vendurehq/tanstack-starter-vendure',
@@ -49,11 +49,11 @@ export const STOREFRONT_STARTERS = [
     {
         id: 'nextjs',
         name: 'Next.js',
-        description: 'A Next.js storefront with routing, internationalization, and checkout',
+        description: 'App Router storefront with next-intl internationalization',
         frameworkName: 'Next.js',
         documentationUrl: 'https://nextjs.org/docs',
         repository: 'vendurehq/nextjs-starter-vendure',
-        ref: 'main',
+        ref: 'af950dcab732c3246d36f01c5cf2427cc9409b21',
         envFile: '.env.local',
         packageScripts: ({ storefrontPort }) => ({
             dev: `next dev --port ${storefrontPort}`,
@@ -69,6 +69,13 @@ export const STOREFRONT_STARTERS = [
 ] as const satisfies readonly StorefrontStarter[];
 
 export type StorefrontId = (typeof STOREFRONT_STARTERS)[number]['id'];
+
+export function resolveCiStorefront(options: {
+    storefront?: StorefrontId;
+    withStorefront?: boolean;
+}): StorefrontId | undefined {
+    return options.storefront ?? (options.withStorefront ? 'nextjs' : undefined);
+}
 
 export function parseStorefrontId(value: string): StorefrontId {
     const normalizedValue = value.toLowerCase();
@@ -94,6 +101,8 @@ export function configureStorefrontPackageJson(
     storefront: StorefrontStarter,
     context: StorefrontSetupContext,
 ): StorefrontPackageJson {
+    // These entries intentionally override the downloaded package.json. Starter repositories must
+    // keep required flags out of their dev/start scripts, or mirror those flags here.
     return {
         ...packageJson,
         name: 'storefront',
@@ -110,15 +119,19 @@ export function renderStorefrontEnvironment(
 ): string {
     return (
         Object.entries(storefront.environment(context))
-            .map(([key, value]) => `${key}=${quoteEnvironmentValue(value)}`)
+            .map(([key, value]) => `${key}=${quoteEnvironmentValue(key, value)}`)
             .join('\n') + '\n'
     );
 }
 
-function quoteEnvironmentValue(value: string): string {
+function quoteEnvironmentValue(key: string, value: string): string {
     const delimiter = [`'`, `"`, '`'].find(candidate => !value.includes(candidate));
     if (!delimiter) {
-        throw new Error('Environment values cannot contain single, double, and backtick quotes together.');
+        throw new Error(
+            `Cannot write ${key} to the storefront env file: the value contains a single quote, ` +
+                'a double quote and a backtick, leaving no character to quote it with. ' +
+                'Choose a project name without one of those characters.',
+        );
     }
     return `${delimiter}${value}${delimiter}`;
 }

--- a/packages/create/src/storefront-starters.ts
+++ b/packages/create/src/storefront-starters.ts
@@ -110,7 +110,15 @@ export function renderStorefrontEnvironment(
 ): string {
     return (
         Object.entries(storefront.environment(context))
-            .map(([key, value]) => `${key}=${value}`)
+            .map(([key, value]) => `${key}=${quoteEnvironmentValue(value)}`)
             .join('\n') + '\n'
     );
+}
+
+function quoteEnvironmentValue(value: string): string {
+    const delimiter = [`'`, `"`, '`'].find(candidate => !value.includes(candidate));
+    if (!delimiter) {
+        throw new Error('Environment values cannot contain single, double, and backtick quotes together.');
+    }
+    return `${delimiter}${value}${delimiter}`;
 }

--- a/packages/create/src/storefront-starters.ts
+++ b/packages/create/src/storefront-starters.ts
@@ -32,7 +32,7 @@ export const STOREFRONT_STARTERS = [
         frameworkName: 'TanStack Start',
         documentationUrl: 'https://tanstack.com/start/latest/docs/framework/react/overview',
         repository: 'vendurehq/tanstack-starter-vendure',
-        ref: 'v1.0.0',
+        ref: 'main',
         envFile: '.env',
         packageScripts: ({ storefrontPort }) => ({
             dev: `vite dev --port ${storefrontPort}`,
@@ -53,7 +53,7 @@ export const STOREFRONT_STARTERS = [
         frameworkName: 'Next.js',
         documentationUrl: 'https://nextjs.org/docs',
         repository: 'vendurehq/nextjs-starter-vendure',
-        ref: 'af950dcab732c3246d36f01c5cf2427cc9409b21',
+        ref: 'main',
         envFile: '.env.local',
         packageScripts: ({ storefrontPort }) => ({
             dev: `next dev --port ${storefrontPort}`,

--- a/packages/create/src/storefront-starters.ts
+++ b/packages/create/src/storefront-starters.ts
@@ -1,0 +1,116 @@
+import { InvalidArgumentError } from 'commander';
+
+export interface StorefrontSetupContext {
+    projectName: string;
+    serverPort: number;
+    storefrontPort: number;
+    revalidationSecret: string;
+}
+
+export interface StorefrontStarter {
+    id: string;
+    name: string;
+    description: string;
+    frameworkName: string;
+    documentationUrl: string;
+    repository: string;
+    ref: string;
+    envFile: string;
+    packageScripts: (context: StorefrontSetupContext) => Record<string, string>;
+    environment: (context: StorefrontSetupContext) => Record<string, string>;
+}
+
+interface StorefrontPackageJson extends Record<string, unknown> {
+    scripts?: Record<string, string>;
+}
+
+export const STOREFRONT_STARTERS = [
+    {
+        id: 'tanstack',
+        name: 'TanStack Start',
+        description: 'A TanStack Start storefront with routing, internationalization, and checkout',
+        frameworkName: 'TanStack Start',
+        documentationUrl: 'https://tanstack.com/start/latest/docs/framework/react/overview',
+        repository: 'vendurehq/tanstack-starter-vendure',
+        ref: 'v1.0.0',
+        envFile: '.env',
+        packageScripts: ({ storefrontPort }) => ({
+            dev: `vite dev --port ${storefrontPort}`,
+            start: 'node .output/server/index.mjs',
+        }),
+        environment: ({ projectName, serverPort, storefrontPort, revalidationSecret }) => ({
+            VENDURE_SHOP_API_URL: `http://localhost:${serverPort}/shop-api`,
+            VENDURE_CHANNEL_TOKEN: '__default_channel__',
+            SITE_URL: `http://localhost:${storefrontPort}`,
+            SITE_NAME: projectName,
+            REVALIDATION_SECRET: revalidationSecret,
+        }),
+    },
+    {
+        id: 'nextjs',
+        name: 'Next.js',
+        description: 'A Next.js storefront with routing, internationalization, and checkout',
+        frameworkName: 'Next.js',
+        documentationUrl: 'https://nextjs.org/docs',
+        repository: 'vendurehq/nextjs-starter-vendure',
+        ref: 'main',
+        envFile: '.env.local',
+        packageScripts: ({ storefrontPort }) => ({
+            dev: `next dev --port ${storefrontPort}`,
+        }),
+        environment: ({ projectName, serverPort, storefrontPort, revalidationSecret }) => ({
+            VENDURE_SHOP_API_URL: `http://localhost:${serverPort}/shop-api`,
+            VENDURE_CHANNEL_TOKEN: '__default_channel__',
+            NEXT_PUBLIC_SITE_URL: `http://localhost:${storefrontPort}`,
+            NEXT_PUBLIC_SITE_NAME: projectName,
+            REVALIDATION_SECRET: revalidationSecret,
+        }),
+    },
+] as const satisfies readonly StorefrontStarter[];
+
+export type StorefrontId = (typeof STOREFRONT_STARTERS)[number]['id'];
+
+export function parseStorefrontId(value: string): StorefrontId {
+    const normalizedValue = value.toLowerCase();
+    const storefront = STOREFRONT_STARTERS.find(candidate => candidate.id === normalizedValue);
+    if (!storefront) {
+        throw new InvalidArgumentError(
+            `Allowed choices are: ${STOREFRONT_STARTERS.map(candidate => candidate.id).join(', ')}.`,
+        );
+    }
+    return storefront.id;
+}
+
+export function getStorefrontStarter(id: StorefrontId): StorefrontStarter {
+    const storefront = STOREFRONT_STARTERS.find(candidate => candidate.id === id);
+    if (!storefront) {
+        throw new Error(`Unknown storefront starter: ${id as string}`);
+    }
+    return storefront;
+}
+
+export function configureStorefrontPackageJson(
+    packageJson: StorefrontPackageJson,
+    storefront: StorefrontStarter,
+    context: StorefrontSetupContext,
+): StorefrontPackageJson {
+    return {
+        ...packageJson,
+        name: 'storefront',
+        scripts: {
+            ...(packageJson.scripts ?? {}),
+            ...storefront.packageScripts(context),
+        },
+    };
+}
+
+export function renderStorefrontEnvironment(
+    storefront: StorefrontStarter,
+    context: StorefrontSetupContext,
+): string {
+    return (
+        Object.entries(storefront.environment(context))
+            .map(([key, value]) => `${key}=${value}`)
+            .join('\n') + '\n'
+    );
+}

--- a/packages/create/src/types.ts
+++ b/packages/create/src/types.ts
@@ -1,3 +1,5 @@
+import type { StorefrontId } from './storefront-starters';
+
 export type DbType = 'mysql' | 'mariadb' | 'postgres' | 'sqlite';
 
 export interface FileSources {
@@ -19,7 +21,7 @@ export interface UserResponses extends FileSources {
     populateProducts: boolean;
     superadminIdentifier: string;
     superadminPassword: string;
-    includeStorefront: boolean;
+    storefront?: StorefrontId;
 }
 
 export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';

--- a/packages/create/templates/agents.hbs
+++ b/packages/create/templates/agents.hbs
@@ -6,7 +6,7 @@ This project was generated with `@vendure/create`.
 ## Workspace Layout
 
 - Vendure backend: `apps/server`
-- Next.js storefront: `apps/storefront`
+- {{ storefrontName }} storefront: `apps/storefront`
 - Start both apps: `npm run dev`
 - Start only the server: `npm run dev:server`
 - Start only the storefront: `npm run dev:storefront`

--- a/packages/create/templates/monorepo/root-readme.hbs
+++ b/packages/create/templates/monorepo/root-readme.hbs
@@ -1,6 +1,6 @@
 # {{ name }}
 
-A full-stack e-commerce application built with [Vendure](https://www.vendure.io/) and [Next.js](https://nextjs.org/).
+A full-stack e-commerce application built with [Vendure](https://www.vendure.io/) and [{{ storefrontName }}]({{ storefrontDocumentationUrl }}).
 
 ## Project Structure
 
@@ -10,7 +10,7 @@ This is a monorepo using {{packageManager}} workspaces:
 {{ name }}/
 ├── apps/
 │   ├── server/       # Vendure backend (GraphQL API, Admin Dashboard)
-│   └── storefront/   # Next.js frontend
+│   └── storefront/   # {{ storefrontName }} frontend
 └── package.json      # Root workspace configuration
 ```
 
@@ -65,5 +65,5 @@ Start the production server:
 ## Learn More
 
 - [Vendure Documentation](https://docs.vendure.io)
-- [Next.js Documentation](https://nextjs.org/docs)
+- [{{ storefrontName }} Documentation]({{ storefrontDocumentationUrl }})
 - [Vendure Discord Community](https://vendure.io/community)

--- a/packages/create/templates/monorepo/storefront-env.hbs
+++ b/packages/create/templates/monorepo/storefront-env.hbs
@@ -1,5 +1,0 @@
-VENDURE_SHOP_API_URL=http://localhost:{{ serverPort }}/shop-api
-VENDURE_CHANNEL_TOKEN=__default_channel__
-NEXT_PUBLIC_SITE_URL=http://localhost:{{ storefrontPort }}
-NEXT_PUBLIC_SITE_NAME={{ name }}
-REVALIDATION_SECRET={{ revalidationSecret }}


### PR DESCRIPTION
# Description

Adds a generic storefront registry to `@vendure/create` and exposes TanStack Start alongside Next.js in interactive and CI creation flows. Starter definitions now own repository references, scripts, environment contracts, and documentation metadata so additional storefronts can be added cleanly. No related issue.

# Breaking changes

No; the legacy `--with-storefront` flag continues to select Next.js.

# Screenshots

Not applicable for this CLI-only change.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789542097&installation_model_id=20193&pr_number=5144&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5144&signature=52b5b6f8dae7c4232bf73efdc4b6bc3859aa07c0e0c880152a2b2e645bff50dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->