### PR TITLE
fix(dashboard): discover each decorated plugin independently

### DIFF
--- a/packages/dashboard/vite/tests/plugin-discovery.spec.ts
+++ b/packages/dashboard/vite/tests/plugin-discovery.spec.ts
@@ -13,12 +13,14 @@ const decoratorForms = [
         prelude: `import { VendurePlugin } from '@vendure/core';`,
         decorate: '__decorate',
         vendurePlugin: 'VendurePlugin',
+        otherDecorator: 'OtherDecorator',
     },
     {
         name: 'tslib_1.__decorate',
-        prelude: `const tslib_1 = require('tslib');\nconst core_1 = require('@vendure/core');`,
+        prelude: `const tslib_1 = require('tslib');\nconst core_1 = require('@vendure/core');\nconst other_1 = require('other-package');`,
         decorate: 'tslib_1.__decorate',
         vendurePlugin: '(0, core_1.VendurePlugin)',
+        otherDecorator: '(0, other_1.OtherDecorator)',
     },
 ];
 
@@ -137,4 +139,37 @@ describe('plugin discovery', () => {
             ]);
         },
     );
+
+    // OSS-724: Dashboard metadata from other decorators must be ignored.
+    it.each(decoratorForms)('ignores non-Vendure decorators with $name', async decoratorForm => {
+        const { pluginPath, pluginSourcePath, plugins } = await discoverFromCompiledSource({
+            pluginNames: ['VendureDashboardPlugin', 'OtherDashboardClass'],
+            tsSource: `
+                import { VendurePlugin } from '@vendure/core';
+                import { OtherDecorator } from 'other-package';
+                @VendurePlugin({ dashboard: './dashboard/vendure.tsx' })
+                export class VendureDashboardPlugin {}
+                @OtherDecorator({ dashboard: './dashboard/other.tsx' })
+                export class OtherDashboardClass {}
+            `,
+            compiledJs: `
+                ${decoratorForm.prelude}
+                VendureDashboardPlugin = ${decoratorForm.decorate}([
+                    ${decoratorForm.vendurePlugin}({ dashboard: './dashboard/vendure.tsx' })
+                ], VendureDashboardPlugin);
+                OtherDashboardClass = ${decoratorForm.decorate}([
+                    ${decoratorForm.otherDecorator}({ dashboard: './dashboard/other.tsx' })
+                ], OtherDashboardClass);
+            `,
+        });
+
+        expect(plugins).toEqual([
+            {
+                name: 'VendureDashboardPlugin',
+                pluginPath,
+                dashboardEntryPath: './dashboard/vendure.tsx',
+                sourcePluginPath: pluginSourcePath,
+            },
+        ]);
+    });
 });

