### PR TITLE
feat(core): add composed Vendure plugin support

### DIFF
--- a/docs/docs/reference/typescript-api/common/bootstrap.mdx
+++ b/docs/docs/reference/typescript-api/common/bootstrap.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## bootstrap
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="198" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="203" packageName="@vendure/core" />
 
 Bootstraps the Vendure server. This is the entry point to the application.
 
@@ -76,7 +76,7 @@ Parameters
 
 ## BootstrapOptions
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="53" packageName="@vendure/core" since="2.2.0" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="58" packageName="@vendure/core" since="2.2.0" />
 
 Additional options that can be used to configure the bootstrap process of the
 Vendure server.

--- a/docs/docs/reference/typescript-api/plugin/plugin-utilities.mdx
+++ b/docs/docs/reference/typescript-api/plugin/plugin-utilities.mdx
@@ -2,6 +2,22 @@
 title: "Plugin Utilities"
 generated: true
 ---
+## flattenPlugins
+
+<GenerationInfo sourceFile="packages/core/src/plugin/plugin-metadata.ts" sourceLine="27" packageName="@vendure/core" since="3.8.0" />
+
+Expands composed Vendure plugins into a depth-first list. Child plugins appear before their parent,
+declared order is preserved, and each plugin class appears once.
+
+```ts title="Signature"
+function flattenPlugins(plugins: Array<Type<any> | DynamicModule>): Array<Type<any> | DynamicModule>
+```
+Parameters
+
+### plugins
+
+<MemberInfo kind="parameter" type={`Array<Type<any> | DynamicModule>`} />
+
 ## createProxyHandler
 
 <GenerationInfo sourceFile="packages/core/src/plugin/plugin-utils.ts" sourceLine="37" packageName="@vendure/core" />

