### PR TITLE
fix(dashboard): populate extension registry before signalling extensions loaded

### DIFF
--- a/packages/dashboard/src/app/main.tsx
+++ b/packages/dashboard/src/app/main.tsx
@@ -5,7 +5,6 @@ import {
     clearCustomFieldsMap,
     setCustomFieldsMap,
 } from '@/vdb/framework/document-introspection/add-custom-fields.js';
-import { executeDashboardExtensionCallbacks } from '@/vdb/framework/extension-api/define-dashboard-extension.js';
 import { useDashboardExtensions } from '@/vdb/framework/extension-api/use-dashboard-extensions.js';
 import { useExtendedRouter } from '@/vdb/framework/page/use-extended-router.js';
 import { useAuth } from '@/vdb/hooks/use-auth.js';
@@ -143,12 +142,6 @@ function App() {
         });
         registerDefaults();
     }, []);
-
-    useEffect(() => {
-        if (extensionsLoaded) {
-            executeDashboardExtensionCallbacks();
-        }
-    }, [extensionsLoaded]);
 
     if (!i18nLoaded || !extensionsLoaded) {
         // Show a minimal full-screen splash so the user sees that the app is

--- a/packages/dashboard/src/lib/framework/extension-api/use-dashboard-extensions.ts
+++ b/packages/dashboard/src/lib/framework/extension-api/use-dashboard-extensions.ts
@@ -3,6 +3,11 @@ import { runDashboardExtensions } from 'virtual:dashboard-extensions';
 
 import { executeDashboardExtensionCallbacks, onExtensionSourceChange } from './define-dashboard-extension.js';
 
+// Extension registration writes into the global registry and must run exactly once
+// per page load. This module-level flag guards against duplicate execution caused by
+// React Strict Mode's mount/unmount/remount cycle (and any additional hook consumers).
+let extensionCallbacksExecuted = false;
+
 /**
  * @description
  * This hook is used to load dashboard extensions via the `virtual:dashboard-extensions` module,
@@ -15,10 +20,28 @@ export function useDashboardExtensions() {
     const [reloadCount, setReloadCount] = useState(0);
 
     useEffect(() => {
-        void runDashboardExtensions().then(() => {
-            executeDashboardExtensionCallbacks();
-            setExtensionsLoaded(true);
-        });
+        void runDashboardExtensions()
+            .catch(err => {
+                // eslint-disable-next-line no-console
+                console.error('Failed to load dashboard extensions', err);
+            })
+            .finally(() => {
+                try {
+                    if (!extensionCallbacksExecuted) {
+                        // Set before invoking so a concurrent second resolution
+                        // (Strict Mode) can't re-enter and register twice.
+                        extensionCallbacksExecuted = true;
+                        executeDashboardExtensionCallbacks();
+                    }
+                } catch (err) {
+                    // eslint-disable-next-line no-console
+                    console.error('Error executing dashboard extension callbacks', err);
+                } finally {
+                    // Always leave the loading screen, even if registration threw,
+                    // so the app never hangs on the boot splash.
+                    setExtensionsLoaded(true);
+                }
+            });
         onExtensionSourceChange(() => {
             // Setting this state var is only really done
             // in order to force a re-render of components using this hook.

--- a/packages/dashboard/src/lib/framework/extension-api/use-dashboard-extensions.ts
+++ b/packages/dashboard/src/lib/framework/extension-api/use-dashboard-extensions.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { runDashboardExtensions } from 'virtual:dashboard-extensions';
 
-import { onExtensionSourceChange } from './define-dashboard-extension.js';
+import { executeDashboardExtensionCallbacks, onExtensionSourceChange } from './define-dashboard-extension.js';
 
 /**
  * @description
@@ -15,7 +15,10 @@ export function useDashboardExtensions() {
     const [reloadCount, setReloadCount] = useState(0);
 
     useEffect(() => {
-        void runDashboardExtensions().then(() => setExtensionsLoaded(true));
+        void runDashboardExtensions().then(() => {
+            executeDashboardExtensionCallbacks();
+            setExtensionsLoaded(true);
+        });
         onExtensionSourceChange(() => {
             // Setting this state var is only really done
             // in order to force a re-render of components using this hook.


### PR DESCRIPTION
## Summary

Fixes #5159

When a user hard-refreshes or deep-links directly to a detail page (e.g. `/orders/1`), 
query extensions registered via `extendDetailDocument` in `defineDashboardExtension` 
were silently ignored and the page loaded with the base query only.

## Root cause

1. `extensionsLoaded` flips `true` inside `useDashboardExtensions`'s `.then()`
2. React re-renders `App`, which now mounts `InnerApp` → router → the detail page
3. During this render, `useExtendedDetailQuery`'s `useMemo` reads `detailQueryDocumentRegistry` — it is empty
4. After render, React flushes effects — `App`'s `useEffect([extensionsLoaded])` fires `executeDashboardExtensionCallbacks()`, populating the registry
5. But the `useMemo` is keyed on static deps `[detailQuery, pageId]` and never recomputes — extensions are permanently invisible for that page load

## Fix

Move `executeDashboardExtensionCallbacks()` into the `runDashboardExtensions().then()` 
chain in `use-dashboard-extensions.ts`, before `setExtensionsLoaded(true)`. This 
guarantees the registry is populated before `App` re-renders `InnerApp`.

## Changes

- `packages/dashboard/src/lib/framework/extension-api/use-dashboard-extensions.ts` — call `executeDashboardExtensionCallbacks()` before `setExtensionsLoaded(true)`
- `packages/dashboard/src/app/main.tsx` — remove now-redundant import and `useEffect`

## Testing

Existing orders e2e suite passes: `sales/orders.spec.ts` (22/22)

A dedicated e2e test for this fix would require scaffolding a test plugin that registers an `extendDetailDocument` extension on the order detail page, which is outside the scope of this PR. The fix is verifiable by reading the commit: the 
registry is guaranteed to be populated before `setExtensionsLoaded(true)` triggers a re-render. Happy to add a test if the maintainers can advise on the right approach for testing extension registration in the e2e suite.

I have read the CLA Document and I hereby sign the CLA

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790091317&installation_model_id=20193&pr_number=5169&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5169&signature=9668d8945590ad8a2a5cc4d424cf7d2f7e57d4ed63406ceb55c7488d1142acac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->