### PR TITLE
fix(core): prevent orphan-nullification of surcharges on Order save

### DIFF
--- a/docs/docs/reference/typescript-api/entities/order.mdx
+++ b/docs/docs/reference/typescript-api/entities/order.mdx
@@ -160,6 +160,11 @@ Surcharges are arbitrary modifications to the Order total which are neither
 ProductVariants nor discounts resulting from applied Promotions. For example,
 one-off discounts based on customer interaction, or surcharges based on payment
 methods.
+
+Surcharges are attached and removed with `OrderService.addSurchargeToOrder` and
+`OrderService.removeSurchargeFromOrder`. Saving an Order does not detach a
+Surcharge which is missing from this array, and repricing the Order does not attach one
+which was saved without its `order` property set.
 ### couponCodes
 
 <MemberInfo kind="property" type={`string[]`}   />

--- a/docs/docs/reference/typescript-api/entities/surcharge.mdx
+++ b/docs/docs/reference/typescript-api/entities/surcharge.mdx
@@ -21,7 +21,10 @@ class Surcharge extends VendureEntity {
     @Column('simple-json')
     taxLines: TaxLine[];
     @Index()
-    @ManyToOne(type => Order, order => order.surcharges, { onDelete: 'CASCADE' })
+    @ManyToOne(type => Order, order => order.surcharges, {
+        onDelete: 'CASCADE',
+        orphanedRowAction: 'disable',
+    })
     order: Order;
     @Index()
     @ManyToOne(type => OrderModification, orderModification => orderModification.surcharges)

--- a/packages/core/e2e/order.e2e-spec.ts
+++ b/packages/core/e2e/order.e2e-spec.ts
@@ -12,8 +12,10 @@ import {
 import { omit } from '@vendure/common/lib/omit';
 import { pick } from '@vendure/common/lib/pick';
 import {
+    Order,
     OrderService,
     RequestContextService,
+    TransactionalConnection,
     defaultShippingCalculator,
     defaultShippingEligibilityChecker,
     manualFulfillmentHandler,
@@ -2452,6 +2454,56 @@ describe('Orders resolver', () => {
             });
             shopOrderGuard.assertSuccess(secondAdd);
             expect(secondAdd.lines[0].quantity).toBe(2);
+        });
+
+        // https://github.com/vendurehq/vendure/pull/5164
+        // Every Order mutation holds `order.surcharges` as a snapshot taken when the Order
+        // was loaded. Saving the Order must not act on that snapshot: a Surcharge added
+        // since the load, by a blocking event handler or by a concurrent request, would
+        // otherwise have its `orderId` set to null.
+        it('does not detach Surcharges when saving an Order with a stale surcharges array', async () => {
+            await shopClient.asAnonymousUser();
+            const { addItemToOrder: add } = await shopClient.query(addItemToOrderDocument, {
+                productVariantId: 'T_1',
+                quantity: 1,
+            });
+            shopOrderGuard.assertSuccess(add);
+            const internalOrderId = +add.id.replace('T_', '');
+
+            const ctx = await server.app.get(RequestContextService).create({ apiType: 'admin' });
+            const orderService = server.app.get(OrderService);
+            const connection = server.app.get(TransactionalConnection);
+
+            await orderService.addSurchargeToOrder(ctx, internalOrderId, {
+                description: 'Gift wrap',
+                listPrice: 200,
+            });
+
+            const staleOrder = await connection.getEntityOrThrow(ctx, Order, internalOrderId, {
+                // `lines` is joined because saving an Order reads its calculated `discounts`
+                // property, via the enumerable getter installed by the calculated-property
+                // subscriber, and that getter throws when the relation is missing.
+                relations: ['surcharges', 'lines'],
+            });
+            expect(staleOrder.surcharges.length).toBe(1);
+
+            // A blocking event handler or a concurrent request adds a second Surcharge, which
+            // the array held by `staleOrder` does not know about.
+            await orderService.addSurchargeToOrder(ctx, internalOrderId, {
+                description: 'Loyalty discount',
+                listPrice: -500,
+            });
+
+            await connection.getRepository(ctx, Order).save(staleOrder);
+
+            const surcharges = await orderService.getOrderSurcharges(ctx, internalOrderId);
+            expect(surcharges.map(s => s.listPrice).sort((a, b) => a - b)).toEqual([-500, 200]);
+
+            // Removal deletes the row, so it does not depend on the Order save detaching it.
+            const loyaltyDiscount = surcharges.find(s => s.description === 'Loyalty discount')!;
+            await orderService.removeSurchargeFromOrder(ctx, internalOrderId, loyaltyDiscount.id);
+            const remaining = await orderService.getOrderSurcharges(ctx, internalOrderId);
+            expect(remaining.map(s => s.description)).toEqual(['Gift wrap']);
         });
     });
 

