### PR TITLE
fix(dashboard): transform JSX when compiling plugin config imports

### DIFF
--- a/docs/docs/reference/typescript-api/common/currency-code.mdx
+++ b/docs/docs/reference/typescript-api/common/currency-code.mdx
@@ -2,7 +2,7 @@
 title: "CurrencyCode"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/common/src/generated-types.ts" sourceLine="1135" packageName="@vendure/common" />
+<GenerationInfo sourceFile="packages/common/src/generated-types.ts" sourceLine="1150" packageName="@vendure/common" />
 
 ISO 4217 currency code
 

--- a/docs/docs/reference/typescript-api/common/job-state.mdx
+++ b/docs/docs/reference/typescript-api/common/job-state.mdx
@@ -2,7 +2,7 @@
 title: "JobState"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/common/src/generated-types.ts" sourceLine="2390" packageName="@vendure/common" />
+<GenerationInfo sourceFile="packages/common/src/generated-types.ts" sourceLine="2405" packageName="@vendure/common" />
 
 The state of a Job in the JobQueue
 

--- a/docs/docs/reference/typescript-api/common/language-code.mdx
+++ b/docs/docs/reference/typescript-api/common/language-code.mdx
@@ -2,7 +2,7 @@
 title: "LanguageCode"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/common/src/generated-types.ts" sourceLine="2408" packageName="@vendure/common" />
+<GenerationInfo sourceFile="packages/common/src/generated-types.ts" sourceLine="2423" packageName="@vendure/common" />
 
 Languages in the form of a ISO 639-1 language code with optional
 region or script modifier (e.g. de_AT). The selection available is based

--- a/docs/docs/reference/typescript-api/common/permission.mdx
+++ b/docs/docs/reference/typescript-api/common/permission.mdx
@@ -2,7 +2,7 @@
 title: "Permission"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/common/src/generated-types.ts" sourceLine="4691" packageName="@vendure/common" />
+<GenerationInfo sourceFile="packages/common/src/generated-types.ts" sourceLine="4735" packageName="@vendure/common" />
 
 Permissions for administrators and customers. Used to control access to
 GraphQL resolvers via the [Allow](/reference/typescript-api/request/allow-decorator#allow) decorator.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1198,7 +1198,7 @@
                   "title": "CurrencyCode",
                   "slug": "currency-code",
                   "file": "docs/reference/typescript-api/common/currency-code.mdx",
-                  "lastModified": "2026-03-06T09:35:25+01:00"
+                  "lastModified": "2026-08-18T09:01:04Z"
                 },
                 {
                   "title": "EntityRelationPaths",
@@ -1234,7 +1234,7 @@
                   "title": "JobState",
                   "slug": "job-state",
                   "file": "docs/reference/typescript-api/common/job-state.mdx",
-                  "lastModified": "2026-03-06T09:35:25+01:00"
+                  "lastModified": "2026-08-18T09:01:04Z"
                 },
                 {
                   "title": "JsonCompatible",
@@ -1246,7 +1246,7 @@
                   "title": "LanguageCode",
                   "slug": "language-code",
                   "file": "docs/reference/typescript-api/common/language-code.mdx",
-                  "lastModified": "2026-03-06T09:35:25+01:00"
+                  "lastModified": "2026-08-18T09:01:04Z"
                 },
                 {
                   "title": "Middleware",
@@ -1264,7 +1264,7 @@
                   "title": "Permission",
                   "slug": "permission",
                   "file": "docs/reference/typescript-api/common/permission.mdx",
-                  "lastModified": "2026-03-06T09:35:25+01:00"
+                  "lastModified": "2026-08-18T09:01:04Z"
                 },
                 {
                   "title": "PriceCalculationResult",

--- a/packages/dashboard/vite/tests/fixtures-jsx/my-plugin/src/invoice.tsx
+++ b/packages/dashboard/vite/tests/fixtures-jsx/my-plugin/src/invoice.tsx
@@ -1,0 +1,6 @@
+/**
+ * Simulates server-side React usage in a plugin, e.g. rendering PDF invoices
+ * or email templates. Imported by the plugin, so it ends up in the config
+ * import graph that the dashboard compiler walks.
+ */
+export const Invoice = () => <div>Invoice</div>;

--- a/packages/dashboard/vite/tests/fixtures-jsx/my-plugin/src/my.plugin.ts
+++ b/packages/dashboard/vite/tests/fixtures-jsx/my-plugin/src/my.plugin.ts
@@ -1,0 +1,12 @@
+import { PluginCommonModule, VendurePlugin } from '@vendure/core';
+
+import { Invoice } from './invoice.js';
+
+@VendurePlugin({
+    imports: [PluginCommonModule],
+    providers: [],
+    dashboard: './dashboard/index.tsx',
+})
+export class MyPlugin {
+    static invoice = Invoice;
+}

--- a/packages/dashboard/vite/tests/fixtures-jsx/package.json
+++ b/packages/dashboard/vite/tests/fixtures-jsx/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "commonjs",
+    "name": "jsx",
+    "version": "0.0.1",
+    "main": "index.ts"
+}

