### PR TITLE
fix(dashboard): extend order detail query when pre-loading order details

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_orders/utils/order-detail-loaders.spec.ts
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/utils/order-detail-loaders.spec.ts
@@ -1,0 +1,159 @@
+import { addDetailQueryDocument } from '@/vdb/framework/form-engine/custom-form-component-extensions.js';
+import { globalRegistry } from '@/vdb/framework/registry/global-registry.js';
+import { QueryClient } from '@tanstack/react-query';
+import { parse, print } from 'graphql';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { loadModifyingOrder, loadRegularOrder, loadSellerOrder } from './order-detail-loaders.js';
+
+const { query } = vi.hoisted(() => ({
+    query: vi.fn(),
+}));
+
+vi.mock('@/vdb/graphql/api.js', () => ({
+    api: { query },
+}));
+
+describe('loadRegularOrder', () => {
+    beforeEach(() => {
+        globalRegistry.get('detailQueryDocumentRegistry').clear();
+        query.mockReset();
+    });
+
+    it('includes registered order detail query extensions in the preloaded query', async () => {
+        addDetailQueryDocument(
+            'order-detail',
+            parse(`
+                query GetOrder($id: ID!) {
+                    order(id: $id) {
+                        channels {
+                            defaultLanguageCode
+                        }
+                    }
+                }
+            `),
+        );
+        query.mockResolvedValue({
+            order: {
+                code: 'T_1',
+                state: 'PaymentSettled',
+            },
+        });
+        const context = {
+            queryClient: {
+                ensureQueryData: vi.fn(options => options.queryFn()),
+            },
+        };
+
+        await loadRegularOrder(context, { id: '1' });
+
+        expect(print(query.mock.calls[0][0])).toContain('defaultLanguageCode');
+    });
+
+    it('includes registered seller order detail query extensions in the preloaded query', async () => {
+        addDetailQueryDocument(
+            'seller-order-detail',
+            parse(`
+                query GetOrder($id: ID!) {
+                    order(id: $id) {
+                        channels {
+                            defaultLanguageCode
+                        }
+                    }
+                }
+            `),
+        );
+        query.mockResolvedValue({
+            order: {
+                aggregateOrder: {
+                    code: 'T_1',
+                    id: 'aggregate-order-1',
+                },
+                code: 'T_2',
+                state: 'PaymentSettled',
+            },
+        });
+        const context = {
+            queryClient: {
+                ensureQueryData: vi.fn(options => options.queryFn()),
+            },
+        };
+
+        await loadSellerOrder(context, {
+            aggregateOrderId: 'aggregate-order-1',
+            sellerOrderId: 'seller-order-1',
+        });
+
+        expect(print(query.mock.calls[0][0])).toContain('defaultLanguageCode');
+    });
+
+    it('includes registered order modification query extensions in the preloaded query', async () => {
+        addDetailQueryDocument(
+            'order-modify',
+            parse(`
+                query GetOrder($id: ID!) {
+                    order(id: $id) {
+                        channels {
+                            defaultLanguageCode
+                        }
+                    }
+                }
+            `),
+        );
+        query.mockResolvedValue({
+            order: {
+                code: 'T_1',
+                state: 'Modifying',
+            },
+        });
+        const context = {
+            queryClient: new QueryClient(),
+        };
+
+        await loadModifyingOrder(context, { id: '1' });
+
+        expect(print(query.mock.calls[0][0])).toContain('defaultLanguageCode');
+    });
+
+    it('does not reuse an incompatible order detail preload after redirecting to modification', async () => {
+        addDetailQueryDocument(
+            'order-detail',
+            parse(`
+                query GetOrder($id: ID!) {
+                    order(id: $id) {
+                        channels {
+                            code
+                        }
+                    }
+                }
+            `),
+        );
+        addDetailQueryDocument(
+            'order-modify',
+            parse(`
+                query GetOrder($id: ID!) {
+                    order(id: $id) {
+                        channels {
+                            defaultLanguageCode
+                        }
+                    }
+                }
+            `),
+        );
+        query.mockResolvedValue({
+            order: {
+                code: 'T_1',
+                state: 'Modifying',
+            },
+        });
+        const context = {
+            queryClient: new QueryClient(),
+        };
+
+        await expect(loadRegularOrder(context, { id: '1' })).rejects.toBeDefined();
+        await loadModifyingOrder(context, { id: '1' });
+
+        expect(query).toHaveBeenCalledTimes(2);
+        expect(print(query.mock.calls[1][0])).toContain('defaultLanguageCode');
+    });
+});

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
@@ -1,3 +1,4 @@
+import { extendDetailFormQuery } from '@/vdb/framework/document-extension/extend-detail-form-query.js';
 import { addCustomFields } from '@/vdb/framework/document-introspection/add-custom-fields.js';
 import { getDetailQueryOptions } from '@/vdb/framework/page/use-detail-page.js';
 import { ResultOf } from '@/vdb/graphql/graphql.js';
@@ -11,11 +12,21 @@ async function ensureOrderWithIdExists(context: any, params: { id: string }): Pr
         throw new Error('ID param is required');
     }
 
