### PR TITLE
feat(cli): add Console project linking

### DIFF
--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -383,28 +383,25 @@ The v1 manifest contains identity metadata only:
 Commit `.vendure/project.json` so that the repository keeps its Project identity. Ignore all other `.vendure` files.
 They are reserved for machine-local state and may contain secrets.
 
-`vendure console link` checks the `.gitignore` file that applies to the resolved project and writes the
-rules if they are missing.
-
-In a single-package project it updates that project's `.gitignore`:
+`vendure console link` updates the resolved project's `.gitignore` with these rules when they are missing:
 
 ```text
 .vendure/*
 !.vendure/project.json
 ```
 
-In a monorepo such as `apps/vendure`, it updates the repository-root `.gitignore` when that is the file
-in force. Root-level `.vendure/*` only matches a `.vendure` directory at the repository root, so the
-command writes patterns that apply at any depth:
+The command normally changes no `.gitignore` file outside the project directory. One exception applies in a
+monorepo: an ancestor rule such as `.vendure/` prevents Git from reading the project's `.gitignore`. The command
+then adds rules for only the selected project to that ancestor file:
 
 ```text
-**/.vendure/*
-!**/.vendure/project.json
+!apps/vendure/.vendure/
+apps/vendure/.vendure/*
+!apps/vendure/.vendure/project.json
 ```
 
-If `apps/vendure` already has its own `.gitignore`, the command updates that file with the
-project-local rules instead. A parent `.vendure/` directory ignore is rewritten because Git cannot
-un-ignore `project.json` while the parent directory is ignored.
+The original ancestor rule stays unchanged, and other projects remain ignored. The command reports the exact
+`.gitignore` file that it changed.
 
 ### Console environments
 

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -383,12 +383,28 @@ The v1 manifest contains identity metadata only:
 Commit `.vendure/project.json` so that the repository keeps its Project identity. Ignore all other `.vendure` files.
 They are reserved for machine-local state and may contain secrets.
 
-`vendure console link` checks the project `.gitignore` file and writes these rules if they are missing:
+`vendure console link` checks the `.gitignore` file that applies to the resolved project and writes the
+rules if they are missing.
+
+In a single-package project it updates that project's `.gitignore`:
 
 ```text
 .vendure/*
 !.vendure/project.json
 ```
+
+In a monorepo such as `apps/vendure`, it updates the repository-root `.gitignore` when that is the file
+in force. Root-level `.vendure/*` only matches a `.vendure` directory at the repository root, so the
+command writes patterns that apply at any depth:
+
+```text
+**/.vendure/*
+!**/.vendure/project.json
+```
+
+If `apps/vendure` already has its own `.gitignore`, the command updates that file with the
+project-local rules instead. A parent `.vendure/` directory ignore is rewritten because Git cannot
+un-ignore `project.json` while the parent directory is ignored.
 
 ### Console environments
 

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -408,17 +408,30 @@ un-ignore `project.json` while the parent directory is ignored.
 
 ### Console environments
 
-The command uses `https://console.vendure.io` and `https://api.vendure.io` by default. To use a local or staging
-environment, set both variables to HTTP or HTTPS origins:
+The command uses `https://console.vendure.io` and `https://api.vendure.io` by default. To use a local Console
+environment, set both link-specific variables:
 
 ```bash
-VENDURE_CONSOLE_URL=http://localhost:3000 \
-VENDURE_CONSOLE_API_URL=http://localhost:3001 \
+VENDURE_CONSOLE_LINK_URL=http://localhost:3000 \
+VENDURE_CONSOLE_LINK_API_URL=http://localhost:3001 \
 npx vendure console link
 ```
 