--- a/docs/docs/reference/typescript-api/plugin/vendure-plugin-metadata.mdx
+++ b/docs/docs/reference/typescript-api/plugin/vendure-plugin-metadata.mdx
@@ -13,6 +13,7 @@ extra properties specific to Vendure.
 
 ```ts title="Signature"
 interface VendurePluginMetadata extends ModuleMetadata {
+    plugins?: Array<Type<any> | DynamicModule>;
     configuration?: PluginConfigurationFn;
     shopApiExtensions?: APIExtensionDefinition;
     adminApiExtensions?: APIExtensionDefinition;
@@ -27,6 +28,12 @@ interface VendurePluginMetadata extends ModuleMetadata {
 
 <div className="members-wrapper">
 
+### plugins
+
+<MemberInfo kind="property" type={`Array<Type<any> | DynamicModule>`}  since="3.8.0"  />
+
+Other Vendure plugins that this plugin composes. Vendure registers these plugins before this plugin
+and adds them to its NestJS module imports.
 ### configuration
 
 <MemberInfo kind="property" type={`<a href='/reference/typescript-api/plugin/vendure-plugin-metadata#pluginconfigurationfn'>PluginConfigurationFn</a>`}   />
@@ -82,7 +89,7 @@ compatibility: '^3.0.0'
 </div>
 ## APIExtensionDefinition
 
-<GenerationInfo sourceFile="packages/core/src/plugin/vendure-plugin.ts" sourceLine="80" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/plugin/vendure-plugin.ts" sourceLine="88" packageName="@vendure/core" />
 
 An object which allows a plugin to extend the Vendure GraphQL API.
 
@@ -129,7 +136,7 @@ Read more about defining custom scalars in the
 </div>
 ## PluginConfigurationFn
 
-<GenerationInfo sourceFile="packages/core/src/plugin/vendure-plugin.ts" sourceLine="119" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/plugin/vendure-plugin.ts" sourceLine="127" packageName="@vendure/core" />
 
 This method is called before the app bootstraps and should be used to perform any needed modifications to the [VendureConfig](/reference/typescript-api/configuration/vendure-config#vendureconfig).
 

--- a/docs/docs/reference/typescript-api/plugin/vendure-plugin.mdx
+++ b/docs/docs/reference/typescript-api/plugin/vendure-plugin.mdx
@@ -2,7 +2,7 @@
 title: "VendurePlugin"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/plugin/vendure-plugin.ts" sourceLine="164" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/plugin/vendure-plugin.ts" sourceLine="172" packageName="@vendure/core" />
 
 The VendurePlugin decorator is a means of configuring and/or extending the functionality of the Vendure server. A Vendure plugin is
 a [Nestjs Module](https://docs.nestjs.com/modules), with optional additional metadata defining things like extensions to the GraphQL API, custom

--- a/docs/docs/reference/typescript-api/worker/bootstrap-worker.mdx
+++ b/docs/docs/reference/typescript-api/worker/bootstrap-worker.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## bootstrapWorker
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="271" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="276" packageName="@vendure/core" />
 
 Bootstraps a Vendure worker. Resolves to a [VendureWorker](/reference/typescript-api/worker/vendure-worker#vendureworker) object containing a reference to the underlying
 NestJs [standalone application](https://docs.nestjs.com/standalone-applications) as well as convenience
@@ -41,7 +41,7 @@ Parameters
 
 ## BootstrapWorkerOptions
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="123" packageName="@vendure/core" since="2.2.0" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="128" packageName="@vendure/core" since="2.2.0" />
 
 Additional options that can be used to configure the bootstrap process of the
 Vendure worker.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1198,7 +1198,7 @@
                   "title": "Bootstrap",
                   "slug": "bootstrap",
                   "file": "docs/reference/typescript-api/common/bootstrap.mdx",
-                  "lastModified": "2026-08-13T14:40:56+02:00"
+                  "lastModified": "2026-08-21T05:35:30Z"
                 },
                 {
                   "title": "CurrencyCode",
@@ -2724,7 +2724,7 @@
                   "title": "Plugin Utilities",
                   "slug": "plugin-utilities",
                   "file": "docs/reference/typescript-api/plugin/plugin-utilities.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-21T05:35:30Z"
                 },
                 {
                   "title": "PluginCommonModule",
@@ -2736,13 +2736,13 @@
                   "title": "VendurePlugin",
                   "slug": "vendure-plugin",
                   "file": "docs/reference/typescript-api/plugin/vendure-plugin.mdx",
-                  "lastModified": "2026-01-28T14:49:21+01:00"
+                  "lastModified": "2026-08-21T05:35:30Z"
                 },
                 {
                   "title": "VendurePluginMetadata",
                   "slug": "vendure-plugin-metadata",
                   "file": "docs/reference/typescript-api/plugin/vendure-plugin-metadata.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-21T05:35:30Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -2780,7 +2780,7 @@
                   "title": "MultiChannelStockLocationStrategy",
                   "slug": "multi-channel-stock-location-strategy",
                   "file": "docs/reference/typescript-api/products-stock/multi-channel-stock-location-strategy.mdx",
-                  "lastModified": "2026-08-17T12:00:11+02:00"
+                  "lastModified": "2026-08-13T17:32:23+01:00"
                 },
                 {
                   "title": "ProductVariantPriceCalculationStrategy",
@@ -2874,7 +2874,7 @@
                   "title": "RequestContext",
                   "slug": "request-context",
                   "file": "docs/reference/typescript-api/request/request-context.mdx",
-                  "lastModified": "2026-08-17T12:00:11+02:00"
+                  "lastModified": "2026-08-13T14:40:56+02:00"
                 },
                 {
                   "title": "RequestContextService",
@@ -3096,7 +3096,7 @@
                   "title": "OrderService",
                   "slug": "order-service",
                   "file": "docs/reference/typescript-api/services/order-service.mdx",
-                  "lastModified": "2026-08-17T12:00:11+02:00"
+                  "lastModified": "2026-08-13T17:32:23+01:00"
                 },
                 {
                   "title": "OrderTestingService",
@@ -3186,7 +3186,7 @@
                   "title": "ShippingMethodService",
                   "slug": "shipping-method-service",
                   "file": "docs/reference/typescript-api/services/shipping-method-service.mdx",
-                  "lastModified": "2026-08-17T12:00:11+02:00"
+                  "lastModified": "2026-08-13T14:40:56+02:00"
                 },
                 {
                   "title": "SlugService",
@@ -3566,7 +3566,7 @@
                   "title": "BootstrapWorker",
                   "slug": "bootstrap-worker",
                   "file": "docs/reference/typescript-api/worker/bootstrap-worker.mdx",
-                  "lastModified": "2026-08-13T14:40:56+02:00"
+                  "lastModified": "2026-08-21T05:35:30Z"
                 },
                 {
                   "title": "VendureWorker",

--- a/packages/core/e2e/fixtures/test-plugins/with-composed-plugins.ts
+++ b/packages/core/e2e/fixtures/test-plugins/with-composed-plugins.ts
@@ -1,0 +1,77 @@
+import { DynamicModule, OnApplicationShutdown } from '@nestjs/common';
+import { Query, Resolver } from '@nestjs/graphql';
+import { VendureEntity, VendurePlugin } from '@vendure/core';
+import gql from 'graphql-tag';
+import { Entity } from 'typeorm';
+
+let configurationInvocationCount = 0;
+
+@VendurePlugin({
+    configuration: config => {
+        configurationInvocationCount++;
+        return config;
+    },
+})
+export class DeduplicatedDynamicPlugin implements OnApplicationShutdown {
+    static init(): DynamicModule {
+        return { module: DeduplicatedDynamicPlugin };
+    }
+
+    static get configurationInvocationCount(): number {
+        return configurationInvocationCount;
+    }
+
+    onApplicationShutdown(): void {
+        configurationInvocationCount = 0;
+    }
+}
+
+@Entity()
+export class CompositeTestEntity extends VendureEntity {}
+
+@VendurePlugin({ entities: [CompositeTestEntity] })
+class CompositeEntityPlugin {}
+
+@VendurePlugin({
+    configuration: config => {
+        config.customFields.Product.push({
+            name: 'composedPluginField',
+            type: 'string',
+            nullable: true,
+        });
+        return config;
+    },
+})
+class CompositeConfigurationPlugin {}
+
+@Resolver()
+class CompositeResolver {
+    @Query()
+    composedPluginQuery(): string {
+        return 'composed';
+    }
+}
+
+@VendurePlugin({
+    shopApiExtensions: {
+        schema: gql`
+            extend type Query {
+                composedPluginQuery: String!
+            }
+        `,
+        resolvers: [CompositeResolver],
+    },
+})
+class CompositeApiPlugin {}
+
+export const deduplicatedDynamicPlugin = DeduplicatedDynamicPlugin.init();
+
+@VendurePlugin({
+    plugins: [
+        CompositeEntityPlugin,
+        CompositeConfigurationPlugin,
+        CompositeApiPlugin,
+        deduplicatedDynamicPlugin,
+    ],
+})
+export class CompositeTestPlugin {}

--- a/packages/core/e2e/plugin.e2e-spec.ts
+++ b/packages/core/e2e/plugin.e2e-spec.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@vendure/core';
 import { createTestEnvironment } from '@vendure/testing';
 import gql from 'graphql-tag';
 import path from 'path';
+import { DataSource } from 'typeorm';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { initialData } from '../../../e2e-common/e2e-initial-data';
@@ -10,6 +11,12 @@ import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-conf
 
 import { TestPluginWithAllLifecycleHooks } from './fixtures/test-plugins/with-all-lifecycle-hooks';
 import { TestAPIExtensionPlugin } from './fixtures/test-plugins/with-api-extensions';
+import {
+    CompositeTestEntity,
+    CompositeTestPlugin,
+    DeduplicatedDynamicPlugin,
+    deduplicatedDynamicPlugin,
+} from './fixtures/test-plugins/with-composed-plugins';
 import { TestPluginWithConfig } from './fixtures/test-plugins/with-config';
 import { PluginWithGlobalProviders } from './fixtures/test-plugins/with-global-providers';
 import { TestLazyExtensionPlugin } from './fixtures/test-plugins/with-lazy-api-extensions';
@@ -31,6 +38,8 @@ describe('Plugins', () => {
             TestRestPlugin,
             PluginWithGlobalProviders,
             WithNewConfigObjectReferencePlugin,
+            CompositeTestPlugin,
+            deduplicatedDynamicPlugin,
         ],
     });
 
@@ -51,6 +60,32 @@ describe('Plugins', () => {
         const configService = server.app.get(ConfigService);
         expect(configService instanceof ConfigService).toBe(true);
         expect(configService.defaultLanguageCode).toBe(LanguageCode.zh);
+    });
+
+    it('registers entities from composed plugins', () => {
+        expect(server.app.get(DataSource).hasMetadata(CompositeTestEntity)).toBe(true);
+    });
+
+    it('registers a composed plugin only once', () => {
+        expect(DeduplicatedDynamicPlugin.configurationInvocationCount).toBe(1);
+    });
+
+    it('runs configuration functions from composed plugins', () => {
+        const configService = server.app.get(ConfigService);
+        expect(configService.customFields.Product).toContainEqual({
+            name: 'composedPluginField',
+            type: 'string',
+            nullable: true,
+        });
+    });
+
+    it('registers API extensions and resolvers from composed plugins', async () => {
+        const result = await shopClient.query(gql`
+            query {
+                composedPluginQuery
+            }
+        `);
+        expect(result.composedPluginQuery).toBe('composed');
     });
 
     // https://github.com/vendurehq/vendure/issues/2906

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -31,7 +31,12 @@ import { patchTypeOrmRelationIdLoader } from './entity/typeorm-relation-id-loade
 import { validateCustomFieldsConfig } from './entity/validate-custom-fields-config';
 import { EventBus } from './event-bus';
 import { BootstrappedEvent } from './event-bus/events/bootstrapped-event';
-import { getCompatibility, getConfigurationFunction, getEntitiesFromPlugins } from './plugin/plugin-metadata';
+import {
+    flattenPlugins,
+    getCompatibility,
+    getConfigurationFunction,
+    getEntitiesFromPlugins,
+} from './plugin/plugin-metadata';
 import { getPluginStartupMessages } from './plugin/plugin-utils';
 import { setProcessContext } from './process-context/process-context';
 import { isTelemetryDisabled } from './telemetry/helpers/is-telemetry-disabled.helper';
@@ -303,6 +308,7 @@ export async function preBootstrapConfig(
     userConfig: Partial<VendureConfig>,
 ): Promise<Readonly<RuntimeVendureConfig>> {
     if (userConfig) {
+        userConfig.plugins = flattenPlugins(userConfig.plugins ?? []);
         await setConfig(userConfig);
     }
 

--- a/packages/core/src/migrate.spec.ts
+++ b/packages/core/src/migrate.spec.ts
@@ -2,9 +2,24 @@ import BetterSqlite3 from 'better-sqlite3';
 import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
+import { Column, Entity } from 'typeorm';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { VendureEntity } from './entity/base/base.entity';
 import { flattenReplication, generateMigration, withDatabase } from './migrate';
+import { VendurePlugin } from './plugin/vendure-plugin';
+
+@Entity()
+class ComposedMigrationEntity extends VendureEntity {
+    @Column()
+    value: string;
+}
+
+@VendurePlugin({ entities: [ComposedMigrationEntity] })
+class MigrationEntityPlugin {}
+
+@VendurePlugin({ plugins: [MigrationEntityPlugin] })
+class CompositeMigrationPlugin {}
 
 /**
  * Integration coverage for the `fromEmpty` (shadow-database) baseline generation. Uses
@@ -92,6 +107,16 @@ describe('generateMigration fromEmpty', () => {
         const content = fs.readFileSync(migrationFile as string, 'utf-8');
         expect(content).toContain('CREATE TABLE');
         expect(content).toContain('"product"');
+    }, 60_000);
+
+    it('includes entities from composed plugins', async () => {
+        const migrationFile = await generateMigration(
+            { ...config, plugins: [CompositeMigrationPlugin] },
+            { name: 'composedPlugin', outputDir, fromEmpty: true },
+        );
+
+        expect(migrationFile).toBeTruthy();
+        expect(fs.readFileSync(migrationFile as string, 'utf-8')).toContain('"composed_migration_entity"');
     }, 60_000);
 });
 

--- a/packages/core/src/plugin/plugin-metadata.spec.ts
+++ b/packages/core/src/plugin/plugin-metadata.spec.ts
@@ -1,0 +1,67 @@
+import { DynamicModule, Module } from '@nestjs/common';
+import { describe, expect, it } from 'vitest';
+
+import { flattenPlugins, getEntitiesFromPlugins, getModuleMetadata } from './plugin-metadata';
+import { VendurePlugin } from './vendure-plugin';
+
+describe('plugin metadata', () => {
+    class FirstPlugin {}
+    class SecondPlugin {}
+
+    it('leaves a flat plugin list unchanged', () => {
+        expect(flattenPlugins([FirstPlugin, SecondPlugin])).toEqual([FirstPlugin, SecondPlugin]);
+    });
+
+    it('flattens nested plugins depth-first in declared order', () => {
+        @VendurePlugin({ plugins: [FirstPlugin, SecondPlugin] })
+        class ChildCompositePlugin {}
+
+        @VendurePlugin({ plugins: [ChildCompositePlugin] })
+        class ParentCompositePlugin {}
+
+        expect(flattenPlugins([ParentCompositePlugin])).toEqual([
+            FirstPlugin,
+            SecondPlugin,
+            ChildCompositePlugin,
+            ParentCompositePlugin,
+        ]);
+    });
+
+    it('deduplicates plugins by class', () => {
+        @VendurePlugin({ plugins: [FirstPlugin] })
+        class CompositePlugin {}
+
+        expect(flattenPlugins([CompositePlugin, FirstPlugin, CompositePlugin])).toEqual([
+            FirstPlugin,
+            CompositePlugin,
+        ]);
+    });
+
+    it('handles DynamicModule entries and deduplicates them by module class', () => {
+        const dynamicPlugin: DynamicModule = { module: FirstPlugin };
+
+        expect(flattenPlugins([dynamicPlugin, FirstPlugin])).toEqual([dynamicPlugin]);
+    });
+
+    it('finds composed entities in a raw, unflattened plugin list', () => {
+        class TestEntity {}
+
+        @VendurePlugin({ entities: [TestEntity] })
+        class EntityPlugin {}
+
+        @VendurePlugin({ plugins: [EntityPlugin] })
+        class CompositePlugin {}
+
+        expect(getEntitiesFromPlugins([CompositePlugin])).toEqual([TestEntity]);
+    });
+
+    it('adds composed plugins to the NestJS module imports', () => {
+        @Module({})
+        class CommonModule {}
+
+        @VendurePlugin({ imports: [CommonModule], plugins: [FirstPlugin, SecondPlugin] })
+        class CompositePlugin {}
+
+        expect(getModuleMetadata(CompositePlugin).imports).toEqual([CommonModule, FirstPlugin, SecondPlugin]);
+    });
+});

--- a/packages/core/src/plugin/plugin-metadata.ts
+++ b/packages/core/src/plugin/plugin-metadata.ts
@@ -7,6 +7,7 @@ import { APIExtensionDefinition, DashboardExtension, PluginConfigurationFn } fro
 
 export const PLUGIN_METADATA = {
     CONFIGURATION: 'configuration',
+    PLUGINS: 'plugins',
     SHOP_API_EXTENSIONS: 'shopApiExtensions',
     ADMIN_API_EXTENSIONS: 'adminApiExtensions',
     ENTITIES: 'entities',
@@ -14,11 +15,43 @@ export const PLUGIN_METADATA = {
     DASHBOARD: 'dashboard',
 };
 
+/**
+ * @description
+ * Expands composed Vendure plugins into a depth-first list. Child plugins appear before their parent,
+ * declared order is preserved, and each plugin class appears once.
+ *
+ * @docsCategory plugin
+ * @docsPage Plugin Utilities
+ * @since 3.8.0
+ */
+export function flattenPlugins(plugins: Array<Type<any> | DynamicModule>): Array<Type<any> | DynamicModule> {
+    const flattened: Array<Type<any> | DynamicModule> = [];
+    const visited = new Set<Type<any>>();
+
+    const visit = (plugin: Type<any> | DynamicModule) => {
+        const pluginClass = isDynamicModule(plugin) ? plugin.module : plugin;
+        if (visited.has(pluginClass)) {
+            return;
+        }
+        visited.add(pluginClass);
+        const composedPlugins = reflectMetadata(plugin, PLUGIN_METADATA.PLUGINS) ?? [];
+        for (const composedPlugin of composedPlugins) {
+            visit(composedPlugin);
+        }
+        flattened.push(plugin);
+    };
+
+    for (const plugin of plugins) {
+        visit(plugin);
+    }
+    return flattened;
+}
+
 export function getEntitiesFromPlugins(plugins?: Array<Type<any> | DynamicModule>): Array<Type<any>> {
     if (!plugins) {
         return [];
     }
-    return plugins
+    return flattenPlugins(plugins)
         .map(p => reflectMetadata(p, PLUGIN_METADATA.ENTITIES))
         .reduce((all, entities) => {
             const resolvedEntities = typeof entities === 'function' ? entities() : (entities ?? []);

--- a/packages/core/src/plugin/vendure-plugin.ts
+++ b/packages/core/src/plugin/vendure-plugin.ts
@@ -1,4 +1,4 @@
-import { Module, Type as NestType, Provider } from '@nestjs/common';
+import { DynamicModule, Module, Type as NestType, Provider } from '@nestjs/common';
 import { MODULE_METADATA } from '@nestjs/common/constants';
 import { ModuleMetadata } from '@nestjs/common/interfaces';
 import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
@@ -21,6 +21,14 @@ import { PLUGIN_METADATA } from './plugin-metadata';
  * @docsPage VendurePluginMetadata
  */
 export interface VendurePluginMetadata extends ModuleMetadata {
+    /**
+     * @description
+     * Other Vendure plugins that this plugin composes. Vendure registers these plugins before this plugin
+     * and adds them to its NestJS module imports.
+     *
+     * @since 3.8.0
+     */
+    plugins?: Array<Type<any> | DynamicModule>;
     /**
      * @description
      * A function which can modify the {@link VendureConfig} object before the server bootstraps.
@@ -171,6 +179,10 @@ export function VendurePlugin(pluginMetadata: VendurePluginMetadata): ClassDecor
             }
         }
         const nestModuleMetadata = pick(pluginMetadata, Object.values(MODULE_METADATA) as any);
+        nestModuleMetadata.imports = [
+            ...(nestModuleMetadata.imports ?? []),
+            ...(pluginMetadata.plugins ?? []),
+        ];
         // Automatically add any of the Plugin's "providers" to the "exports" array. This is done
         // because when a plugin defines GraphQL resolvers, these resolvers are used to dynamically
         // created a new Module in the ApiModule, and if those resolvers depend on any providers,


### PR DESCRIPTION
Add a `plugins` metadata field to `@VendurePlugin` so a plugin can compose other Vendure plugins.

Composed plugins are expanded depth-first before bootstrap. This preserves declaration order, registers child plugins before their parent, and prevents duplicate registration by plugin class. The decorator also adds composed plugins to NestJS module imports.

This makes entities, configuration functions, and API extensions from composed plugins available during bootstrap and migration generation.

Add unit and e2e coverage for flattening, deduplication, module imports, entity discovery, configuration, API extensions, and migration generation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789882430&installation_model_id=20193&pr_number=5162&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5162&signature=45cd29520d35489fe5892d176c73e38659e537bab345fa007db982012c01bbf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->