--- a/packages/dashboard/vite/tests/plugin-discovery.spec.ts
+++ b/packages/dashboard/vite/tests/plugin-discovery.spec.ts
@@ -1,0 +1,140 @@
+import fs from 'fs-extra';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { noopLogger } from '../utils/logger.js';
+import { discoverPlugins } from '../utils/plugin-discovery.js';
+
+// These snippets mirror TypeScript's direct and importHelpers decorator output.
+const decoratorForms = [
+    {
+        name: 'direct __decorate',
+        prelude: `import { VendurePlugin } from '@vendure/core';`,
+        decorate: '__decorate',
+        vendurePlugin: 'VendurePlugin',
+    },
+    {
+        name: 'tslib_1.__decorate',
+        prelude: `const tslib_1 = require('tslib');\nconst core_1 = require('@vendure/core');`,
+        decorate: 'tslib_1.__decorate',
+        vendurePlugin: '(0, core_1.VendurePlugin)',
+    },
+];
+
+describe('plugin discovery', () => {
+    const tempDirs: string[] = [];
+
+    afterEach(async () => {
+        await Promise.all(tempDirs.splice(0).map(tempDir => fs.remove(tempDir)));
+    });
+
+    async function discoverFromCompiledSource({
+        pluginNames,
+        tsSource,
+        compiledJs,
+    }: {
+        pluginNames: string[];
+        tsSource: string;
+        compiledJs: string;
+    }) {
+        const tempDir = await fs.mkdtemp(path.join(tmpdir(), 'vendure-plugin-discovery-'));
+        const outputPath = path.join(tempDir, 'dist');
+        const vendureConfigPath = path.join(tempDir, 'vendure-config.ts');
+        const pluginSourcePath = path.join(tempDir, 'plugins.ts');
+        const pluginPath = path.join(outputPath, 'plugins.js');
+        tempDirs.push(tempDir);
+
+        await fs.outputFile(
+            vendureConfigPath,
+            `import { ${pluginNames.join(', ')} } from './plugins';\nexport const config = { plugins: [${pluginNames.join(', ')}] };`,
+        );
+        await fs.outputFile(pluginSourcePath, tsSource);
+        await fs.outputFile(pluginPath, compiledJs);
+
+        const plugins = await discoverPlugins({
+            vendureConfigPath,
+            transformTsConfigPathMappings: ({ patterns }) => patterns,
+            logger: noopLogger,
+            outputPath,
+            pluginPackageScanner: {
+                nodeModulesRoot: path.join(tempDir, 'node_modules'),
+            },
+        });
+
+        return { pluginPath, pluginSourcePath, plugins };
+    }
+
+    // OSS-724: Each decorator call must emit its own matched plugin entry.
+    it.each(decoratorForms)('discovers each plugin class with $name', async decoratorForm => {
+        const { pluginPath, pluginSourcePath, plugins } = await discoverFromCompiledSource({
+            pluginNames: ['FirstPlugin', 'SecondPlugin'],
+            tsSource: `
+                import { VendurePlugin } from '@vendure/core';
+                @VendurePlugin({ dashboard: './dashboard/first.tsx' })
+                export class FirstPlugin {}
+                @VendurePlugin({ dashboard: { location: './dashboard/second.tsx' } })
+                export class SecondPlugin {}
+            `,
+            compiledJs: `
+                ${decoratorForm.prelude}
+                FirstPlugin = ${decoratorForm.decorate}([
+                    ${decoratorForm.vendurePlugin}({ dashboard: './dashboard/first.tsx' })
+                ], FirstPlugin);
+                SecondPlugin = ${decoratorForm.decorate}([
+                    ${decoratorForm.vendurePlugin}({ dashboard: { location: './dashboard/second.tsx' } })
+                ], SecondPlugin);
+            `,
+        });
+
+        expect(plugins).toEqual([
+            {
+                name: 'FirstPlugin',
+                pluginPath,
+                dashboardEntryPath: './dashboard/first.tsx',
+                sourcePluginPath: pluginSourcePath,
+            },
+            {
+                name: 'SecondPlugin',
+                pluginPath,
+                dashboardEntryPath: './dashboard/second.tsx',
+                sourcePluginPath: pluginSourcePath,
+            },
+        ]);
+    });
+
+    // OSS-724: A later class without a dashboard must not reuse an earlier path.
+    it.each(decoratorForms)(
+        'does not pair an earlier dashboard path with a later class using $name',
+        async decoratorForm => {
+            const { pluginPath, pluginSourcePath, plugins } = await discoverFromCompiledSource({
+                pluginNames: ['FirstPlugin', 'SecondPlugin'],
+                tsSource: `
+                import { VendurePlugin } from '@vendure/core';
+                @VendurePlugin({ dashboard: { location: './dashboard/first.tsx' } })
+                export class FirstPlugin {}
+                @VendurePlugin({})
+                export class SecondPlugin {}
+            `,
+                compiledJs: `
+                ${decoratorForm.prelude}
+                FirstPlugin = ${decoratorForm.decorate}([
+                    ${decoratorForm.vendurePlugin}({ dashboard: { location: './dashboard/first.tsx' } })
+                ], FirstPlugin);
+                SecondPlugin = ${decoratorForm.decorate}([
+                    ${decoratorForm.vendurePlugin}({})
+                ], SecondPlugin);
+            `,
+            });
+
+            expect(plugins).toEqual([
+                {
+                    name: 'FirstPlugin',
+                    pluginPath,
+                    dashboardEntryPath: './dashboard/first.tsx',
+                    sourcePluginPath: pluginSourcePath,
+                },
+            ]);
+        },
+    );
+});

--- a/packages/dashboard/vite/utils/plugin-discovery.ts
+++ b/packages/dashboard/vite/utils/plugin-discovery.ts
@@ -71,10 +71,6 @@ export async function discoverPlugins({
                 sourceType: 'module',
             });
 