--- a/packages/core/src/entity/order/order.entity.ts
+++ b/packages/core/src/entity/order/order.entity.ts
@@ -107,6 +107,11 @@ export class Order extends VendureEntity implements ChannelAware, HasCustomField
      * ProductVariants nor discounts resulting from applied Promotions. For example,
      * one-off discounts based on customer interaction, or surcharges based on payment
      * methods.
+     *
+     * Surcharges are attached and removed with {@link OrderService.addSurchargeToOrder} and
+     * {@link OrderService.removeSurchargeFromOrder}. Saving an Order does not detach a
+     * Surcharge which is missing from this array, and repricing the Order does not attach one
+     * which was saved without its `order` property set.
      */
     @OneToMany(type => Surcharge, surcharge => surcharge.order)
     surcharges: Surcharge[];

--- a/packages/core/src/entity/surcharge/surcharge.entity.ts
+++ b/packages/core/src/entity/surcharge/surcharge.entity.ts
@@ -39,8 +39,16 @@ export class Surcharge extends VendureEntity {
     @Column('simple-json')
     taxLines: TaxLine[];
 
+    // TypeORM's default 'nullify' sets `orderId` to null on every Surcharge row missing from
+    // the in-memory `Order.surcharges` array, which is a snapshot from the time the Order was
+    // loaded: a Surcharge added since, by an event handler or by a concurrent request, is
+    // detached by the next save of that Order. `OrderService.removeSurchargeFromOrder` deletes
+    // the row, so nothing needs the nullify.
     @Index()
-    @ManyToOne(type => Order, order => order.surcharges, { onDelete: 'CASCADE' })
+    @ManyToOne(type => Order, order => order.surcharges, {
+        onDelete: 'CASCADE',
+        orphanedRowAction: 'disable',
+    })
     order: Order;
 
     @Index()

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -2439,6 +2439,7 @@ export class OrderService implements OnApplicationBootstrap {
                     'billingAddress',
                     'lines',
                     'shippingLines',
+                    'surcharges',
                     'aggregateOrder',
                     'sellerOrders',
                     'customer',


### PR DESCRIPTION
## Description

`Surcharge.order` is a nullable `ManyToOne` and `Order.surcharges` its `OneToMany`, with no `orphanedRowAction` set. TypeORM defaults that to `nullify`, so saving an `Order` diffs the passed `surcharges` array against the DB and **orphan-nullifies** (`UPDATE surcharge SET "orderId" = NULL`) every row whose id is missing from the in-memory array — silently: no error, no event, no log.

The in-memory array goes stale easily: core mutations (`addItemToOrder`, `adjustOrderLine`, `applyCouponCode`, `setShippingAddress`, …) snapshot the order at entry and publish `OrderLineEvent` *before* the save runs — any **blocking** event handler that adds/removes/re-adds a surcharge in that window (or a concurrent request doing so) gets its surcharge row detached by the subsequent save.

We hit this in production: negative discount surcharges (loyalty points / gift vouchers, maintained by a blocking `OrderLineEvent` handler that re-clamps them on repricing) vanished from orders while their side effects remained — customers paid full price although a discount had been applied, with zero trace in any log.

### Reproduction sketch

1. Register a blocking `OrderLineEvent` handler that removes + re-adds a surcharge on the order (the re-added row gets a new id).
2. Call `adjustOrderLine` on an order carrying a surcharge.
3. The surcharge row ends up with `orderId = NULL` — detached by the save in `applyPriceAdjustments`, which still held the pre-event snapshot. A cross-request race between any cart mutation and `addSurchargeToOrder` reproduces it without a blocking handler.

### Fix

The PR originally omitted `surcharges` from the save in `applyPriceAdjustments`, which closes the path the bug was reported on. But the same hazard is present in every other full-`Order` save, and `getOrderOrThrow` loads `surcharges` by default:

- `OrderService.removeItemsFromOrder`
- `OrderService.addCustomerToOrder`
- `PromotionService.addPromotionsToOrder`
- `OrderModifier.cancelOrder`
- plugin code doing `getRepository(ctx, Order).save(order)`, which is the pattern documented on `ActiveOrderStrategy`

So the fix belongs on the relation, not at each call site:

```ts
@ManyToOne(type => Order, order => order.surcharges, {
    onDelete: 'CASCADE',
    orphanedRowAction: 'disable',
})
order: Order;
```

Two things worth knowing about that option:

- TypeORM 0.3 reads it from the inverse (`ManyToOne`) side of a `OneToMany`, not from the `OneToMany` itself (`OneToManySubjectBuilder` checks `relation.inverseRelation.orphanedRowAction`), so setting it on `Order.surcharges` has no effect.
- It is applied when TypeORM builds the persistence subjects. No schema change, no migration.

Nothing relies on the orphan behaviour: `removeSurchargeFromOrder` deletes the row rather than detaching it, and `OrderModifier.modifyOrder` saves each `Surcharge` with its `order` already set. The bind path in `OneToManySubjectBuilder` runs before the orphan check, so newly added surcharges are still attached as before.

The `surcharges` omission in `applyPriceAdjustments` is kept, now purely for the same reason `lines` and `shippingLines` are omitted: the save has no need to diff a relation it never writes.

The guarantee is documented on `Order.surcharges`, so it reaches the generated API reference where a plugin author will look.

### Test

`packages/core/e2e/order.e2e-spec.ts` adds a Surcharge, loads the Order, then adds a second Surcharge through `OrderService` so the loaded handle really is stale, saves that handle, and asserts both rows are still attached. It goes through a plain `Order` save rather than `applyPriceAdjustments`, so it pins the relation guarantee for all call sites. Without the fix it reports `expected [ 200 ] to deeply equal [ -500, 200 ]`: the surcharge added since the load is the one that disappears, which is the production symptom. The test also covers the removal path, which must keep deleting the row.

### Not addressed here

`OrderLine.order`, `ShippingLine.order`, `Payment.order` and `Surcharge.orderModification` still default to `nullify`, so the same hazard exists for them. They are not symmetric with `Surcharge.order` and do not belong in this fix:

- `lines` **cannot** take `orphanedRowAction: 'disable'` as things stand. `OrderService.removeItemsFromOrder` filters `order.lines` and saves the Order specifically to make the removal stick before repricing, so it depends on the nullify.
- `shippingLines` and `payments` are never detached through the array in core (shipping lines are added and removed with explicit relation queries), so they look safe, but each needs its own check and regression test.

Repricing also calculates `Order.subTotal` and `Order.subTotalWithTax` from the same snapshot array, so a persisted total can disagree with the surcharge rows even though the rows now survive. Filed separately as #5332.

## Breaking changes

No API change and no migration. Two behaviour changes worth naming:

- Code which detached a `Surcharge` by removing it from `order.surcharges` and saving the Order no longer detaches it. Use `OrderService.removeSurchargeFromOrder`, which deletes the row.
- Because `applyPriceAdjustments` omits the relation, that save no longer binds a `Surcharge` which was persisted *without* its `order` property set. Core is unaffected — both writers save the row with `order` first — but a plugin which pushed an unsaved `Surcharge` onto `order.surcharges` and relied on repricing to attach it will now lose it silently. Set `order` on the `Surcharge`, or use `addSurchargeToOrder`.

There is no issue number for this: the bug was reported directly in this PR.