--- a/packages/dashboard/vite/tests/fixtures-jsx/vendure-config.ts
+++ b/packages/dashboard/vite/tests/fixtures-jsx/vendure-config.ts
@@ -1,0 +1,11 @@
+import { VendureConfig } from '@vendure/core';
+
+import { MyPlugin } from './my-plugin/src/my.plugin.js';
+
+export const config: VendureConfig = {
+    apiOptions: { port: 3000 },
+    authOptions: { tokenMethod: 'bearer' },
+    dbConnectionOptions: { type: 'postgres' },
+    paymentOptions: { paymentMethodHandlers: [] },
+    plugins: [MyPlugin],
+};

--- a/packages/dashboard/vite/tests/jsx-compilation.spec.ts
+++ b/packages/dashboard/vite/tests/jsx-compilation.spec.ts
@@ -1,0 +1,29 @@
+import { readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { compile } from '../utils/compiler.js';
+import { debugLogger, noopLogger } from '../utils/logger.js';
+
+describe('compiling plugins which import .tsx files', () => {
+    for (const module of ['commonjs', 'esm'] as const) {
+        it(`should transform JSX in ${module} mode`, { timeout: 60_000 }, async () => {
+            const tempDir = join(__dirname, `./__temp/jsx-${module}`);
+            await rm(tempDir, { recursive: true, force: true });
+
+            const result = await compile({
+                outputPath: tempDir,
+                vendureConfigPath: join(__dirname, 'fixtures-jsx', 'vendure-config.ts'),
+                logger: process.env.LOG ? debugLogger : noopLogger,
+                module,
+            });
+
+            const emitted = await readFile(join(tempDir, 'my-plugin', 'src', 'invoice.js'), 'utf-8');
+            expect(emitted).toContain('react/jsx-runtime');
+            expect(emitted).not.toContain('<div');
+
+            expect(result.pluginInfo).toHaveLength(1);
+            expect(result.pluginInfo[0].name).toBe('MyPlugin');
+        });
+    }
+});

--- a/packages/dashboard/vite/utils/compiler.ts
+++ b/packages/dashboard/vite/utils/compiler.ts
@@ -250,6 +250,10 @@ async function compileTypeScript({
     const compilerOptions: ts.CompilerOptions = {
         target: ts.ScriptTarget.ES2020,
         module: module === 'esm' ? ts.ModuleKind.ESNext : ts.ModuleKind.CommonJS,
+        // Plugin import graphs can transitively reach .tsx files (e.g. server-side
+        // React for PDF or email rendering). Without this, transpileModule emits raw
+        // JSX into the .js output and the compiled config fails to import.
+        jsx: ts.JsxEmit.ReactJSX,
         experimentalDecorators: true,
         emitDecoratorMetadata: true,
         esModuleInterop: true,


### PR DESCRIPTION
Takeover of #3726 by @hans-rollingridges-dev, who diagnosed this a year ago and is credited as co-author on the commit. The original was opened against the pre-#4561 `ts.createProgram` implementation and no longer applied, so the one-line fix is rebased onto the current `ts.transpileModule` compiler here.

## The bug

The dashboard's config compiler walks the Vendure config's import graph and transpiles each file with `ts.transpileModule()`. No `jsx` option was set, so any `.tsx` file reachable from the config, for example server-side React used for PDF invoice or email template rendering, was emitted with its JSX untransformed.

TypeScript reports no diagnostic for this, so the failure only surfaces when the compiled config is imported, and it surfaces as a misleading `Could not find a variable exported as VendureConfig with the name "config"`. That error names the wrong thing entirely, which is why the original report took work to pin down.

## The fix

`jsx: ts.JsxEmit.ReactJSX` in `packages/dashboard/vite/utils/compiler.ts`.

## Coverage

The original had none. Added here: a `vite/tests/fixtures-jsx` fixture whose plugin imports a `.tsx`, and `vite/tests/jsx-compilation.spec.ts` running it in both commonjs and esm mode.

With the `jsx` line removed, both cases fail with the exact `Could not find a variable exported as VendureConfig` error from the original report. With it in place the full `vite/tests` suite passes: 14 files, 110 tests.

## Verification

- `bunx vitest run vite/tests` — 14 files passed, 1 skipped; 110 tests passed, 4 skipped
- `bunx tsc --project tsconfig.vite.json --noEmit` — exit 0
- `bunx prettier --check` on the changed files — pass
- eslint not run: `packages/dashboard/eslint.config.js` scopes to `**/*.{js,jsx}`, so both changed files report "File ignored because no matching configuration was supplied"

Relates to #3726

Co-authored-by: RollingRidges <hans@rollingridges.dev>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789632036&installation_model_id=20193&pr_number=5152&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5152&signature=cea8c28333925f632603fa3a23024242ea4d9a1716dd9a6f53c3908189909ea4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->