-            let hasVendurePlugin = false;
-            let pluginName: string | undefined;
-            let dashboardPath: string | undefined;
-
             // Walk the AST to find the plugin class and its decorator
             walkSimple(ast, {
                 CallExpression(node: any) {
@@ -91,57 +87,31 @@ export async function discoverPlugins({
                     const isDecoratorWithArgs = calleeName === '__decorate' && nodeArgs.length >= 2;
 
                     if (isDecoratorWithArgs) {
-                        // Check the decorators array (first argument)
-                        const decorators = nodeArgs[0];
-                        if (decorators.type === 'ArrayExpression') {
-                            for (const decorator of decorators.elements) {
-                                const props = getDecoratorObjectProps(decorator);
-                                for (const prop of props) {
-                                    if (prop.key.name === 'dashboard') {
-                                        if (prop.value.type === 'Literal') {
-                                            // Handle string format: dashboard: './path/to/dashboard'
-                                            dashboardPath = prop.value.value;
-                                            hasVendurePlugin = true;
-                                        } else if (prop.value.type === 'ObjectExpression') {
-                                            // Handle object format: dashboard: { location: './path/to/dashboard' }
-                                            const locationProp = prop.value.properties?.find(
-                                                (p: any) => p.key?.name === 'location',
-                                            );
-                                            if (locationProp?.value.type === 'Literal') {
-                                                dashboardPath = locationProp.value.value;
-                                                hasVendurePlugin = true;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        // Get the plugin class name (second argument)
+                        const dashboardPath = getDashboardPath(nodeArgs[0]);
                         const targetClass = nodeArgs[1];
-                        if (targetClass.type === 'Identifier') {
-                            pluginName = targetClass.name;
+                        if (targetClass.type === 'Identifier' && dashboardPath) {
+                            const pluginName: string = targetClass.name;
+                            logger.debug(
+                                `[discoverPlugins] Found plugin "${pluginName}" in file: ${filePath}`,
+                            );
+                            // Keep the dashboard path relative to the plugin file
+                            const resolvedDashboardPath = dashboardPath.startsWith('.')
+                                ? dashboardPath // Keep the relative path as-is
+                                : './' + path.relative(path.dirname(filePath), dashboardPath); // Make absolute path relative
+
+                            // Check if this is a local plugin we found earlier
+                            const sourcePluginPath = localPluginLocations.get(pluginName);
+
+                            plugins.push({
+                                name: pluginName,
+                                pluginPath: filePath,
+                                dashboardEntryPath: resolvedDashboardPath,
+                                ...(sourcePluginPath && { sourcePluginPath }),
+                            });
                         }
                     }
                 },
             });
-
-            if (hasVendurePlugin && pluginName && dashboardPath) {
-                logger.debug(`[discoverPlugins] Found plugin "${pluginName}" in file: ${filePath}`);
-                // Keep the dashboard path relative to the plugin file
-                const resolvedDashboardPath = dashboardPath.startsWith('.')
-                    ? dashboardPath // Keep the relative path as-is
-                    : './' + path.relative(path.dirname(filePath), dashboardPath); // Make absolute path relative
-
-                // Check if this is a local plugin we found earlier
-                const sourcePluginPath = localPluginLocations.get(pluginName);
-
-                plugins.push({
-                    name: pluginName,
-                    pluginPath: filePath,
-                    dashboardEntryPath: resolvedDashboardPath,
-                    ...(sourcePluginPath && { sourcePluginPath }),
-                });
-            }
         } catch (e) {
             logger.error(`Failed to parse ${filePath}: ${e instanceof Error ? e.message : String(e)}`);
         }
@@ -160,6 +130,33 @@ function getDecoratorObjectProps(decorator: any): any[] {
         return decorator.arguments[0].properties ?? [];
     }
     return [];
+}
+
+function getDashboardPath(decorators: any): string | undefined {
+    if (decorators.type !== 'ArrayExpression') {
+        return;
+    }
+    for (const decorator of decorators.elements) {
+        const props = getDecoratorObjectProps(decorator);
+        for (const prop of props) {
+            if (prop.key.name !== 'dashboard') {
+                continue;
+            }
+            if (prop.value.type === 'Literal') {
+                // Handle string format: dashboard: './path/to/dashboard'
+                return prop.value.value;
+            }
+            if (prop.value.type === 'ObjectExpression') {
+                // Handle object format: dashboard: { location: './path/to/dashboard' }
+                const locationProp = prop.value.properties?.find(
+                    (property: any) => property.key?.name === 'location',
+                );
+                if (locationProp?.value.type === 'Literal') {
+                    return locationProp.value.value;
+                }
+            }
+        }
+    }
 }
 
 /**

--- a/packages/dashboard/vite/utils/plugin-discovery.ts
+++ b/packages/dashboard/vite/utils/plugin-discovery.ts
@@ -123,6 +123,7 @@ export async function discoverPlugins({
 function getDecoratorObjectProps(decorator: any): any[] {
     if (
         decorator.type === 'CallExpression' &&
+        isVendurePluginDecoratorCall(decorator.callee) &&
         decorator.arguments.length === 1 &&
         decorator.arguments[0].type === 'ObjectExpression'
     ) {
@@ -130,6 +131,17 @@ function getDecoratorObjectProps(decorator: any): any[] {
         return decorator.arguments[0].properties ?? [];
     }
     return [];
+}
+
+function isVendurePluginDecoratorCall(callee: any): boolean {
+    if (callee.type === 'Identifier') {
+        return callee.name === 'VendurePlugin';
+    }
+    if (callee.type === 'SequenceExpression') {
+        const expression = callee.expressions.at(-1);
+        return expression?.type === 'MemberExpression' && expression.property?.name === 'VendurePlugin';
+    }
+    return false;
 }
 
 function getDashboardPath(decorators: any): string | undefined {


### PR DESCRIPTION
Fix plugin discovery so each compiled decorator call produces its own plugin entry.

Previously, shared state could cause a dashboard path from one plugin class to be paired with a later class. Discovery now extracts the dashboard path and class name within each `__decorate` call.

Add tests for direct TypeScript decorator output and `importHelpers`/`tslib` output, including multiple dashboard plugins and a later plugin without a dashboard entry.

Fixes OSS-724

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789882037&installation_model_id=20193&pr_number=5161&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5161&signature=2a174a494691556a6cf0a4217fda64d494ac2debc3d6a0aefd34df7b656f6cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