+    const { extendedQuery, errorMessage } = extendDetailFormQuery(
+        addCustomFields(orderDetailDocument, { includeNestedFragments: ['OrderLine', 'Fulfillment'] }),
+        'order-detail',
+    );
+
+    if (errorMessage) {
+        console.warn(
+            'Query extension error:',
+            errorMessage,
+            'The page will continue with the default query.',
+        );
+    }
+
     const result: ResultOf<typeof orderDetailDocument> = await context.queryClient.ensureQueryData(
-        getDetailQueryOptions(
-            addCustomFields(orderDetailDocument, { includeNestedFragments: ['OrderLine', 'Fulfillment'] }),
-            { id: params.id },
-        ),
+        getDetailQueryOptions(extendedQuery, { id: params.id }),
     );
 
     if (!result.order) {

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
@@ -7,23 +7,19 @@ import { redirect } from '@tanstack/react-router';
 import { OrderDetail } from '../components/order-detail-shared.js';
 import { orderDetailDocument } from '../orders.graphql.js';
 
-async function ensureOrderWithIdExists(context: any, params: { id: string }): Promise<OrderDetail> {
+async function ensureOrderWithIdExists(
+    context: any,
+    params: { id: string },
+    pageId = 'order-detail',
+): Promise<OrderDetail> {
     if (!params.id) {
         throw new Error('ID param is required');
     }
 
-    const { extendedQuery, errorMessage } = extendDetailFormQuery(
+    const { extendedQuery } = extendDetailFormQuery(
         addCustomFields(orderDetailDocument, { includeNestedFragments: ['OrderLine', 'Fulfillment'] }),
-        'order-detail',
+        pageId,
     );
-
-    if (errorMessage) {
-        console.warn(
-            'Query extension error:',
-            errorMessage,
-            'The page will continue with the default query.',
-        );
-    }
 
     const result: ResultOf<typeof orderDetailDocument> = await context.queryClient.ensureQueryData(
         getDetailQueryOptions(extendedQuery, { id: params.id }),
@@ -35,10 +31,22 @@ async function ensureOrderWithIdExists(context: any, params: { id: string }): Pr
     return result.order;
 }
 
-export async function commonRegularOrderLoader(context: any, params: { id: string }): Promise<OrderDetail> {
-    const order = await ensureOrderWithIdExists(context, params);
+function clearPreloadedOrder(context: any, id: string) {
+    context.queryClient.removeQueries({
+        queryKey: getDetailQueryOptions(orderDetailDocument, { id }).queryKey,
+        exact: true,
+    });
+}
+
+export async function commonRegularOrderLoader(
+    context: any,
+    params: { id: string },
+    pageId = 'order-detail',
+): Promise<OrderDetail> {
+    const order = await ensureOrderWithIdExists(context, params, pageId);
 
     if (order.state === 'Draft') {
+        clearPreloadedOrder(context, params.id);
         throw redirect({
             to: `/orders/draft/${params.id}`,
         });
@@ -50,6 +58,7 @@ export async function loadRegularOrder(context: any, params: { id: string }) {
     const order = await commonRegularOrderLoader(context, params);
 
     if (order.state === 'Modifying') {
+        clearPreloadedOrder(context, params.id);
         throw redirect({
             to: `/orders/${params.id}/modify`,
         });
@@ -64,6 +73,7 @@ export async function loadDraftOrder(context: any, params: { id: string }) {
     const order = await ensureOrderWithIdExists(context, params);
 
     if (order.state !== 'Draft') {
+        clearPreloadedOrder(context, params.id);
         throw redirect({
             to: `/orders/${params.id}`,
         });
@@ -75,8 +85,9 @@ export async function loadDraftOrder(context: any, params: { id: string }) {
 }
 
 export async function loadModifyingOrder(context: any, params: { id: string }) {
-    const order = await commonRegularOrderLoader(context, params);
+    const order = await commonRegularOrderLoader(context, params, 'order-modify');
     if (order.state !== 'Modifying') {
+        clearPreloadedOrder(context, params.id);
         throw redirect({
             to: `/orders/${params.id}`,
         });
@@ -99,11 +110,13 @@ export async function loadSellerOrder(
         throw new Error('Both seller order ID and aggregate order ID params are required');
     }
 
+    const { extendedQuery } = extendDetailFormQuery(
+        addCustomFields(orderDetailDocument, { includeNestedFragments: ['OrderLine', 'Fulfillment'] }),
+        'seller-order-detail',
+    );
+
     const result: ResultOf<typeof orderDetailDocument> = await context.queryClient.ensureQueryData(
-        getDetailQueryOptions(
-            addCustomFields(orderDetailDocument, { includeNestedFragments: ['OrderLine', 'Fulfillment'] }),
-            { id: params.sellerOrderId },
-        ),
+        getDetailQueryOptions(extendedQuery, { id: params.sellerOrderId }),
     );
 
     if (!result.order) {
@@ -123,12 +136,14 @@ export async function loadSellerOrder(
     }
 
     if (result.order.state === 'Draft') {
+        clearPreloadedOrder(context, params.sellerOrderId);
         throw redirect({
             to: `/orders/draft/${params.sellerOrderId}`,
         });
     }
 
     if (result.order.state === 'Modifying') {
+        clearPreloadedOrder(context, params.sellerOrderId);
         throw redirect({
             to: `/orders/${params.sellerOrderId}/modify`,
         });


### PR DESCRIPTION
# Description

Fixes: https://github.com/vendurehq/vendure/pull/5169
See: https://github.com/vendurehq/vendure/issues/5159#issuecomment-5407397440

### Summary

Orders get pre-loaded with un-extended order detail query document. When the order detail query gets extended on the order detail page, the extended query never fires due to caching of tanstack query.

# Breaking changes

Does this PR include any breaking changes we should be aware of?

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790238503&installation_model_id=20193&pr_number=5173&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5173&signature=9c0cfbeb23b5e9a952abe83c2e9b28e5216905a0c73122952e027807445351bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->