-The CLI rejects partial endpoint configuration. It also rejects URLs that contain credentials, paths, queries, or
-fragments.
+The variables apply only to the unauthenticated Project Link exchange. They do not configure Console authentication,
+Environment Credentials, Registry access, package downloads, or Vendure Cloud operations.
+
+The CLI rejects partial endpoint configuration and URLs that contain credentials, paths, queries, or fragments. It
+requires HTTPS except for `localhost`, `127.0.0.1`, and `::1`. The production Console and API origins must be used
+together.
+
+Before it contacts a custom remote environment, the CLI displays both origins and asks for confirmation. In a
+non-interactive environment, pass `--allow-custom-console` to confirm them explicitly:
+
+```bash
+VENDURE_CONSOLE_LINK_URL=https://console.staging.example.com \
+VENDURE_CONSOLE_LINK_API_URL=https://api.staging.example.com \
+npx vendure console link --allow-custom-console
+```
 
 ## Working in Monorepos
 

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -381,8 +381,9 @@ The v1 manifest contains identity metadata only:
 ```
 
 Commit `.vendure/project.json` so that the repository keeps its Project identity. Ignore all other `.vendure` files.
-They are reserved for machine-local state and may contain secrets. For an existing project, use these `.gitignore`
-rules:
+They are reserved for machine-local state and may contain secrets.
+
+`vendure console link` checks the project `.gitignore` file and writes these rules if they are missing:
 
 ```text
 .vendure/*

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'CLI'
 metaTitle: "Vendure CLI - Automate Plugin, Entity, and API Scaffolding"
-metaDescription: "Use the Vendure CLI to scaffold plugins, entities, and API extensions. Supports interactive and non-interactive modes for streamlined development."
+metaDescription: "Use the Vendure CLI to scaffold features, diagnose projects, and link a local project to Vendure Console."
 ---
 
 The Vendure CLI is a command-line tool for boosting your productivity as a developer by automating common tasks
@@ -310,6 +310,99 @@ npx vendure doctor --strict --format json
 | `--format <type>`   | Output format: `text` (default) or `json`                                              | `vendure doctor --format json`                |
 | `--strict`          | Treat warnings as failures (useful for CI)                                             | `vendure doctor --strict`                     |
 
+## The Console Command
+
+The `console` command links a local Vendure application to a Project in Vendure Console. Run the command from a
+Vendure project directory:
+
+```bash
+npx vendure console link
+```
+
+The CLI creates a short-lived request and opens Vendure Console in your browser. Sign in, select an active Project,
+and approve the request. The CLI then writes `.vendure/project.json` in the resolved Vendure project.
+
+The browser owns authentication and authorization. The CLI does not store your Console access token. The one-time
+polling secret stays in memory and is not included in the browser URL, output, or manifest. If the browser cannot open,
+the CLI prints the verification URL so that you can open it manually.
+
+### Link status
+
+Use `status` to validate and display the local link:
+
+```bash
+npx vendure console status
+```
+
+The output includes the Account, Project, schema version, protocol version, and local authentication state. This
+command reads local state only. It does not contact Vendure Console.
+
+### Unlink a project
+
+Use `unlink` to remove the local manifest:
+
+```bash
+npx vendure console unlink
+```
+
+This command removes only `.vendure/project.json`. It does not delete the Console Project, revoke server-side
+credentials, or change the completed link request.
+
+### Project selection and confirmation
+
+The CLI uses the nearest project that has a direct `@vendure/core` dependency. From a monorepo root, it uses the only
+Vendure project under `packages`, `apps`, `libs`, `services`, or `modules`. If more than one project exists, select one:
+
+```bash
+npx vendure console status --project ./apps/server
+```
+
+Replacing or removing a manifest requires confirmation. In non-interactive environments, use `--force` to confirm the
+specific action:
+
+```bash
+npx vendure console link --force
+npx vendure console unlink --force
+```
+
+`--force` does not bypass ambiguous project selection or a manifest that belongs to another project root.
+
+### Manifest and source control
+
+The v1 manifest contains identity metadata only:
+
+```json
+{
+    "schemaVersion": 1,
+    "project": { "id": "<uuid>", "name": "<display name>" },
+    "account": { "id": "<uuid>", "name": "<display name>" },
+    "link": { "id": "<uuid>", "protocolVersion": 1 }
+}
+```
+
+Commit `.vendure/project.json` so that the repository keeps its Project identity. Ignore all other `.vendure` files.
+They are reserved for machine-local state and may contain secrets. For an existing project, use these `.gitignore`
+rules:
+
+```text
+.vendure/*
+!.vendure/project.json
+```
+
+### Console environments
+
+The command uses `https://console.vendure.io` and `https://api.vendure.io` by default. To use a local or staging
+environment, set both variables to HTTP or HTTPS origins:
+
+```bash
+VENDURE_CONSOLE_URL=http://localhost:3000 \
+VENDURE_CONSOLE_API_URL=http://localhost:3001 \
+npx vendure console link
+```
+
+The CLI rejects partial endpoint configuration. It also rejects URLs that contain credentials, paths, queries, or
+fragments.
+
 ## Working in Monorepos
 
 The Vendure CLI automatically supports monorepo structures where packages have their own `tsconfig.json` files that extend a shared base configuration.
@@ -464,5 +557,6 @@ npx vendure add --help
 npx vendure migrate --help
 npx vendure schema --help
 npx vendure doctor --help
+npx vendure console --help
 npx vendure plugins --help
 ```

--- a/docs/docs/reference/dashboard/detail-views/use-detail-page.mdx
+++ b/docs/docs/reference/dashboard/detail-views/use-detail-page.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## useDetailPage
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/use-detail-page.ts" sourceLine="271" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/use-detail-page.ts" sourceLine="292" packageName="@vendure/dashboard" since="3.3.0" />
 
 **Status: Developer Preview**
 
@@ -80,7 +80,7 @@ Parameters
 
 ## DetailPageOptions
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/use-detail-page.ts" sourceLine="49" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/use-detail-page.ts" sourceLine="54" packageName="@vendure/dashboard" since="3.3.0" />
 
 Options used to configure the result of the `useDetailPage` hook.
 
@@ -101,6 +101,7 @@ interface DetailPageOptions<T extends TypedDocumentNode<any, any>, C extends Typ
     transformCreateInput?: (input: VariablesOf<C>[VarNameCreate]) => VariablesOf<C>[VarNameCreate];
     transformUpdateInput?: (input: VariablesOf<U>[VarNameUpdate]) => VariablesOf<U>[VarNameUpdate];
     extendSchema?: (schema: ZodObject<any>) => ZodTypeAny;
+    sendOnlyChangedFields?: boolean;
     onSuccess?: (entity: ResultOf<C>[keyof ResultOf<C>] | ResultOf<U>[keyof ResultOf<U>]) => void;
     onError?: (error: unknown) => void;
 }
@@ -188,6 +189,19 @@ extendSchema: schema =>
         code: z.string().min(1, { message: t`This field is required` }),
     }),
 ```
+### sendOnlyChangedFields
+
+<MemberInfo kind="property" type={`boolean`} default={`false`}  since="3.8.0"  />
+
+By default an update mutation sends the full form payload. Set this to `true` to instead send
+only the fields the user actually changed, so that an untouched field's stale page-load value
+cannot silently overwrite a concurrent change made by another admin or via the API.
+
+Only enable this for a detail page whose update mutation is patch-style: an absent field must
+be left unchanged, and no persisted value may be *derived* from the (now partial) input.
+Vendure's built-in Product, Collection and ProductVariant update paths satisfy this; a
+resolver that recomputes a field from the input — as `updatePromotion` does for
+`priorityScore` — does not, and would corrupt that field when it is omitted.
 ### onSuccess
 
 <MemberInfo kind="property" type={`(entity: ResultOf<C>[keyof ResultOf<C>] | ResultOf<U>[keyof ResultOf<U>]) => void`}   />
@@ -203,7 +217,7 @@ The function to call when the update is successful.
 </div>
 ## UseDetailPageResult
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/use-detail-page.ts" sourceLine="189" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/use-detail-page.ts" sourceLine="210" packageName="@vendure/dashboard" since="3.3.0" />
 
 
 

--- a/docs/docs/reference/dashboard/detail-views/use-generated-form.mdx
+++ b/docs/docs/reference/dashboard/detail-views/use-generated-form.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## useGeneratedForm
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/form-engine/use-generated-form.tsx" sourceLine="130" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/form-engine/use-generated-form.tsx" sourceLine="151" packageName="@vendure/dashboard" since="3.3.0" />
 
 This hook is used to create a form from a document and an entity.
 It will create a form with the fields defined in the document's input type.
@@ -40,9 +40,34 @@ Parameters
 
 <MemberInfo kind="parameter" type={`<a href='/reference/dashboard/detail-views/use-generated-form#generatedformoptions'>GeneratedFormOptions</a><T, VarName, E>`} />
 
+## GeneratedFormSubmitMeta
+
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/form-engine/use-generated-form.tsx" sourceLine="32" packageName="@vendure/dashboard" since="3.8.0" />
+
+Metadata passed as the second argument to a [GeneratedFormOptions](/reference/dashboard/detail-views/use-generated-form#generatedformoptions) `onSubmit`
+handler, describing which fields the user changed relative to the loaded entity.
+
+```ts title="Signature"
+interface GeneratedFormSubmitMeta {
+    changedFields?: ReadonlySet<string>;
+}
+```
+
+<div className="members-wrapper">
+
+### changedFields
+
+<MemberInfo kind="property" type={`ReadonlySet<string>`}   />
+
+The set of top-level input field names the user actually changed relative to
+the loaded entity (plus non-nullable fields which are always included).
+`undefined` when creating a new entity (there is no baseline to diff against).
+
+
+</div>
 ## GeneratedFormOptions
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/form-engine/use-generated-form.tsx" sourceLine="39" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/form-engine/use-generated-form.tsx" sourceLine="59" packageName="@vendure/dashboard" since="3.3.0" />
 
 Options for the useGeneratedForm hook.
 
@@ -60,6 +85,7 @@ interface GeneratedFormOptions<T extends TypedDocumentNode<any, any>, VarName ex
     >;
     onSubmit?: (
         values: VarName extends keyof VariablesOf<T> ? VariablesOf<T>[VarName] : VariablesOf<T>,
+        meta?: GeneratedFormSubmitMeta,
     ) => void;
 }
 ```
@@ -121,7 +147,7 @@ extendSchema: schema =>
 
 ### onSubmit
 
-<MemberInfo kind="property" type={`(         values: VarName extends keyof VariablesOf<T> ? VariablesOf<T>[VarName] : VariablesOf<T>,     ) => void`}   />
+<MemberInfo kind="property" type={`(         values: VarName extends keyof VariablesOf<T> ? VariablesOf<T>[VarName] : VariablesOf<T>,         meta?: <a href='/reference/dashboard/detail-views/use-generated-form#generatedformsubmitmeta'>GeneratedFormSubmitMeta</a>,     ) => void`}   />
 
 
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -218,7 +218,7 @@
           "title": "CLI",
           "slug": "cli",
           "file": "docs/guides/developer-guide/cli/index.mdx",
-          "lastModified": "2026-08-19T13:44:35+02:00"
+          "lastModified": "2026-08-24T10:48:37+02:00"
         },
         {
           "title": "AI-assisted Development",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -218,7 +218,7 @@
           "title": "CLI",
           "slug": "cli",
           "file": "docs/guides/developer-guide/cli/index.mdx",
-          "lastModified": "2026-08-17T11:43:39+02:00"
+          "lastModified": "2026-08-19T13:44:35+02:00"
         },
         {
           "title": "AI-assisted Development",
@@ -2780,7 +2780,7 @@
                   "title": "MultiChannelStockLocationStrategy",
                   "slug": "multi-channel-stock-location-strategy",
                   "file": "docs/reference/typescript-api/products-stock/multi-channel-stock-location-strategy.mdx",
-                  "lastModified": "2026-08-17T12:00:11+02:00"
+                  "lastModified": "2026-08-13T17:32:23+01:00"
                 },
                 {
                   "title": "ProductVariantPriceCalculationStrategy",
@@ -2874,7 +2874,7 @@
                   "title": "RequestContext",
                   "slug": "request-context",
                   "file": "docs/reference/typescript-api/request/request-context.mdx",
-                  "lastModified": "2026-08-17T12:00:11+02:00"
+                  "lastModified": "2026-08-13T14:40:56+02:00"
                 },
                 {
                   "title": "RequestContextService",
@@ -3096,7 +3096,7 @@
                   "title": "OrderService",
                   "slug": "order-service",
                   "file": "docs/reference/typescript-api/services/order-service.mdx",
-                  "lastModified": "2026-08-17T12:00:11+02:00"
+                  "lastModified": "2026-08-13T17:32:23+01:00"
                 },
                 {
                   "title": "OrderTestingService",
@@ -3186,7 +3186,7 @@
                   "title": "ShippingMethodService",
                   "slug": "shipping-method-service",
                   "file": "docs/reference/typescript-api/services/shipping-method-service.mdx",
-                  "lastModified": "2026-08-17T12:00:11+02:00"
+                  "lastModified": "2026-08-13T14:40:56+02:00"
                 },
                 {
                   "title": "SlugService",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -218,7 +218,7 @@
           "title": "CLI",
           "slug": "cli",
           "file": "docs/guides/developer-guide/cli/index.mdx",
-          "lastModified": "2026-08-24T11:50:56+02:00"
+          "lastModified": "2026-08-24T13:59:38+02:00"
         },
         {
           "title": "AI-assisted Development",
@@ -2780,7 +2780,7 @@
                   "title": "MultiChannelStockLocationStrategy",
                   "slug": "multi-channel-stock-location-strategy",
                   "file": "docs/reference/typescript-api/products-stock/multi-channel-stock-location-strategy.mdx",
-                  "lastModified": "2026-08-17T12:00:11+02:00"
+                  "lastModified": "2026-08-13T17:32:23+01:00"
                 },
                 {
                   "title": "ProductVariantPriceCalculationStrategy",
@@ -2874,7 +2874,7 @@
                   "title": "RequestContext",
                   "slug": "request-context",
                   "file": "docs/reference/typescript-api/request/request-context.mdx",
-                  "lastModified": "2026-08-17T12:00:11+02:00"
+                  "lastModified": "2026-08-13T14:40:56+02:00"
                 },
                 {
                   "title": "RequestContextService",
@@ -3096,7 +3096,7 @@
                   "title": "OrderService",
                   "slug": "order-service",
                   "file": "docs/reference/typescript-api/services/order-service.mdx",
-                  "lastModified": "2026-08-17T12:00:11+02:00"
+                  "lastModified": "2026-08-13T17:32:23+01:00"
                 },
                 {
                   "title": "OrderTestingService",
@@ -3186,7 +3186,7 @@
                   "title": "ShippingMethodService",
                   "slug": "shipping-method-service",
                   "file": "docs/reference/typescript-api/services/shipping-method-service.mdx",
-                  "lastModified": "2026-08-17T12:00:11+02:00"
+                  "lastModified": "2026-08-13T14:40:56+02:00"
                 },
                 {
                   "title": "SlugService",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -218,7 +218,7 @@
           "title": "CLI",
           "slug": "cli",
           "file": "docs/guides/developer-guide/cli/index.mdx",
-          "lastModified": "2026-08-24T10:48:37+02:00"
+          "lastModified": "2026-08-24T11:04:10+02:00"
         },
         {
           "title": "AI-assisted Development",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -218,7 +218,7 @@
           "title": "CLI",
           "slug": "cli",
           "file": "docs/guides/developer-guide/cli/index.mdx",
-          "lastModified": "2026-08-24T11:04:10+02:00"
+          "lastModified": "2026-08-24T11:50:56+02:00"
         },
         {
           "title": "AI-assisted Development",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2780,7 +2780,7 @@
                   "title": "MultiChannelStockLocationStrategy",
                   "slug": "multi-channel-stock-location-strategy",
                   "file": "docs/reference/typescript-api/products-stock/multi-channel-stock-location-strategy.mdx",
-                  "lastModified": "2026-08-13T17:32:23+01:00"
+                  "lastModified": "2026-08-17T12:00:11+02:00"
                 },
                 {
                   "title": "ProductVariantPriceCalculationStrategy",
@@ -2874,7 +2874,7 @@
                   "title": "RequestContext",
                   "slug": "request-context",
                   "file": "docs/reference/typescript-api/request/request-context.mdx",
-                  "lastModified": "2026-08-13T14:40:56+02:00"
+                  "lastModified": "2026-08-17T12:00:11+02:00"
                 },
                 {
                   "title": "RequestContextService",
@@ -3096,7 +3096,7 @@
                   "title": "OrderService",
                   "slug": "order-service",
                   "file": "docs/reference/typescript-api/services/order-service.mdx",
-                  "lastModified": "2026-08-13T17:32:23+01:00"
+                  "lastModified": "2026-08-17T12:00:11+02:00"
                 },
                 {
                   "title": "OrderTestingService",
@@ -3186,7 +3186,7 @@
                   "title": "ShippingMethodService",
                   "slug": "shipping-method-service",
                   "file": "docs/reference/typescript-api/services/shipping-method-service.mdx",
-                  "lastModified": "2026-08-13T14:40:56+02:00"
+                  "lastModified": "2026-08-17T12:00:11+02:00"
                 },
                 {
                   "title": "SlugService",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -4031,13 +4031,13 @@
                   "title": "UseDetailPage",
                   "slug": "use-detail-page",
                   "file": "docs/reference/dashboard/detail-views/use-detail-page.mdx",
-                  "lastModified": "2026-07-20T15:59:41+02:00"
+                  "lastModified": "2026-08-24T12:05:27Z"
                 },
                 {
                   "title": "UseGeneratedForm",
                   "slug": "use-generated-form",
                   "file": "docs/reference/dashboard/detail-views/use-generated-form.mdx",
-                  "lastModified": "2026-07-22T14:03:14Z"
+                  "lastModified": "2026-08-24T12:05:27Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"

--- a/packages/cli/e2e/console-command.e2e-spec.ts
+++ b/packages/cli/e2e/console-command.e2e-spec.ts
@@ -20,6 +20,17 @@ describe('CLI Console Command E2E', () => {
         expect(result.stdout).toContain('--force');
     });
 
+    it('requires a value when --project is present', async () => {
+        testProject = createTestProject('console-project-option');
+
+        const result = await testProject.runCliCommand(['console', 'status', '--project'], {
+            expectError: true,
+        });
+
+        expect(result.exitCode).toBe(1);
+        expect(`${result.stdout}\n${result.stderr}`).toContain("option '--project <path>' argument missing");
+    });
+
     it('reports an unlinked project without contacting Console', async () => {
         testProject = createTestProject('console-status');
 

--- a/packages/cli/e2e/console-command.e2e-spec.ts
+++ b/packages/cli/e2e/console-command.e2e-spec.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { CliTestProject, createTestProject } from './cli-test-utils';
+
+describe('CLI Console Command E2E', () => {
+    let testProject: CliTestProject;
+
+    afterEach(() => {
+        testProject?.cleanup();
+    });
+
+    it('shows the Console actions and safety options in help', async () => {
+        testProject = createTestProject('console-help');
+
+        const result = await testProject.runCliCommand(['console', '--help']);
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('link | status | unlink');
+        expect(result.stdout).toContain('--project <path>');
+        expect(result.stdout).toContain('--force');
+    });
+
+    it('reports an unlinked project without contacting Console', async () => {
+        testProject = createTestProject('console-status');
+
+        const result = await testProject.runCliCommand(['console', 'status']);
+
+        expect(result.exitCode).toBe(0);
+        expect(`${result.stdout}\n${result.stderr}`).toContain('Project: Not linked');
+        expect(`${result.stdout}\n${result.stderr}`).toContain('Authentication: Not stored locally');
+    });
+
+    it('removes only the local manifest with --force', async () => {
+        testProject = createTestProject('console-unlink');
+        testProject.writeFile(
+            '.vendure/project.json',
+            JSON.stringify({
+                schemaVersion: 1,
+                project: { id: '22222222-2222-4222-8222-222222222222', name: 'Storefront' },
+                account: { id: '11111111-1111-4111-8111-111111111111', name: 'Acme' },
+                link: { id: '33333333-3333-4333-8333-333333333333', protocolVersion: 1 },
+            }),
+        );
+        testProject.writeFile('.vendure/credentials.json', 'machine-local');
+
+        const result = await testProject.runCliCommand(['console', 'unlink', '--force']);
+
+        expect(result.exitCode).toBe(0);
+        expect(testProject.fileExists('.vendure/project.json')).toBe(false);
+        expect(testProject.readFile('.vendure/credentials.json')).toBe('machine-local');
+    });
+});

--- a/packages/cli/src/commands/builtins.ts
+++ b/packages/cli/src/commands/builtins.ts
@@ -3,6 +3,7 @@ import { CliCommandDefinition } from '../shared/cli-command-definition';
 import { addCommandDef } from './add/command';
 import { buildCommandDef } from './build/command';
 import { codemodCommandDef } from './codemod/command';
+import { consoleCommandDef } from './console/command';
 import { devCommandDef } from './dev/command';
 import { doctorCommandDef } from './doctor/command';
 import { migrateCommandDef } from './migrate/command';
@@ -23,6 +24,7 @@ export const builtinCommandDefs: CliCommandDefinition[] = [
     codemodCommandDef,
     schemaCommandDef,
     doctorCommandDef,
+    consoleCommandDef,
     pluginsCommandDef,
 ];
 

--- a/packages/cli/src/commands/console/command.ts
+++ b/packages/cli/src/commands/console/command.ts
@@ -1,0 +1,32 @@
+import { CliCommandDefinition } from '../../shared/cli-command-definition';
+import { runCliCommand } from '../../shared/cli-command-exit';
+
+export const consoleCommandDef: CliCommandDefinition = {
+    name: 'console',
+    description: 'Link this Vendure project to Vendure Console',
+    arguments: [
+        {
+            name: 'action',
+            description: 'Action to run: link | status | unlink',
+            required: false,
+        },
+    ],
+    options: [
+        {
+            long: '--project <path>',
+            description: 'Vendure project directory (required when project discovery is ambiguous)',
+            required: true,
+        },
+        {
+            long: '--force',
+            description: 'Confirm replacement or unlink without an interactive prompt',
+            required: false,
+        },
+    ],
+    action: async (action, options) => {
+        return runCliCommand(async () => {
+            const { consoleCommand } = await import('./console');
+            return consoleCommand(action, options);
+        });
+    },
+};

--- a/packages/cli/src/commands/console/command.ts
+++ b/packages/cli/src/commands/console/command.ts
@@ -13,6 +13,11 @@ export const consoleCommandDef: CliCommandDefinition = {
     ],
     options: [
         {
+            long: '--allow-custom-console',
+            description: 'Allow custom remote Console endpoints without an interactive prompt',
+            required: false,
+        },
+        {
             long: '--project <path>',
             description: 'Vendure project directory (required when project discovery is ambiguous)',
             required: true,

--- a/packages/cli/src/commands/console/console.fixtures.ts
+++ b/packages/cli/src/commands/console/console.fixtures.ts
@@ -1,0 +1,30 @@
+import type { ProjectLinkManifest } from './project-link-manifest';
+
+export const NOW = Date.parse('2026-08-19T10:00:00.000Z');
+export const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
+export const PROJECT_ID = '22222222-2222-4222-8222-222222222222';
+export const LINK_ID = '33333333-3333-4333-8333-333333333333';
+export const OTHER_LINK_ID = '44444444-4444-4444-8444-444444444444';
+export const POLLING_SECRET = 'one-time-polling-secret';
+
+export const manifest: ProjectLinkManifest = {
+    schemaVersion: 1,
+    project: { id: PROJECT_ID, name: 'Storefront' },
+    account: { id: ACCOUNT_ID, name: 'Acme' },
+    link: { id: LINK_ID, protocolVersion: 1 },
+};
+
+export function expiry(): string {
+    return new Date(NOW + 10 * 60 * 1_000).toISOString();
+}
+
+export function createResponse(expiresAt = expiry()) {
+    return {
+        id: LINK_ID,
+        state: 'pending',
+        protocolVersion: 1,
+        expiresAt,
+        pollingSecret: POLLING_SECRET,
+        verificationPath: `/?link=${LINK_ID}`,
+    };
+}

--- a/packages/cli/src/commands/console/console.integration.spec.ts
+++ b/packages/cli/src/commands/console/console.integration.spec.ts
@@ -64,6 +64,9 @@ describe('Console project-link integration', () => {
 
         expect(await consoleCommand('link', {}, dependencies)).toBe(0);
         expect(fs.readJsonSync(getProjectLinkManifestPath(projectRoot))).toEqual(manifest);
+        expect(fs.readFileSync(path.join(projectRoot, '.gitignore'), 'utf8')).toContain(
+            '!.vendure/project.json',
+        );
         expect(requestBodies).toEqual([{ pollingSecret: POLLING_SECRET }]);
         expect(messages.join('\n')).not.toContain(POLLING_SECRET);
     });

--- a/packages/cli/src/commands/console/console.integration.spec.ts
+++ b/packages/cli/src/commands/console/console.integration.spec.ts
@@ -1,0 +1,129 @@
+import fs from 'fs-extra';
+import { IncomingMessage, Server, ServerResponse, createServer } from 'node:http';
+import { AddressInfo } from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ConsoleCommandDependencies, ConsoleReporter, consoleCommand } from './console';
+import { ProjectLinkManifest, getProjectLinkManifestPath } from './project-link-manifest';
+
+const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
+const PROJECT_ID = '22222222-2222-4222-8222-222222222222';
+const LINK_ID = '33333333-3333-4333-8333-333333333333';
+const POLLING_SECRET = 'integration-polling-secret';
+
+const manifest: ProjectLinkManifest = {
+    schemaVersion: 1,
+    project: { id: PROJECT_ID, name: 'Integration Project' },
+    account: { id: ACCOUNT_ID, name: 'Integration Account' },
+    link: { id: LINK_ID, protocolVersion: 1 },
+};
+
+let server: Server | undefined;
+let projectRoot: string | undefined;
+
+afterEach(async () => {
+    if (server) {
+        await new Promise<void>((resolve, reject) =>
+            server?.close(error => (error ? reject(error) : resolve())),
+        );
+        server = undefined;
+    }
+    if (projectRoot) {
+        fs.removeSync(projectRoot);
+        projectRoot = undefined;
+    }
+});
+
+describe('Console project-link integration', () => {
+    it('completes the protocol against an HTTP server and writes the manifest', async () => {
+        const requestBodies: unknown[] = [];
+        server = createServer((request, response) => {
+            void respondToProjectLinkRequest(request, response, requestBodies);
+        });
+        await new Promise<void>(resolve => server?.listen(0, '127.0.0.1', resolve));
+        const address = server.address() as AddressInfo;
+        const apiUrl = `http://127.0.0.1:${address.port}`;
+
+        projectRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'vendure-console-integration-')));
+        fs.writeJsonSync(path.join(projectRoot, 'package.json'), {
+            dependencies: { '@vendure/core': '3.7.2' },
+        });
+        const messages: string[] = [];
+        const reporter: ConsoleReporter = {
+            error: message => messages.push(message),
+            info: message => messages.push(message),
+            success: message => messages.push(message),
+            warn: message => messages.push(message),
+            url: value => messages.push(value),
+        };
+        const dependencies: Partial<ConsoleCommandDependencies> = {
+            cwd: projectRoot,
+            env: {
+                VENDURE_CLI_NON_INTERACTIVE: 'true',
+                VENDURE_CONSOLE_URL: 'http://localhost:3000',
+                VENDURE_CONSOLE_API_URL: apiUrl,
+            },
+            fetch: globalThis.fetch,
+            isNonInteractive: () => true,
+            openUrl: () => Promise.resolve(),
+            prompt: () => Promise.resolve(true),
+            reporter,
+            sleep: () => Promise.resolve(),
+        };
+
+        expect(await consoleCommand('link', {}, dependencies)).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(projectRoot))).toEqual(manifest);
+        expect(requestBodies).toEqual([{ pollingSecret: POLLING_SECRET }]);
+        expect(messages.join('\n')).not.toContain(POLLING_SECRET);
+    });
+});
+
+async function respondToProjectLinkRequest(
+    request: IncomingMessage,
+    response: ServerResponse,
+    requestBodies: unknown[],
+): Promise<void> {
+    const body = await readBody(request);
+    if (body !== undefined) {
+        requestBodies.push(body);
+    }
+    response.setHeader('Content-Type', 'application/json');
+    if (request.method === 'POST' && request.url === '/project-links') {
+        response.end(
+            JSON.stringify({
+                id: LINK_ID,
+                state: 'pending',
+                protocolVersion: 1,
+                expiresAt: new Date(Date.now() + 60_000).toISOString(),
+                pollingSecret: POLLING_SECRET,
+                verificationPath: `/?link=${LINK_ID}`,
+            }),
+        );
+        return;
+    }
+    if (request.method === 'POST' && request.url === `/project-links/${LINK_ID}/poll`) {
+        response.end(
+            JSON.stringify({
+                state: 'approved',
+                expiresAt: new Date(Date.now() + 60_000).toISOString(),
+                manifest,
+            }),
+        );
+        return;
+    }
+    response.statusCode = 404;
+    response.end(JSON.stringify({ code: 'not_found' }));
+}
+
+async function readBody(request: IncomingMessage): Promise<unknown | undefined> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    if (chunks.length === 0) {
+        return undefined;
+    }
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+}

--- a/packages/cli/src/commands/console/console.integration.spec.ts
+++ b/packages/cli/src/commands/console/console.integration.spec.ts
@@ -51,8 +51,8 @@ describe('Console project-link integration', () => {
             cwd: projectRoot,
             env: {
                 VENDURE_CLI_NON_INTERACTIVE: 'true',
-                VENDURE_CONSOLE_URL: 'http://localhost:3000',
-                VENDURE_CONSOLE_API_URL: apiUrl,
+                VENDURE_CONSOLE_LINK_URL: 'http://localhost:3000',
+                VENDURE_CONSOLE_LINK_API_URL: apiUrl,
             },
             fetch: globalThis.fetch,
             isNonInteractive: () => true,

--- a/packages/cli/src/commands/console/console.integration.spec.ts
+++ b/packages/cli/src/commands/console/console.integration.spec.ts
@@ -82,7 +82,7 @@ async function respondToProjectLinkRequest(
         requestBodies.push(body);
     }
     response.setHeader('Content-Type', 'application/json');
-    if (request.method === 'POST' && request.url === '/project-links') {
+    if (request.method === 'POST' && request.url === '/v1/project-links') {
         response.end(
             JSON.stringify({
                 id: LINK_ID,
@@ -95,7 +95,7 @@ async function respondToProjectLinkRequest(
         );
         return;
     }
-    if (request.method === 'POST' && request.url === `/project-links/${LINK_ID}/poll`) {
+    if (request.method === 'POST' && request.url === `/v1/project-links/${LINK_ID}/poll`) {
         response.end(
             JSON.stringify({
                 state: 'approved',

--- a/packages/cli/src/commands/console/console.integration.spec.ts
+++ b/packages/cli/src/commands/console/console.integration.spec.ts
@@ -6,19 +6,8 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { ConsoleCommandDependencies, ConsoleReporter, consoleCommand } from './console';
-import { ProjectLinkManifest, getProjectLinkManifestPath } from './project-link-manifest';
-
-const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
-const PROJECT_ID = '22222222-2222-4222-8222-222222222222';
-const LINK_ID = '33333333-3333-4333-8333-333333333333';
-const POLLING_SECRET = 'integration-polling-secret';
-
-const manifest: ProjectLinkManifest = {
-    schemaVersion: 1,
-    project: { id: PROJECT_ID, name: 'Integration Project' },
-    account: { id: ACCOUNT_ID, name: 'Integration Account' },
-    link: { id: LINK_ID, protocolVersion: 1 },
-};
+import { LINK_ID, POLLING_SECRET, manifest } from './console.fixtures';
+import { getProjectLinkManifestPath } from './project-link-manifest';
 
 let server: Server | undefined;
 let projectRoot: string | undefined;

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -309,6 +309,75 @@ describe('console command', () => {
         expect(fs.existsSync(getProjectLinkManifestPath(root))).toBe(false);
     });
 
+    it('aborts a stalled response body instead of hanging', async () => {
+        const root = vendureProject();
+        const externalAbort = new AbortController();
+        const hanging = new Promise<never>(() => undefined);
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: () => hanging,
+            text: () => hanging,
+            body: {
+                getReader: () => ({
+                    read: () => hanging,
+                    cancel: () => Promise.resolve(),
+                    releaseLock: () => undefined,
+                }),
+            },
+        }) as unknown as typeof fetch;
+        const test = testDependencies(root, fetchMock, {
+            signal: externalAbort.signal,
+        });
+        const pending = consoleCommand('link', {}, test.dependencies);
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+        externalAbort.abort();
+
+        expect(await pending).toBe(130);
+        expect(fs.existsSync(getProjectLinkManifestPath(root))).toBe(false);
+    });
+
+    it('rejects an oversized Console API response', async () => {
+        const root = vendureProject();
+        const fetchMock = sequenceFetch(
+            jsonResponse({
+                ...createResponse(),
+                padding: 'x'.repeat(70_000),
+            }),
+        );
+        const test = testDependencies(root, fetchMock);
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(1);
+        expect(test.messages.join('\n')).toContain('maximum size');
+        expect(fs.existsSync(getProjectLinkManifestPath(root))).toBe(false);
+    });
+
+    it('retries HTTP 429 poll responses as transient failures', async () => {
+        const root = vendureProject();
+        const fetchMock = sequenceFetch(
+            jsonResponse(createResponse()),
+            new Response('', { status: 429 }),
+            jsonResponse({ state: 'approved', expiresAt: expiry(), manifest }),
+        );
+        const test = testDependencies(root, fetchMock);
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(test.sleeps).toEqual([500]);
+    });
+
+    it('rejects a non-string poll state instead of treating it as pending', async () => {
+        const root = vendureProject();
+        const fetchMock = sequenceFetch(
+            jsonResponse(createResponse()),
+            jsonResponse({ state: ['approved'], expiresAt: expiry(), manifest }),
+        );
+        const test = testDependencies(root, fetchMock);
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(1);
+        expect(test.messages.join('\n')).toContain('unknown Project Link state');
+        expect(fs.existsSync(getProjectLinkManifestPath(root))).toBe(false);
+    });
+
     it('retries transient poll failures until expiry and does not retry request creation', async () => {
         const root = vendureProject();
         const fetchMock = sequenceFetch(
@@ -359,6 +428,19 @@ describe('console command', () => {
         const test = testDependencies(root, fetchMock);
 
         expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+    });
+
+    it('does not let --force bypass a cross-root Project Link Manifest', async () => {
+        const { workspace, project } = vendureMonorepo();
+        const ancestorManifest = getProjectLinkManifestPath(workspace);
+        fs.ensureDirSync(path.dirname(ancestorManifest));
+        fs.writeJsonSync(ancestorManifest, manifest);
+        const fetchMock = vi.fn() as unknown as typeof fetch;
+        const test = testDependencies(workspace, fetchMock);
+
+        expect(await consoleCommand('link', { project, force: true }, test.dependencies)).toBe(1);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(test.messages.join('\n')).toContain('outside the selected Vendure project');
     });
 
     it('fails closed for replacement in non-interactive mode and allows --force', async () => {
@@ -443,6 +525,7 @@ describe('console command', () => {
         const linked = testDependencies(root, fetchMock);
         expect(await consoleCommand('status', {}, linked.dependencies)).toBe(0);
         expect(linked.messages.join('\n')).toContain(`Account: Acme (${ACCOUNT_ID})`);
+        expect(linked.messages.join('\n')).toContain(`Manifest: ${getProjectLinkManifestPath(root)}`);
         expect(linked.messages.join('\n')).toContain('Authentication: Not stored locally');
 
         fs.writeFileSync(getProjectLinkManifestPath(root), '{invalid');

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -90,12 +90,6 @@ describe('console command', () => {
                 VENDURE_CONSOLE_LINK_API_URL: 'https://api.vendure.io',
             }),
         ).toThrow('production Console and API origins must be used together');
-        expect(() =>
-            resolveConsoleEndpoints({
-                VENDURE_CONSOLE_URL: 'https://console.example.com',
-                VENDURE_CONSOLE_API_URL: 'https://api.example.com',
-            }),
-        ).toThrow('link-specific');
     });
 
     it('requires explicit approval for custom remote Console endpoints in non-interactive mode', async () => {
@@ -511,12 +505,7 @@ describe('console command', () => {
     it('reports linked, unlinked, and malformed status without network access', async () => {
         const root = vendureProject();
         const fetchMock = vi.fn() as unknown as typeof fetch;
-        const unlinked = testDependencies(root, fetchMock, {
-            env: {
-                VENDURE_CONSOLE_URL: 'https://console.example.com',
-                VENDURE_CONSOLE_API_URL: 'https://api.example.com',
-            },
-        });
+        const unlinked = testDependencies(root, fetchMock);
         expect(await consoleCommand('status', {}, unlinked.dependencies)).toBe(0);
         expect(unlinked.messages.join('\n')).toContain('Project: Not linked');
 

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -129,6 +129,38 @@ describe('console command', () => {
         expect(test.messages.join('\n')).toContain('Could not update');
     });
 
+    it('links an apps/vendure monorepo from the workspace root and updates that gitignore', async () => {
+        const { workspace, project } = vendureMonorepo({ gitignore: 'node_modules\n' });
+        const fetchMock = sequenceFetch(
+            jsonResponse(createResponse()),
+            jsonResponse({ state: 'approved', expiresAt: expiry(), manifest }),
+        );
+        const test = testDependencies(workspace, fetchMock);
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(project))).toEqual(manifest);
+        expect(fs.existsSync(path.join(project, '.gitignore'))).toBe(false);
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain('**/.vendure/*');
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain(
+            '!**/.vendure/project.json',
+        );
+        expect(test.messages.join('\n')).toContain(path.join(workspace, '.gitignore'));
+    });
+
+    it('rewrites a monorepo root directory ignore during link', async () => {
+        const { workspace, project } = vendureMonorepo({ gitignore: '.vendure/\n' });
+        const fetchMock = sequenceFetch(
+            jsonResponse(createResponse()),
+            jsonResponse({ state: 'approved', expiresAt: expiry(), manifest }),
+        );
+        const test = testDependencies(workspace, fetchMock);
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(project))).toEqual(manifest);
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain('**/.vendure/*');
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).not.toMatch(/^\.vendure\/$/m);
+    });
+
     it('accepts unknown API fields and version-agnostic UUIDs', async () => {
         const root = vendureProject();
         const versionSevenManifest: ProjectLinkManifest = {
@@ -462,4 +494,20 @@ function vendureProject(): string {
         dependencies: { '@vendure/core': '3.7.2' },
     });
     return root;
+}
+
+function vendureMonorepo(options: { gitignore?: string } = {}): { workspace: string; project: string } {
+    const workspace = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'vendure-console-monorepo-')));
+    temporaryDirectories.push(workspace);
+    fs.ensureDirSync(path.join(workspace, '.git'));
+    fs.writeJsonSync(path.join(workspace, 'package.json'), { private: true });
+    if (options.gitignore !== undefined) {
+        fs.writeFileSync(path.join(workspace, '.gitignore'), options.gitignore);
+    }
+    const project = path.join(workspace, 'apps', 'vendure');
+    fs.ensureDirSync(project);
+    fs.writeJsonSync(path.join(project, 'package.json'), {
+        dependencies: { '@vendure/core': '3.7.2' },
+    });
+    return { workspace, project: fs.realpathSync(project) };
 }

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -87,9 +87,46 @@ describe('console command', () => {
         expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
 
         expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+        expect(fs.readFileSync(path.join(root, '.gitignore'), 'utf8')).toContain('.vendure/*');
+        expect(fs.readFileSync(path.join(root, '.gitignore'), 'utf8')).toContain('!.vendure/project.json');
         expect(fetchMock).toHaveBeenCalledTimes(3);
         expect(fetchMock.mock.calls[1][1]?.body).toBe(JSON.stringify({ pollingSecret: POLLING_SECRET }));
+        expect(test.messages.join('\n')).toContain('Updated');
+        expect(test.messages.join('\n')).toContain('.gitignore');
+    });
+
+    it('does not rewrite a gitignore that already has the Project Link rules', async () => {
+        const root = vendureProject();
+        const gitignore = [
+            'node_modules',
+            '.vendure/*',
+            '!.vendure/project.json',
+            '',
+        ].join('\n');
+        fs.writeFileSync(path.join(root, '.gitignore'), gitignore);
+        const fetchMock = sequenceFetch(
+            jsonResponse(createResponse()),
+            jsonResponse({ state: 'approved', expiresAt: expiry(), manifest }),
+        );
+        const test = testDependencies(root, fetchMock);
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(fs.readFileSync(path.join(root, '.gitignore'), 'utf8')).toBe(gitignore);
         expect(test.messages.join('\n')).toContain('safe to commit');
+    });
+
+    it('still writes the manifest when the project gitignore cannot be updated', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.join(root, '.gitignore'));
+        const fetchMock = sequenceFetch(
+            jsonResponse(createResponse()),
+            jsonResponse({ state: 'approved', expiresAt: expiry(), manifest }),
+        );
+        const test = testDependencies(root, fetchMock);
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+        expect(test.messages.join('\n')).toContain('Could not update');
     });
 
     it('accepts unknown API fields and version-agnostic UUIDs', async () => {
@@ -145,6 +182,7 @@ describe('console command', () => {
         );
         expect(await consoleCommand('link', {}, denied.dependencies)).toBe(1);
         expect(fs.existsSync(getProjectLinkManifestPath(deniedRoot))).toBe(false);
+        expect(fs.existsSync(path.join(deniedRoot, '.gitignore'))).toBe(false);
 
         const malformedRoot = vendureProject();
         const malformed = testDependencies(

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -148,6 +148,10 @@ describe('console command', () => {
         expect(fs.readFileSync(path.join(root, '.gitignore'), 'utf8')).toContain('.vendure/*');
         expect(fs.readFileSync(path.join(root, '.gitignore'), 'utf8')).toContain('!.vendure/project.json');
         expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:3001/v1/project-links');
+        expect(fetchMock.mock.calls[1][0]).toBe(
+            `http://localhost:3001/v1/project-links/${LINK_ID}/poll`,
+        );
         expect(fetchMock.mock.calls[0][1]?.redirect).toBe('error');
         expect(fetchMock.mock.calls[1][1]?.redirect).toBe('error');
         expect(fetchMock.mock.calls[1][1]?.body).toBe(JSON.stringify({ pollingSecret: POLLING_SECRET }));

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -184,7 +184,7 @@ describe('console command', () => {
         expect(test.messages.join('\n')).toContain('Could not update');
     });
 
-    it('links an apps/vendure monorepo from the workspace root and updates that gitignore', async () => {
+    it('links an apps/vendure monorepo from the workspace root and updates the project gitignore', async () => {
         const { workspace, project } = vendureMonorepo({ gitignore: 'node_modules\n' });
         const fetchMock = sequenceFetch(
             jsonResponse(createResponse()),
@@ -194,12 +194,9 @@ describe('console command', () => {
 
         expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
         expect(fs.readJsonSync(getProjectLinkManifestPath(project))).toEqual(manifest);
-        expect(fs.existsSync(path.join(project, '.gitignore'))).toBe(false);
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain('**/.vendure/*');
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain(
-            '!**/.vendure/project.json',
-        );
-        expect(test.messages.join('\n')).toContain(path.join(workspace, '.gitignore'));
+        expect(fs.readFileSync(path.join(project, '.gitignore'), 'utf8')).toContain('.vendure/*');
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe('node_modules\n');
+        expect(test.messages.join('\n')).toContain(path.join(project, '.gitignore'));
     });
 
     it('rewrites a monorepo root directory ignore during link', async () => {
@@ -212,8 +209,13 @@ describe('console command', () => {
 
         expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
         expect(fs.readJsonSync(getProjectLinkManifestPath(project))).toEqual(manifest);
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain('**/.vendure/*');
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).not.toMatch(/^\.vendure\/$/m);
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain(
+            'apps/vendure/.vendure/*',
+        );
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain(
+            '!apps/vendure/.vendure/project.json',
+        );
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toMatch(/^\.vendure\/$/m);
     });
 
     it('accepts unknown API fields and version-agnostic UUIDs', async () => {

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -1,0 +1,374 @@
+import fs from 'fs-extra';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { CliCommandExit } from '../../shared/cli-command-exit';
+
+import {
+    ConsoleCommandDependencies,
+    ConsoleReporter,
+    consoleCommand,
+    resolveConsoleEndpoints,
+} from './console';
+import { ProjectLinkManifest, getProjectLinkManifestPath } from './project-link-manifest';
+
+const NOW = Date.parse('2026-08-19T10:00:00.000Z');
+const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
+const PROJECT_ID = '22222222-2222-4222-8222-222222222222';
+const LINK_ID = '33333333-3333-4333-8333-333333333333';
+const POLLING_SECRET = 'one-time-polling-secret';
+
+const manifest: ProjectLinkManifest = {
+    schemaVersion: 1,
+    project: { id: PROJECT_ID, name: 'Storefront' },
+    account: { id: ACCOUNT_ID, name: 'Acme' },
+    link: { id: LINK_ID, protocolVersion: 1 },
+};
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    for (const directory of temporaryDirectories.splice(0)) {
+        fs.removeSync(directory);
+    }
+});
+
+describe('console command', () => {
+    it('reports missing and unknown actions with examples', async () => {
+        const root = vendureProject();
+        const first = testDependencies(root, vi.fn());
+        const second = testDependencies(root, vi.fn());
+
+        expect(await consoleCommand(undefined, {}, first.dependencies)).toBe(1);
+        expect(await consoleCommand('unknown', {}, second.dependencies)).toBe(1);
+        expect(first.messages.join('\n')).toContain('vendure console link');
+        expect(second.messages.join('\n')).toContain('Unknown console action');
+    });
+
+    it('requires paired endpoint overrides and validates origins', () => {
+        expect(resolveConsoleEndpoints({})).toEqual({
+            consoleUrl: 'https://console.vendure.io',
+            apiUrl: 'https://api.vendure.io',
+        });
+        expect(resolveConsoleEndpoints({ VENDURE_CONSOLE_URL: '', VENDURE_CONSOLE_API_URL: '   ' })).toEqual({
+            consoleUrl: 'https://console.vendure.io',
+            apiUrl: 'https://api.vendure.io',
+        });
+        expect(() => resolveConsoleEndpoints({ VENDURE_CONSOLE_URL: 'http://localhost:3000' })).toThrow(
+            'Set both',
+        );
+        expect(() =>
+            resolveConsoleEndpoints({
+                VENDURE_CONSOLE_URL: 'http://localhost:3000/path',
+                VENDURE_CONSOLE_API_URL: 'http://localhost:3001',
+            }),
+        ).toThrow('without a path');
+    });
+
+    it('completes create, pending poll, approval, and atomic manifest write', async () => {
+        const root = vendureProject();
+        const fetchMock = sequenceFetch(
+            jsonResponse(createResponse()),
+            jsonResponse({ state: 'pending', expiresAt: expiry() }),
+            jsonResponse({ state: 'approved', expiresAt: expiry(), manifest }),
+        );
+        const test = testDependencies(root, fetchMock);
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(fetchMock.mock.calls[1][1]?.body).toBe(JSON.stringify({ pollingSecret: POLLING_SECRET }));
+        expect(test.messages.join('\n')).toContain('safe to commit');
+    });
+
+    it('prints the safe verification URL and continues when browser launch fails', async () => {
+        const root = vendureProject();
+        const fetchMock = sequenceFetch(
+            jsonResponse(createResponse()),
+            jsonResponse({ state: 'approved', expiresAt: expiry(), manifest }),
+        );
+        const test = testDependencies(root, fetchMock, {
+            openUrl: () => Promise.reject(new Error('browser unavailable')),
+        });
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(test.urls).toEqual([`http://localhost:3000/?link=${LINK_ID}`]);
+        expect(test.messages.join('\n')).not.toContain(POLLING_SECRET);
+    });
+
+    it('does not write a manifest after denial or a malformed approval', async () => {
+        const deniedRoot = vendureProject();
+        const denied = testDependencies(
+            deniedRoot,
+            sequenceFetch(
+                jsonResponse(createResponse()),
+                jsonResponse({ state: 'denied', expiresAt: expiry() }),
+            ),
+        );
+        expect(await consoleCommand('link', {}, denied.dependencies)).toBe(1);
+        expect(fs.existsSync(getProjectLinkManifestPath(deniedRoot))).toBe(false);
+
+        const malformedRoot = vendureProject();
+        const malformed = testDependencies(
+            malformedRoot,
+            sequenceFetch(
+                jsonResponse(createResponse()),
+                jsonResponse({
+                    state: 'approved',
+                    expiresAt: expiry(),
+                    manifest: { ...manifest, pollingSecret: POLLING_SECRET },
+                }),
+            ),
+        );
+        expect(await consoleCommand('link', {}, malformed.dependencies)).toBe(1);
+        expect(fs.existsSync(getProjectLinkManifestPath(malformedRoot))).toBe(false);
+        expect(malformed.messages.join('\n')).not.toContain(POLLING_SECRET);
+    });
+
+    it('reports an expired request without writing a manifest', async () => {
+        const root = vendureProject();
+        const test = testDependencies(
+            root,
+            sequenceFetch(
+                jsonResponse(createResponse()),
+                jsonResponse({ state: 'expired', expiresAt: new Date(NOW - 1).toISOString() }),
+            ),
+        );
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(1);
+        expect(test.messages.join('\n')).toContain('request expired');
+        expect(fs.existsSync(getProjectLinkManifestPath(root))).toBe(false);
+    });
+
+    it('retries transient poll failures and does not retry request creation', async () => {
+        const root = vendureProject();
+        const fetchMock = sequenceFetch(
+            jsonResponse(createResponse()),
+            new Response('', { status: 503 }),
+            new Response('', { status: 502 }),
+            jsonResponse({ state: 'approved', expiresAt: expiry(), manifest }),
+        );
+        const test = testDependencies(root, fetchMock);
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(test.sleeps).toEqual([500, 1_000]);
+
+        const createFailure = vi.fn(() =>
+            Promise.resolve(new Response('', { status: 503 })),
+        ) as unknown as typeof fetch;
+        const failed = testDependencies(vendureProject(), createFailure);
+        expect(await consoleCommand('link', {}, failed.dependencies)).toBe(1);
+        expect(createFailure).toHaveBeenCalledOnce();
+    });
+
+    it('never prints the polling secret when polling becomes unreachable', async () => {
+        const root = vendureProject();
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(jsonResponse(createResponse()))
+            .mockRejectedValue(new Error(`network error ${POLLING_SECRET}`)) as unknown as typeof fetch;
+        const test = testDependencies(root, fetchMock);
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(1);
+        expect([...test.messages, ...test.urls].join('\n')).not.toContain(POLLING_SECRET);
+        expect(fs.existsSync(getProjectLinkManifestPath(root))).toBe(false);
+    });
+
+    it('fails closed for replacement in non-interactive mode and allows --force', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const blockedFetch = vi.fn() as unknown as typeof fetch;
+        const blocked = testDependencies(root, blockedFetch);
+
+        expect(await consoleCommand('link', {}, blocked.dependencies)).toBe(1);
+        expect(blockedFetch).not.toHaveBeenCalled();
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+
+        const replacement = { ...manifest, project: { ...manifest.project, name: 'Replacement' } };
+        const allowed = testDependencies(
+            root,
+            sequenceFetch(
+                jsonResponse(createResponse()),
+                jsonResponse({ state: 'approved', expiresAt: expiry(), manifest: replacement }),
+            ),
+        );
+        expect(await consoleCommand('link', { force: true }, allowed.dependencies)).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(replacement);
+    });
+
+    it('rethrows CliCommandExit from the prompt so the CLI host owns the exit', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const test = testDependencies(root, vi.fn() as unknown as typeof fetch, {
+            isNonInteractive: () => false,
+            prompt: () => Promise.reject(new CliCommandExit(1)),
+        });
+
+        await expect(consoleCommand('link', {}, test.dependencies)).rejects.toBeInstanceOf(CliCommandExit);
+        expect(test.messages.join('\n')).not.toContain('requested exit code');
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+    });
+
+    it('leaves an existing manifest unchanged when interactive replacement is cancelled', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const fetchMock = vi.fn() as unknown as typeof fetch;
+        const test = testDependencies(root, fetchMock, {
+            isNonInteractive: () => false,
+            prompt: () => Promise.resolve(false),
+        });
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+    });
+
+    it('reports linked, unlinked, and malformed status without network access', async () => {
+        const root = vendureProject();
+        const fetchMock = vi.fn() as unknown as typeof fetch;
+        const unlinked = testDependencies(root, fetchMock);
+        expect(await consoleCommand('status', {}, unlinked.dependencies)).toBe(0);
+        expect(unlinked.messages.join('\n')).toContain('Project: Not linked');
+
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const linked = testDependencies(root, fetchMock);
+        expect(await consoleCommand('status', {}, linked.dependencies)).toBe(0);
+        expect(linked.messages.join('\n')).toContain(`Account: Acme (${ACCOUNT_ID})`);
+        expect(linked.messages.join('\n')).toContain('Authentication: Not stored locally');
+
+        fs.writeFileSync(getProjectLinkManifestPath(root), '{invalid');
+        const malformed = testDependencies(root, fetchMock);
+        expect(await consoleCommand('status', {}, malformed.dependencies)).toBe(1);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('unlinks only the local manifest after explicit confirmation', async () => {
+        const root = vendureProject();
+        const manifestPath = getProjectLinkManifestPath(root);
+        const siblingPath = path.join(path.dirname(manifestPath), 'credentials.json');
+        fs.ensureDirSync(path.dirname(manifestPath));
+        fs.writeJsonSync(manifestPath, manifest);
+        fs.writeFileSync(siblingPath, 'machine-local');
+        const test = testDependencies(root, vi.fn() as unknown as typeof fetch);
+
+        expect(await consoleCommand('unlink', { force: true }, test.dependencies)).toBe(0);
+        expect(fs.existsSync(manifestPath)).toBe(false);
+        expect(fs.readFileSync(siblingPath, 'utf8')).toBe('machine-local');
+        expect(fs.existsSync(path.dirname(manifestPath))).toBe(true);
+    });
+
+    it('returns an interrupt exit code and leaves no partial manifest', async () => {
+        const root = vendureProject();
+        const externalAbort = new AbortController();
+        const test = testDependencies(
+            root,
+            sequenceFetch(
+                jsonResponse(createResponse()),
+                jsonResponse({ state: 'pending', expiresAt: expiry() }),
+            ),
+            {
+                signal: externalAbort.signal,
+                sleep: () => {
+                    externalAbort.abort();
+                    return Promise.resolve();
+                },
+            },
+        );
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(130);
+        expect(fs.existsSync(getProjectLinkManifestPath(root))).toBe(false);
+        expect(test.messages.join('\n')).toContain('No Project Link Manifest was changed');
+    });
+});
+
+function testDependencies(
+    root: string,
+    fetchImplementation: typeof fetch,
+    overrides: Partial<ConsoleCommandDependencies> = {},
+): {
+    dependencies: Partial<ConsoleCommandDependencies>;
+    messages: string[];
+    sleeps: number[];
+    urls: string[];
+} {
+    const messages: string[] = [];
+    const urls: string[] = [];
+    const sleeps: number[] = [];
+    const reporter: ConsoleReporter = {
+        error: message => messages.push(message),
+        info: message => messages.push(message),
+        success: message => messages.push(message),
+        warn: message => messages.push(message),
+        url: value => urls.push(value),
+    };
+    return {
+        dependencies: {
+            cwd: root,
+            env: {
+                VENDURE_CLI_NON_INTERACTIVE: 'true',
+                VENDURE_CONSOLE_URL: 'http://localhost:3000',
+                VENDURE_CONSOLE_API_URL: 'http://localhost:3001',
+            },
+            fetch: fetchImplementation,
+            isNonInteractive: () => true,
+            now: () => NOW,
+            openUrl: () => Promise.resolve(),
+            prompt: () => Promise.resolve(true),
+            reporter,
+            sleep: milliseconds => {
+                sleeps.push(milliseconds);
+                return Promise.resolve();
+            },
+            ...overrides,
+        },
+        messages,
+        sleeps,
+        urls,
+    };
+}
+
+function createResponse() {
+    return {
+        id: LINK_ID,
+        state: 'pending',
+        protocolVersion: 1,
+        expiresAt: expiry(),
+        pollingSecret: POLLING_SECRET,
+        verificationPath: `/?link=${LINK_ID}`,
+    };
+}
+
+function expiry(): string {
+    return new Date(NOW + 10 * 60 * 1_000).toISOString();
+}
+
+function jsonResponse(value: unknown): Response {
+    return new Response(JSON.stringify(value), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+function sequenceFetch(...responses: Response[]): ReturnType<typeof vi.fn> {
+    const fetchMock = vi.fn();
+    for (const response of responses) {
+        fetchMock.mockResolvedValueOnce(response);
+    }
+    return fetchMock;
+}
+
+function vendureProject(): string {
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'vendure-console-command-')));
+    temporaryDirectories.push(root);
+    fs.writeJsonSync(path.join(root, 'package.json'), {
+        dependencies: { '@vendure/core': '3.7.2' },
+    });
+    return root;
+}

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -11,20 +11,18 @@ import {
     consoleCommand,
     resolveConsoleEndpoints,
 } from './console';
+import {
+    ACCOUNT_ID,
+    LINK_ID,
+    NOW,
+    POLLING_SECRET,
+    createResponse,
+    expiry,
+    manifest,
+} from './console.fixtures';
 import { ProjectLinkManifest, getProjectLinkManifestPath } from './project-link-manifest';
 
-const NOW = Date.parse('2026-08-19T10:00:00.000Z');
-const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
-const PROJECT_ID = '22222222-2222-4222-8222-222222222222';
-const LINK_ID = '33333333-3333-4333-8333-333333333333';
-const POLLING_SECRET = 'one-time-polling-secret';
-
-const manifest: ProjectLinkManifest = {
-    schemaVersion: 1,
-    project: { id: PROJECT_ID, name: 'Storefront' },
-    account: { id: ACCOUNT_ID, name: 'Acme' },
-    link: { id: LINK_ID, protocolVersion: 1 },
-};
+const UUID_V7_LINK_ID = '33333333-3333-7333-8333-333333333333';
 
 const temporaryDirectories: string[] = [];
 
@@ -45,6 +43,16 @@ describe('console command', () => {
         expect(await consoleCommand('unknown', {}, second.dependencies)).toBe(1);
         expect(first.messages.join('\n')).toContain('vendure console link');
         expect(second.messages.join('\n')).toContain('Unknown console action');
+    });
+
+    it('resolves the default working directory when the command runs', async () => {
+        const root = vendureProject();
+        const test = testDependencies(root, vi.fn() as unknown as typeof fetch);
+        delete test.dependencies.cwd;
+        vi.spyOn(process, 'cwd').mockReturnValue(root);
+
+        expect(await consoleCommand('status', {}, test.dependencies)).toBe(0);
+        expect(test.messages.join('\n')).toContain('Project: Not linked');
     });
 
     it('requires paired endpoint overrides and validates origins', () => {
@@ -82,6 +90,33 @@ describe('console command', () => {
         expect(fetchMock).toHaveBeenCalledTimes(3);
         expect(fetchMock.mock.calls[1][1]?.body).toBe(JSON.stringify({ pollingSecret: POLLING_SECRET }));
         expect(test.messages.join('\n')).toContain('safe to commit');
+    });
+
+    it('accepts unknown API fields and version-agnostic UUIDs', async () => {
+        const root = vendureProject();
+        const versionSevenManifest: ProjectLinkManifest = {
+            ...manifest,
+            link: { id: UUID_V7_LINK_ID, protocolVersion: 1 },
+        };
+        const fetchMock = sequenceFetch(
+            jsonResponse({
+                ...createResponse(),
+                id: UUID_V7_LINK_ID,
+                verificationPath: `/?link=${UUID_V7_LINK_ID}`,
+                serverCapability: 'future-value',
+            }),
+            jsonResponse({ state: 'pending', expiresAt: expiry(), retryHint: 'future-value' }),
+            jsonResponse({
+                state: 'approved',
+                expiresAt: expiry(),
+                manifest: versionSevenManifest,
+                auditId: 'future-value',
+            }),
+        );
+        const test = testDependencies(root, fetchMock);
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(versionSevenManifest);
     });
 
     it('prints the safe verification URL and continues when browser launch fails', async () => {
@@ -143,10 +178,12 @@ describe('console command', () => {
         expect(fs.existsSync(getProjectLinkManifestPath(root))).toBe(false);
     });
 
-    it('retries transient poll failures and does not retry request creation', async () => {
+    it('retries transient poll failures until expiry and does not retry request creation', async () => {
         const root = vendureProject();
         const fetchMock = sequenceFetch(
             jsonResponse(createResponse()),
+            new Response('', { status: 503 }),
+            new Response('', { status: 502 }),
             new Response('', { status: 503 }),
             new Response('', { status: 502 }),
             jsonResponse({ state: 'approved', expiresAt: expiry(), manifest }),
@@ -154,7 +191,7 @@ describe('console command', () => {
         const test = testDependencies(root, fetchMock);
 
         expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
-        expect(test.sleeps).toEqual([500, 1_000]);
+        expect(test.sleeps).toEqual([500, 1_000, 2_000, 2_000]);
 
         const createFailure = vi.fn(() =>
             Promise.resolve(new Response('', { status: 503 })),
@@ -168,13 +205,29 @@ describe('console command', () => {
         const root = vendureProject();
         const fetchMock = vi
             .fn()
-            .mockResolvedValueOnce(jsonResponse(createResponse()))
+            .mockResolvedValueOnce(jsonResponse(createResponse(new Date(NOW + 1_500).toISOString())))
             .mockRejectedValue(new Error(`network error ${POLLING_SECRET}`)) as unknown as typeof fetch;
         const test = testDependencies(root, fetchMock);
 
         expect(await consoleCommand('link', {}, test.dependencies)).toBe(1);
         expect([...test.messages, ...test.urls].join('\n')).not.toContain(POLLING_SECRET);
         expect(fs.existsSync(getProjectLinkManifestPath(root))).toBe(false);
+    });
+
+    it('uses the latest expiry returned by polling', async () => {
+        const root = vendureProject();
+        const fetchMock = sequenceFetch(
+            jsonResponse(createResponse(new Date(NOW + 1_000).toISOString())),
+            jsonResponse({ state: 'pending', expiresAt: new Date(NOW + 5_000).toISOString() }),
+            jsonResponse({
+                state: 'approved',
+                expiresAt: new Date(NOW + 5_000).toISOString(),
+                manifest,
+            }),
+        );
+        const test = testDependencies(root, fetchMock);
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
     });
 
     it('fails closed for replacement in non-interactive mode and allows --force', async () => {
@@ -226,6 +279,19 @@ describe('console command', () => {
 
         expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
         expect(fetchMock).not.toHaveBeenCalled();
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+    });
+
+    it('returns an interrupt exit code when the confirmation prompt is cancelled', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const test = testDependencies(root, vi.fn() as unknown as typeof fetch, {
+            isNonInteractive: () => false,
+            prompt: () => Promise.resolve(undefined),
+        });
+
+        expect(await consoleCommand('unlink', {}, test.dependencies)).toBe(130);
         expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
     });
 
@@ -301,6 +367,7 @@ function testDependencies(
     const messages: string[] = [];
     const urls: string[] = [];
     const sleeps: number[] = [];
+    let currentTime = NOW;
     const reporter: ConsoleReporter = {
         error: message => messages.push(message),
         info: message => messages.push(message),
@@ -318,12 +385,13 @@ function testDependencies(
             },
             fetch: fetchImplementation,
             isNonInteractive: () => true,
-            now: () => NOW,
+            now: () => currentTime,
             openUrl: () => Promise.resolve(),
             prompt: () => Promise.resolve(true),
             reporter,
             sleep: milliseconds => {
                 sleeps.push(milliseconds);
+                currentTime += milliseconds;
                 return Promise.resolve();
             },
             ...overrides,
@@ -332,21 +400,6 @@ function testDependencies(
         sleeps,
         urls,
     };
-}
-
-function createResponse() {
-    return {
-        id: LINK_ID,
-        state: 'pending',
-        protocolVersion: 1,
-        expiresAt: expiry(),
-        pollingSecret: POLLING_SECRET,
-        verificationPath: `/?link=${LINK_ID}`,
-    };
-}
-
-function expiry(): string {
-    return new Date(NOW + 10 * 60 * 1_000).toISOString();
 }
 
 function jsonResponse(value: unknown): Response {

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -60,19 +60,83 @@ describe('console command', () => {
             consoleUrl: 'https://console.vendure.io',
             apiUrl: 'https://api.vendure.io',
         });
-        expect(resolveConsoleEndpoints({ VENDURE_CONSOLE_URL: '', VENDURE_CONSOLE_API_URL: '   ' })).toEqual({
+        expect(
+            resolveConsoleEndpoints({
+                VENDURE_CONSOLE_LINK_URL: '',
+                VENDURE_CONSOLE_LINK_API_URL: '   ',
+            }),
+        ).toEqual({
             consoleUrl: 'https://console.vendure.io',
             apiUrl: 'https://api.vendure.io',
         });
-        expect(() => resolveConsoleEndpoints({ VENDURE_CONSOLE_URL: 'http://localhost:3000' })).toThrow(
+        expect(() => resolveConsoleEndpoints({ VENDURE_CONSOLE_LINK_URL: 'http://localhost:3000' })).toThrow(
             'Set both',
         );
         expect(() =>
             resolveConsoleEndpoints({
-                VENDURE_CONSOLE_URL: 'http://localhost:3000/path',
-                VENDURE_CONSOLE_API_URL: 'http://localhost:3001',
+                VENDURE_CONSOLE_LINK_URL: 'http://localhost:3000/path',
+                VENDURE_CONSOLE_LINK_API_URL: 'http://localhost:3001',
             }),
         ).toThrow('without a path');
+        expect(() =>
+            resolveConsoleEndpoints({
+                VENDURE_CONSOLE_LINK_URL: 'http://console.example.com',
+                VENDURE_CONSOLE_LINK_API_URL: 'https://api.example.com',
+            }),
+        ).toThrow('must use HTTPS unless it is a loopback URL');
+        expect(() =>
+            resolveConsoleEndpoints({
+                VENDURE_CONSOLE_LINK_URL: 'https://console.example.com',
+                VENDURE_CONSOLE_LINK_API_URL: 'https://api.vendure.io',
+            }),
+        ).toThrow('production Console and API origins must be used together');
+        expect(() =>
+            resolveConsoleEndpoints({
+                VENDURE_CONSOLE_URL: 'https://console.example.com',
+                VENDURE_CONSOLE_API_URL: 'https://api.example.com',
+            }),
+        ).toThrow('link-specific');
+    });
+
+    it('requires explicit approval for custom remote Console endpoints in non-interactive mode', async () => {
+        const env = {
+            VENDURE_CLI_NON_INTERACTIVE: 'true',
+            VENDURE_CONSOLE_LINK_URL: 'https://console.staging.example.com',
+            VENDURE_CONSOLE_LINK_API_URL: 'https://api.staging.example.com',
+        };
+        const blockedFetch = vi.fn() as unknown as typeof fetch;
+        const blocked = testDependencies(vendureProject(), blockedFetch, { env });
+
+        expect(await consoleCommand('link', {}, blocked.dependencies)).toBe(1);
+        expect(blockedFetch).not.toHaveBeenCalled();
+        expect(blocked.messages.join('\n')).toContain('--allow-custom-console');
+
+        const allowedFetch = sequenceFetch(
+            jsonResponse(createResponse()),
+            jsonResponse({ state: 'approved', expiresAt: expiry(), manifest }),
+        );
+        const allowed = testDependencies(vendureProject(), allowedFetch, { env });
+
+        expect(await consoleCommand('link', { allowCustomConsole: true }, allowed.dependencies)).toBe(0);
+        expect(allowedFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('shows custom remote Console origins before an interactive request', async () => {
+        const fetchMock = vi.fn() as unknown as typeof fetch;
+        const prompt = vi.fn(() => Promise.resolve(false));
+        const test = testDependencies(vendureProject(), fetchMock, {
+            env: {
+                VENDURE_CONSOLE_LINK_URL: 'https://console.staging.example.com',
+                VENDURE_CONSOLE_LINK_API_URL: 'https://api.staging.example.com',
+            },
+            isNonInteractive: () => false,
+            prompt,
+        });
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(prompt).toHaveBeenCalledWith(expect.stringContaining('console.staging.example.com'));
+        expect(prompt).toHaveBeenCalledWith(expect.stringContaining('api.staging.example.com'));
     });
 
     it('completes create, pending poll, approval, and atomic manifest write', async () => {
@@ -90,6 +154,8 @@ describe('console command', () => {
         expect(fs.readFileSync(path.join(root, '.gitignore'), 'utf8')).toContain('.vendure/*');
         expect(fs.readFileSync(path.join(root, '.gitignore'), 'utf8')).toContain('!.vendure/project.json');
         expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(fetchMock.mock.calls[0][1]?.redirect).toBe('error');
+        expect(fetchMock.mock.calls[1][1]?.redirect).toBe('error');
         expect(fetchMock.mock.calls[1][1]?.body).toBe(JSON.stringify({ pollingSecret: POLLING_SECRET }));
         expect(test.messages.join('\n')).toContain('Updated');
         expect(test.messages.join('\n')).toContain('.gitignore');
@@ -97,12 +163,7 @@ describe('console command', () => {
 
     it('does not rewrite a gitignore that already has the Project Link rules', async () => {
         const root = vendureProject();
-        const gitignore = [
-            'node_modules',
-            '.vendure/*',
-            '!.vendure/project.json',
-            '',
-        ].join('\n');
+        const gitignore = ['node_modules', '.vendure/*', '!.vendure/project.json', ''].join('\n');
         fs.writeFileSync(path.join(root, '.gitignore'), gitignore);
         const fetchMock = sequenceFetch(
             jsonResponse(createResponse()),
@@ -368,7 +429,12 @@ describe('console command', () => {
     it('reports linked, unlinked, and malformed status without network access', async () => {
         const root = vendureProject();
         const fetchMock = vi.fn() as unknown as typeof fetch;
-        const unlinked = testDependencies(root, fetchMock);
+        const unlinked = testDependencies(root, fetchMock, {
+            env: {
+                VENDURE_CONSOLE_URL: 'https://console.example.com',
+                VENDURE_CONSOLE_API_URL: 'https://api.example.com',
+            },
+        });
         expect(await consoleCommand('status', {}, unlinked.dependencies)).toBe(0);
         expect(unlinked.messages.join('\n')).toContain('Project: Not linked');
 
@@ -450,8 +516,8 @@ function testDependencies(
             cwd: root,
             env: {
                 VENDURE_CLI_NON_INTERACTIVE: 'true',
-                VENDURE_CONSOLE_URL: 'http://localhost:3000',
-                VENDURE_CONSOLE_API_URL: 'http://localhost:3001',
+                VENDURE_CONSOLE_LINK_URL: 'http://localhost:3000',
+                VENDURE_CONSOLE_LINK_API_URL: 'http://localhost:3001',
             },
             fetch: fetchImplementation,
             isNonInteractive: () => true,

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -199,7 +199,7 @@ describe('console command', () => {
         expect(test.messages.join('\n')).toContain(path.join(project, '.gitignore'));
     });
 
-    it('rewrites a monorepo root directory ignore during link', async () => {
+    it('does not rewrite a monorepo root gitignore during link', async () => {
         const { workspace, project } = vendureMonorepo({ gitignore: '.vendure/\n' });
         const fetchMock = sequenceFetch(
             jsonResponse(createResponse()),
@@ -209,13 +209,10 @@ describe('console command', () => {
 
         expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
         expect(fs.readJsonSync(getProjectLinkManifestPath(project))).toEqual(manifest);
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain(
-            'apps/vendure/.vendure/*',
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe('.vendure/\n');
+        expect(fs.readFileSync(path.join(project, '.gitignore'), 'utf8')).toBe(
+            '.vendure/*\n!.vendure/project.json\n',
         );
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain(
-            '!apps/vendure/.vendure/project.json',
-        );
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toMatch(/^\.vendure\/$/m);
     });
 
     it('accepts unknown API fields and version-agnostic UUIDs', async () => {
@@ -460,6 +457,23 @@ describe('console command', () => {
         );
         expect(await consoleCommand('link', { force: true }, allowed.dependencies)).toBe(0);
         expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(replacement);
+    });
+
+    it('validates Console endpoints before prompting to replace a manifest', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const prompt = vi.fn(() => Promise.resolve(true));
+        const test = testDependencies(root, vi.fn() as unknown as typeof fetch, {
+            env: { VENDURE_CONSOLE_LINK_URL: 'https://console.example.com' },
+            isNonInteractive: () => false,
+            prompt,
+        });
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(1);
+        expect(prompt).not.toHaveBeenCalled();
+        expect(test.messages.join('\n')).toContain('Set both VENDURE_CONSOLE_LINK_URL');
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
     });
 
     it('rethrows CliCommandExit from the prompt so the CLI host owns the exit', async () => {

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -193,11 +193,6 @@ async function runConsoleCommand(
 }
 
 export function resolveConsoleEndpoints(env: NodeJS.ProcessEnv): ConsoleEndpoints {
-    if (env.VENDURE_CONSOLE_URL?.trim() || env.VENDURE_CONSOLE_API_URL?.trim()) {
-        throw new Error(
-            'Use the link-specific VENDURE_CONSOLE_LINK_URL and VENDURE_CONSOLE_LINK_API_URL variables for this command.',
-        );
-    }
     const consoleOverride = env.VENDURE_CONSOLE_LINK_URL?.trim() || undefined;
     const apiOverride = env.VENDURE_CONSOLE_LINK_API_URL?.trim() || undefined;
     if (Boolean(consoleOverride) !== Boolean(apiOverride)) {

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -1,0 +1,593 @@
+import { confirm, isCancel, log } from '@clack/prompts';
+import { ChildProcess, spawn } from 'node:child_process';
+
+import { CliCommandExit } from '../../shared/cli-command-exit';
+import { isNonInteractiveEnvironment, withInteractiveTimeout } from '../../utilities/utils';
+
+import {
+    ManifestReadResult,
+    ProjectLinkManifest,
+    parseProjectLinkManifest,
+    readProjectLinkManifest,
+    removeProjectLinkManifest,
+    resolveProjectRoot,
+    writeProjectLinkManifestAtomic,
+} from './project-link-manifest';
+
+const DEFAULT_CONSOLE_URL = 'https://console.vendure.io';
+const DEFAULT_CONSOLE_API_URL = 'https://api.vendure.io';
+const POLL_INTERVAL_MS = 2_000;
+const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_POLL_ATTEMPTS = 3;
+const RETRY_DELAYS_MS = [500, 1_000];
+
+export interface ConsoleCommandOptions {
+    project?: string;
+    force?: boolean;
+}
+
+export interface ConsoleReporter {
+    error(message: string): void;
+    info(message: string): void;
+    success(message: string): void;
+    warn(message: string): void;
+    url(value: string): void;
+}
+
+export interface ConsoleCommandDependencies {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    fetch: typeof globalThis.fetch;
+    isNonInteractive: () => boolean;
+    now: () => number;
+    openUrl: (url: string) => Promise<void>;
+    prompt: (message: string) => Promise<boolean | undefined>;
+    reporter: ConsoleReporter;
+    signal?: AbortSignal;
+    sleep: (milliseconds: number, signal: AbortSignal) => Promise<void>;
+}
+
+interface ConsoleEndpoints {
+    apiUrl: string;
+    consoleUrl: string;
+}
+
+interface ProjectLinkRequest {
+    id: string;
+    expiresAt: number;
+    pollingSecret: string;
+    verificationUrl: string;
+}
+
+interface ProjectLinkPollResult {
+    state: 'pending' | 'approved' | 'denied' | 'expired';
+    expiresAt: number;
+    manifest?: ProjectLinkManifest;
+}
+
+class ConsoleRequestError extends Error {
+    constructor(
+        message: string,
+        readonly transient: boolean,
+    ) {
+        super(message);
+        this.name = 'ConsoleRequestError';
+    }
+}
+
+class CommandInterruptedError extends Error {
+    constructor(readonly exitCode: number) {
+        super('The Console command was interrupted.');
+        this.name = 'CommandInterruptedError';
+    }
+}
+
+const defaultReporter: ConsoleReporter = {
+    error: message => log.error(message),
+    info: message => log.info(message),
+    success: message => log.success(message),
+    warn: message => log.warn(message),
+    url: value => process.stdout.write(`${value}\n`),
+};
+
+const defaultDependencies: ConsoleCommandDependencies = {
+    cwd: process.cwd(),
+    env: process.env,
+    fetch: globalThis.fetch,
+    isNonInteractive: () => isNonInteractiveEnvironment(),
+    now: () => Date.now(),
+    openUrl: openUrlInBrowser,
+    prompt: async message => {
+        const result = await withInteractiveTimeout(() => confirm({ message }), {
+            examples: ['vendure console link --force', 'vendure console unlink --force'],
+            helpCommands: ['vendure console --help'],
+        });
+        return isCancel(result) ? undefined : result;
+    },
+    reporter: defaultReporter,
+    sleep: abortableSleep,
+};
+
+export async function consoleCommand(
+    action?: string,
+    options: ConsoleCommandOptions = {},
+    dependencies: Partial<ConsoleCommandDependencies> = {},
+): Promise<number> {
+    const abortController = new AbortController();
+    let interruptedExitCode: number | undefined;
+    const onSigint = () => {
+        interruptedExitCode = 130;
+        abortController.abort();
+    };
+    const onSigterm = () => {
+        interruptedExitCode = 143;
+        abortController.abort();
+    };
+    process.once('SIGINT', onSigint);
+    process.once('SIGTERM', onSigterm);
+    const externalSignal = dependencies.signal;
+    const onExternalAbort = () => abortController.abort();
+    if (externalSignal?.aborted) {
+        abortController.abort();
+    } else {
+        externalSignal?.addEventListener('abort', onExternalAbort, { once: true });
+    }
+
+    try {
+        return await runConsoleCommand(
+            action,
+            options,
+            { ...defaultDependencies, ...dependencies },
+            abortController.signal,
+        );
+    } catch (error) {
+        const deps = { ...defaultDependencies, ...dependencies };
+        if (interruptedExitCode !== undefined || error instanceof CommandInterruptedError) {
+            const exitCode = interruptedExitCode ?? (error as CommandInterruptedError).exitCode;
+            deps.reporter.warn('Console command interrupted. No Project Link Manifest was changed.');
+            return exitCode;
+        }
+        if (error instanceof CliCommandExit) {
+            throw error;
+        }
+        deps.reporter.error(error instanceof Error ? error.message : String(error));
+        return 1;
+    } finally {
+        process.removeListener('SIGINT', onSigint);
+        process.removeListener('SIGTERM', onSigterm);
+        externalSignal?.removeEventListener('abort', onExternalAbort);
+    }
+}
+
+export async function runConsoleCommand(
+    action: string | undefined,
+    options: ConsoleCommandOptions,
+    dependencies: ConsoleCommandDependencies,
+    signal: AbortSignal,
+): Promise<number> {
+    const normalizedAction = action?.trim().toLowerCase();
+    if (!normalizedAction || !['link', 'status', 'unlink'].includes(normalizedAction)) {
+        dependencies.reporter.error(
+            normalizedAction ? `Unknown console action "${String(action)}".` : 'Missing console action.',
+        );
+        dependencies.reporter.info(
+            'Examples:\n   vendure console link\n   vendure console status\n   vendure console unlink',
+        );
+        return 1;
+    }
+
+    const projectRoot = resolveProjectRoot(dependencies.cwd, options.project);
+    if (normalizedAction === 'status') {
+        return status(projectRoot, dependencies.reporter);
+    }
+    if (normalizedAction === 'unlink') {
+        return unlink(projectRoot, options, dependencies);
+    }
+    return link(projectRoot, options, dependencies, signal);
+}
+
+export function resolveConsoleEndpoints(env: NodeJS.ProcessEnv): ConsoleEndpoints {
+    const consoleOverride = env.VENDURE_CONSOLE_URL?.trim() || undefined;
+    const apiOverride = env.VENDURE_CONSOLE_API_URL?.trim() || undefined;
+    if (Boolean(consoleOverride) !== Boolean(apiOverride)) {
+        throw new Error(
+            'Set both VENDURE_CONSOLE_URL and VENDURE_CONSOLE_API_URL, or unset both to use production.',
+        );
+    }
+    return {
+        consoleUrl: baseUrl(consoleOverride ?? DEFAULT_CONSOLE_URL, 'VENDURE_CONSOLE_URL'),
+        apiUrl: baseUrl(apiOverride ?? DEFAULT_CONSOLE_API_URL, 'VENDURE_CONSOLE_API_URL'),
+    };
+}
+
+async function link(
+    projectRoot: string,
+    options: ConsoleCommandOptions,
+    dependencies: ConsoleCommandDependencies,
+    signal: AbortSignal,
+): Promise<number> {
+    const existing = readProjectLinkManifest(projectRoot);
+    if (existing.kind !== 'missing') {
+        const confirmed = await confirmManifestChange('replace', existing, options, dependencies);
+        if (confirmed !== 'confirmed') {
+            return confirmed === 'cancelled' ? 0 : 1;
+        }
+    }
+
+    const endpoints = resolveConsoleEndpoints(dependencies.env);
+    const request = await createProjectLink(endpoints, dependencies, signal);
+    if (dependencies.now() >= request.expiresAt) {
+        throw new Error('The Project Link request expired. Run vendure console link again.');
+    }
+    dependencies.reporter.info('Approve the Project link in your browser.');
+    try {
+        await dependencies.openUrl(request.verificationUrl);
+    } catch {
+        dependencies.reporter.warn('Could not open the browser automatically. Open this URL to continue:');
+        dependencies.reporter.url(request.verificationUrl);
+    }
+
+    const manifest = await waitForApproval(request, endpoints, dependencies, signal);
+    throwIfAborted(signal);
+    const manifestPath = await writeProjectLinkManifestAtomic(projectRoot, manifest);
+    dependencies.reporter.success(`Linked ${manifest.project.name} to ${manifest.account.name}.`);
+    dependencies.reporter.info(`Wrote ${manifestPath}`);
+    dependencies.reporter.info(
+        'This file contains identity metadata only and is safe to commit. Keep every other .vendure file ignored because it may contain machine-local secrets.',
+    );
+    return 0;
+}
+
+function status(projectRoot: string, reporter: ConsoleReporter): number {
+    const result = readProjectLinkManifest(projectRoot);
+    if (result.kind === 'missing') {
+        reporter.info(`Project: Not linked\nManifest: ${result.path}\nAuthentication: Not stored locally`);
+        reporter.info(
+            'Console authorization happens in the browser; the CLI stores no Console access token.',
+        );
+        return 0;
+    }
+    if (result.kind === 'invalid') {
+        reporter.error(`Invalid Project Link Manifest at ${result.path}: ${result.reason}`);
+        return 1;
+    }
+
+    const { manifest } = result;
+    reporter.info(
+        [
+            `Account: ${manifest.account.name} (${manifest.account.id})`,
+            `Project: ${manifest.project.name} (${manifest.project.id})`,
+            `Schema version: ${manifest.schemaVersion}`,
+            `Protocol version: ${manifest.link.protocolVersion}`,
+            `Link: ${manifest.link.id}`,
+            'Authentication: Not stored locally (browser authorization)',
+        ].join('\n'),
+    );
+    return 0;
+}
+
+async function unlink(
+    projectRoot: string,
+    options: ConsoleCommandOptions,
+    dependencies: ConsoleCommandDependencies,
+): Promise<number> {
+    const existing = readProjectLinkManifest(projectRoot);
+    if (existing.kind === 'missing') {
+        dependencies.reporter.info(`Project is not linked. No manifest exists at ${existing.path}.`);
+        return 0;
+    }
+
+    const confirmed = await confirmManifestChange('remove', existing, options, dependencies);
+    if (confirmed !== 'confirmed') {
+        return confirmed === 'cancelled' ? 0 : 1;
+    }
+    removeProjectLinkManifest(projectRoot);
+    dependencies.reporter.success(`Removed local Project Link Manifest at ${existing.path}.`);
+    dependencies.reporter.info('The Console Project and server-side link request were not changed.');
+    return 0;
+}
+
+async function confirmManifestChange(
+    action: 'replace' | 'remove',
+    existing: Exclude<ManifestReadResult, { kind: 'missing' }>,
+    options: ConsoleCommandOptions,
+    dependencies: ConsoleCommandDependencies,
+): Promise<'confirmed' | 'cancelled' | 'required'> {
+    if (options.force) {
+        return 'confirmed';
+    }
+    if (dependencies.isNonInteractive()) {
+        dependencies.reporter.error(
+            `Refusing to ${action} ${existing.path} without confirmation in a non-interactive environment.`,
+        );
+        dependencies.reporter.info(
+            `Run vendure console ${action === 'replace' ? 'link' : 'unlink'} --force to confirm this action.`,
+        );
+        return 'required';
+    }
+
+    const detail =
+        existing.kind === 'valid'
+            ? `${existing.manifest.project.name} in ${existing.manifest.account.name}`
+            : `the invalid manifest at ${existing.path}`;
+    const result = await dependencies.prompt(
+        `${action === 'replace' ? 'Replace' : 'Remove'} the local link for ${detail}?`,
+    );
+    if (result !== true) {
+        dependencies.reporter.info('No Project Link Manifest changes were made.');
+        return 'cancelled';
+    }
+    return 'confirmed';
+}
+
+async function createProjectLink(
+    endpoints: ConsoleEndpoints,
+    dependencies: ConsoleCommandDependencies,
+    signal: AbortSignal,
+): Promise<ProjectLinkRequest> {
+    const value = await requestJson(
+        `${endpoints.apiUrl}/project-links`,
+        { method: 'POST' },
+        dependencies,
+        signal,
+    );
+    const object = exactObject(
+        value,
+        ['id', 'state', 'protocolVersion', 'expiresAt', 'pollingSecret', 'verificationPath'],
+        'project-link response',
+    );
+    const id = uuid(object.id, 'project-link id');
+    if (object.state !== 'pending' || object.protocolVersion !== 1) {
+        throw new Error('Console returned an unsupported Project Link request.');
+    }
+    const expiresAt = timestamp(object.expiresAt, 'project-link expiry');
+    const pollingSecret = nonEmptyString(object.pollingSecret, 'polling secret');
+    const verificationPath = nonEmptyString(object.verificationPath, 'verification path');
+    if (!verificationPath.startsWith('/') || verificationPath.startsWith('//')) {
+        throw new Error('Console returned an invalid verification path.');
+    }
+    const verificationUrl = new URL(verificationPath, `${endpoints.consoleUrl}/`).toString();
+    if (new URL(verificationUrl).origin !== new URL(endpoints.consoleUrl).origin) {
+        throw new Error('Console returned a verification URL for an unexpected origin.');
+    }
+    if (verificationUrl.includes(pollingSecret)) {
+        throw new Error('Console returned an unsafe verification URL.');
+    }
+    return { id, expiresAt, pollingSecret, verificationUrl };
+}
+
+async function waitForApproval(
+    request: ProjectLinkRequest,
+    endpoints: ConsoleEndpoints,
+    dependencies: ConsoleCommandDependencies,
+    signal: AbortSignal,
+): Promise<ProjectLinkManifest> {
+    while (true) {
+        throwIfAborted(signal);
+        if (dependencies.now() >= request.expiresAt) {
+            throw new Error('The Project Link request expired. Run vendure console link again.');
+        }
+
+        const result = await pollWithRetry(request, endpoints, dependencies, signal);
+        if (result.state === 'approved') {
+            if (!result.manifest) {
+                throw new Error('Console approved the request without returning a Project Link Manifest.');
+            }
+            return result.manifest;
+        }
+        if (result.state === 'denied') {
+            throw new Error('The Project Link request was denied in Console.');
+        }
+        if (result.state === 'expired' || dependencies.now() >= result.expiresAt) {
+            throw new Error('The Project Link request expired. Run vendure console link again.');
+        }
+        await dependencies.sleep(POLL_INTERVAL_MS, signal);
+    }
+}
+
+async function pollWithRetry(
+    request: ProjectLinkRequest,
+    endpoints: ConsoleEndpoints,
+    dependencies: ConsoleCommandDependencies,
+    signal: AbortSignal,
+): Promise<ProjectLinkPollResult> {
+    for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+        try {
+            const value = await requestJson(
+                `${endpoints.apiUrl}/project-links/${encodeURIComponent(request.id)}/poll`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ pollingSecret: request.pollingSecret }),
+                },
+                dependencies,
+                signal,
+            );
+            return parsePollResult(value, request.id);
+        } catch (error) {
+            if (
+                !(error instanceof ConsoleRequestError) ||
+                !error.transient ||
+                attempt === MAX_POLL_ATTEMPTS - 1
+            ) {
+                throw error;
+            }
+            await dependencies.sleep(RETRY_DELAYS_MS[attempt], signal);
+        }
+    }
+    throw new Error('Console polling failed.');
+}
+
+function parsePollResult(value: unknown, expectedLinkId: string): ProjectLinkPollResult {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        throw new Error('Console returned a malformed Project Link polling response.');
+    }
+    const record = value as Record<string, unknown>;
+    const state = record.state;
+    if (!['pending', 'approved', 'denied', 'expired'].includes(String(state))) {
+        throw new Error('Console returned an unknown Project Link state.');
+    }
+    const expectedKeys = state === 'approved' ? ['state', 'expiresAt', 'manifest'] : ['state', 'expiresAt'];
+    const object = exactObject(value, expectedKeys, 'project-link polling response');
+    const result: ProjectLinkPollResult = {
+        state: state as ProjectLinkPollResult['state'],
+        expiresAt: timestamp(object.expiresAt, 'project-link expiry'),
+    };
+    if (state === 'approved') {
+        result.manifest = parseProjectLinkManifest(object.manifest, expectedLinkId);
+    }
+    return result;
+}
+
+async function requestJson(
+    url: string,
+    init: RequestInit,
+    dependencies: ConsoleCommandDependencies,
+    signal: AbortSignal,
+): Promise<unknown> {
+    throwIfAborted(signal);
+    const requestController = new AbortController();
+    let timedOut = false;
+    const onAbort = () => requestController.abort();
+    signal.addEventListener('abort', onAbort, { once: true });
+    const timeout = setTimeout(() => {
+        timedOut = true;
+        requestController.abort();
+    }, REQUEST_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+        response = await dependencies.fetch(url, { ...init, signal: requestController.signal });
+    } catch {
+        if (signal.aborted) {
+            throw new CommandInterruptedError(130);
+        }
+        throw new ConsoleRequestError(
+            timedOut
+                ? 'The Vendure Console API request timed out. Check the configured endpoint and try again.'
+                : 'Could not reach the Vendure Console API. Check your connection and configured endpoint.',
+            true,
+        );
+    } finally {
+        clearTimeout(timeout);
+        signal.removeEventListener('abort', onAbort);
+    }
+
+    if (!response.ok) {
+        throw new ConsoleRequestError(
+            `Vendure Console API request failed with HTTP ${response.status}.`,
+            response.status >= 500,
+        );
+    }
+    try {
+        return await response.json();
+    } catch {
+        throw new ConsoleRequestError('Vendure Console API returned malformed JSON.', false);
+    }
+}
+
+function baseUrl(value: string, label: string): string {
+    let url: URL;
+    try {
+        url = new URL(value);
+    } catch {
+        throw new Error(`${label} must be an absolute HTTP or HTTPS URL.`);
+    }
+    if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password) {
+        throw new Error(`${label} must be an absolute HTTP or HTTPS URL without credentials.`);
+    }
+    if (url.search || url.hash || (url.pathname !== '/' && url.pathname !== '')) {
+        throw new Error(`${label} must contain only an origin without a path, query, or fragment.`);
+    }
+    return url.origin;
+}
+
+function exactObject(value: unknown, keys: string[], label: string): Record<string, unknown> {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        throw new Error(`Console returned a malformed ${label}.`);
+    }
+    const object = value as Record<string, unknown>;
+    const actualKeys = Object.keys(object).sort();
+    const expectedKeys = [...keys].sort();
+    if (
+        actualKeys.length !== expectedKeys.length ||
+        actualKeys.some((key, index) => key !== expectedKeys[index])
+    ) {
+        throw new Error(`Console returned a ${label} with unexpected or missing fields.`);
+    }
+    return object;
+}
+
+function uuid(value: unknown, label: string): string {
+    if (
+        typeof value !== 'string' ||
+        !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+    ) {
+        throw new Error(`Console returned an invalid ${label}.`);
+    }
+    return value;
+}
+
+function timestamp(value: unknown, label: string): number {
+    if (typeof value !== 'string') {
+        throw new Error(`Console returned an invalid ${label}.`);
+    }
+    const result = Date.parse(value);
+    if (!Number.isFinite(result)) {
+        throw new Error(`Console returned an invalid ${label}.`);
+    }
+    return result;
+}
+
+function nonEmptyString(value: unknown, label: string): string {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+        throw new Error(`Console returned an invalid ${label}.`);
+    }
+    return value;
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+    if (signal.aborted) {
+        throw new CommandInterruptedError(130);
+    }
+}
+
+function abortableSleep(milliseconds: number, signal: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+        if (signal.aborted) {
+            reject(new CommandInterruptedError(130));
+            return;
+        }
+        const timeout = setTimeout(() => {
+            signal.removeEventListener('abort', onAbort);
+            resolve();
+        }, milliseconds);
+        const onAbort = () => {
+            clearTimeout(timeout);
+            reject(new CommandInterruptedError(130));
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+    });
+}
+
+function openUrlInBrowser(url: string): Promise<void> {
+    // explorer.exe drops URL query strings, so Windows must go through the url.dll protocol handler.
+    const isWindows = process.platform === 'win32';
+    const command = process.platform === 'darwin' ? 'open' : isWindows ? 'rundll32' : 'xdg-open';
+    const args = isWindows ? ['url.dll,FileProtocolHandler', url] : [url];
+    return new Promise((resolve, reject) => {
+        let child: ChildProcess;
+        try {
+            child = spawn(command, args, { detached: true, stdio: 'ignore' });
+        } catch (error) {
+            reject(error);
+            return;
+        }
+        child.once('error', reject);
+        child.once('spawn', () => {
+            child.removeListener('error', reject);
+            child.unref();
+            resolve();
+        });
+    });
+}

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -13,13 +13,13 @@ import {
     resolveProjectRoot,
     writeProjectLinkManifestAtomic,
 } from './project-link-manifest';
+import { nonEmptyStringValue, objectValue, uuidValue } from './project-link-validation';
 
 const DEFAULT_CONSOLE_URL = 'https://console.vendure.io';
 const DEFAULT_CONSOLE_API_URL = 'https://api.vendure.io';
 const POLL_INTERVAL_MS = 2_000;
 const REQUEST_TIMEOUT_MS = 10_000;
-const MAX_POLL_ATTEMPTS = 3;
-const RETRY_DELAYS_MS = [500, 1_000];
+const MAX_RETRY_DELAY_MS = 2_000;
 
 export interface ConsoleCommandOptions {
     project?: string;
@@ -90,29 +90,32 @@ const defaultReporter: ConsoleReporter = {
     url: value => process.stdout.write(`${value}\n`),
 };
 
-const defaultDependencies: ConsoleCommandDependencies = {
-    cwd: process.cwd(),
-    env: process.env,
-    fetch: globalThis.fetch,
-    isNonInteractive: () => isNonInteractiveEnvironment(),
-    now: () => Date.now(),
-    openUrl: openUrlInBrowser,
-    prompt: async message => {
-        const result = await withInteractiveTimeout(() => confirm({ message }), {
-            examples: ['vendure console link --force', 'vendure console unlink --force'],
-            helpCommands: ['vendure console --help'],
-        });
-        return isCancel(result) ? undefined : result;
-    },
-    reporter: defaultReporter,
-    sleep: abortableSleep,
-};
+function createDefaultDependencies(): ConsoleCommandDependencies {
+    return {
+        cwd: process.cwd(),
+        env: process.env,
+        fetch: globalThis.fetch,
+        isNonInteractive: () => isNonInteractiveEnvironment(),
+        now: () => Date.now(),
+        openUrl: openUrlInBrowser,
+        prompt: async message => {
+            const result = await withInteractiveTimeout(() => confirm({ message }), {
+                examples: ['vendure console link --force', 'vendure console unlink --force'],
+                helpCommands: ['vendure console --help'],
+            });
+            return isCancel(result) ? undefined : result;
+        },
+        reporter: defaultReporter,
+        sleep: abortableSleep,
+    };
+}
 
 export async function consoleCommand(
     action?: string,
     options: ConsoleCommandOptions = {},
     dependencies: Partial<ConsoleCommandDependencies> = {},
 ): Promise<number> {
+    const resolvedDependencies = { ...createDefaultDependencies(), ...dependencies };
     const abortController = new AbortController();
     let interruptedExitCode: number | undefined;
     const onSigint = () => {
@@ -134,23 +137,19 @@ export async function consoleCommand(
     }
 
     try {
-        return await runConsoleCommand(
-            action,
-            options,
-            { ...defaultDependencies, ...dependencies },
-            abortController.signal,
-        );
+        return await runConsoleCommand(action, options, resolvedDependencies, abortController.signal);
     } catch (error) {
-        const deps = { ...defaultDependencies, ...dependencies };
         if (interruptedExitCode !== undefined || error instanceof CommandInterruptedError) {
             const exitCode = interruptedExitCode ?? (error as CommandInterruptedError).exitCode;
-            deps.reporter.warn('Console command interrupted. No Project Link Manifest was changed.');
+            resolvedDependencies.reporter.warn(
+                'Console command interrupted. No Project Link Manifest was changed.',
+            );
             return exitCode;
         }
         if (error instanceof CliCommandExit) {
             throw error;
         }
-        deps.reporter.error(error instanceof Error ? error.message : String(error));
+        resolvedDependencies.reporter.error(error instanceof Error ? error.message : String(error));
         return 1;
     } finally {
         process.removeListener('SIGINT', onSigint);
@@ -159,7 +158,7 @@ export async function consoleCommand(
     }
 }
 
-export async function runConsoleCommand(
+async function runConsoleCommand(
     action: string | undefined,
     options: ConsoleCommandOptions,
     dependencies: ConsoleCommandDependencies,
@@ -176,7 +175,7 @@ export async function runConsoleCommand(
         return 1;
     }
 
-    const projectRoot = resolveProjectRoot(dependencies.cwd, options.project);
+    const projectRoot = resolveProjectRoot(dependencies.cwd, options.project, options.force);
     if (normalizedAction === 'status') {
         return status(projectRoot, dependencies.reporter);
     }
@@ -216,9 +215,6 @@ async function link(
 
     const endpoints = resolveConsoleEndpoints(dependencies.env);
     const request = await createProjectLink(endpoints, dependencies, signal);
-    if (dependencies.now() >= request.expiresAt) {
-        throw new Error('The Project Link request expired. Run vendure console link again.');
-    }
     dependencies.reporter.info('Approve the Project link in your browser.');
     try {
         await dependencies.openUrl(request.verificationUrl);
@@ -313,6 +309,9 @@ async function confirmManifestChange(
     const result = await dependencies.prompt(
         `${action === 'replace' ? 'Replace' : 'Remove'} the local link for ${detail}?`,
     );
+    if (result === undefined) {
+        throw new CommandInterruptedError(130);
+    }
     if (result !== true) {
         dependencies.reporter.info('No Project Link Manifest changes were made.');
         return 'cancelled';
@@ -331,11 +330,7 @@ async function createProjectLink(
         dependencies,
         signal,
     );
-    const object = exactObject(
-        value,
-        ['id', 'state', 'protocolVersion', 'expiresAt', 'pollingSecret', 'verificationPath'],
-        'project-link response',
-    );
+    const object = objectValue(value, 'Console returned a malformed project-link response.');
     const id = uuid(object.id, 'project-link id');
     if (object.state !== 'pending' || object.protocolVersion !== 1) {
         throw new Error('Console returned an unsupported Project Link request.');
@@ -362,13 +357,15 @@ async function waitForApproval(
     dependencies: ConsoleCommandDependencies,
     signal: AbortSignal,
 ): Promise<ProjectLinkManifest> {
+    let expiresAt = request.expiresAt;
     while (true) {
         throwIfAborted(signal);
-        if (dependencies.now() >= request.expiresAt) {
+        if (dependencies.now() >= expiresAt) {
             throw new Error('The Project Link request expired. Run vendure console link again.');
         }
 
-        const result = await pollWithRetry(request, endpoints, dependencies, signal);
+        const result = await pollWithRetry(request, expiresAt, endpoints, dependencies, signal);
+        expiresAt = result.expiresAt;
         if (result.state === 'approved') {
             if (!result.manifest) {
                 throw new Error('Console approved the request without returning a Project Link Manifest.');
@@ -387,11 +384,16 @@ async function waitForApproval(
 
 async function pollWithRetry(
     request: ProjectLinkRequest,
+    expiresAt: number,
     endpoints: ConsoleEndpoints,
     dependencies: ConsoleCommandDependencies,
     signal: AbortSignal,
 ): Promise<ProjectLinkPollResult> {
-    for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+    let attempt = 0;
+    while (true) {
+        if (dependencies.now() >= expiresAt) {
+            throw new Error('The Project Link request expired. Run vendure console link again.');
+        }
         try {
             const value = await requestJson(
                 `${endpoints.apiUrl}/project-links/${encodeURIComponent(request.id)}/poll`,
@@ -405,36 +407,35 @@ async function pollWithRetry(
             );
             return parsePollResult(value, request.id);
         } catch (error) {
-            if (
-                !(error instanceof ConsoleRequestError) ||
-                !error.transient ||
-                attempt === MAX_POLL_ATTEMPTS - 1
-            ) {
+            if (!(error instanceof ConsoleRequestError) || !error.transient) {
                 throw error;
             }
-            await dependencies.sleep(RETRY_DELAYS_MS[attempt], signal);
+            const remainingMs = expiresAt - dependencies.now();
+            if (remainingMs <= 0) {
+                throw new Error('The Project Link request expired. Run vendure console link again.');
+            }
+            await dependencies.sleep(Math.min(retryDelay(attempt), remainingMs), signal);
+            attempt++;
         }
     }
-    throw new Error('Console polling failed.');
+}
+
+function retryDelay(attempt: number): number {
+    return Math.min(attempt === 0 ? 500 : attempt * 1_000, MAX_RETRY_DELAY_MS);
 }
 
 function parsePollResult(value: unknown, expectedLinkId: string): ProjectLinkPollResult {
-    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-        throw new Error('Console returned a malformed Project Link polling response.');
-    }
-    const record = value as Record<string, unknown>;
+    const record = objectValue(value, 'Console returned a malformed Project Link polling response.');
     const state = record.state;
     if (!['pending', 'approved', 'denied', 'expired'].includes(String(state))) {
         throw new Error('Console returned an unknown Project Link state.');
     }
-    const expectedKeys = state === 'approved' ? ['state', 'expiresAt', 'manifest'] : ['state', 'expiresAt'];
-    const object = exactObject(value, expectedKeys, 'project-link polling response');
     const result: ProjectLinkPollResult = {
         state: state as ProjectLinkPollResult['state'],
-        expiresAt: timestamp(object.expiresAt, 'project-link expiry'),
+        expiresAt: timestamp(record.expiresAt, 'project-link expiry'),
     };
     if (state === 'approved') {
-        result.manifest = parseProjectLinkManifest(object.manifest, expectedLinkId);
+        result.manifest = parseProjectLinkManifest(record.manifest, expectedLinkId);
     }
     return result;
 }
@@ -502,30 +503,8 @@ function baseUrl(value: string, label: string): string {
     return url.origin;
 }
 
-function exactObject(value: unknown, keys: string[], label: string): Record<string, unknown> {
-    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-        throw new Error(`Console returned a malformed ${label}.`);
-    }
-    const object = value as Record<string, unknown>;
-    const actualKeys = Object.keys(object).sort((a, b) => a.localeCompare(b));
-    const expectedKeys = [...keys].sort((a, b) => a.localeCompare(b));
-    if (
-        actualKeys.length !== expectedKeys.length ||
-        actualKeys.some((key, index) => key !== expectedKeys[index])
-    ) {
-        throw new Error(`Console returned a ${label} with unexpected or missing fields.`);
-    }
-    return object;
-}
-
 function uuid(value: unknown, label: string): string {
-    if (
-        typeof value !== 'string' ||
-        !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
-    ) {
-        throw new Error(`Console returned an invalid ${label}.`);
-    }
-    return value;
+    return uuidValue(value, `Console returned an invalid ${label}.`);
 }
 
 function timestamp(value: unknown, label: string): number {
@@ -540,10 +519,7 @@ function timestamp(value: unknown, label: string): number {
 }
 
 function nonEmptyString(value: unknown, label: string): string {
-    if (typeof value !== 'string' || value.trim().length === 0) {
-        throw new Error(`Console returned an invalid ${label}.`);
-    }
-    return value;
+    return nonEmptyStringValue(value, `Console returned an invalid ${label}.`);
 }
 
 function throwIfAborted(signal: AbortSignal): void {

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -7,6 +7,7 @@ import { isNonInteractiveEnvironment, withInteractiveTimeout } from '../../utili
 import { ensureProjectLinkGitignore } from './project-link-gitignore';
 import {
     ManifestReadResult,
+    PROJECT_LINK_MANIFEST_RELATIVE_PATH,
     ProjectLinkManifest,
     parseProjectLinkManifest,
     readProjectLinkManifest,
@@ -14,7 +15,7 @@ import {
     resolveProjectRoot,
     writeProjectLinkManifestAtomic,
 } from './project-link-manifest';
-import { nonEmptyStringValue, objectValue, uuidValue } from './project-link-validation';
+import { nonEmptyString, objectValue, uuid } from './project-link-validation';
 
 const DEFAULT_CONSOLE_URL = 'https://console.vendure.io';
 const DEFAULT_CONSOLE_API_URL = 'https://api.vendure.io';
@@ -79,7 +80,7 @@ class ConsoleRequestError extends Error {
 }
 
 class CommandInterruptedError extends Error {
-    constructor(readonly exitCode: number) {
+    constructor() {
         super('The Console command was interrupted.');
         this.name = 'CommandInterruptedError';
     }
@@ -147,7 +148,7 @@ export async function consoleCommand(
         return await runConsoleCommand(action, options, resolvedDependencies, abortController.signal);
     } catch (error) {
         if (interruptedExitCode !== undefined || error instanceof CommandInterruptedError) {
-            const exitCode = interruptedExitCode ?? (error as CommandInterruptedError).exitCode;
+            const exitCode = interruptedExitCode ?? 130;
             resolvedDependencies.reporter.warn(
                 'Console command interrupted. No Project Link Manifest was changed.',
             );
@@ -271,7 +272,7 @@ async function confirmCustomConsoleEndpoints(
         ].join('\n'),
     );
     if (result === undefined) {
-        throw new CommandInterruptedError(130);
+        throw new CommandInterruptedError();
     }
     if (!result) {
         dependencies.reporter.info('No Console requests or Project Link Manifest changes were made.');
@@ -313,13 +314,13 @@ function reportProjectLinkGitignore(projectRoot: string, reporter: ConsoleReport
     const gitignore = ensureProjectLinkGitignore(projectRoot);
     if (gitignore.kind === 'created' || gitignore.kind === 'updated') {
         reporter.info(
-            `Updated ${gitignore.path} so .vendure/project.json can be committed and other .vendure files stay ignored.`,
+            `Updated ${gitignore.path} so ${PROJECT_LINK_MANIFEST_RELATIVE_PATH} can be committed and other .vendure files stay ignored.`,
         );
         return;
     }
     if (gitignore.kind === 'failed') {
         reporter.warn(
-            `Could not update ${gitignore.path}: ${gitignore.reason}. Commit .vendure/project.json and ignore other .vendure files.`,
+            `Could not update ${gitignore.path}: ${gitignore.reason}. Commit ${PROJECT_LINK_MANIFEST_RELATIVE_PATH} and ignore other .vendure files.`,
         );
         return;
     }
@@ -376,7 +377,7 @@ async function confirmManifestChange(
         `${action === 'replace' ? 'Replace' : 'Remove'} the local link for ${detail}?`,
     );
     if (result === undefined) {
-        throw new CommandInterruptedError(130);
+        throw new CommandInterruptedError();
     }
     if (result !== true) {
         dependencies.reporter.info('No Project Link Manifest changes were made.');
@@ -397,13 +398,16 @@ async function createProjectLink(
         signal,
     );
     const object = objectValue(value, 'Console returned a malformed project-link response.');
-    const id = uuid(object.id, 'project-link id');
+    const id = uuid(object.id, 'Console returned an invalid project-link id.');
     if (object.state !== 'pending' || object.protocolVersion !== 1) {
         throw new Error('Console returned an unsupported Project Link request.');
     }
     const expiresAt = timestamp(object.expiresAt, 'project-link expiry');
-    const pollingSecret = nonEmptyString(object.pollingSecret, 'polling secret');
-    const verificationPath = nonEmptyString(object.verificationPath, 'verification path');
+    const pollingSecret = nonEmptyString(object.pollingSecret, 'Console returned an invalid polling secret.');
+    const verificationPath = nonEmptyString(
+        object.verificationPath,
+        'Console returned an invalid verification path.',
+    );
     if (!verificationPath.startsWith('/') || verificationPath.startsWith('//')) {
         throw new Error('Console returned an invalid verification path.');
     }
@@ -540,7 +544,7 @@ async function requestJson(
             throw error;
         }
         if (signal.aborted) {
-            throw new CommandInterruptedError(130);
+            throw new CommandInterruptedError();
         }
         throw new ConsoleRequestError(
             timedOut
@@ -592,18 +596,17 @@ async function readCappedText(response: Response, signal: AbortSignal): Promise<
             received += value.byteLength;
             if (received > MAX_RESPONSE_BYTES) {
                 await reader.cancel().catch(() => undefined);
-                throw new ConsoleRequestError('Vendure Console API response exceeded the maximum size.', false);
+                throw new ConsoleRequestError(
+                    'Vendure Console API response exceeded the maximum size.',
+                    false,
+                );
             }
             chunks.push(decoder.decode(value, { stream: true }));
         }
         chunks.push(decoder.decode());
         return chunks.join('');
     } finally {
-        try {
-            reader.releaseLock();
-        } catch {
-            // cancel() already released the lock
-        }
+        reader.releaseLock();
     }
 }
 
@@ -663,10 +666,6 @@ function usesCustomRemoteEndpoints(endpoints: ConsoleEndpoints): boolean {
     );
 }
 
-function uuid(value: unknown, label: string): string {
-    return uuidValue(value, `Console returned an invalid ${label}.`);
-}
-
 function timestamp(value: unknown, label: string): number {
     if (typeof value !== 'string') {
         throw new Error(`Console returned an invalid ${label}.`);
@@ -678,20 +677,16 @@ function timestamp(value: unknown, label: string): number {
     return result;
 }
 
-function nonEmptyString(value: unknown, label: string): string {
-    return nonEmptyStringValue(value, `Console returned an invalid ${label}.`);
-}
-
 function throwIfAborted(signal: AbortSignal): void {
     if (signal.aborted) {
-        throw new CommandInterruptedError(130);
+        throw new CommandInterruptedError();
     }
 }
 
 function abortableSleep(milliseconds: number, signal: AbortSignal): Promise<void> {
     return new Promise((resolve, reject) => {
         if (signal.aborted) {
-            reject(new CommandInterruptedError(130));
+            reject(new CommandInterruptedError());
             return;
         }
         const timeout = setTimeout(() => {
@@ -700,7 +695,7 @@ function abortableSleep(milliseconds: number, signal: AbortSignal): Promise<void
         }, milliseconds);
         const onAbort = () => {
             clearTimeout(timeout);
-            reject(new CommandInterruptedError(130));
+            reject(new CommandInterruptedError());
         };
         signal.addEventListener('abort', onAbort, { once: true });
     });

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -507,8 +507,8 @@ function exactObject(value: unknown, keys: string[], label: string): Record<stri
         throw new Error(`Console returned a malformed ${label}.`);
     }
     const object = value as Record<string, unknown>;
-    const actualKeys = Object.keys(object).sort();
-    const expectedKeys = [...keys].sort();
+    const actualKeys = Object.keys(object).sort((a, b) => a.localeCompare(b));
+    const expectedKeys = [...keys].sort((a, b) => a.localeCompare(b));
     if (
         actualKeys.length !== expectedKeys.length ||
         actualKeys.some((key, index) => key !== expectedKeys[index])

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -148,6 +148,7 @@ export async function consoleCommand(
         return await runConsoleCommand(action, options, resolvedDependencies, abortController.signal);
     } catch (error) {
         if (interruptedExitCode !== undefined || error instanceof CommandInterruptedError) {
+            // A process signal wins so SIGTERM retains exit code 143. Prompt cancellation and external aborts use 130.
             const exitCode = interruptedExitCode ?? 130;
             resolvedDependencies.reporter.warn(
                 'Console command interrupted. No Project Link Manifest was changed.',
@@ -215,6 +216,7 @@ async function link(
     dependencies: ConsoleCommandDependencies,
     signal: AbortSignal,
 ): Promise<number> {
+    const endpoints = resolveConsoleEndpoints(dependencies.env);
     const existing = readProjectLinkManifest(projectRoot);
     if (existing.kind !== 'missing') {
         const confirmed = await confirmManifestChange('replace', existing, options, dependencies);
@@ -223,7 +225,6 @@ async function link(
         }
     }
 
-    const endpoints = resolveConsoleEndpoints(dependencies.env);
     const endpointApproval = await confirmCustomConsoleEndpoints(endpoints, options, dependencies);
     if (endpointApproval !== 'confirmed') {
         return endpointApproval === 'cancelled' ? 0 : 1;

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -19,6 +19,7 @@ import { nonEmptyString, objectValue, uuid } from './project-link-validation';
 
 const DEFAULT_CONSOLE_URL = 'https://console.vendure.io';
 const DEFAULT_CONSOLE_API_URL = 'https://api.vendure.io';
+const PROJECT_LINKS_PATH = '/v1/project-links';
 const POLL_INTERVAL_MS = 2_000;
 const REQUEST_TIMEOUT_MS = 10_000;
 const MAX_RESPONSE_BYTES = 64 * 1024;
@@ -393,7 +394,7 @@ async function createProjectLink(
     signal: AbortSignal,
 ): Promise<ProjectLinkRequest> {
     const value = await requestJson(
-        `${endpoints.apiUrl}/project-links`,
+        `${endpoints.apiUrl}${PROJECT_LINKS_PATH}`,
         { method: 'POST' },
         dependencies,
         signal,
@@ -467,7 +468,7 @@ async function pollWithRetry(
         }
         try {
             const value = await requestJson(
-                `${endpoints.apiUrl}/project-links/${encodeURIComponent(request.id)}/poll`,
+                `${endpoints.apiUrl}${PROJECT_LINKS_PATH}/${encodeURIComponent(request.id)}/poll`,
                 {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -4,6 +4,7 @@ import { ChildProcess, spawn } from 'node:child_process';
 import { CliCommandExit } from '../../shared/cli-command-exit';
 import { isNonInteractiveEnvironment, withInteractiveTimeout } from '../../utilities/utils';
 
+import { ensureProjectLinkGitignore } from './project-link-gitignore';
 import {
     ManifestReadResult,
     ProjectLinkManifest,
@@ -228,9 +229,7 @@ async function link(
     const manifestPath = await writeProjectLinkManifestAtomic(projectRoot, manifest);
     dependencies.reporter.success(`Linked ${manifest.project.name} to ${manifest.account.name}.`);
     dependencies.reporter.info(`Wrote ${manifestPath}`);
-    dependencies.reporter.info(
-        'This file contains identity metadata only and is safe to commit. Keep every other .vendure file ignored because it may contain machine-local secrets.',
-    );
+    reportProjectLinkGitignore(projectRoot, dependencies.reporter);
     return 0;
 }
 
@@ -260,6 +259,25 @@ function status(projectRoot: string, reporter: ConsoleReporter): number {
         ].join('\n'),
     );
     return 0;
+}
+
+function reportProjectLinkGitignore(projectRoot: string, reporter: ConsoleReporter): void {
+    const gitignore = ensureProjectLinkGitignore(projectRoot);
+    if (gitignore.kind === 'created' || gitignore.kind === 'updated') {
+        reporter.info(
+            `Updated ${gitignore.path} so .vendure/project.json can be committed and other .vendure files stay ignored.`,
+        );
+        return;
+    }
+    if (gitignore.kind === 'failed') {
+        reporter.warn(
+            `Could not update ${gitignore.path}: ${gitignore.reason}. Commit .vendure/project.json and ignore other .vendure files.`,
+        );
+        return;
+    }
+    reporter.info(
+        'This file contains identity metadata only and is safe to commit. Other .vendure files stay ignored because they may contain machine-local secrets.',
+    );
 }
 
 async function unlink(

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -23,6 +23,7 @@ const REQUEST_TIMEOUT_MS = 10_000;
 const MAX_RETRY_DELAY_MS = 2_000;
 
 export interface ConsoleCommandOptions {
+    allowCustomConsole?: boolean;
     project?: string;
     force?: boolean;
 }
@@ -101,7 +102,11 @@ function createDefaultDependencies(): ConsoleCommandDependencies {
         openUrl: openUrlInBrowser,
         prompt: async message => {
             const result = await withInteractiveTimeout(() => confirm({ message }), {
-                examples: ['vendure console link --force', 'vendure console unlink --force'],
+                examples: [
+                    'vendure console link --allow-custom-console',
+                    'vendure console link --force',
+                    'vendure console unlink --force',
+                ],
                 helpCommands: ['vendure console --help'],
             });
             return isCancel(result) ? undefined : result;
@@ -187,17 +192,24 @@ async function runConsoleCommand(
 }
 
 export function resolveConsoleEndpoints(env: NodeJS.ProcessEnv): ConsoleEndpoints {
-    const consoleOverride = env.VENDURE_CONSOLE_URL?.trim() || undefined;
-    const apiOverride = env.VENDURE_CONSOLE_API_URL?.trim() || undefined;
-    if (Boolean(consoleOverride) !== Boolean(apiOverride)) {
+    if (env.VENDURE_CONSOLE_URL?.trim() || env.VENDURE_CONSOLE_API_URL?.trim()) {
         throw new Error(
-            'Set both VENDURE_CONSOLE_URL and VENDURE_CONSOLE_API_URL, or unset both to use production.',
+            'Use the link-specific VENDURE_CONSOLE_LINK_URL and VENDURE_CONSOLE_LINK_API_URL variables for this command.',
         );
     }
-    return {
-        consoleUrl: baseUrl(consoleOverride ?? DEFAULT_CONSOLE_URL, 'VENDURE_CONSOLE_URL'),
-        apiUrl: baseUrl(apiOverride ?? DEFAULT_CONSOLE_API_URL, 'VENDURE_CONSOLE_API_URL'),
-    };
+    const consoleOverride = env.VENDURE_CONSOLE_LINK_URL?.trim() || undefined;
+    const apiOverride = env.VENDURE_CONSOLE_LINK_API_URL?.trim() || undefined;
+    if (Boolean(consoleOverride) !== Boolean(apiOverride)) {
+        throw new Error(
+            'Set both VENDURE_CONSOLE_LINK_URL and VENDURE_CONSOLE_LINK_API_URL, or unset both to use production.',
+        );
+    }
+    const consoleUrl = baseUrl(consoleOverride ?? DEFAULT_CONSOLE_URL, 'VENDURE_CONSOLE_LINK_URL');
+    const apiUrl = baseUrl(apiOverride ?? DEFAULT_CONSOLE_API_URL, 'VENDURE_CONSOLE_LINK_API_URL');
+    if ((consoleUrl === DEFAULT_CONSOLE_URL) !== (apiUrl === DEFAULT_CONSOLE_API_URL)) {
+        throw new Error('The production Console and API origins must be used together.');
+    }
+    return { consoleUrl, apiUrl };
 }
 
 async function link(
@@ -215,6 +227,10 @@ async function link(
     }
 
     const endpoints = resolveConsoleEndpoints(dependencies.env);
+    const endpointApproval = await confirmCustomConsoleEndpoints(endpoints, options, dependencies);
+    if (endpointApproval !== 'confirmed') {
+        return endpointApproval === 'cancelled' ? 0 : 1;
+    }
     const request = await createProjectLink(endpoints, dependencies, signal);
     dependencies.reporter.info('Approve the Project link in your browser.');
     try {
@@ -231,6 +247,41 @@ async function link(
     dependencies.reporter.info(`Wrote ${manifestPath}`);
     reportProjectLinkGitignore(projectRoot, dependencies.reporter);
     return 0;
+}
+
+async function confirmCustomConsoleEndpoints(
+    endpoints: ConsoleEndpoints,
+    options: ConsoleCommandOptions,
+    dependencies: ConsoleCommandDependencies,
+): Promise<'confirmed' | 'cancelled' | 'required'> {
+    if (!usesCustomRemoteEndpoints(endpoints) || options.allowCustomConsole) {
+        return 'confirmed';
+    }
+    if (dependencies.isNonInteractive()) {
+        dependencies.reporter.error(
+            'Refusing to use custom remote Console endpoints without explicit approval in a non-interactive environment.',
+        );
+        dependencies.reporter.info(
+            'Run vendure console link --allow-custom-console to approve these endpoints.',
+        );
+        return 'required';
+    }
+    const result = await dependencies.prompt(
+        [
+            'Link through these custom Console endpoints?',
+            `Console: ${endpoints.consoleUrl}`,
+            `API: ${endpoints.apiUrl}`,
+            'The API controls the Project Link Manifest written to this repository.',
+        ].join('\n'),
+    );
+    if (result === undefined) {
+        throw new CommandInterruptedError(130);
+    }
+    if (!result) {
+        dependencies.reporter.info('No Console requests or Project Link Manifest changes were made.');
+        return 'cancelled';
+    }
+    return 'confirmed';
 }
 
 function status(projectRoot: string, reporter: ConsoleReporter): number {
@@ -476,7 +527,11 @@ async function requestJson(
 
     let response: Response;
     try {
-        response = await dependencies.fetch(url, { ...init, signal: requestController.signal });
+        response = await dependencies.fetch(url, {
+            ...init,
+            redirect: 'error',
+            signal: requestController.signal,
+        });
     } catch {
         if (signal.aborted) {
             throw new CommandInterruptedError(130);
@@ -518,7 +573,23 @@ function baseUrl(value: string, label: string): string {
     if (url.search || url.hash || (url.pathname !== '/' && url.pathname !== '')) {
         throw new Error(`${label} must contain only an origin without a path, query, or fragment.`);
     }
+    if (url.protocol === 'http:' && !isLoopbackHostname(url.hostname)) {
+        throw new Error(`${label} must use HTTPS unless it is a loopback URL.`);
+    }
     return url.origin;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+}
+
+function usesCustomRemoteEndpoints(endpoints: ConsoleEndpoints): boolean {
+    if (endpoints.consoleUrl === DEFAULT_CONSOLE_URL && endpoints.apiUrl === DEFAULT_CONSOLE_API_URL) {
+        return false;
+    }
+    return ![endpoints.consoleUrl, endpoints.apiUrl].every(value =>
+        isLoopbackHostname(new URL(value).hostname),
+    );
 }
 
 function uuid(value: unknown, label: string): string {

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -20,6 +20,7 @@ const DEFAULT_CONSOLE_URL = 'https://console.vendure.io';
 const DEFAULT_CONSOLE_API_URL = 'https://api.vendure.io';
 const POLL_INTERVAL_MS = 2_000;
 const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_RESPONSE_BYTES = 64 * 1024;
 const MAX_RETRY_DELAY_MS = 2_000;
 
 export interface ConsoleCommandOptions {
@@ -181,7 +182,7 @@ async function runConsoleCommand(
         return 1;
     }
 
-    const projectRoot = resolveProjectRoot(dependencies.cwd, options.project, options.force);
+    const projectRoot = resolveProjectRoot(dependencies.cwd, options.project);
     if (normalizedAction === 'status') {
         return status(projectRoot, dependencies.reporter);
     }
@@ -306,6 +307,7 @@ function status(projectRoot: string, reporter: ConsoleReporter): number {
             `Schema version: ${manifest.schemaVersion}`,
             `Protocol version: ${manifest.link.protocolVersion}`,
             `Link: ${manifest.link.id}`,
+            `Manifest: ${result.path}`,
             'Authentication: Not stored locally (browser authorization)',
         ].join('\n'),
     );
@@ -496,7 +498,7 @@ function retryDelay(attempt: number): number {
 function parsePollResult(value: unknown, expectedLinkId: string): ProjectLinkPollResult {
     const record = objectValue(value, 'Console returned a malformed Project Link polling response.');
     const state = record.state;
-    if (!['pending', 'approved', 'denied', 'expired'].includes(String(state))) {
+    if (typeof state !== 'string' || !['pending', 'approved', 'denied', 'expired'].includes(state)) {
         throw new Error('Console returned an unknown Project Link state.');
     }
     const result: ProjectLinkPollResult = {
@@ -525,14 +527,23 @@ async function requestJson(
         requestController.abort();
     }, REQUEST_TIMEOUT_MS);
 
-    let response: Response;
     try {
-        response = await dependencies.fetch(url, {
+        const response = await dependencies.fetch(url, {
             ...init,
             redirect: 'error',
             signal: requestController.signal,
         });
-    } catch {
+        if (!response.ok) {
+            throw new ConsoleRequestError(
+                `Vendure Console API request failed with HTTP ${response.status}.`,
+                isTransientHttpStatus(response.status),
+            );
+        }
+        return await readJsonBody(response, requestController.signal);
+    } catch (error) {
+        if (error instanceof ConsoleRequestError) {
+            throw error;
+        }
         if (signal.aborted) {
             throw new CommandInterruptedError(130);
         }
@@ -546,18 +557,83 @@ async function requestJson(
         clearTimeout(timeout);
         signal.removeEventListener('abort', onAbort);
     }
+}
 
-    if (!response.ok) {
-        throw new ConsoleRequestError(
-            `Vendure Console API request failed with HTTP ${response.status}.`,
-            response.status >= 500,
-        );
-    }
+function isTransientHttpStatus(status: number): boolean {
+    return status >= 500 || status === 408 || status === 429;
+}
+
+async function readJsonBody(response: Response, signal: AbortSignal): Promise<unknown> {
+    const text = await readCappedText(response, signal);
     try {
-        return await response.json();
+        return JSON.parse(text);
     } catch {
         throw new ConsoleRequestError('Vendure Console API returned malformed JSON.', false);
     }
+}
+
+async function readCappedText(response: Response, signal: AbortSignal): Promise<string> {
+    if (!response.body) {
+        const text = await abortable(response.text(), signal);
+        if (Buffer.byteLength(text, 'utf8') > MAX_RESPONSE_BYTES) {
+            throw new ConsoleRequestError('Vendure Console API response exceeded the maximum size.', false);
+        }
+        return text;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    const chunks: string[] = [];
+    let received = 0;
+    try {
+        while (true) {
+            if (signal.aborted) {
+                throw abortError();
+            }
+            const { done, value } = await abortable(reader.read(), signal);
+            if (done) {
+                break;
+            }
+            received += value.byteLength;
+            if (received > MAX_RESPONSE_BYTES) {
+                await reader.cancel().catch(() => undefined);
+                throw new ConsoleRequestError('Vendure Console API response exceeded the maximum size.', false);
+            }
+            chunks.push(decoder.decode(value, { stream: true }));
+        }
+        chunks.push(decoder.decode());
+        return chunks.join('');
+    } finally {
+        try {
+            reader.releaseLock();
+        } catch {
+            // cancel() already released the lock
+        }
+    }
+}
+
+function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+    if (signal.aborted) {
+        return Promise.reject(abortError());
+    }
+    return new Promise((resolve, reject) => {
+        const onAbort = () => reject(abortError());
+        signal.addEventListener('abort', onAbort, { once: true });
+        promise.then(
+            value => {
+                signal.removeEventListener('abort', onAbort);
+                resolve(value);
+            },
+            error => {
+                signal.removeEventListener('abort', onAbort);
+                reject(error);
+            },
+        );
+    });
+}
+
+function abortError(): DOMException {
+    return new DOMException('The operation was aborted.', 'AbortError');
 }
 
 function baseUrl(value: string, label: string): string {

--- a/packages/cli/src/commands/console/project-link-gitignore.spec.ts
+++ b/packages/cli/src/commands/console/project-link-gitignore.spec.ts
@@ -218,6 +218,21 @@ describe('Project Link gitignore', () => {
         expect(fs.readFileSync(getProjectLinkGitignorePath(project), 'utf8')).toBe(packageIgnore);
     });
 
+    it('rewrites a path-specific directory ignore so the manifest can be committed', () => {
+        const { workspace, project } = vendureMonorepo({ gitignore: 'apps/vendure/.vendure/\n' });
+
+        expect(ensureProjectLinkGitignore(project).kind).toBe('updated');
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain(
+            PROJECT_LINK_NESTED_IGNORE_CONTENTS,
+        );
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain(
+            PROJECT_LINK_NESTED_KEEP_MANIFEST,
+        );
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).not.toContain(
+            'apps/vendure/.vendure/',
+        );
+    });
+
     it('accepts path-specific repo-root rules for apps/vendure', () => {
         const original = ['apps/vendure/.vendure/*', '!apps/vendure/.vendure/project.json', ''].join('\n');
         const { workspace, project } = vendureMonorepo({ gitignore: original });

--- a/packages/cli/src/commands/console/project-link-gitignore.spec.ts
+++ b/packages/cli/src/commands/console/project-link-gitignore.spec.ts
@@ -7,6 +7,8 @@ import {
     PROJECT_LINK_GITIGNORE_COMMENT,
     PROJECT_LINK_IGNORE_CONTENTS,
     PROJECT_LINK_KEEP_MANIFEST,
+    PROJECT_LINK_NESTED_IGNORE_CONTENTS,
+    PROJECT_LINK_NESTED_KEEP_MANIFEST,
     applyProjectLinkGitignoreRules,
     ensureProjectLinkGitignore,
     getProjectLinkGitignorePath,
@@ -122,10 +124,142 @@ describe('Project Link gitignore', () => {
         expect(result.path).toBe(getProjectLinkGitignorePath(root));
         expect(fs.statSync(getProjectLinkGitignorePath(root)).isDirectory()).toBe(true);
     });
+
+    it('updates the repo-root gitignore for an apps/vendure monorepo', () => {
+        const { workspace, project } = vendureMonorepo({ gitignore: 'node_modules\n' });
+
+        const result = ensureProjectLinkGitignore(project);
+
+        expect(result).toEqual({
+            kind: 'updated',
+            path: path.join(workspace, '.gitignore'),
+        });
+        expect(fs.existsSync(getProjectLinkGitignorePath(project))).toBe(false);
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe(
+            [
+                'node_modules',
+                '',
+                PROJECT_LINK_GITIGNORE_COMMENT,
+                PROJECT_LINK_NESTED_IGNORE_CONTENTS,
+                PROJECT_LINK_NESTED_KEEP_MANIFEST,
+                '',
+            ].join('\n'),
+        );
+    });
+
+    it('leaves a monorepo root gitignore unchanged when nested rules already apply', () => {
+        const original = [
+            'node_modules',
+            PROJECT_LINK_NESTED_IGNORE_CONTENTS,
+            PROJECT_LINK_NESTED_KEEP_MANIFEST,
+            '',
+        ].join('\n');
+        const { workspace, project } = vendureMonorepo({ gitignore: original });
+
+        expect(ensureProjectLinkGitignore(project)).toEqual({
+            kind: 'unchanged',
+            path: path.join(workspace, '.gitignore'),
+        });
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe(original);
+        expect(fs.existsSync(getProjectLinkGitignorePath(project))).toBe(false);
+    });
+
+    it('rewrites a repo-root directory ignore so apps/vendure/.vendure/project.json can be committed', () => {
+        const { workspace, project } = vendureMonorepo({ gitignore: '.vendure/\n' });
+
+        expect(ensureProjectLinkGitignore(project).kind).toBe('updated');
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe(
+            [
+                PROJECT_LINK_NESTED_IGNORE_CONTENTS,
+                '',
+                PROJECT_LINK_GITIGNORE_COMMENT,
+                PROJECT_LINK_NESTED_KEEP_MANIFEST,
+                '',
+            ].join('\n'),
+        );
+        expect(fs.existsSync(getProjectLinkGitignorePath(project))).toBe(false);
+    });
+
+    it('prefers an existing apps/vendure gitignore over the repo root', () => {
+        const { workspace, project } = vendureMonorepo({ gitignore: 'node_modules\n' });
+        fs.writeFileSync(getProjectLinkGitignorePath(project), 'dist\n');
+
+        const result = ensureProjectLinkGitignore(project);
+
+        expect(result).toEqual({
+            kind: 'updated',
+            path: getProjectLinkGitignorePath(project),
+        });
+        expect(fs.readFileSync(getProjectLinkGitignorePath(project), 'utf8')).toContain(
+            PROJECT_LINK_IGNORE_CONTENTS,
+        );
+        expect(fs.readFileSync(getProjectLinkGitignorePath(project), 'utf8')).toContain(
+            PROJECT_LINK_KEEP_MANIFEST,
+        );
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe('node_modules\n');
+    });
+
+    it('fixes a blocking repo-root directory ignore when the package already has local rules', () => {
+        const { workspace, project } = vendureMonorepo({ gitignore: '.vendure/\n' });
+        const packageIgnore = [
+            PROJECT_LINK_IGNORE_CONTENTS,
+            PROJECT_LINK_KEEP_MANIFEST,
+            '',
+        ].join('\n');
+        fs.writeFileSync(getProjectLinkGitignorePath(project), packageIgnore);
+
+        expect(ensureProjectLinkGitignore(project).kind).toBe('updated');
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain(
+            PROJECT_LINK_NESTED_IGNORE_CONTENTS,
+        );
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain(
+            PROJECT_LINK_NESTED_KEEP_MANIFEST,
+        );
+        expect(fs.readFileSync(getProjectLinkGitignorePath(project), 'utf8')).toBe(packageIgnore);
+    });
+
+    it('accepts path-specific repo-root rules for apps/vendure', () => {
+        const original = ['apps/vendure/.vendure/*', '!apps/vendure/.vendure/project.json', ''].join('\n');
+        const { workspace, project } = vendureMonorepo({ gitignore: original });
+
+        expect(ensureProjectLinkGitignore(project)).toEqual({
+            kind: 'unchanged',
+            path: path.join(workspace, '.gitignore'),
+        });
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe(original);
+    });
+
+    it('writes nested rules when apply runs in nested mode', () => {
+        expect(applyProjectLinkGitignoreRules('node_modules\n', 'nested')).toBe(
+            [
+                'node_modules',
+                '',
+                PROJECT_LINK_GITIGNORE_COMMENT,
+                PROJECT_LINK_NESTED_IGNORE_CONTENTS,
+                PROJECT_LINK_NESTED_KEEP_MANIFEST,
+                '',
+            ].join('\n'),
+        );
+    });
 });
 
 function temporaryDirectory(): string {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'vendure-console-gitignore-'));
     temporaryDirectories.push(directory);
     return fs.realpathSync(directory);
+}
+
+function vendureMonorepo(options: { gitignore?: string } = {}): { workspace: string; project: string } {
+    const workspace = temporaryDirectory();
+    fs.ensureDirSync(path.join(workspace, '.git'));
+    fs.writeJsonSync(path.join(workspace, 'package.json'), { private: true });
+    if (options.gitignore !== undefined) {
+        fs.writeFileSync(path.join(workspace, '.gitignore'), options.gitignore);
+    }
+    const project = path.join(workspace, 'apps', 'vendure');
+    fs.ensureDirSync(project);
+    fs.writeJsonSync(path.join(project, 'package.json'), {
+        dependencies: { '@vendure/core': '3.7.2' },
+    });
+    return { workspace, project: fs.realpathSync(project) };
 }

--- a/packages/cli/src/commands/console/project-link-gitignore.spec.ts
+++ b/packages/cli/src/commands/console/project-link-gitignore.spec.ts
@@ -1,0 +1,131 @@
+import fs from 'fs-extra';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+    PROJECT_LINK_GITIGNORE_COMMENT,
+    PROJECT_LINK_IGNORE_CONTENTS,
+    PROJECT_LINK_KEEP_MANIFEST,
+    applyProjectLinkGitignoreRules,
+    ensureProjectLinkGitignore,
+    getProjectLinkGitignorePath,
+} from './project-link-gitignore';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+        fs.removeSync(directory);
+    }
+});
+
+describe('Project Link gitignore', () => {
+    it('creates the project gitignore when it is missing', () => {
+        const root = temporaryDirectory();
+
+        expect(ensureProjectLinkGitignore(root)).toEqual({
+            kind: 'created',
+            path: getProjectLinkGitignorePath(root),
+        });
+        expect(fs.readFileSync(getProjectLinkGitignorePath(root), 'utf8')).toBe(
+            `${PROJECT_LINK_GITIGNORE_COMMENT}\n${PROJECT_LINK_IGNORE_CONTENTS}\n${PROJECT_LINK_KEEP_MANIFEST}\n`,
+        );
+    });
+
+    it('leaves an already-correct gitignore unchanged', () => {
+        const root = temporaryDirectory();
+        const original = [
+            'node_modules',
+            PROJECT_LINK_GITIGNORE_COMMENT,
+            PROJECT_LINK_IGNORE_CONTENTS,
+            PROJECT_LINK_KEEP_MANIFEST,
+            '',
+        ].join('\n');
+        fs.writeFileSync(getProjectLinkGitignorePath(root), original);
+
+        expect(ensureProjectLinkGitignore(root)).toEqual({
+            kind: 'unchanged',
+            path: getProjectLinkGitignorePath(root),
+        });
+        expect(fs.readFileSync(getProjectLinkGitignorePath(root), 'utf8')).toBe(original);
+    });
+
+    it('appends missing rules to an existing gitignore', () => {
+        const root = temporaryDirectory();
+        fs.writeFileSync(getProjectLinkGitignorePath(root), 'node_modules\ndist\n');
+
+        expect(ensureProjectLinkGitignore(root).kind).toBe('updated');
+        expect(fs.readFileSync(getProjectLinkGitignorePath(root), 'utf8')).toBe(
+            [
+                'node_modules',
+                'dist',
+                '',
+                PROJECT_LINK_GITIGNORE_COMMENT,
+                PROJECT_LINK_IGNORE_CONTENTS,
+                PROJECT_LINK_KEEP_MANIFEST,
+                '',
+            ].join('\n'),
+        );
+    });
+
+    it('adds only the un-ignore rule when contents are already ignored', () => {
+        expect(applyProjectLinkGitignoreRules('.vendure/*\n')).toBe(
+            ['.vendure/*', '', PROJECT_LINK_GITIGNORE_COMMENT, PROJECT_LINK_KEEP_MANIFEST, ''].join('\n'),
+        );
+    });
+
+    it('rewrites a directory ignore so the manifest can be committed', () => {
+        expect(applyProjectLinkGitignoreRules('.vendure/\n')).toBe(
+            [
+                PROJECT_LINK_IGNORE_CONTENTS,
+                '',
+                PROJECT_LINK_GITIGNORE_COMMENT,
+                PROJECT_LINK_KEEP_MANIFEST,
+                '',
+            ].join('\n'),
+        );
+        expect(applyProjectLinkGitignoreRules('.vendure\n!.vendure/project.json\n')).toBe(
+            `${PROJECT_LINK_IGNORE_CONTENTS}\n${PROJECT_LINK_KEEP_MANIFEST}\n`,
+        );
+    });
+
+    it('accepts root-anchored and nested equivalent rules', () => {
+        expect(applyProjectLinkGitignoreRules('/.vendure/*\n!/.vendure/project.json\n')).toBe(
+            '/.vendure/*\n!/.vendure/project.json\n',
+        );
+        expect(applyProjectLinkGitignoreRules('**/.vendure/**\n!**/.vendure/project.json\n')).toBe(
+            '**/.vendure/**\n!**/.vendure/project.json\n',
+        );
+    });
+
+    it('preserves CRLF when updating an existing file', () => {
+        expect(applyProjectLinkGitignoreRules('node_modules\r\n')).toBe(
+            [
+                'node_modules',
+                '',
+                PROJECT_LINK_GITIGNORE_COMMENT,
+                PROJECT_LINK_IGNORE_CONTENTS,
+                PROJECT_LINK_KEEP_MANIFEST,
+                '',
+            ].join('\r\n'),
+        );
+    });
+
+    it('does not fail the caller when the gitignore path cannot be written', () => {
+        const root = temporaryDirectory();
+        fs.ensureDirSync(getProjectLinkGitignorePath(root));
+
+        const result = ensureProjectLinkGitignore(root);
+
+        expect(result.kind).toBe('failed');
+        expect(result.path).toBe(getProjectLinkGitignorePath(root));
+        expect(fs.statSync(getProjectLinkGitignorePath(root)).isDirectory()).toBe(true);
+    });
+});
+
+function temporaryDirectory(): string {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'vendure-console-gitignore-'));
+    temporaryDirectories.push(directory);
+    return fs.realpathSync(directory);
+}

--- a/packages/cli/src/commands/console/project-link-gitignore.spec.ts
+++ b/packages/cli/src/commands/console/project-link-gitignore.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import { spawnSync } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -125,59 +126,64 @@ describe('Project Link gitignore', () => {
         expect(fs.statSync(getProjectLinkGitignorePath(root)).isDirectory()).toBe(true);
     });
 
-    it('updates the repo-root gitignore for an apps/vendure monorepo', () => {
+    it('uses the project gitignore in an apps/vendure monorepo', () => {
         const { workspace, project } = vendureMonorepo({ gitignore: 'node_modules\n' });
 
         const result = ensureProjectLinkGitignore(project);
 
         expect(result).toEqual({
+            kind: 'created',
+            path: getProjectLinkGitignorePath(project),
+        });
+        expect(fs.readFileSync(getProjectLinkGitignorePath(project), 'utf8')).toBe(
+            `${PROJECT_LINK_GITIGNORE_COMMENT}\n${PROJECT_LINK_IGNORE_CONTENTS}\n${PROJECT_LINK_KEEP_MANIFEST}\n`,
+        );
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe('node_modules\n');
+        expectGitIgnored(workspace, project, '.vendure/project.json', false);
+        expectGitIgnored(workspace, project, '.vendure/cache.db', true);
+    });
+
+    it('uses the deepest gitignore when an intermediate file also ignores Vendure state', () => {
+        const original = ['node_modules', PROJECT_LINK_NESTED_IGNORE_CONTENTS, ''].join('\n');
+        const { workspace, project } = vendureMonorepo({ gitignore: original });
+        const appsGitignore = path.join(workspace, 'apps', '.gitignore');
+        fs.writeFileSync(appsGitignore, `${PROJECT_LINK_NESTED_IGNORE_CONTENTS}\n`);
+
+        expect(ensureProjectLinkGitignore(project)).toEqual({
+            kind: 'created',
+            path: getProjectLinkGitignorePath(project),
+        });
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe(original);
+        expect(fs.readFileSync(appsGitignore, 'utf8')).toBe(`${PROJECT_LINK_NESTED_IGNORE_CONTENTS}\n`);
+        expectGitIgnored(workspace, project, '.vendure/project.json', false);
+        expectGitIgnored(workspace, project, '.vendure/cache.db', true);
+    });
+
+    it('adds a project-specific exception to a blocking repo-root directory ignore', () => {
+        const { workspace, project } = vendureMonorepo({ gitignore: '.vendure/\n' });
+
+        expect(ensureProjectLinkGitignore(project)).toEqual({
             kind: 'updated',
             path: path.join(workspace, '.gitignore'),
         });
-        expect(fs.existsSync(getProjectLinkGitignorePath(project))).toBe(false);
         expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe(
             [
-                'node_modules',
+                '.vendure/',
                 '',
                 PROJECT_LINK_GITIGNORE_COMMENT,
-                PROJECT_LINK_NESTED_IGNORE_CONTENTS,
-                PROJECT_LINK_NESTED_KEEP_MANIFEST,
+                '!apps/vendure/.vendure/',
+                'apps/vendure/.vendure/*',
+                '!apps/vendure/.vendure/project.json',
                 '',
             ].join('\n'),
         );
-    });
-
-    it('leaves a monorepo root gitignore unchanged when nested rules already apply', () => {
-        const original = [
-            'node_modules',
-            PROJECT_LINK_NESTED_IGNORE_CONTENTS,
-            PROJECT_LINK_NESTED_KEEP_MANIFEST,
-            '',
-        ].join('\n');
-        const { workspace, project } = vendureMonorepo({ gitignore: original });
-
+        expect(fs.existsSync(getProjectLinkGitignorePath(project))).toBe(false);
+        expectGitIgnored(workspace, project, '.vendure/project.json', false);
+        expectGitIgnored(workspace, project, '.vendure/cache.db', true);
         expect(ensureProjectLinkGitignore(project)).toEqual({
             kind: 'unchanged',
             path: path.join(workspace, '.gitignore'),
         });
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe(original);
-        expect(fs.existsSync(getProjectLinkGitignorePath(project))).toBe(false);
-    });
-
-    it('rewrites a repo-root directory ignore so apps/vendure/.vendure/project.json can be committed', () => {
-        const { workspace, project } = vendureMonorepo({ gitignore: '.vendure/\n' });
-
-        expect(ensureProjectLinkGitignore(project).kind).toBe('updated');
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe(
-            [
-                PROJECT_LINK_NESTED_IGNORE_CONTENTS,
-                '',
-                PROJECT_LINK_GITIGNORE_COMMENT,
-                PROJECT_LINK_NESTED_KEEP_MANIFEST,
-                '',
-            ].join('\n'),
-        );
-        expect(fs.existsSync(getProjectLinkGitignorePath(project))).toBe(false);
     });
 
     it('prefers an existing apps/vendure gitignore over the repo root', () => {
@@ -199,49 +205,30 @@ describe('Project Link gitignore', () => {
         expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe('node_modules\n');
     });
 
-    it('fixes a blocking repo-root directory ignore when the package already has local rules', () => {
-        const { workspace, project } = vendureMonorepo({ gitignore: '.vendure/\n' });
-        const packageIgnore = [
-            PROJECT_LINK_IGNORE_CONTENTS,
-            PROJECT_LINK_KEEP_MANIFEST,
-            '',
-        ].join('\n');
-        fs.writeFileSync(getProjectLinkGitignorePath(project), packageIgnore);
+    it('does not rewrite a directory ignore for an unrelated project', () => {
+        const original = 'other-app/.vendure/\n';
+        const { workspace, project } = vendureMonorepo({ gitignore: original });
 
-        expect(ensureProjectLinkGitignore(project).kind).toBe('updated');
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain(
-            PROJECT_LINK_NESTED_IGNORE_CONTENTS,
-        );
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain(
-            PROJECT_LINK_NESTED_KEEP_MANIFEST,
-        );
-        expect(fs.readFileSync(getProjectLinkGitignorePath(project), 'utf8')).toBe(packageIgnore);
+        expect(ensureProjectLinkGitignore(project)).toEqual({
+            kind: 'created',
+            path: getProjectLinkGitignorePath(project),
+        });
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe(original);
+        expectGitIgnored(workspace, path.join(workspace, 'other-app'), '.vendure/project.json', true);
+        expectGitIgnored(workspace, project, '.vendure/project.json', false);
     });
 
-    it('rewrites a path-specific directory ignore so the manifest can be committed', () => {
-        const { workspace, project } = vendureMonorepo({ gitignore: 'apps/vendure/.vendure/\n' });
-
-        expect(ensureProjectLinkGitignore(project).kind).toBe('updated');
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain(
-            PROJECT_LINK_NESTED_IGNORE_CONTENTS,
-        );
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toContain(
-            PROJECT_LINK_NESTED_KEEP_MANIFEST,
-        );
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).not.toContain(
-            'apps/vendure/.vendure/',
-        );
-    });
-
-    it('accepts path-specific repo-root rules for apps/vendure', () => {
+    it('does not rely on path-specific rules from an ancestor gitignore', () => {
         const original = ['apps/vendure/.vendure/*', '!apps/vendure/.vendure/project.json', ''].join('\n');
         const { workspace, project } = vendureMonorepo({ gitignore: original });
 
         expect(ensureProjectLinkGitignore(project)).toEqual({
-            kind: 'unchanged',
-            path: path.join(workspace, '.gitignore'),
+            kind: 'created',
+            path: getProjectLinkGitignorePath(project),
         });
         expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe(original);
+        expectGitIgnored(workspace, project, '.vendure/project.json', false);
+        expectGitIgnored(workspace, project, '.vendure/cache.db', true);
     });
 
     it('writes nested rules when apply runs in nested mode', () => {
@@ -256,6 +243,20 @@ describe('Project Link gitignore', () => {
             ].join('\n'),
         );
     });
+
+    it('does not update an incidental repository outside the project', () => {
+        const home = temporaryDirectory();
+        initializeGitRepository(home);
+        fs.writeFileSync(path.join(home, '.gitignore'), 'node_modules\n');
+        const project = path.join(home, 'code', 'my-project');
+        fs.ensureDirSync(project);
+
+        expect(ensureProjectLinkGitignore(project)).toEqual({
+            kind: 'created',
+            path: getProjectLinkGitignorePath(project),
+        });
+        expect(fs.readFileSync(path.join(home, '.gitignore'), 'utf8')).toBe('node_modules\n');
+    });
 });
 
 function temporaryDirectory(): string {
@@ -266,7 +267,7 @@ function temporaryDirectory(): string {
 
 function vendureMonorepo(options: { gitignore?: string } = {}): { workspace: string; project: string } {
     const workspace = temporaryDirectory();
-    fs.ensureDirSync(path.join(workspace, '.git'));
+    initializeGitRepository(workspace);
     fs.writeJsonSync(path.join(workspace, 'package.json'), { private: true });
     if (options.gitignore !== undefined) {
         fs.writeFileSync(path.join(workspace, '.gitignore'), options.gitignore);
@@ -277,4 +278,21 @@ function vendureMonorepo(options: { gitignore?: string } = {}): { workspace: str
         dependencies: { '@vendure/core': '3.7.2' },
     });
     return { workspace, project: fs.realpathSync(project) };
+}
+
+function initializeGitRepository(directory: string): void {
+    const result = spawnSync('git', ['init', '--quiet'], { cwd: directory, encoding: 'utf8' });
+    if (result.status !== 0) {
+        throw new Error(result.stderr);
+    }
+}
+
+function expectGitIgnored(workspace: string, project: string, relativePath: string, ignored: boolean): void {
+    const target = path.join(project, relativePath);
+    fs.ensureFileSync(target);
+    const result = spawnSync('git', ['check-ignore', '--quiet', '--no-index', target], {
+        cwd: workspace,
+        encoding: 'utf8',
+    });
+    expect(result.status, result.stderr).toBe(ignored ? 0 : 1);
 }

--- a/packages/cli/src/commands/console/project-link-gitignore.spec.ts
+++ b/packages/cli/src/commands/console/project-link-gitignore.spec.ts
@@ -5,17 +5,15 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
-    PROJECT_LINK_GITIGNORE_COMMENT,
     PROJECT_LINK_IGNORE_CONTENTS,
     PROJECT_LINK_KEEP_MANIFEST,
-    PROJECT_LINK_NESTED_IGNORE_CONTENTS,
-    PROJECT_LINK_NESTED_KEEP_MANIFEST,
     applyProjectLinkGitignoreRules,
     ensureProjectLinkGitignore,
     getProjectLinkGitignorePath,
 } from './project-link-gitignore';
 
 const temporaryDirectories: string[] = [];
+const projectLinkRules = `${PROJECT_LINK_IGNORE_CONTENTS}\n${PROJECT_LINK_KEEP_MANIFEST}\n`;
 
 afterEach(() => {
     for (const directory of temporaryDirectories.splice(0)) {
@@ -31,91 +29,65 @@ describe('Project Link gitignore', () => {
             kind: 'created',
             path: getProjectLinkGitignorePath(root),
         });
-        expect(fs.readFileSync(getProjectLinkGitignorePath(root), 'utf8')).toBe(
-            `${PROJECT_LINK_GITIGNORE_COMMENT}\n${PROJECT_LINK_IGNORE_CONTENTS}\n${PROJECT_LINK_KEEP_MANIFEST}\n`,
+        expect(fs.readFileSync(getProjectLinkGitignorePath(root), 'utf8')).toBe(projectLinkRules);
+    });
+
+    it('replaces the scaffolded directory rule', () => {
+        expect(applyProjectLinkGitignoreRules('node_modules\n.vendure/\ndist\n')).toBe(
+            `node_modules\n${projectLinkRules}dist\n`,
         );
+        expect(applyProjectLinkGitignoreRules('node_modules\n.vendure\ndist\n')).toBe(
+            `node_modules\n${projectLinkRules}dist\n`,
+        );
+    });
+
+    it('appends the rules when the scaffolded directory rule is absent', () => {
+        expect(applyProjectLinkGitignoreRules('node_modules\ndist\n')).toBe(
+            `node_modules\ndist\n\n${projectLinkRules}`,
+        );
+    });
+
+    it('makes the manifest committable in a non-scaffolded project', () => {
+        const root = temporaryDirectory();
+        runGit(root, ['init', '--quiet']);
+        fs.writeFileSync(getProjectLinkGitignorePath(root), 'node_modules\n');
+
+        expect(ensureProjectLinkGitignore(root).kind).toBe('updated');
+        expectGitIgnored(root, '.vendure/project.json', false);
+        expectGitIgnored(root, '.vendure/cache.db', true);
     });
 
     it('leaves an already-correct gitignore unchanged', () => {
-        const root = temporaryDirectory();
-        const original = [
-            'node_modules',
-            PROJECT_LINK_GITIGNORE_COMMENT,
-            PROJECT_LINK_IGNORE_CONTENTS,
-            PROJECT_LINK_KEEP_MANIFEST,
-            '',
-        ].join('\n');
-        fs.writeFileSync(getProjectLinkGitignorePath(root), original);
-
-        expect(ensureProjectLinkGitignore(root)).toEqual({
-            kind: 'unchanged',
-            path: getProjectLinkGitignorePath(root),
-        });
-        expect(fs.readFileSync(getProjectLinkGitignorePath(root), 'utf8')).toBe(original);
+        const original = `node_modules\n${projectLinkRules}`;
+        expect(applyProjectLinkGitignoreRules(original)).toBe(original);
     });
 
-    it('appends missing rules to an existing gitignore', () => {
-        const root = temporaryDirectory();
-        fs.writeFileSync(getProjectLinkGitignorePath(root), 'node_modules\ndist\n');
-
-        expect(ensureProjectLinkGitignore(root).kind).toBe('updated');
-        expect(fs.readFileSync(getProjectLinkGitignorePath(root), 'utf8')).toBe(
-            [
-                'node_modules',
-                'dist',
-                '',
-                PROJECT_LINK_GITIGNORE_COMMENT,
-                PROJECT_LINK_IGNORE_CONTENTS,
-                PROJECT_LINK_KEEP_MANIFEST,
-                '',
-            ].join('\n'),
-        );
-    });
-
-    it('adds only the un-ignore rule when contents are already ignored', () => {
-        expect(applyProjectLinkGitignoreRules('.vendure/*\n')).toBe(
-            ['.vendure/*', '', PROJECT_LINK_GITIGNORE_COMMENT, PROJECT_LINK_KEEP_MANIFEST, ''].join('\n'),
-        );
-    });
-
-    it('rewrites a directory ignore so the manifest can be committed', () => {
-        expect(applyProjectLinkGitignoreRules('.vendure/\n')).toBe(
-            [
-                PROJECT_LINK_IGNORE_CONTENTS,
-                '',
-                PROJECT_LINK_GITIGNORE_COMMENT,
-                PROJECT_LINK_KEEP_MANIFEST,
-                '',
-            ].join('\n'),
-        );
-        expect(applyProjectLinkGitignoreRules('.vendure\n!.vendure/project.json\n')).toBe(
-            `${PROJECT_LINK_IGNORE_CONTENTS}\n${PROJECT_LINK_KEEP_MANIFEST}\n`,
-        );
-    });
-
-    it('accepts root-anchored and nested equivalent rules', () => {
-        expect(applyProjectLinkGitignoreRules('/.vendure/*\n!/.vendure/project.json\n')).toBe(
-            '/.vendure/*\n!/.vendure/project.json\n',
-        );
-        expect(applyProjectLinkGitignoreRules('**/.vendure/**\n!**/.vendure/project.json\n')).toBe(
-            '**/.vendure/**\n!**/.vendure/project.json\n',
-        );
+    it('does not treat similar patterns as the scaffolded rule', () => {
+        const original = 'other-app/.vendure/\n**/.vendure/\n';
+        expect(applyProjectLinkGitignoreRules(original)).toBe(`${original}\n${projectLinkRules}`);
     });
 
     it('preserves CRLF when updating an existing file', () => {
-        expect(applyProjectLinkGitignoreRules('node_modules\r\n')).toBe(
-            [
-                'node_modules',
-                '',
-                PROJECT_LINK_GITIGNORE_COMMENT,
-                PROJECT_LINK_IGNORE_CONTENTS,
-                PROJECT_LINK_KEEP_MANIFEST,
-                '',
-            ].join('\r\n'),
+        expect(applyProjectLinkGitignoreRules('node_modules\r\n.vendure/\r\n')).toBe(
+            `node_modules\r\n${PROJECT_LINK_IGNORE_CONTENTS}\r\n${PROJECT_LINK_KEEP_MANIFEST}\r\n`,
         );
     });
 
-    it('does not fail the caller when the gitignore path cannot be written', () => {
+    it('updates only the project gitignore', () => {
+        const workspace = temporaryDirectory();
+        const project = path.join(workspace, 'apps', 'vendure');
+        fs.ensureDirSync(project);
+        fs.writeFileSync(path.join(workspace, '.gitignore'), '.vendure/\n');
+
+        expect(ensureProjectLinkGitignore(project)).toEqual({
+            kind: 'created',
+            path: getProjectLinkGitignorePath(project),
+        });
+        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe('.vendure/\n');
+        expect(fs.readFileSync(getProjectLinkGitignorePath(project), 'utf8')).toBe(projectLinkRules);
+    });
+
+    it('reports a project gitignore that cannot be written', () => {
         const root = temporaryDirectory();
         fs.ensureDirSync(getProjectLinkGitignorePath(root));
 
@@ -123,139 +95,6 @@ describe('Project Link gitignore', () => {
 
         expect(result.kind).toBe('failed');
         expect(result.path).toBe(getProjectLinkGitignorePath(root));
-        expect(fs.statSync(getProjectLinkGitignorePath(root)).isDirectory()).toBe(true);
-    });
-
-    it('uses the project gitignore in an apps/vendure monorepo', () => {
-        const { workspace, project } = vendureMonorepo({ gitignore: 'node_modules\n' });
-
-        const result = ensureProjectLinkGitignore(project);
-
-        expect(result).toEqual({
-            kind: 'created',
-            path: getProjectLinkGitignorePath(project),
-        });
-        expect(fs.readFileSync(getProjectLinkGitignorePath(project), 'utf8')).toBe(
-            `${PROJECT_LINK_GITIGNORE_COMMENT}\n${PROJECT_LINK_IGNORE_CONTENTS}\n${PROJECT_LINK_KEEP_MANIFEST}\n`,
-        );
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe('node_modules\n');
-        expectGitIgnored(workspace, project, '.vendure/project.json', false);
-        expectGitIgnored(workspace, project, '.vendure/cache.db', true);
-    });
-
-    it('uses the deepest gitignore when an intermediate file also ignores Vendure state', () => {
-        const original = ['node_modules', PROJECT_LINK_NESTED_IGNORE_CONTENTS, ''].join('\n');
-        const { workspace, project } = vendureMonorepo({ gitignore: original });
-        const appsGitignore = path.join(workspace, 'apps', '.gitignore');
-        fs.writeFileSync(appsGitignore, `${PROJECT_LINK_NESTED_IGNORE_CONTENTS}\n`);
-
-        expect(ensureProjectLinkGitignore(project)).toEqual({
-            kind: 'created',
-            path: getProjectLinkGitignorePath(project),
-        });
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe(original);
-        expect(fs.readFileSync(appsGitignore, 'utf8')).toBe(`${PROJECT_LINK_NESTED_IGNORE_CONTENTS}\n`);
-        expectGitIgnored(workspace, project, '.vendure/project.json', false);
-        expectGitIgnored(workspace, project, '.vendure/cache.db', true);
-    });
-
-    it('adds a project-specific exception to a blocking repo-root directory ignore', () => {
-        const { workspace, project } = vendureMonorepo({ gitignore: '.vendure/\n' });
-
-        expect(ensureProjectLinkGitignore(project)).toEqual({
-            kind: 'updated',
-            path: path.join(workspace, '.gitignore'),
-        });
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe(
-            [
-                '.vendure/',
-                '',
-                PROJECT_LINK_GITIGNORE_COMMENT,
-                '!apps/vendure/.vendure/',
-                'apps/vendure/.vendure/*',
-                '!apps/vendure/.vendure/project.json',
-                '',
-            ].join('\n'),
-        );
-        expect(fs.existsSync(getProjectLinkGitignorePath(project))).toBe(false);
-        expectGitIgnored(workspace, project, '.vendure/project.json', false);
-        expectGitIgnored(workspace, project, '.vendure/cache.db', true);
-        expect(ensureProjectLinkGitignore(project)).toEqual({
-            kind: 'unchanged',
-            path: path.join(workspace, '.gitignore'),
-        });
-    });
-
-    it('prefers an existing apps/vendure gitignore over the repo root', () => {
-        const { workspace, project } = vendureMonorepo({ gitignore: 'node_modules\n' });
-        fs.writeFileSync(getProjectLinkGitignorePath(project), 'dist\n');
-
-        const result = ensureProjectLinkGitignore(project);
-
-        expect(result).toEqual({
-            kind: 'updated',
-            path: getProjectLinkGitignorePath(project),
-        });
-        expect(fs.readFileSync(getProjectLinkGitignorePath(project), 'utf8')).toContain(
-            PROJECT_LINK_IGNORE_CONTENTS,
-        );
-        expect(fs.readFileSync(getProjectLinkGitignorePath(project), 'utf8')).toContain(
-            PROJECT_LINK_KEEP_MANIFEST,
-        );
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe('node_modules\n');
-    });
-
-    it('does not rewrite a directory ignore for an unrelated project', () => {
-        const original = 'other-app/.vendure/\n';
-        const { workspace, project } = vendureMonorepo({ gitignore: original });
-
-        expect(ensureProjectLinkGitignore(project)).toEqual({
-            kind: 'created',
-            path: getProjectLinkGitignorePath(project),
-        });
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe(original);
-        expectGitIgnored(workspace, path.join(workspace, 'other-app'), '.vendure/project.json', true);
-        expectGitIgnored(workspace, project, '.vendure/project.json', false);
-    });
-
-    it('does not rely on path-specific rules from an ancestor gitignore', () => {
-        const original = ['apps/vendure/.vendure/*', '!apps/vendure/.vendure/project.json', ''].join('\n');
-        const { workspace, project } = vendureMonorepo({ gitignore: original });
-
-        expect(ensureProjectLinkGitignore(project)).toEqual({
-            kind: 'created',
-            path: getProjectLinkGitignorePath(project),
-        });
-        expect(fs.readFileSync(path.join(workspace, '.gitignore'), 'utf8')).toBe(original);
-        expectGitIgnored(workspace, project, '.vendure/project.json', false);
-        expectGitIgnored(workspace, project, '.vendure/cache.db', true);
-    });
-
-    it('writes nested rules when apply runs in nested mode', () => {
-        expect(applyProjectLinkGitignoreRules('node_modules\n', 'nested')).toBe(
-            [
-                'node_modules',
-                '',
-                PROJECT_LINK_GITIGNORE_COMMENT,
-                PROJECT_LINK_NESTED_IGNORE_CONTENTS,
-                PROJECT_LINK_NESTED_KEEP_MANIFEST,
-                '',
-            ].join('\n'),
-        );
-    });
-
-    it('does not update an incidental repository outside the project', () => {
-        const home = temporaryDirectory();
-        initializeGitRepository(home);
-        fs.writeFileSync(path.join(home, '.gitignore'), 'node_modules\n');
-        const project = path.join(home, 'code', 'my-project');
-        fs.ensureDirSync(project);
-
-        expect(ensureProjectLinkGitignore(project)).toEqual({
-            kind: 'created',
-            path: getProjectLinkGitignorePath(project),
-        });
-        expect(fs.readFileSync(path.join(home, '.gitignore'), 'utf8')).toBe('node_modules\n');
     });
 });
 
@@ -265,34 +104,16 @@ function temporaryDirectory(): string {
     return fs.realpathSync(directory);
 }
 
-function vendureMonorepo(options: { gitignore?: string } = {}): { workspace: string; project: string } {
-    const workspace = temporaryDirectory();
-    initializeGitRepository(workspace);
-    fs.writeJsonSync(path.join(workspace, 'package.json'), { private: true });
-    if (options.gitignore !== undefined) {
-        fs.writeFileSync(path.join(workspace, '.gitignore'), options.gitignore);
-    }
-    const project = path.join(workspace, 'apps', 'vendure');
-    fs.ensureDirSync(project);
-    fs.writeJsonSync(path.join(project, 'package.json'), {
-        dependencies: { '@vendure/core': '3.7.2' },
-    });
-    return { workspace, project: fs.realpathSync(project) };
+function expectGitIgnored(root: string, relativePath: string, ignored: boolean): void {
+    fs.ensureFileSync(path.join(root, relativePath));
+    const result = runGit(root, ['check-ignore', '--quiet', '--no-index', relativePath]);
+    expect(result.status, result.stderr).toBe(ignored ? 0 : 1);
 }
 
-function initializeGitRepository(directory: string): void {
-    const result = spawnSync('git', ['init', '--quiet'], { cwd: directory, encoding: 'utf8' });
-    if (result.status !== 0) {
+function runGit(root: string, args: string[]): ReturnType<typeof spawnSync> {
+    const result = spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+    if (result.status !== 0 && args[0] !== 'check-ignore') {
         throw new Error(result.stderr);
     }
-}
-
-function expectGitIgnored(workspace: string, project: string, relativePath: string, ignored: boolean): void {
-    const target = path.join(project, relativePath);
-    fs.ensureFileSync(target);
-    const result = spawnSync('git', ['check-ignore', '--quiet', '--no-index', target], {
-        cwd: workspace,
-        encoding: 'utf8',
-    });
-    expect(result.status, result.stderr).toBe(ignored ? 0 : 1);
+    return result;
 }

--- a/packages/cli/src/commands/console/project-link-gitignore.ts
+++ b/packages/cli/src/commands/console/project-link-gitignore.ts
@@ -358,7 +358,7 @@ function isDirectoryIgnore(pattern: string): boolean {
     if (pattern.startsWith('!')) {
         return false;
     }
-    return /^(?:\*\*\/)?\.vendure\/?$/.test(stripRootAnchor(pattern));
+    return /(?:^|\/)(?:\*\*\/)?\.vendure\/?$/.test(stripRootAnchor(pattern));
 }
 
 function stripRootAnchor(pattern: string): string {

--- a/packages/cli/src/commands/console/project-link-gitignore.ts
+++ b/packages/cli/src/commands/console/project-link-gitignore.ts
@@ -1,0 +1,171 @@
+import fs from 'fs-extra';
+import path from 'node:path';
+
+export const PROJECT_LINK_GITIGNORE_RELATIVE_PATH = '.gitignore';
+export const PROJECT_LINK_IGNORE_CONTENTS = '.vendure/*';
+export const PROJECT_LINK_KEEP_MANIFEST = '!.vendure/project.json';
+export const PROJECT_LINK_GITIGNORE_COMMENT =
+    '# Commit the identity-only Project Link Manifest. Keep all other local Vendure state ignored.';
+
+export type ProjectLinkGitignoreResult =
+    | { kind: 'unchanged'; path: string }
+    | { kind: 'created'; path: string }
+    | { kind: 'updated'; path: string }
+    | { kind: 'failed'; path: string; reason: string };
+
+export function getProjectLinkGitignorePath(projectRoot: string): string {
+    return path.join(projectRoot, PROJECT_LINK_GITIGNORE_RELATIVE_PATH);
+}
+
+export function ensureProjectLinkGitignore(projectRoot: string): ProjectLinkGitignoreResult {
+    const gitignorePath = getProjectLinkGitignorePath(projectRoot);
+    try {
+        if (!fs.existsSync(gitignorePath)) {
+            fs.writeFileSync(gitignorePath, createdGitignoreContents(), 'utf8');
+            return { kind: 'created', path: gitignorePath };
+        }
+
+        const raw = fs.readFileSync(gitignorePath, 'utf8');
+        const next = applyProjectLinkGitignoreRules(raw);
+        if (next === raw) {
+            return { kind: 'unchanged', path: gitignorePath };
+        }
+
+        fs.writeFileSync(gitignorePath, next, 'utf8');
+        return { kind: 'updated', path: gitignorePath };
+    } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        return { kind: 'failed', path: gitignorePath, reason };
+    }
+}
+
+export function applyProjectLinkGitignoreRules(content: string): string {
+    if (hasRequiredProjectLinkGitignoreRules(content)) {
+        return content;
+    }
+
+    const newline = detectNewline(content);
+    const lines = content.split(/\r?\n/);
+    let sawIgnoreContents = false;
+    let sawKeepManifest = false;
+    let changed = false;
+
+    const nextLines = lines.map(line => {
+        const pattern = ignorePattern(line);
+        if (!pattern) {
+            return line;
+        }
+        if (isIgnoreContents(pattern)) {
+            sawIgnoreContents = true;
+            return line;
+        }
+        if (isKeepManifest(pattern)) {
+            sawKeepManifest = true;
+            return line;
+        }
+        if (isDirectoryIgnore(pattern)) {
+            changed = true;
+            sawIgnoreContents = true;
+            return PROJECT_LINK_IGNORE_CONTENTS;
+        }
+        return line;
+    });
+
+    const missing: string[] = [];
+    if (!sawIgnoreContents) {
+        missing.push(PROJECT_LINK_IGNORE_CONTENTS);
+    }
+    if (!sawKeepManifest) {
+        missing.push(PROJECT_LINK_KEEP_MANIFEST);
+    }
+
+    let output = nextLines.join(newline);
+    if (missing.length > 0) {
+        output = appendRuleBlock(output, missing, newline);
+        changed = true;
+    } else if (changed) {
+        output = ensureTrailingNewline(output, newline);
+    }
+
+    return output;
+}
+
+function createdGitignoreContents(): string {
+    return `${[PROJECT_LINK_GITIGNORE_COMMENT, PROJECT_LINK_IGNORE_CONTENTS, PROJECT_LINK_KEEP_MANIFEST].join(
+        '\n',
+    )}\n`;
+}
+
+function hasRequiredProjectLinkGitignoreRules(content: string): boolean {
+    let sawIgnoreContents = false;
+    let sawKeepManifest = false;
+    for (const line of content.split(/\r?\n/)) {
+        const pattern = ignorePattern(line);
+        if (!pattern) {
+            continue;
+        }
+        if (isIgnoreContents(pattern)) {
+            sawIgnoreContents = true;
+        }
+        if (isKeepManifest(pattern)) {
+            sawKeepManifest = true;
+        }
+    }
+    return sawIgnoreContents && sawKeepManifest && !hasDirectoryIgnore(content);
+}
+
+function hasDirectoryIgnore(content: string): boolean {
+    return content.split(/\r?\n/).some(line => {
+        const pattern = ignorePattern(line);
+        return pattern !== undefined && isDirectoryIgnore(pattern);
+    });
+}
+
+function appendRuleBlock(content: string, rules: string[], newline: string): string {
+    let next = content;
+    if (next.length > 0 && !next.endsWith('\n')) {
+        next += newline;
+    }
+    if (next.length > 0 && !/(?:\r?\n){2}$/.test(next)) {
+        next += newline;
+    }
+    return `${next}${[PROJECT_LINK_GITIGNORE_COMMENT, ...rules].join(newline)}${newline}`;
+}
+
+function ensureTrailingNewline(content: string, newline: string): string {
+    if (content.length === 0 || content.endsWith('\n')) {
+        return content;
+    }
+    return `${content}${newline}`;
+}
+
+function detectNewline(content: string): string {
+    return content.includes('\r\n') ? '\r\n' : '\n';
+}
+
+function ignorePattern(line: string): string | undefined {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith('#')) {
+        return undefined;
+    }
+    return trimmed;
+}
+
+function isIgnoreContents(pattern: string): boolean {
+    return /^(?:\*\*\/)?\.vendure\/\*\*?$/.test(stripRootAnchor(pattern));
+}
+
+function isKeepManifest(pattern: string): boolean {
+    return /^!(?:\*\*\/)?\.vendure\/project\.json$/.test(pattern.replace(/^!\/(?=\.)/, '!'));
+}
+
+function isDirectoryIgnore(pattern: string): boolean {
+    if (pattern.startsWith('!')) {
+        return false;
+    }
+    return /^(?:\*\*\/)?\.vendure\/?$/.test(stripRootAnchor(pattern));
+}
+
+function stripRootAnchor(pattern: string): string {
+    return pattern.startsWith('/') ? pattern.slice(1) : pattern;
+}

--- a/packages/cli/src/commands/console/project-link-gitignore.ts
+++ b/packages/cli/src/commands/console/project-link-gitignore.ts
@@ -4,8 +4,12 @@ import path from 'node:path';
 export const PROJECT_LINK_GITIGNORE_RELATIVE_PATH = '.gitignore';
 export const PROJECT_LINK_IGNORE_CONTENTS = '.vendure/*';
 export const PROJECT_LINK_KEEP_MANIFEST = '!.vendure/project.json';
+export const PROJECT_LINK_NESTED_IGNORE_CONTENTS = '**/.vendure/*';
+export const PROJECT_LINK_NESTED_KEEP_MANIFEST = '!**/.vendure/project.json';
 export const PROJECT_LINK_GITIGNORE_COMMENT =
     '# Commit the identity-only Project Link Manifest. Keep all other local Vendure state ignored.';
+
+export type ProjectLinkGitignoreMode = 'local' | 'nested';
 
 export type ProjectLinkGitignoreResult =
     | { kind: 'unchanged'; path: string }
@@ -13,37 +17,40 @@ export type ProjectLinkGitignoreResult =
     | { kind: 'updated'; path: string }
     | { kind: 'failed'; path: string; reason: string };
 
+interface GitignoreFile {
+    path: string;
+    content: string;
+    scope: 'project' | 'ancestor';
+}
+
 export function getProjectLinkGitignorePath(projectRoot: string): string {
     return path.join(projectRoot, PROJECT_LINK_GITIGNORE_RELATIVE_PATH);
 }
 
 export function ensureProjectLinkGitignore(projectRoot: string): ProjectLinkGitignoreResult {
-    const gitignorePath = getProjectLinkGitignorePath(projectRoot);
+    const projectGitignorePath = getProjectLinkGitignorePath(projectRoot);
     try {
-        if (!fs.existsSync(gitignorePath)) {
-            fs.writeFileSync(gitignorePath, createdGitignoreContents(), 'utf8');
-            return { kind: 'created', path: gitignorePath };
+        const gitRoot = findGitRoot(projectRoot);
+        if (!gitRoot) {
+            return ensureSingleGitignore(projectGitignorePath, 'local');
         }
-
-        const raw = fs.readFileSync(gitignorePath, 'utf8');
-        const next = applyProjectLinkGitignoreRules(raw);
-        if (next === raw) {
-            return { kind: 'unchanged', path: gitignorePath };
-        }
-
-        fs.writeFileSync(gitignorePath, next, 'utf8');
-        return { kind: 'updated', path: gitignorePath };
+        return ensureGitignoreInRepo(projectRoot, gitRoot);
     } catch (error) {
         const reason = error instanceof Error ? error.message : String(error);
-        return { kind: 'failed', path: gitignorePath, reason };
+        return { kind: 'failed', path: projectGitignorePath, reason };
     }
 }
 
-export function applyProjectLinkGitignoreRules(content: string): string {
-    if (hasRequiredProjectLinkGitignoreRules(content)) {
+export function applyProjectLinkGitignoreRules(
+    content: string,
+    mode: ProjectLinkGitignoreMode = 'local',
+): string {
+    if (mode === 'nested' ? hasNestedCoverage(content) : hasLocalCoverage(content)) {
         return content;
     }
 
+    const ignoreRule = mode === 'nested' ? PROJECT_LINK_NESTED_IGNORE_CONTENTS : PROJECT_LINK_IGNORE_CONTENTS;
+    const keepRule = mode === 'nested' ? PROJECT_LINK_NESTED_KEEP_MANIFEST : PROJECT_LINK_KEEP_MANIFEST;
     const newline = detectNewline(content);
     const lines = content.split(/\r?\n/);
     let sawIgnoreContents = false;
@@ -55,28 +62,28 @@ export function applyProjectLinkGitignoreRules(content: string): string {
         if (!pattern) {
             return line;
         }
-        if (isIgnoreContents(pattern)) {
+        if (mode === 'nested' ? isNestedIgnoreContents(pattern) : isAnyIgnoreContents(pattern)) {
             sawIgnoreContents = true;
             return line;
         }
-        if (isKeepManifest(pattern)) {
+        if (mode === 'nested' ? isNestedKeepManifest(pattern) : isAnyKeepManifest(pattern)) {
             sawKeepManifest = true;
             return line;
         }
         if (isDirectoryIgnore(pattern)) {
             changed = true;
             sawIgnoreContents = true;
-            return PROJECT_LINK_IGNORE_CONTENTS;
+            return ignoreRule;
         }
         return line;
     });
 
     const missing: string[] = [];
     if (!sawIgnoreContents) {
-        missing.push(PROJECT_LINK_IGNORE_CONTENTS);
+        missing.push(ignoreRule);
     }
     if (!sawKeepManifest) {
-        missing.push(PROJECT_LINK_KEEP_MANIFEST);
+        missing.push(keepRule);
     }
 
     let output = nextLines.join(newline);
@@ -90,13 +97,185 @@ export function applyProjectLinkGitignoreRules(content: string): string {
     return output;
 }
 
-function createdGitignoreContents(): string {
-    return `${[PROJECT_LINK_GITIGNORE_COMMENT, PROJECT_LINK_IGNORE_CONTENTS, PROJECT_LINK_KEEP_MANIFEST].join(
-        '\n',
-    )}\n`;
+function ensureGitignoreInRepo(projectRoot: string, gitRoot: string): ProjectLinkGitignoreResult {
+    const projectGitignorePath = getProjectLinkGitignorePath(projectRoot);
+    const chain = collectGitignoreChain(projectRoot, gitRoot);
+    const dirty = new Map<string, string>();
+
+    for (const file of chain) {
+        if (!hasDirectoryIgnore(file.content)) {
+            continue;
+        }
+        const next = applyProjectLinkGitignoreRules(file.content, file.scope === 'project' ? 'local' : 'nested');
+        if (next !== file.content) {
+            file.content = next;
+            dirty.set(file.path, next);
+        }
+    }
+
+    if (isProjectCovered(projectRoot, chain)) {
+        return writeDirty(dirty, coveringGitignorePath(projectRoot, chain), dirty.size > 0 ? 'updated' : 'unchanged');
+    }
+
+    const target = pickTarget(projectRoot, chain);
+    const mode: ProjectLinkGitignoreMode = target.scope === 'project' ? 'local' : 'nested';
+    const existed = fs.existsSync(target.path) && fs.statSync(target.path).isFile();
+    const next = applyProjectLinkGitignoreRules(target.content, mode);
+    if (next !== target.content || !existed) {
+        dirty.set(target.path, next);
+    }
+
+    if (dirty.size === 0) {
+        return { kind: 'unchanged', path: target.path };
+    }
+
+    return writeDirty(dirty, target.path, existed ? 'updated' : 'created');
 }
 
-function hasRequiredProjectLinkGitignoreRules(content: string): boolean {
+function ensureSingleGitignore(
+    gitignorePath: string,
+    mode: ProjectLinkGitignoreMode,
+): ProjectLinkGitignoreResult {
+    if (!fs.existsSync(gitignorePath)) {
+        fs.writeFileSync(gitignorePath, createdGitignoreContents(mode), 'utf8');
+        return { kind: 'created', path: gitignorePath };
+    }
+
+    const raw = fs.readFileSync(gitignorePath, 'utf8');
+    const next = applyProjectLinkGitignoreRules(raw, mode);
+    if (next === raw) {
+        return { kind: 'unchanged', path: gitignorePath };
+    }
+
+    fs.writeFileSync(gitignorePath, next, 'utf8');
+    return { kind: 'updated', path: gitignorePath };
+}
+
+function writeDirty(
+    dirty: Map<string, string>,
+    resultPath: string,
+    kind: 'created' | 'updated' | 'unchanged',
+): ProjectLinkGitignoreResult {
+    for (const [filePath, content] of dirty) {
+        fs.writeFileSync(filePath, content, 'utf8');
+    }
+    return { kind, path: resultPath };
+}
+
+function pickTarget(projectRoot: string, chain: GitignoreFile[]): GitignoreFile {
+    const projectFile = chain.find(file => file.scope === 'project');
+    if (projectFile) {
+        return projectFile;
+    }
+    if (chain.length > 0) {
+        return chain[chain.length - 1];
+    }
+    return {
+        path: getProjectLinkGitignorePath(projectRoot),
+        content: '',
+        scope: 'project',
+    };
+}
+
+function coveringGitignorePath(projectRoot: string, chain: GitignoreFile[]): string {
+    const projectFile = chain.find(file => file.scope === 'project');
+    if (projectFile && hasLocalCoverage(projectFile.content)) {
+        return projectFile.path;
+    }
+    const coveringAncestor = [...chain].reverse().find(file => fileCoversProject(projectRoot, file));
+    return coveringAncestor?.path ?? getProjectLinkGitignorePath(projectRoot);
+}
+
+function isProjectCovered(projectRoot: string, chain: GitignoreFile[]): boolean {
+    if (chain.some(file => hasDirectoryIgnore(file.content))) {
+        return false;
+    }
+    return chain.some(file => fileCoversProject(projectRoot, file));
+}
+
+function fileCoversProject(projectRoot: string, file: GitignoreFile): boolean {
+    if (file.scope === 'project') {
+        return hasLocalCoverage(file.content);
+    }
+    if (hasNestedCoverage(file.content)) {
+        return true;
+    }
+    const relativeProject = posixRelative(path.dirname(file.path), projectRoot);
+    return hasPathSpecificCoverage(file.content, relativeProject);
+}
+
+function collectGitignoreChain(projectRoot: string, gitRoot: string): GitignoreFile[] {
+    const files: GitignoreFile[] = [];
+    let current = projectRoot;
+    while (true) {
+        const gitignorePath = path.join(current, PROJECT_LINK_GITIGNORE_RELATIVE_PATH);
+        if (fs.existsSync(gitignorePath) && fs.statSync(gitignorePath).isFile()) {
+            files.push({
+                path: gitignorePath,
+                content: fs.readFileSync(gitignorePath, 'utf8'),
+                scope: current === projectRoot ? 'project' : 'ancestor',
+            });
+        }
+        if (current === gitRoot) {
+            return files;
+        }
+        const parent = path.dirname(current);
+        if (parent === current) {
+            return files;
+        }
+        current = parent;
+    }
+}
+
+function findGitRoot(start: string): string | undefined {
+    let current = start;
+    while (true) {
+        if (fs.existsSync(path.join(current, '.git'))) {
+            return current;
+        }
+        const parent = path.dirname(current);
+        if (parent === current) {
+            return undefined;
+        }
+        current = parent;
+    }
+}
+
+function createdGitignoreContents(mode: ProjectLinkGitignoreMode = 'local'): string {
+    const rules =
+        mode === 'nested'
+            ? [PROJECT_LINK_NESTED_IGNORE_CONTENTS, PROJECT_LINK_NESTED_KEEP_MANIFEST]
+            : [PROJECT_LINK_IGNORE_CONTENTS, PROJECT_LINK_KEEP_MANIFEST];
+    return `${[PROJECT_LINK_GITIGNORE_COMMENT, ...rules].join('\n')}\n`;
+}
+
+function hasLocalCoverage(content: string): boolean {
+    return hasRuleCoverage(content, isAnyIgnoreContents, isAnyKeepManifest);
+}
+
+function hasNestedCoverage(content: string): boolean {
+    return hasRuleCoverage(content, isNestedIgnoreContents, isNestedKeepManifest);
+}
+
+function hasPathSpecificCoverage(content: string, projectRel: string): boolean {
+    if (!projectRel || projectRel === '.' || projectRel.startsWith('../') || projectRel.startsWith('..')) {
+        return false;
+    }
+    const ignoreRule = `${projectRel}/.vendure/*`;
+    const ignoreRuleRecursive = `${projectRel}/.vendure/**`;
+    const keepRule = `!${projectRel}/.vendure/project.json`;
+    return hasRuleCoverage(
+        content,
+        pattern => pattern === ignoreRule || pattern === ignoreRuleRecursive || pattern === `/${ignoreRule}`,
+        pattern => pattern === keepRule || pattern === `!/${projectRel}/.vendure/project.json`,
+    );
+}
+
+function hasRuleCoverage(
+    content: string,
+    isIgnore: (pattern: string) => boolean,
+    isKeep: (pattern: string) => boolean,
+): boolean {
     let sawIgnoreContents = false;
     let sawKeepManifest = false;
     for (const line of content.split(/\r?\n/)) {
@@ -104,10 +283,10 @@ function hasRequiredProjectLinkGitignoreRules(content: string): boolean {
         if (!pattern) {
             continue;
         }
-        if (isIgnoreContents(pattern)) {
+        if (isIgnore(pattern)) {
             sawIgnoreContents = true;
         }
-        if (isKeepManifest(pattern)) {
+        if (isKeep(pattern)) {
             sawKeepManifest = true;
         }
     }
@@ -151,12 +330,28 @@ function ignorePattern(line: string): string | undefined {
     return trimmed;
 }
 
-function isIgnoreContents(pattern: string): boolean {
-    return /^(?:\*\*\/)?\.vendure\/\*\*?$/.test(stripRootAnchor(pattern));
+function isAnyIgnoreContents(pattern: string): boolean {
+    return isLocalIgnoreContents(pattern) || isNestedIgnoreContents(pattern);
 }
 
-function isKeepManifest(pattern: string): boolean {
-    return /^!(?:\*\*\/)?\.vendure\/project\.json$/.test(pattern.replace(/^!\/(?=\.)/, '!'));
+function isLocalIgnoreContents(pattern: string): boolean {
+    return /^\.vendure\/\*\*?$/.test(stripRootAnchor(pattern));
+}
+
+function isNestedIgnoreContents(pattern: string): boolean {
+    return /^\*\*\/\.vendure\/\*\*?$/.test(pattern);
+}
+
+function isAnyKeepManifest(pattern: string): boolean {
+    return isLocalKeepManifest(pattern) || isNestedKeepManifest(pattern);
+}
+
+function isLocalKeepManifest(pattern: string): boolean {
+    return /^!\.vendure\/project\.json$/.test(pattern.replace(/^!\/(?=\.)/, '!'));
+}
+
+function isNestedKeepManifest(pattern: string): boolean {
+    return /^!\*\*\/\.vendure\/project\.json$/.test(pattern);
 }
 
 function isDirectoryIgnore(pattern: string): boolean {
@@ -168,4 +363,8 @@ function isDirectoryIgnore(pattern: string): boolean {
 
 function stripRootAnchor(pattern: string): string {
     return pattern.startsWith('/') ? pattern.slice(1) : pattern;
+}
+
+function posixRelative(from: string, to: string): string {
+    return path.relative(from, to).split(path.sep).join('/');
 }

--- a/packages/cli/src/commands/console/project-link-gitignore.ts
+++ b/packages/cli/src/commands/console/project-link-gitignore.ts
@@ -1,11 +1,17 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 
+import { detectMonorepoStructure } from '../../utilities/monorepo-utils';
+
+import { PROJECT_LINK_MANIFEST_RELATIVE_PATH, findGitRoot } from './project-link-manifest';
+
 export const PROJECT_LINK_GITIGNORE_RELATIVE_PATH = '.gitignore';
-export const PROJECT_LINK_IGNORE_CONTENTS = '.vendure/*';
-export const PROJECT_LINK_KEEP_MANIFEST = '!.vendure/project.json';
-export const PROJECT_LINK_NESTED_IGNORE_CONTENTS = '**/.vendure/*';
-export const PROJECT_LINK_NESTED_KEEP_MANIFEST = '!**/.vendure/project.json';
+const PROJECT_LINK_MANIFEST_PATH = PROJECT_LINK_MANIFEST_RELATIVE_PATH.split(path.sep).join('/');
+const PROJECT_LINK_DIRECTORY = path.posix.dirname(PROJECT_LINK_MANIFEST_PATH);
+export const PROJECT_LINK_IGNORE_CONTENTS = `${PROJECT_LINK_DIRECTORY}/*`;
+export const PROJECT_LINK_KEEP_MANIFEST = `!${PROJECT_LINK_MANIFEST_PATH}`;
+export const PROJECT_LINK_NESTED_IGNORE_CONTENTS = `**/${PROJECT_LINK_IGNORE_CONTENTS}`;
+export const PROJECT_LINK_NESTED_KEEP_MANIFEST = `!**/${PROJECT_LINK_MANIFEST_PATH}`;
 export const PROJECT_LINK_GITIGNORE_COMMENT =
     '# Commit the identity-only Project Link Manifest. Keep all other local Vendure state ignored.';
 
@@ -20,7 +26,10 @@ export type ProjectLinkGitignoreResult =
 interface GitignoreFile {
     path: string;
     content: string;
-    scope: 'project' | 'ancestor';
+}
+
+interface AncestorGitignore extends GitignoreFile {
+    needsUpdate: boolean;
 }
 
 export function getProjectLinkGitignorePath(projectRoot: string): string {
@@ -29,15 +38,22 @@ export function getProjectLinkGitignorePath(projectRoot: string): string {
 
 export function ensureProjectLinkGitignore(projectRoot: string): ProjectLinkGitignoreResult {
     const projectGitignorePath = getProjectLinkGitignorePath(projectRoot);
+    let target = projectGitignorePath;
+
     try {
-        const gitRoot = findGitRoot(projectRoot);
-        if (!gitRoot) {
-            return ensureSingleGitignore(projectGitignorePath, 'local');
+        if (!fs.existsSync(projectGitignorePath)) {
+            const ancestor = findAncestorGitignore(projectRoot);
+            if (ancestor) {
+                target = ancestor.path;
+                return ancestor.needsUpdate
+                    ? ensureAncestorGitignore(projectRoot, ancestor)
+                    : { kind: 'unchanged', path: ancestor.path };
+            }
         }
-        return ensureGitignoreInRepo(projectRoot, gitRoot);
+        return ensureSingleGitignore(projectGitignorePath, 'local');
     } catch (error) {
         const reason = error instanceof Error ? error.message : String(error);
-        return { kind: 'failed', path: projectGitignorePath, reason };
+        return { kind: 'failed', path: target, reason };
     }
 }
 
@@ -70,7 +86,7 @@ export function applyProjectLinkGitignoreRules(
             sawKeepManifest = true;
             return line;
         }
-        if (isDirectoryIgnore(pattern)) {
+        if (isVendureDirectoryRule(pattern)) {
             changed = true;
             sawIgnoreContents = true;
             return ignoreRule;
@@ -89,47 +105,51 @@ export function applyProjectLinkGitignoreRules(
     let output = nextLines.join(newline);
     if (missing.length > 0) {
         output = appendRuleBlock(output, missing, newline);
-        changed = true;
     } else if (changed) {
         output = ensureTrailingNewline(output, newline);
     }
-
     return output;
 }
 
-function ensureGitignoreInRepo(projectRoot: string, gitRoot: string): ProjectLinkGitignoreResult {
-    const projectGitignorePath = getProjectLinkGitignorePath(projectRoot);
-    const chain = collectGitignoreChain(projectRoot, gitRoot);
-    const dirty = new Map<string, string>();
+function findAncestorGitignore(projectRoot: string): AncestorGitignore | undefined {
+    const gitRoot = findGitRoot(projectRoot);
+    const monorepo = detectMonorepoStructure(projectRoot);
+    if (!gitRoot || !monorepo.isMonorepo || path.resolve(monorepo.root ?? '') !== path.resolve(gitRoot)) {
+        return undefined;
+    }
 
-    for (const file of chain) {
-        if (!hasDirectoryIgnore(file.content)) {
-            continue;
+    let deepestFile: GitignoreFile | undefined;
+    let directoryIgnored: boolean | undefined;
+    let current = path.dirname(projectRoot);
+    while (isWithin(gitRoot, current)) {
+        const gitignorePath = path.join(current, PROJECT_LINK_GITIGNORE_RELATIVE_PATH);
+        if (fs.existsSync(gitignorePath) && fs.statSync(gitignorePath).isFile()) {
+            const content = fs.readFileSync(gitignorePath, 'utf8');
+            deepestFile ??= { path: gitignorePath, content };
+            const projectPath = posixRelative(current, projectRoot);
+            if (deepestFile.path === gitignorePath && hasTargetedCoverage(content, projectPath)) {
+                return { ...deepestFile, needsUpdate: false };
+            }
+            directoryIgnored ??= vendureDirectoryState(content, projectPath);
+            if (directoryIgnored === true) {
+                return { ...deepestFile, needsUpdate: true };
+            }
         }
-        const next = applyProjectLinkGitignoreRules(file.content, file.scope === 'project' ? 'local' : 'nested');
-        if (next !== file.content) {
-            file.content = next;
-            dirty.set(file.path, next);
+        if (current === gitRoot) {
+            break;
         }
+        current = path.dirname(current);
     }
+    return undefined;
+}
 
-    if (isProjectCovered(projectRoot, chain)) {
-        return writeDirty(dirty, coveringGitignorePath(projectRoot, chain), dirty.size > 0 ? 'updated' : 'unchanged');
-    }
-
-    const target = pickTarget(projectRoot, chain);
-    const mode: ProjectLinkGitignoreMode = target.scope === 'project' ? 'local' : 'nested';
-    const existed = fs.existsSync(target.path) && fs.statSync(target.path).isFile();
-    const next = applyProjectLinkGitignoreRules(target.content, mode);
-    if (next !== target.content || !existed) {
-        dirty.set(target.path, next);
-    }
-
-    if (dirty.size === 0) {
-        return { kind: 'unchanged', path: target.path };
-    }
-
-    return writeDirty(dirty, target.path, existed ? 'updated' : 'created');
+function ensureAncestorGitignore(projectRoot: string, file: GitignoreFile): ProjectLinkGitignoreResult {
+    const projectPath = posixRelative(path.dirname(file.path), projectRoot);
+    const vendurePath = `${projectPath}/${PROJECT_LINK_DIRECTORY}`;
+    const rules = [`!${vendurePath}/`, `${vendurePath}/*`, `!${vendurePath}/project.json`];
+    const next = appendRuleBlock(file.content, rules, detectNewline(file.content));
+    fs.writeFileSync(file.path, next, 'utf8');
+    return { kind: 'updated', path: file.path };
 }
 
 function ensureSingleGitignore(
@@ -151,97 +171,42 @@ function ensureSingleGitignore(
     return { kind: 'updated', path: gitignorePath };
 }
 
-function writeDirty(
-    dirty: Map<string, string>,
-    resultPath: string,
-    kind: 'created' | 'updated' | 'unchanged',
-): ProjectLinkGitignoreResult {
-    for (const [filePath, content] of dirty) {
-        fs.writeFileSync(filePath, content, 'utf8');
-    }
-    return { kind, path: resultPath };
-}
-
-function pickTarget(projectRoot: string, chain: GitignoreFile[]): GitignoreFile {
-    const projectFile = chain.find(file => file.scope === 'project');
-    if (projectFile) {
-        return projectFile;
-    }
-    if (chain.length > 0) {
-        return chain[chain.length - 1];
-    }
-    return {
-        path: getProjectLinkGitignorePath(projectRoot),
-        content: '',
-        scope: 'project',
-    };
-}
-
-function coveringGitignorePath(projectRoot: string, chain: GitignoreFile[]): string {
-    const projectFile = chain.find(file => file.scope === 'project');
-    if (projectFile && hasLocalCoverage(projectFile.content)) {
-        return projectFile.path;
-    }
-    const coveringAncestor = [...chain].reverse().find(file => fileCoversProject(projectRoot, file));
-    return coveringAncestor?.path ?? getProjectLinkGitignorePath(projectRoot);
-}
-
-function isProjectCovered(projectRoot: string, chain: GitignoreFile[]): boolean {
-    if (chain.some(file => hasDirectoryIgnore(file.content))) {
-        return false;
-    }
-    return chain.some(file => fileCoversProject(projectRoot, file));
-}
-
-function fileCoversProject(projectRoot: string, file: GitignoreFile): boolean {
-    if (file.scope === 'project') {
-        return hasLocalCoverage(file.content);
-    }
-    if (hasNestedCoverage(file.content)) {
-        return true;
-    }
-    const relativeProject = posixRelative(path.dirname(file.path), projectRoot);
-    return hasPathSpecificCoverage(file.content, relativeProject);
-}
-
-function collectGitignoreChain(projectRoot: string, gitRoot: string): GitignoreFile[] {
-    const files: GitignoreFile[] = [];
-    let current = projectRoot;
-    while (true) {
-        const gitignorePath = path.join(current, PROJECT_LINK_GITIGNORE_RELATIVE_PATH);
-        if (fs.existsSync(gitignorePath) && fs.statSync(gitignorePath).isFile()) {
-            files.push({
-                path: gitignorePath,
-                content: fs.readFileSync(gitignorePath, 'utf8'),
-                scope: current === projectRoot ? 'project' : 'ancestor',
-            });
+function vendureDirectoryState(content: string, projectPath: string): boolean | undefined {
+    let ignored: boolean | undefined;
+    for (const line of content.split(/\r?\n/)) {
+        const pattern = ignorePattern(line);
+        if (!pattern) {
+            continue;
         }
-        if (current === gitRoot) {
-            return files;
+        const negated = pattern.startsWith('!');
+        const normalized = stripRootAnchor(pattern.replace(/^!/, '')).replace(/\/$/, '');
+        if (
+            normalized === PROJECT_LINK_DIRECTORY ||
+            normalized === `**/${PROJECT_LINK_DIRECTORY}` ||
+            normalized === `${projectPath}/${PROJECT_LINK_DIRECTORY}`
+        ) {
+            ignored = !negated;
         }
-        const parent = path.dirname(current);
-        if (parent === current) {
-            return files;
-        }
-        current = parent;
     }
+    return ignored;
 }
 
-function findGitRoot(start: string): string | undefined {
-    let current = start;
-    while (true) {
-        if (fs.existsSync(path.join(current, '.git'))) {
-            return current;
-        }
-        const parent = path.dirname(current);
-        if (parent === current) {
-            return undefined;
-        }
-        current = parent;
-    }
+function hasTargetedCoverage(content: string, projectPath: string): boolean {
+    const vendurePath = `${projectPath}/${PROJECT_LINK_DIRECTORY}`;
+    const patterns = new Set(
+        content
+            .split(/\r?\n/)
+            .map(ignorePattern)
+            .filter((pattern): pattern is string => pattern !== undefined),
+    );
+    return (
+        patterns.has(`!${vendurePath}/`) &&
+        patterns.has(`${vendurePath}/*`) &&
+        patterns.has(`!${vendurePath}/project.json`)
+    );
 }
 
-function createdGitignoreContents(mode: ProjectLinkGitignoreMode = 'local'): string {
+function createdGitignoreContents(mode: ProjectLinkGitignoreMode): string {
     const rules =
         mode === 'nested'
             ? [PROJECT_LINK_NESTED_IGNORE_CONTENTS, PROJECT_LINK_NESTED_KEEP_MANIFEST]
@@ -257,20 +222,6 @@ function hasNestedCoverage(content: string): boolean {
     return hasRuleCoverage(content, isNestedIgnoreContents, isNestedKeepManifest);
 }
 
-function hasPathSpecificCoverage(content: string, projectRel: string): boolean {
-    if (!projectRel || projectRel === '.' || projectRel.startsWith('../') || projectRel.startsWith('..')) {
-        return false;
-    }
-    const ignoreRule = `${projectRel}/.vendure/*`;
-    const ignoreRuleRecursive = `${projectRel}/.vendure/**`;
-    const keepRule = `!${projectRel}/.vendure/project.json`;
-    return hasRuleCoverage(
-        content,
-        pattern => pattern === ignoreRule || pattern === ignoreRuleRecursive || pattern === `/${ignoreRule}`,
-        pattern => pattern === keepRule || pattern === `!/${projectRel}/.vendure/project.json`,
-    );
-}
-
 function hasRuleCoverage(
     content: string,
     isIgnore: (pattern: string) => boolean,
@@ -280,23 +231,20 @@ function hasRuleCoverage(
     let sawKeepManifest = false;
     for (const line of content.split(/\r?\n/)) {
         const pattern = ignorePattern(line);
-        if (!pattern) {
-            continue;
-        }
-        if (isIgnore(pattern)) {
+        if (pattern && isIgnore(pattern)) {
             sawIgnoreContents = true;
         }
-        if (isKeep(pattern)) {
+        if (pattern && isKeep(pattern)) {
             sawKeepManifest = true;
         }
     }
-    return sawIgnoreContents && sawKeepManifest && !hasDirectoryIgnore(content);
+    return sawIgnoreContents && sawKeepManifest && !hasVendureDirectoryIgnore(content);
 }
 
-function hasDirectoryIgnore(content: string): boolean {
+function hasVendureDirectoryIgnore(content: string): boolean {
     return content.split(/\r?\n/).some(line => {
         const pattern = ignorePattern(line);
-        return pattern !== undefined && isDirectoryIgnore(pattern);
+        return pattern !== undefined && isVendureDirectoryRule(pattern);
     });
 }
 
@@ -312,10 +260,7 @@ function appendRuleBlock(content: string, rules: string[], newline: string): str
 }
 
 function ensureTrailingNewline(content: string, newline: string): string {
-    if (content.length === 0 || content.endsWith('\n')) {
-        return content;
-    }
-    return `${content}${newline}`;
+    return content.length === 0 || content.endsWith('\n') ? content : `${content}${newline}`;
 }
 
 function detectNewline(content: string): string {
@@ -324,10 +269,7 @@ function detectNewline(content: string): string {
 
 function ignorePattern(line: string): string | undefined {
     const trimmed = line.trim();
-    if (trimmed.length === 0 || trimmed.startsWith('#')) {
-        return undefined;
-    }
-    return trimmed;
+    return trimmed.length === 0 || trimmed.startsWith('#') ? undefined : trimmed;
 }
 
 function isAnyIgnoreContents(pattern: string): boolean {
@@ -354,11 +296,11 @@ function isNestedKeepManifest(pattern: string): boolean {
     return /^!\*\*\/\.vendure\/project\.json$/.test(pattern);
 }
 
-function isDirectoryIgnore(pattern: string): boolean {
+function isVendureDirectoryRule(pattern: string): boolean {
     if (pattern.startsWith('!')) {
         return false;
     }
-    return /(?:^|\/)(?:\*\*\/)?\.vendure\/?$/.test(stripRootAnchor(pattern));
+    return /^(?:\*\*\/)?\.vendure\/?$/.test(stripRootAnchor(pattern));
 }
 
 function stripRootAnchor(pattern: string): string {
@@ -367,4 +309,9 @@ function stripRootAnchor(pattern: string): string {
 
 function posixRelative(from: string, to: string): string {
     return path.relative(from, to).split(path.sep).join('/');
+}
+
+function isWithin(parent: string, candidate: string): boolean {
+    const relative = path.relative(parent, candidate);
+    return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }

--- a/packages/cli/src/commands/console/project-link-gitignore.ts
+++ b/packages/cli/src/commands/console/project-link-gitignore.ts
@@ -1,21 +1,13 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 
-import { detectMonorepoStructure } from '../../utilities/monorepo-utils';
-
-import { PROJECT_LINK_MANIFEST_RELATIVE_PATH, findGitRoot } from './project-link-manifest';
+import { PROJECT_LINK_MANIFEST_RELATIVE_PATH } from './project-link-manifest';
 
 export const PROJECT_LINK_GITIGNORE_RELATIVE_PATH = '.gitignore';
 const PROJECT_LINK_MANIFEST_PATH = PROJECT_LINK_MANIFEST_RELATIVE_PATH.split(path.sep).join('/');
 const PROJECT_LINK_DIRECTORY = path.posix.dirname(PROJECT_LINK_MANIFEST_PATH);
 export const PROJECT_LINK_IGNORE_CONTENTS = `${PROJECT_LINK_DIRECTORY}/*`;
 export const PROJECT_LINK_KEEP_MANIFEST = `!${PROJECT_LINK_MANIFEST_PATH}`;
-export const PROJECT_LINK_NESTED_IGNORE_CONTENTS = `**/${PROJECT_LINK_IGNORE_CONTENTS}`;
-export const PROJECT_LINK_NESTED_KEEP_MANIFEST = `!**/${PROJECT_LINK_MANIFEST_PATH}`;
-export const PROJECT_LINK_GITIGNORE_COMMENT =
-    '# Commit the identity-only Project Link Manifest. Keep all other local Vendure state ignored.';
-
-export type ProjectLinkGitignoreMode = 'local' | 'nested';
 
 export type ProjectLinkGitignoreResult =
     | { kind: 'unchanged'; path: string }
@@ -23,232 +15,51 @@ export type ProjectLinkGitignoreResult =
     | { kind: 'updated'; path: string }
     | { kind: 'failed'; path: string; reason: string };
 
-interface GitignoreFile {
-    path: string;
-    content: string;
-}
-
-interface AncestorGitignore extends GitignoreFile {
-    needsUpdate: boolean;
-}
-
 export function getProjectLinkGitignorePath(projectRoot: string): string {
     return path.join(projectRoot, PROJECT_LINK_GITIGNORE_RELATIVE_PATH);
 }
 
 export function ensureProjectLinkGitignore(projectRoot: string): ProjectLinkGitignoreResult {
-    const projectGitignorePath = getProjectLinkGitignorePath(projectRoot);
-    let target = projectGitignorePath;
+    const gitignorePath = getProjectLinkGitignorePath(projectRoot);
 
     try {
-        if (!fs.existsSync(projectGitignorePath)) {
-            const ancestor = findAncestorGitignore(projectRoot);
-            if (ancestor) {
-                target = ancestor.path;
-                return ancestor.needsUpdate
-                    ? ensureAncestorGitignore(projectRoot, ancestor)
-                    : { kind: 'unchanged', path: ancestor.path };
-            }
+        if (!fs.existsSync(gitignorePath)) {
+            fs.writeFileSync(gitignorePath, projectLinkRules('\n'), 'utf8');
+            return { kind: 'created', path: gitignorePath };
         }
-        return ensureSingleGitignore(projectGitignorePath, 'local');
+
+        const current = fs.readFileSync(gitignorePath, 'utf8');
+        const next = applyProjectLinkGitignoreRules(current);
+        if (next === current) {
+            return { kind: 'unchanged', path: gitignorePath };
+        }
+
+        fs.writeFileSync(gitignorePath, next, 'utf8');
+        return { kind: 'updated', path: gitignorePath };
     } catch (error) {
         const reason = error instanceof Error ? error.message : String(error);
-        return { kind: 'failed', path: target, reason };
+        return { kind: 'failed', path: gitignorePath, reason };
     }
 }
 
-export function applyProjectLinkGitignoreRules(
-    content: string,
-    mode: ProjectLinkGitignoreMode = 'local',
-): string {
-    if (mode === 'nested' ? hasNestedCoverage(content) : hasLocalCoverage(content)) {
+export function applyProjectLinkGitignoreRules(content: string): string {
+    const newline = content.includes('\r\n') ? '\r\n' : '\n';
+    const lines = content.split(/\r?\n/);
+    const hasIgnoreRule = lines.includes(PROJECT_LINK_IGNORE_CONTENTS);
+    const hasKeepRule = lines.includes(PROJECT_LINK_KEEP_MANIFEST);
+
+    if (hasIgnoreRule && hasKeepRule) {
         return content;
     }
 
-    const ignoreRule = mode === 'nested' ? PROJECT_LINK_NESTED_IGNORE_CONTENTS : PROJECT_LINK_IGNORE_CONTENTS;
-    const keepRule = mode === 'nested' ? PROJECT_LINK_NESTED_KEEP_MANIFEST : PROJECT_LINK_KEEP_MANIFEST;
-    const newline = detectNewline(content);
-    const lines = content.split(/\r?\n/);
-    let sawIgnoreContents = false;
-    let sawKeepManifest = false;
-    let changed = false;
-
-    const nextLines = lines.map(line => {
-        const pattern = ignorePattern(line);
-        if (!pattern) {
-            return line;
-        }
-        if (mode === 'nested' ? isNestedIgnoreContents(pattern) : isAnyIgnoreContents(pattern)) {
-            sawIgnoreContents = true;
-            return line;
-        }
-        if (mode === 'nested' ? isNestedKeepManifest(pattern) : isAnyKeepManifest(pattern)) {
-            sawKeepManifest = true;
-            return line;
-        }
-        if (isVendureDirectoryRule(pattern)) {
-            changed = true;
-            sawIgnoreContents = true;
-            return ignoreRule;
-        }
-        return line;
-    });
-
-    const missing: string[] = [];
-    if (!sawIgnoreContents) {
-        missing.push(ignoreRule);
-    }
-    if (!sawKeepManifest) {
-        missing.push(keepRule);
-    }
-
-    let output = nextLines.join(newline);
-    if (missing.length > 0) {
-        output = appendRuleBlock(output, missing, newline);
-    } else if (changed) {
-        output = ensureTrailingNewline(output, newline);
-    }
-    return output;
-}
-
-function findAncestorGitignore(projectRoot: string): AncestorGitignore | undefined {
-    const gitRoot = findGitRoot(projectRoot);
-    const monorepo = detectMonorepoStructure(projectRoot);
-    if (!gitRoot || !monorepo.isMonorepo || path.resolve(monorepo.root ?? '') !== path.resolve(gitRoot)) {
-        return undefined;
-    }
-
-    let deepestFile: GitignoreFile | undefined;
-    let directoryIgnored: boolean | undefined;
-    let current = path.dirname(projectRoot);
-    while (isWithin(gitRoot, current)) {
-        const gitignorePath = path.join(current, PROJECT_LINK_GITIGNORE_RELATIVE_PATH);
-        if (fs.existsSync(gitignorePath) && fs.statSync(gitignorePath).isFile()) {
-            const content = fs.readFileSync(gitignorePath, 'utf8');
-            deepestFile ??= { path: gitignorePath, content };
-            const projectPath = posixRelative(current, projectRoot);
-            if (deepestFile.path === gitignorePath && hasTargetedCoverage(content, projectPath)) {
-                return { ...deepestFile, needsUpdate: false };
-            }
-            directoryIgnored ??= vendureDirectoryState(content, projectPath);
-            if (directoryIgnored === true) {
-                return { ...deepestFile, needsUpdate: true };
-            }
-        }
-        if (current === gitRoot) {
-            break;
-        }
-        current = path.dirname(current);
-    }
-    return undefined;
-}
-
-function ensureAncestorGitignore(projectRoot: string, file: GitignoreFile): ProjectLinkGitignoreResult {
-    const projectPath = posixRelative(path.dirname(file.path), projectRoot);
-    const vendurePath = `${projectPath}/${PROJECT_LINK_DIRECTORY}`;
-    const rules = [`!${vendurePath}/`, `${vendurePath}/*`, `!${vendurePath}/project.json`];
-    const next = appendRuleBlock(file.content, rules, detectNewline(file.content));
-    fs.writeFileSync(file.path, next, 'utf8');
-    return { kind: 'updated', path: file.path };
-}
-
-function ensureSingleGitignore(
-    gitignorePath: string,
-    mode: ProjectLinkGitignoreMode,
-): ProjectLinkGitignoreResult {
-    if (!fs.existsSync(gitignorePath)) {
-        fs.writeFileSync(gitignorePath, createdGitignoreContents(mode), 'utf8');
-        return { kind: 'created', path: gitignorePath };
-    }
-
-    const raw = fs.readFileSync(gitignorePath, 'utf8');
-    const next = applyProjectLinkGitignoreRules(raw, mode);
-    if (next === raw) {
-        return { kind: 'unchanged', path: gitignorePath };
-    }
-
-    fs.writeFileSync(gitignorePath, next, 'utf8');
-    return { kind: 'updated', path: gitignorePath };
-}
-
-function vendureDirectoryState(content: string, projectPath: string): boolean | undefined {
-    let ignored: boolean | undefined;
-    for (const line of content.split(/\r?\n/)) {
-        const pattern = ignorePattern(line);
-        if (!pattern) {
-            continue;
-        }
-        const negated = pattern.startsWith('!');
-        const normalized = stripRootAnchor(pattern.replace(/^!/, '')).replace(/\/$/, '');
-        if (
-            normalized === PROJECT_LINK_DIRECTORY ||
-            normalized === `**/${PROJECT_LINK_DIRECTORY}` ||
-            normalized === `${projectPath}/${PROJECT_LINK_DIRECTORY}`
-        ) {
-            ignored = !negated;
-        }
-    }
-    return ignored;
-}
-
-function hasTargetedCoverage(content: string, projectPath: string): boolean {
-    const vendurePath = `${projectPath}/${PROJECT_LINK_DIRECTORY}`;
-    const patterns = new Set(
-        content
-            .split(/\r?\n/)
-            .map(ignorePattern)
-            .filter((pattern): pattern is string => pattern !== undefined),
+    const scaffoldRuleIndex = lines.findIndex(
+        line => line === PROJECT_LINK_DIRECTORY || line === `${PROJECT_LINK_DIRECTORY}/`,
     );
-    return (
-        patterns.has(`!${vendurePath}/`) &&
-        patterns.has(`${vendurePath}/*`) &&
-        patterns.has(`!${vendurePath}/project.json`)
-    );
-}
-
-function createdGitignoreContents(mode: ProjectLinkGitignoreMode): string {
-    const rules =
-        mode === 'nested'
-            ? [PROJECT_LINK_NESTED_IGNORE_CONTENTS, PROJECT_LINK_NESTED_KEEP_MANIFEST]
-            : [PROJECT_LINK_IGNORE_CONTENTS, PROJECT_LINK_KEEP_MANIFEST];
-    return `${[PROJECT_LINK_GITIGNORE_COMMENT, ...rules].join('\n')}\n`;
-}
-
-function hasLocalCoverage(content: string): boolean {
-    return hasRuleCoverage(content, isAnyIgnoreContents, isAnyKeepManifest);
-}
-
-function hasNestedCoverage(content: string): boolean {
-    return hasRuleCoverage(content, isNestedIgnoreContents, isNestedKeepManifest);
-}
-
-function hasRuleCoverage(
-    content: string,
-    isIgnore: (pattern: string) => boolean,
-    isKeep: (pattern: string) => boolean,
-): boolean {
-    let sawIgnoreContents = false;
-    let sawKeepManifest = false;
-    for (const line of content.split(/\r?\n/)) {
-        const pattern = ignorePattern(line);
-        if (pattern && isIgnore(pattern)) {
-            sawIgnoreContents = true;
-        }
-        if (pattern && isKeep(pattern)) {
-            sawKeepManifest = true;
-        }
+    if (scaffoldRuleIndex !== -1) {
+        lines.splice(scaffoldRuleIndex, 1, PROJECT_LINK_IGNORE_CONTENTS, PROJECT_LINK_KEEP_MANIFEST);
+        return lines.join(newline);
     }
-    return sawIgnoreContents && sawKeepManifest && !hasVendureDirectoryIgnore(content);
-}
 
-function hasVendureDirectoryIgnore(content: string): boolean {
-    return content.split(/\r?\n/).some(line => {
-        const pattern = ignorePattern(line);
-        return pattern !== undefined && isVendureDirectoryRule(pattern);
-    });
-}
-
-function appendRuleBlock(content: string, rules: string[], newline: string): string {
     let next = content;
     if (next.length > 0 && !next.endsWith('\n')) {
         next += newline;
@@ -256,62 +67,9 @@ function appendRuleBlock(content: string, rules: string[], newline: string): str
     if (next.length > 0 && !/(?:\r?\n){2}$/.test(next)) {
         next += newline;
     }
-    return `${next}${[PROJECT_LINK_GITIGNORE_COMMENT, ...rules].join(newline)}${newline}`;
+    return `${next}${projectLinkRules(newline)}`;
 }
 
-function ensureTrailingNewline(content: string, newline: string): string {
-    return content.length === 0 || content.endsWith('\n') ? content : `${content}${newline}`;
-}
-
-function detectNewline(content: string): string {
-    return content.includes('\r\n') ? '\r\n' : '\n';
-}
-
-function ignorePattern(line: string): string | undefined {
-    const trimmed = line.trim();
-    return trimmed.length === 0 || trimmed.startsWith('#') ? undefined : trimmed;
-}
-
-function isAnyIgnoreContents(pattern: string): boolean {
-    return isLocalIgnoreContents(pattern) || isNestedIgnoreContents(pattern);
-}
-
-function isLocalIgnoreContents(pattern: string): boolean {
-    return /^\.vendure\/\*\*?$/.test(stripRootAnchor(pattern));
-}
-
-function isNestedIgnoreContents(pattern: string): boolean {
-    return /^\*\*\/\.vendure\/\*\*?$/.test(pattern);
-}
-
-function isAnyKeepManifest(pattern: string): boolean {
-    return isLocalKeepManifest(pattern) || isNestedKeepManifest(pattern);
-}
-
-function isLocalKeepManifest(pattern: string): boolean {
-    return /^!\.vendure\/project\.json$/.test(pattern.replace(/^!\/(?=\.)/, '!'));
-}
-
-function isNestedKeepManifest(pattern: string): boolean {
-    return /^!\*\*\/\.vendure\/project\.json$/.test(pattern);
-}
-
-function isVendureDirectoryRule(pattern: string): boolean {
-    if (pattern.startsWith('!')) {
-        return false;
-    }
-    return /^(?:\*\*\/)?\.vendure\/?$/.test(stripRootAnchor(pattern));
-}
-
-function stripRootAnchor(pattern: string): string {
-    return pattern.startsWith('/') ? pattern.slice(1) : pattern;
-}
-
-function posixRelative(from: string, to: string): string {
-    return path.relative(from, to).split(path.sep).join('/');
-}
-
-function isWithin(parent: string, candidate: string): boolean {
-    const relative = path.relative(parent, candidate);
-    return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+function projectLinkRules(newline: string): string {
+    return `${PROJECT_LINK_IGNORE_CONTENTS}${newline}${PROJECT_LINK_KEEP_MANIFEST}${newline}`;
 }

--- a/packages/cli/src/commands/console/project-link-manifest.spec.ts
+++ b/packages/cli/src/commands/console/project-link-manifest.spec.ts
@@ -67,6 +67,18 @@ describe('Project Link Manifest', () => {
         expect(resolveProjectRoot(nested)).toBe(root);
     });
 
+    it('resolves apps/vendure from the workspace root', () => {
+        const workspace = temporaryDirectory();
+        fs.ensureDirSync(path.join(workspace, '.git'));
+        fs.writeJsonSync(path.join(workspace, 'package.json'), { private: true });
+        const project = vendureProject(path.join(workspace, 'apps', 'vendure'));
+        const nested = path.join(project, 'src');
+        fs.ensureDirSync(nested);
+
+        expect(resolveProjectRoot(workspace)).toBe(project);
+        expect(resolveProjectRoot(nested)).toBe(project);
+    });
+
     it('resolves one workspace project and rejects ambiguous workspaces', () => {
         const workspace = temporaryDirectory();
         fs.writeJsonSync(path.join(workspace, 'package.json'), { private: true });

--- a/packages/cli/src/commands/console/project-link-manifest.spec.ts
+++ b/packages/cli/src/commands/console/project-link-manifest.spec.ts
@@ -101,7 +101,6 @@ describe('Project Link Manifest', () => {
         expect(() => resolveProjectRoot(workspace, selected)).toThrow(
             'A Project Link Manifest exists outside the selected Vendure project',
         );
-        expect(resolveProjectRoot(workspace, selected, true)).toBe(selected);
     });
 
     it('does not inspect manifests above the Git workspace boundary', () => {

--- a/packages/cli/src/commands/console/project-link-manifest.spec.ts
+++ b/packages/cli/src/commands/console/project-link-manifest.spec.ts
@@ -1,0 +1,129 @@
+import fs from 'fs-extra';
+import * as fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+    ProjectLinkManifest,
+    getProjectLinkManifestPath,
+    parseProjectLinkManifest,
+    readProjectLinkManifest,
+    resolveProjectRoot,
+    writeProjectLinkManifestAtomic,
+} from './project-link-manifest';
+
+const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
+const PROJECT_ID = '22222222-2222-4222-8222-222222222222';
+const LINK_ID = '33333333-3333-4333-8333-333333333333';
+const OTHER_LINK_ID = '44444444-4444-4444-8444-444444444444';
+
+const manifest: ProjectLinkManifest = {
+    schemaVersion: 1,
+    project: { id: PROJECT_ID, name: 'Storefront' },
+    account: { id: ACCOUNT_ID, name: 'Acme' },
+    link: { id: LINK_ID, protocolVersion: 1 },
+};
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+        fs.removeSync(directory);
+    }
+});
+
+describe('Project Link Manifest', () => {
+    it('parses and reconstructs the exact v1 contract', () => {
+        expect(parseProjectLinkManifest(structuredClone(manifest), LINK_ID)).toEqual(manifest);
+    });
+
+    it('rejects unexpected fields and a mismatched link ID', () => {
+        expect(() => parseProjectLinkManifest({ ...manifest, pollingSecret: 'secret' })).toThrow(
+            'unexpected or missing fields',
+        );
+        expect(() => parseProjectLinkManifest(manifest, OTHER_LINK_ID)).toThrow(
+            'does not match the created link request',
+        );
+    });
+
+    it('reports malformed JSON without including file contents', () => {
+        const root = vendureProject();
+        const manifestPath = getProjectLinkManifestPath(root);
+        fs.ensureDirSync(path.dirname(manifestPath));
+        fs.writeFileSync(manifestPath, '{"pollingSecret":"do-not-print"');
+
+        const result = readProjectLinkManifest(root);
+
+        expect(result).toMatchObject({ kind: 'invalid', reason: 'The file is not valid JSON.' });
+        expect(JSON.stringify(result)).not.toContain('do-not-print');
+    });
+
+    it('resolves the nearest ancestor Vendure project', () => {
+        const root = vendureProject();
+        const nested = path.join(root, 'src', 'plugins', 'example');
+        fs.ensureDirSync(nested);
+
+        expect(resolveProjectRoot(nested)).toBe(root);
+    });
+
+    it('resolves one workspace project and rejects ambiguous workspaces', () => {
+        const workspace = temporaryDirectory();
+        fs.writeJsonSync(path.join(workspace, 'package.json'), { private: true });
+        const first = vendureProject(path.join(workspace, 'apps', 'server'));
+
+        expect(resolveProjectRoot(workspace)).toBe(first);
+
+        vendureProject(path.join(workspace, 'packages', 'second-server'));
+        expect(() => resolveProjectRoot(workspace)).toThrow('Multiple Vendure projects were found');
+    });
+
+    it('uses an explicit project and rejects an ancestor manifest for another root', () => {
+        const workspace = temporaryDirectory();
+        fs.writeJsonSync(path.join(workspace, 'package.json'), { private: true });
+        const selected = vendureProject(path.join(workspace, 'apps', 'server'));
+        const ancestorManifest = getProjectLinkManifestPath(workspace);
+        fs.ensureDirSync(path.dirname(ancestorManifest));
+        fs.writeJsonSync(ancestorManifest, manifest);
+
+        expect(() => resolveProjectRoot(workspace, selected)).toThrow(
+            'A Project Link Manifest exists outside the selected Vendure project',
+        );
+    });
+
+    it('atomically writes a manifest and preserves the old file if rename fails', async () => {
+        const root = vendureProject();
+        const manifestPath = await writeProjectLinkManifestAtomic(root, manifest);
+        expect(fs.readJsonSync(manifestPath)).toEqual(manifest);
+
+        const replacement: ProjectLinkManifest = {
+            ...manifest,
+            link: { id: OTHER_LINK_ID, protocolVersion: 1 },
+        };
+        await expect(
+            writeProjectLinkManifestAtomic(root, replacement, {
+                mkdir: fsPromises.mkdir,
+                open: fsPromises.open,
+                rename: () => Promise.reject(new Error('simulated rename failure')),
+                unlink: fsPromises.unlink,
+            }),
+        ).rejects.toThrow('simulated rename failure');
+
+        expect(fs.readJsonSync(manifestPath)).toEqual(manifest);
+        expect(fs.readdirSync(path.dirname(manifestPath)).filter(name => name.endsWith('.tmp'))).toEqual([]);
+    });
+});
+
+function temporaryDirectory(): string {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'vendure-console-manifest-'));
+    temporaryDirectories.push(directory);
+    return fs.realpathSync(directory);
+}
+
+function vendureProject(directory = temporaryDirectory()): string {
+    fs.ensureDirSync(directory);
+    fs.writeJsonSync(path.join(directory, 'package.json'), {
+        dependencies: { '@vendure/core': '3.7.2' },
+    });
+    return fs.realpathSync(directory);
+}

--- a/packages/cli/src/commands/console/project-link-manifest.spec.ts
+++ b/packages/cli/src/commands/console/project-link-manifest.spec.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { LINK_ID, OTHER_LINK_ID, manifest } from './console.fixtures';
 import {
     ProjectLinkManifest,
     getProjectLinkManifestPath,
@@ -13,17 +14,7 @@ import {
     writeProjectLinkManifestAtomic,
 } from './project-link-manifest';
 
-const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
-const PROJECT_ID = '22222222-2222-4222-8222-222222222222';
-const LINK_ID = '33333333-3333-4333-8333-333333333333';
-const OTHER_LINK_ID = '44444444-4444-4444-8444-444444444444';
-
-const manifest: ProjectLinkManifest = {
-    schemaVersion: 1,
-    project: { id: PROJECT_ID, name: 'Storefront' },
-    account: { id: ACCOUNT_ID, name: 'Acme' },
-    link: { id: LINK_ID, protocolVersion: 1 },
-};
+const UUID_V7_LINK_ID = '55555555-5555-7555-8555-555555555555';
 
 const temporaryDirectories: string[] = [];
 
@@ -45,6 +36,15 @@ describe('Project Link Manifest', () => {
         expect(() => parseProjectLinkManifest(manifest, OTHER_LINK_ID)).toThrow(
             'does not match the created link request',
         );
+    });
+
+    it('accepts UUIDs without restricting the server to version 4', () => {
+        const versionSevenManifest: ProjectLinkManifest = {
+            ...manifest,
+            project: { ...manifest.project, id: UUID_V7_LINK_ID },
+        };
+
+        expect(parseProjectLinkManifest(versionSevenManifest)).toEqual(versionSevenManifest);
     });
 
     it('reports malformed JSON without including file contents', () => {
@@ -89,6 +89,19 @@ describe('Project Link Manifest', () => {
         expect(() => resolveProjectRoot(workspace, selected)).toThrow(
             'A Project Link Manifest exists outside the selected Vendure project',
         );
+        expect(resolveProjectRoot(workspace, selected, true)).toBe(selected);
+    });
+
+    it('does not inspect manifests above the Git workspace boundary', () => {
+        const outer = temporaryDirectory();
+        const workspace = path.join(outer, 'workspace');
+        fs.ensureDirSync(path.join(workspace, '.git'));
+        const selected = vendureProject(path.join(workspace, 'apps', 'server'));
+        const outerManifest = getProjectLinkManifestPath(outer);
+        fs.ensureDirSync(path.dirname(outerManifest));
+        fs.writeJsonSync(outerManifest, manifest);
+
+        expect(resolveProjectRoot(workspace, selected)).toBe(selected);
     });
 
     it('atomically writes a manifest and preserves the old file if rename fails', async () => {

--- a/packages/cli/src/commands/console/project-link-manifest.ts
+++ b/packages/cli/src/commands/console/project-link-manifest.ts
@@ -5,6 +5,8 @@ import path from 'node:path';
 
 import { MONOREPO_PACKAGE_DIRS } from '../../utilities/monorepo-utils';
 
+import { exactObjectValue, nonEmptyStringValue, uuidValue } from './project-link-validation';
+
 export const PROJECT_LINK_MANIFEST_RELATIVE_PATH = path.join('.vendure', 'project.json');
 
 export interface ProjectLinkManifest {
@@ -33,9 +35,11 @@ const defaultFileOperations: AtomicFileOperations = {
     unlink: fsPromises.unlink,
 };
 
-const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-export function resolveProjectRoot(cwd: string, selectedProject?: string): string {
+export function resolveProjectRoot(
+    cwd: string,
+    selectedProject?: string,
+    allowCrossRootManifest = false,
+): string {
     const resolvedCwd = realDirectory(cwd, 'Current working directory');
     let projectRoot: string;
 
@@ -64,7 +68,9 @@ export function resolveProjectRoot(cwd: string, selectedProject?: string): strin
         }
     }
 
-    assertNoCrossRootManifest(resolvedCwd, projectRoot);
+    if (!allowCrossRootManifest) {
+        assertNoCrossRootManifest(resolvedCwd, projectRoot);
+    }
     return projectRoot;
 }
 
@@ -205,6 +211,7 @@ function findWorkspaceVendureProjects(root: string): string[] {
 
 function assertNoCrossRootManifest(cwd: string, projectRoot: string): void {
     const targetManifest = getProjectLinkManifestPath(projectRoot);
+    const boundary = findManifestSearchBoundary(cwd, projectRoot);
     let current = cwd;
     while (true) {
         const ancestorManifest = getProjectLinkManifestPath(current);
@@ -221,12 +228,44 @@ function assertNoCrossRootManifest(cwd: string, projectRoot: string): void {
                 ].join('\n'),
             );
         }
+        if (current === boundary) {
+            return;
+        }
+        current = path.dirname(current);
+    }
+}
+
+function findManifestSearchBoundary(cwd: string, projectRoot: string): string {
+    let current = cwd;
+    while (true) {
+        if (fs.existsSync(path.join(current, '.git')) && pathsOverlap(current, projectRoot)) {
+            return current;
+        }
         const parent = path.dirname(current);
         if (parent === current) {
-            return;
+            break;
         }
         current = parent;
     }
+    if (isPathWithin(cwd, projectRoot)) {
+        return cwd;
+    }
+    if (isPathWithin(projectRoot, cwd)) {
+        return projectRoot;
+    }
+    return cwd;
+}
+
+function pathsOverlap(first: string, second: string): boolean {
+    return isPathWithin(first, second) || isPathWithin(second, first);
+}
+
+function isPathWithin(parent: string, candidate: string): boolean {
+    const relative = path.relative(parent, candidate);
+    return (
+        relative === '' ||
+        (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+    );
 }
 
 function assertVendureProject(projectRoot: string): void {
@@ -273,31 +312,18 @@ function identityObject(value: unknown, label: string): { id: string; name: stri
 }
 
 function exactObject(value: unknown, keys: string[], label: string): Record<string, unknown> {
-    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-        throw new Error(`The ${label} must be an object.`);
-    }
-    const object = value as Record<string, unknown>;
-    const actualKeys = Object.keys(object).sort((a, b) => a.localeCompare(b));
-    const expectedKeys = [...keys].sort((a, b) => a.localeCompare(b));
-    if (
-        actualKeys.length !== expectedKeys.length ||
-        actualKeys.some((key, index) => key !== expectedKeys[index])
-    ) {
-        throw new Error(`The ${label} contains unexpected or missing fields.`);
-    }
-    return object;
+    return exactObjectValue(
+        value,
+        keys,
+        `The ${label} must be an object.`,
+        `The ${label} contains unexpected or missing fields.`,
+    );
 }
 
 function uuid(value: unknown, label: string): string {
-    if (typeof value !== 'string' || !UUID_V4_PATTERN.test(value)) {
-        throw new Error(`The ${label} must be a UUID v4.`);
-    }
-    return value;
+    return uuidValue(value, `The ${label} must be a UUID.`);
 }
 
 function nonEmptyString(value: unknown, label: string): string {
-    if (typeof value !== 'string' || value.trim().length === 0) {
-        throw new Error(`The ${label} must be a non-empty string.`);
-    }
-    return value;
+    return nonEmptyStringValue(value, `The ${label} must be a non-empty string.`);
 }

--- a/packages/cli/src/commands/console/project-link-manifest.ts
+++ b/packages/cli/src/commands/console/project-link-manifest.ts
@@ -200,7 +200,7 @@ function findWorkspaceVendureProjects(root: string): string[] {
             }
         }
     }
-    return [...candidates].sort();
+    return [...candidates].sort((a, b) => a.localeCompare(b));
 }
 
 function assertNoCrossRootManifest(cwd: string, projectRoot: string): void {
@@ -277,8 +277,8 @@ function exactObject(value: unknown, keys: string[], label: string): Record<stri
         throw new Error(`The ${label} must be an object.`);
     }
     const object = value as Record<string, unknown>;
-    const actualKeys = Object.keys(object).sort();
-    const expectedKeys = [...keys].sort();
+    const actualKeys = Object.keys(object).sort((a, b) => a.localeCompare(b));
+    const expectedKeys = [...keys].sort((a, b) => a.localeCompare(b));
     if (
         actualKeys.length !== expectedKeys.length ||
         actualKeys.some((key, index) => key !== expectedKeys[index])

--- a/packages/cli/src/commands/console/project-link-manifest.ts
+++ b/packages/cli/src/commands/console/project-link-manifest.ts
@@ -1,0 +1,303 @@
+import fs from 'fs-extra';
+import { randomUUID } from 'node:crypto';
+import * as fsPromises from 'node:fs/promises';
+import path from 'node:path';
+
+import { MONOREPO_PACKAGE_DIRS } from '../../utilities/monorepo-utils';
+
+export const PROJECT_LINK_MANIFEST_RELATIVE_PATH = path.join('.vendure', 'project.json');
+
+export interface ProjectLinkManifest {
+    schemaVersion: 1;
+    project: { id: string; name: string };
+    account: { id: string; name: string };
+    link: { id: string; protocolVersion: 1 };
+}
+
+export type ManifestReadResult =
+    | { kind: 'missing'; path: string }
+    | { kind: 'valid'; path: string; manifest: ProjectLinkManifest }
+    | { kind: 'invalid'; path: string; reason: string };
+
+export interface AtomicFileOperations {
+    mkdir: typeof fsPromises.mkdir;
+    open: typeof fsPromises.open;
+    rename: typeof fsPromises.rename;
+    unlink: typeof fsPromises.unlink;
+}
+
+const defaultFileOperations: AtomicFileOperations = {
+    mkdir: fsPromises.mkdir,
+    open: fsPromises.open,
+    rename: fsPromises.rename,
+    unlink: fsPromises.unlink,
+};
+
+const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function resolveProjectRoot(cwd: string, selectedProject?: string): string {
+    const resolvedCwd = realDirectory(cwd, 'Current working directory');
+    let projectRoot: string;
+
+    if (selectedProject) {
+        projectRoot = realDirectory(path.resolve(resolvedCwd, selectedProject), 'Selected project');
+        assertVendureProject(projectRoot);
+    } else {
+        const nearest = findNearestVendureProject(resolvedCwd);
+        if (nearest) {
+            projectRoot = nearest;
+        } else {
+            const candidates = findWorkspaceVendureProjects(resolvedCwd);
+            if (candidates.length === 0) {
+                throw new Error(
+                    'Could not find a Vendure project. Run this command from a project that depends on @vendure/core, or pass --project <path>.',
+                );
+            }
+            if (candidates.length > 1) {
+                throw new Error(
+                    `Multiple Vendure projects were found:\n${candidates
+                        .map(candidate => `   ${candidate}`)
+                        .join('\n')}\nRun the command again with --project <path>.`,
+                );
+            }
+            projectRoot = candidates[0];
+        }
+    }
+
+    assertNoCrossRootManifest(resolvedCwd, projectRoot);
+    return projectRoot;
+}
+
+export function getProjectLinkManifestPath(projectRoot: string): string {
+    return path.join(projectRoot, PROJECT_LINK_MANIFEST_RELATIVE_PATH);
+}
+
+export function readProjectLinkManifest(projectRoot: string): ManifestReadResult {
+    const manifestPath = getProjectLinkManifestPath(projectRoot);
+    if (!fs.existsSync(manifestPath)) {
+        return { kind: 'missing', path: manifestPath };
+    }
+
+    let value: unknown;
+    try {
+        value = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    } catch {
+        return {
+            kind: 'invalid',
+            path: manifestPath,
+            reason: 'The file is not valid JSON.',
+        };
+    }
+    try {
+        return { kind: 'valid', path: manifestPath, manifest: parseProjectLinkManifest(value) };
+    } catch (error) {
+        return {
+            kind: 'invalid',
+            path: manifestPath,
+            reason: error instanceof Error ? error.message : 'The manifest is invalid.',
+        };
+    }
+}
+
+export function parseProjectLinkManifest(value: unknown, expectedLinkId?: string): ProjectLinkManifest {
+    const root = exactObject(value, ['schemaVersion', 'project', 'account', 'link'], 'manifest');
+    if (root.schemaVersion !== 1) {
+        throw new Error('The manifest schemaVersion must be 1.');
+    }
+
+    const project = identityObject(root.project, 'project');
+    const account = identityObject(root.account, 'account');
+    const link = exactObject(root.link, ['id', 'protocolVersion'], 'link');
+    const linkId = uuid(link.id, 'link.id');
+    if (link.protocolVersion !== 1) {
+        throw new Error('The manifest link.protocolVersion must be 1.');
+    }
+    if (expectedLinkId && linkId !== expectedLinkId) {
+        throw new Error('The approved manifest does not match the created link request.');
+    }
+
+    return {
+        schemaVersion: 1,
+        project,
+        account,
+        link: { id: linkId, protocolVersion: 1 },
+    };
+}
+
+export async function writeProjectLinkManifestAtomic(
+    projectRoot: string,
+    manifest: ProjectLinkManifest,
+    operations: AtomicFileOperations = defaultFileOperations,
+): Promise<string> {
+    const manifestPath = getProjectLinkManifestPath(projectRoot);
+    const manifestDir = path.dirname(manifestPath);
+    const temporaryPath = path.join(manifestDir, `.project-${randomUUID()}.tmp`);
+    let handle: Awaited<ReturnType<typeof fsPromises.open>> | undefined;
+
+    try {
+        await operations.mkdir(manifestDir, { recursive: true });
+        handle = await operations.open(temporaryPath, 'wx', 0o600);
+        await handle.writeFile(`${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+        await handle.sync();
+        await handle.close();
+        handle = undefined;
+        await operations.rename(temporaryPath, manifestPath);
+        return manifestPath;
+    } catch (error) {
+        if (handle) {
+            await handle.close().catch(() => undefined);
+        }
+        await operations.unlink(temporaryPath).catch(() => undefined);
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(`Could not write ${manifestPath} atomically: ${detail}`);
+    }
+}
+
+export function removeProjectLinkManifest(projectRoot: string): void {
+    fs.unlinkSync(getProjectLinkManifestPath(projectRoot));
+}
+
+function findNearestVendureProject(start: string): string | undefined {
+    let current = start;
+    while (true) {
+        if (hasVendureCoreDependency(current)) {
+            return current;
+        }
+        const parent = path.dirname(current);
+        if (parent === current) {
+            return undefined;
+        }
+        current = parent;
+    }
+}
+
+function findWorkspaceVendureProjects(root: string): string[] {
+    const candidates = new Set<string>();
+    for (const packageDir of MONOREPO_PACKAGE_DIRS) {
+        const container = path.join(root, packageDir);
+        if (!fs.existsSync(container)) {
+            continue;
+        }
+        for (const entry of fs.readdirSync(container, { withFileTypes: true })) {
+            if (!entry.isDirectory()) {
+                continue;
+            }
+            const candidate = path.join(container, entry.name);
+            if (hasVendureCoreDependency(candidate)) {
+                candidates.add(fs.realpathSync(candidate));
+                continue;
+            }
+            if (entry.name.startsWith('@')) {
+                for (const scopedEntry of fs.readdirSync(candidate, { withFileTypes: true })) {
+                    if (!scopedEntry.isDirectory()) {
+                        continue;
+                    }
+                    const scopedCandidate = path.join(candidate, scopedEntry.name);
+                    if (hasVendureCoreDependency(scopedCandidate)) {
+                        candidates.add(fs.realpathSync(scopedCandidate));
+                    }
+                }
+            }
+        }
+    }
+    return [...candidates].sort();
+}
+
+function assertNoCrossRootManifest(cwd: string, projectRoot: string): void {
+    const targetManifest = getProjectLinkManifestPath(projectRoot);
+    let current = cwd;
+    while (true) {
+        const ancestorManifest = getProjectLinkManifestPath(current);
+        if (
+            fs.existsSync(ancestorManifest) &&
+            path.resolve(ancestorManifest) !== path.resolve(targetManifest)
+        ) {
+            throw new Error(
+                [
+                    'A Project Link Manifest exists outside the selected Vendure project.',
+                    `   Existing: ${ancestorManifest}`,
+                    `   Selected: ${projectRoot}`,
+                    'Run the command from the intended project directory.',
+                ].join('\n'),
+            );
+        }
+        const parent = path.dirname(current);
+        if (parent === current) {
+            return;
+        }
+        current = parent;
+    }
+}
+
+function assertVendureProject(projectRoot: string): void {
+    if (!hasVendureCoreDependency(projectRoot)) {
+        throw new Error(`${projectRoot} is not a Vendure project with a direct @vendure/core dependency.`);
+    }
+}
+
+function hasVendureCoreDependency(projectRoot: string): boolean {
+    const packageJsonPath = path.join(projectRoot, 'package.json');
+    if (!fs.existsSync(packageJsonPath)) {
+        return false;
+    }
+    try {
+        const packageJson = fs.readJsonSync(packageJsonPath);
+        return Boolean(
+            packageJson.dependencies?.['@vendure/core'] ??
+            packageJson.devDependencies?.['@vendure/core'] ??
+            packageJson.optionalDependencies?.['@vendure/core'],
+        );
+    } catch {
+        return false;
+    }
+}
+
+function realDirectory(directory: string, label: string): string {
+    try {
+        const realPath = fs.realpathSync(directory);
+        if (!fs.statSync(realPath).isDirectory()) {
+            throw new Error('not a directory');
+        }
+        return realPath;
+    } catch {
+        throw new Error(`${label} does not exist or is not a directory: ${directory}`);
+    }
+}
+
+function identityObject(value: unknown, label: string): { id: string; name: string } {
+    const object = exactObject(value, ['id', 'name'], label);
+    return {
+        id: uuid(object.id, `${label}.id`),
+        name: nonEmptyString(object.name, `${label}.name`),
+    };
+}
+
+function exactObject(value: unknown, keys: string[], label: string): Record<string, unknown> {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        throw new Error(`The ${label} must be an object.`);
+    }
+    const object = value as Record<string, unknown>;
+    const actualKeys = Object.keys(object).sort();
+    const expectedKeys = [...keys].sort();
+    if (
+        actualKeys.length !== expectedKeys.length ||
+        actualKeys.some((key, index) => key !== expectedKeys[index])
+    ) {
+        throw new Error(`The ${label} contains unexpected or missing fields.`);
+    }
+    return object;
+}
+
+function uuid(value: unknown, label: string): string {
+    if (typeof value !== 'string' || !UUID_V4_PATTERN.test(value)) {
+        throw new Error(`The ${label} must be a UUID v4.`);
+    }
+    return value;
+}
+
+function nonEmptyString(value: unknown, label: string): string {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+        throw new Error(`The ${label} must be a non-empty string.`);
+    }
+    return value;
+}

--- a/packages/cli/src/commands/console/project-link-manifest.ts
+++ b/packages/cli/src/commands/console/project-link-manifest.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 
 import { MONOREPO_PACKAGE_DIRS } from '../../utilities/monorepo-utils';
 
-import { exactObjectValue, nonEmptyStringValue, uuidValue } from './project-link-validation';
+import { exactObjectValue, nonEmptyString, uuid } from './project-link-validation';
 
 export const PROJECT_LINK_MANIFEST_RELATIVE_PATH = path.join('.vendure', 'project.json');
 
@@ -108,7 +108,7 @@ export function parseProjectLinkManifest(value: unknown, expectedLinkId?: string
     const project = identityObject(root.project, 'project');
     const account = identityObject(root.account, 'account');
     const link = exactObject(root.link, ['id', 'protocolVersion'], 'link');
-    const linkId = uuid(link.id, 'link.id');
+    const linkId = uuid(link.id, 'The link.id must be a UUID.');
     if (link.protocolVersion !== 1) {
         throw new Error('The manifest link.protocolVersion must be 1.');
     }
@@ -230,16 +230,9 @@ function assertNoCrossRootManifest(cwd: string, projectRoot: string): void {
 }
 
 function findManifestSearchBoundary(cwd: string, projectRoot: string): string {
-    let current = cwd;
-    while (true) {
-        if (fs.existsSync(path.join(current, '.git')) && pathsOverlap(current, projectRoot)) {
-            return current;
-        }
-        const parent = path.dirname(current);
-        if (parent === current) {
-            break;
-        }
-        current = parent;
+    const gitRoot = findGitRoot(cwd);
+    if (gitRoot && pathsOverlap(gitRoot, projectRoot)) {
+        return gitRoot;
     }
     if (isPathWithin(cwd, projectRoot)) {
         return cwd;
@@ -248,6 +241,20 @@ function findManifestSearchBoundary(cwd: string, projectRoot: string): string {
         return projectRoot;
     }
     return cwd;
+}
+
+export function findGitRoot(start: string): string | undefined {
+    let current = start;
+    while (true) {
+        if (fs.existsSync(path.join(current, '.git'))) {
+            return current;
+        }
+        const parent = path.dirname(current);
+        if (parent === current) {
+            return undefined;
+        }
+        current = parent;
+    }
 }
 
 function pathsOverlap(first: string, second: string): boolean {
@@ -300,8 +307,8 @@ function realDirectory(directory: string, label: string): string {
 function identityObject(value: unknown, label: string): { id: string; name: string } {
     const object = exactObject(value, ['id', 'name'], label);
     return {
-        id: uuid(object.id, `${label}.id`),
-        name: nonEmptyString(object.name, `${label}.name`),
+        id: uuid(object.id, `The ${label}.id must be a UUID.`),
+        name: nonEmptyString(object.name, `The ${label}.name must be a non-empty string.`),
     };
 }
 
@@ -312,12 +319,4 @@ function exactObject(value: unknown, keys: string[], label: string): Record<stri
         `The ${label} must be an object.`,
         `The ${label} contains unexpected or missing fields.`,
     );
-}
-
-function uuid(value: unknown, label: string): string {
-    return uuidValue(value, `The ${label} must be a UUID.`);
-}
-
-function nonEmptyString(value: unknown, label: string): string {
-    return nonEmptyStringValue(value, `The ${label} must be a non-empty string.`);
 }

--- a/packages/cli/src/commands/console/project-link-manifest.ts
+++ b/packages/cli/src/commands/console/project-link-manifest.ts
@@ -35,11 +35,7 @@ const defaultFileOperations: AtomicFileOperations = {
     unlink: fsPromises.unlink,
 };
 
-export function resolveProjectRoot(
-    cwd: string,
-    selectedProject?: string,
-    allowCrossRootManifest = false,
-): string {
+export function resolveProjectRoot(cwd: string, selectedProject?: string): string {
     const resolvedCwd = realDirectory(cwd, 'Current working directory');
     let projectRoot: string;
 
@@ -68,9 +64,7 @@ export function resolveProjectRoot(
         }
     }
 
-    if (!allowCrossRootManifest) {
-        assertNoCrossRootManifest(resolvedCwd, projectRoot);
-    }
+    assertNoCrossRootManifest(resolvedCwd, projectRoot);
     return projectRoot;
 }
 

--- a/packages/cli/src/commands/console/project-link-validation.ts
+++ b/packages/cli/src/commands/console/project-link-validation.ts
@@ -1,0 +1,41 @@
+export function objectValue(value: unknown, errorMessage: string): Record<string, unknown> {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        throw new Error(errorMessage);
+    }
+    return value as Record<string, unknown>;
+}
+
+export function exactObjectValue(
+    value: unknown,
+    keys: string[],
+    objectErrorMessage: string,
+    fieldsErrorMessage: string,
+): Record<string, unknown> {
+    const object = objectValue(value, objectErrorMessage);
+    const actualKeys = Object.keys(object).sort((a, b) => a.localeCompare(b));
+    const expectedKeys = [...keys].sort((a, b) => a.localeCompare(b));
+    if (
+        actualKeys.length !== expectedKeys.length ||
+        actualKeys.some((key, index) => key !== expectedKeys[index])
+    ) {
+        throw new Error(fieldsErrorMessage);
+    }
+    return object;
+}
+
+export function uuidValue(value: unknown, errorMessage: string): string {
+    if (
+        typeof value !== 'string' ||
+        !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+    ) {
+        throw new Error(errorMessage);
+    }
+    return value;
+}
+
+export function nonEmptyStringValue(value: unknown, errorMessage: string): string {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+        throw new Error(errorMessage);
+    }
+    return value;
+}

--- a/packages/cli/src/commands/console/project-link-validation.ts
+++ b/packages/cli/src/commands/console/project-link-validation.ts
@@ -23,7 +23,7 @@ export function exactObjectValue(
     return object;
 }
 
-export function uuidValue(value: unknown, errorMessage: string): string {
+export function uuid(value: unknown, errorMessage: string): string {
     if (
         typeof value !== 'string' ||
         !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
@@ -33,7 +33,7 @@ export function uuidValue(value: unknown, errorMessage: string): string {
     return value;
 }
 
-export function nonEmptyStringValue(value: unknown, errorMessage: string): string {
+export function nonEmptyString(value: unknown, errorMessage: string): string {
     if (typeof value !== 'string' || value.trim().length === 0) {
         throw new Error(errorMessage);
     }

--- a/packages/create/templates/gitignore.template
+++ b/packages/create/templates/gitignore.template
@@ -3,4 +3,6 @@ dist
 admin-ui
 static/assets
 static/email/test-emails
-.vendure/
+# Commit the identity-only Project Link Manifest. Keep all other local Vendure state ignored.
+.vendure/*
+!.vendure/project.json


### PR DESCRIPTION
# Description

Adds `vendure console link`, `status`, and `unlink` with secure browser approval, strict v1 manifest validation, safe monorepo project selection, and atomic local writes. Updates the CLI documentation and generated-project source-control guidance, with unit, HTTP integration, and compiled CLI e2e coverage. Relates to [PDEV-49](https://linear.app/vendure/issue/PDEV-49/deliver-add-vendure-console-linkstatusunlink-cli-commands).

# Breaking changes

None.

# Screenshots

Not applicable; this is a CLI-only change.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789731917&installation_model_id=20193&pr_number=5157&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5157&signature=912184f944fce99a7908eb7864e57ad80e056734cbffe661d9e563d2fa1d010c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->