### PR TITLE
fix(create): restore selectStorefront lost in back-merge

### DIFF
--- a/packages/create/src/gather-user-responses.ts
+++ b/packages/create/src/gather-user-responses.ts
@@ -25,27 +25,20 @@ interface PromptAnswers {
 }
 
 async function selectStorefront(): Promise<StorefrontId | undefined> {
-    const options: Array<{
-        label: string;
-        value: StorefrontId | 'none';
-        hint?: string;
-    }> = [
-        { label: 'None', value: 'none' },
-        ...STOREFRONT_STARTERS.map(storefront => ({
-            label: storefront.name,
-            value: storefront.id,
-            hint: storefront.description,
-        })),
-    ];
-    const selected = await select<typeof options, StorefrontId | 'none'>({
+    const selected = await select({
         message: 'Would you like to include a storefront?',
-        options,
-        initialValue: 'none',
+        options: [
+            { label: 'None', value: 'none' },
+            ...STOREFRONT_STARTERS.map(storefront => ({
+                label: storefront.name,
+                value: storefront.id,
+                hint: storefront.description,
+            })),
+        ],
+        initialValue: 'none' as const,
     });
-    if (!checkCancel(selected)) {
-        return undefined;
-    }
-    return selected === 'none' ? undefined : selected;
+    checkCancel(selected);
+    return selected === 'none' ? undefined : (selected as StorefrontId);
 }
 
 /* eslint-disable no-console */


### PR DESCRIPTION
## Problem

The build fails on `minor`, and therefore on every PR targeting `minor`:

```
src/gather-user-responses.ts(40,35): error TS2558: Expected 1 type arguments, but got 2.
src/gather-user-responses.ts(48,12): error TS2367: This comparison appears to be unintentional because the types '{ label: string; value: "tanstack" | "nextjs" | "none"; hint?: string | undefined; }[]' and 'string' have no overlap.
src/gather-user-responses.ts(48,46): error TS2322: Type '{ label: string; value: "tanstack" | "nextjs" | "none"; hint?: string | undefined; }[]' is not assignable to type '"tanstack" | "nextjs" | undefined'.
```

## Cause

The merge commit e0cbd6020 (`chore(repo): merge master into minor`) re-authored `selectStorefront` by hand rather than taking the incoming version.

Both parents of that merge hold the identical blob `7ebf6b5ec` for `gather-user-responses.ts`:

| commit | blob |
| --- | --- |
| `69fa37dee` (parent 1, minor) | `7ebf6b5ec` |
| `51cc49128` (parent 2, master) | `7ebf6b5ec` |
| `e0cbd6020` (merge result) | `fb41da99d` |
| merge base `a4b852b85` | `352e0889c` |

Identical on both sides means git merges cleanly with no conflict. The result blob `fb41da99d` appears in no regular commit anywhere in history:

```
$ git log --all --full-history -m --oneline -S 'select<typeof options' -- packages/create/src/gather-user-responses.ts
a4b74efce (from 656db1d8c) Merge remote-tracking branch 'origin/master' into minor
e0cbd6020 (from 69fa37dee) chore(repo): merge master into minor
e0cbd6020 (from 51cc49128) chore(repo): merge master into minor
```

The merge base predates #5144 entirely (no `selectStorefront`, `includeStorefront: boolean | symbol` instead of `storefront?: StorefrontId`), so the resolution rebuilt the function on top of that older shape.

The rebuilt version uses the `@clack/prompts` 0.7.x call signature, `select<typeof options, Value>`. `packages/create` depends on `^0.11.0`, where `select` takes one type argument. Hence TS2558; the two bogus type arguments then poison inference on `options` and `initialValue`, producing TS2367 and TS2322 on line 48.

`a4b74efce` carried it forward, so `minor` has been red since.

## Fix

Restores `packages/create/src/gather-user-responses.ts` to the version on `master` (blob `7ebf6b5ec`), which is what the merge would have produced on its own. No other file was affected: `git diff --name-only 69fa37dee e0cbd6020` lists only this one.

The rebuilt version also had a dead branch, `if (!checkCancel(selected)) { return undefined; }`. `checkCancel` is a `value is T` type predicate that calls `process.exit(0)` on cancel, so the negated branch narrows to `never` and is unreachable. That goes away with the revert too.

## Verification

Typechecked `packages/create` against the installed `@clack/prompts@0.11.0`, before and after:

```
$ npx tsc -p ./tsconfig.build.json --noEmit   # with fix
FIXED EXIT: 0

$ git stash && npx tsc -p ./tsconfig.build.json --noEmit   # without fix
src/gather-user-responses.ts(40,35): error TS2558: Expected 1 type arguments, but got 2.
src/gather-user-responses.ts(48,12): error TS2367: ...
src/gather-user-responses.ts(48,46): error TS2322: ...
BROKEN EXIT: 2
```

The three errors match CI exactly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789655056&installation_model_id=20193&pr_number=5155&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5155&signature=c0fd0ad2c11c8a98a50fbcd44465d5e795fae5654e989eb642521c2eacbf42f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->