### PR TITLE
fix(dashboard): match the add-payment option exactly

### DIFF
--- a/docs/docs/reference/graphql-api/shop/mutations.mdx
+++ b/docs/docs/reference/graphql-api/shop/mutations.mdx
@@ -224,7 +224,7 @@ type Mutation {
   }}
 >
 {`"""
-Register a Customer account with the given credentials. There are three possible registration flows:
+Register a Customer account with the given credentials. There are four possible registration flows:
 
 _If \`authOptions.requireVerification\` is set to \`true\`:_
 
@@ -238,6 +238,19 @@ _If \`authOptions.requireVerification\` is set to \`true\`:_
 _If \`authOptions.requireVerification\` is set to \`false\`:_
 
 3. The Customer _must_ be registered _with_ a password. No further action is needed - the Customer is able to authenticate immediately.
+
+_Whatever the setting, if an account already exists for the email address through another authentication strategy
+(for example an SSO provider) and has no password yet:_
+
+4. **The supplied password is never stored.** A verificationToken is created and emailed to the address, and this mutation
+   answers with a generic success so that it does not reveal whether the account exists. The password is set only when that
+   token is passed to the \`verifyCustomerAccount\` mutation _with_ the chosen password, which proves the caller controls the
+   mailbox. This holds even when \`requireVerification\` is \`false\`, so the Customer cannot be authenticated straight after
+   registering. Registering again issues a fresh token and sends the email again.
+
+In every flow the caller-supplied \`firstName\`, \`lastName\`, \`phoneNumber\` and custom fields are ignored whenever a User already
+exists for the email address, since the caller has not proven they own it. This includes an account an administrator created
+earlier. A Customer with no User, such as one left by a guest checkout, is not an account and its details are still filled in.
 """
 type Mutation {
   registerCustomerAccount(input: RegisterCustomerInput!): RegisterCustomerAccountResult!
@@ -609,7 +622,9 @@ type Mutation {
   }}
 >
 {`"""
-Verify a Customer email address with the token sent to that address. Only applicable if \`authOptions.requireVerification\` is set to true.
+Verify a Customer email address with the token sent to that address. Applicable whenever a verificationToken was issued:
+that is when \`authOptions.requireVerification\` is set to true, and also when a password was registered against an account
+that already existed through another authentication strategy, whatever that setting is.
 
 If the Customer was not registered with a password in the \`registerCustomerAccount\` mutation, the password _must_ be
 provided here.

--- a/docs/docs/reference/typescript-api/auth/native-authentication-strategy.mdx
+++ b/docs/docs/reference/typescript-api/auth/native-authentication-strategy.mdx
@@ -2,7 +2,7 @@
 title: "NativeAuthenticationStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/auth/native-authentication-strategy.ts" sourceLine="36" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/auth/native-authentication-strategy.ts" sourceLine="43" packageName="@vendure/core" />
 
 This strategy implements a username/password credential-based authentication, with the credentials
 being stored in the Vendure database. This is the default method of authentication, and it is advised

--- a/docs/docs/reference/typescript-api/request/request-context.mdx
+++ b/docs/docs/reference/typescript-api/request/request-context.mdx
@@ -42,8 +42,8 @@ myMutation(@Ctx() ctx: RequestContext) {
 class RequestContext {
     empty() => RequestContext;
     deserialize(ctxObject: SerializedRequestContext) => RequestContext;
-    userHasPermissions(permissions: Permission[]) => boolean;
-    userHasAllPermissions(permissions: Permission[]) => boolean;
+    userHasPermissions(permissions: Permission[], channelId: ID = this.channelId) => boolean;
+    userHasAllPermissions(permissions: Permission[], channelId: ID = this.channelId) => boolean;
     serialize() => SerializedRequestContext;
     copy(channel?: Channel) => RequestContext;
     req: Request | undefined
@@ -81,10 +81,11 @@ Creates a new RequestContext object from a serialized object created by the
 `serialize()` method.
 ### userHasPermissions
 
-<MemberInfo kind="method" type={`(permissions: <a href='/reference/typescript-api/common/permission#permission'>Permission</a>[]) => boolean`}   />
+<MemberInfo kind="method" type={`(permissions: <a href='/reference/typescript-api/common/permission#permission'>Permission</a>[], channelId: <a href='/reference/typescript-api/common/id#id'>ID</a> = this.channelId) => boolean`}   />
 
 Returns `true` if there is an active Session & User associated with this request,
-and that User has **at least one** of the specified permissions on the active Channel.
+and that User has **at least one** of the specified permissions on the given Channel.
+The Channel defaults to the active Channel of this request.
 
 This method uses OR logic - it checks if the user has ANY of the given permissions,
 not ALL of them. For AND logic, use `userHasAllPermissions`.
@@ -92,15 +93,19 @@ not ALL of them. For AND logic, use `userHasAllPermissions`.
 *Example*
 
 ```ts
-// Returns true if user has ReadProduct OR ReadCatalog
+// Returns true if user has ReadProduct OR ReadCatalog on the active Channel
 ctx.userHasPermissions([Permission.ReadProduct, Permission.ReadCatalog]);
+
+// Returns true if user has UpdateChannel on the Channel with the given id
+ctx.userHasPermissions([Permission.UpdateChannel], channelId);
 ```
 ### userHasAllPermissions
 
-<MemberInfo kind="method" type={`(permissions: <a href='/reference/typescript-api/common/permission#permission'>Permission</a>[]) => boolean`}  since="3.6.0"  />
+<MemberInfo kind="method" type={`(permissions: <a href='/reference/typescript-api/common/permission#permission'>Permission</a>[], channelId: <a href='/reference/typescript-api/common/id#id'>ID</a> = this.channelId) => boolean`}  since="3.6.0"  />
 
 Returns `true` if there is an active Session & User associated with this request,
-and that User has **all** of the specified permissions on the active Channel.
+and that User has **all** of the specified permissions on the given Channel.
+The Channel defaults to the active Channel of this request.
 
 This method uses AND logic - it checks if the user has EVERY one of the given permissions.
 For OR logic (any permission), use `userHasPermissions`.
@@ -108,8 +113,11 @@ For OR logic (any permission), use `userHasPermissions`.
 *Example*
 
 ```ts
-// Returns true only if user has BOTH ReadProduct AND UpdateProduct
+// Returns true only if user has BOTH ReadProduct AND UpdateProduct on the active Channel
 ctx.userHasAllPermissions([Permission.ReadProduct, Permission.UpdateProduct]);
+
+// Returns true only if user has BOTH permissions on the Channel with the given id
+ctx.userHasAllPermissions([Permission.ReadProduct, Permission.UpdateProduct], channelId);
 ```
 ### serialize
 

--- a/docs/docs/reference/typescript-api/services/administrator-service.mdx
+++ b/docs/docs/reference/typescript-api/services/administrator-service.mdx
@@ -32,6 +32,9 @@ Get a paginated list of Administrators.
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, administratorId: <a href='/reference/typescript-api/common/id#id'>ID</a>, relations?: RelationPaths<<a href='/reference/typescript-api/entities/administrator#administrator'>Administrator</a>>) => Promise<<a href='/reference/typescript-api/entities/administrator#administrator'>Administrator</a> | undefined>`}   />
 
 Get an Administrator by id.
+
+Resolves to `undefined` if the Administrator is not visible to the active user, so that a
+caller cannot confirm the existence of an Administrator they are not allowed to see.
 ### findOneByUserId
 
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, userId: <a href='/reference/typescript-api/common/id#id'>ID</a>, relations?: RelationPaths<<a href='/reference/typescript-api/entities/administrator#administrator'>Administrator</a>>) => Promise<<a href='/reference/typescript-api/entities/administrator#administrator'>Administrator</a> | undefined>`}   />

--- a/docs/docs/reference/typescript-api/services/channel-service.mdx
+++ b/docs/docs/reference/typescript-api/services/channel-service.mdx
@@ -2,7 +2,7 @@
 title: "ChannelService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/channel.service.ts" sourceLine="54" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/channel.service.ts" sourceLine="61" packageName="@vendure/core" />
 
 Contains methods relating to [Channel](/reference/typescript-api/entities/channel#channel) entities.
 
@@ -84,12 +84,16 @@ Returns the default Channel.
 
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, input: UpdateChannelInput) => Promise<<a href='/reference/typescript-api/errors/error-result-union#errorresultunion'>ErrorResultUnion</a><UpdateChannelResult, <a href='/reference/typescript-api/entities/channel#channel'>Channel</a>>>`}   />
 
-
+Updates a Channel. Throws a ForbiddenError if the active user does not hold the
+`UpdateChannel` permission on the target Channel. A SuperAdmin is exempt. A RequestContext
+with no session skips the check.
 ### delete
 
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, id: <a href='/reference/typescript-api/common/id#id'>ID</a>) => Promise<DeletionResponse>`}   />
 
-
+Deletes a Channel. Throws a ForbiddenError if the active user does not hold the
+`DeleteChannel` permission on the target Channel. A SuperAdmin is exempt. A RequestContext
+with no session skips the check.
 ### isChannelAware
 
 <MemberInfo kind="method" type={`(entity: <a href='/reference/typescript-api/entities/vendure-entity#vendureentity'>VendureEntity</a>) => entity is <a href='/reference/typescript-api/entities/vendure-entity#vendureentity'>VendureEntity</a> &#38; <a href='/reference/typescript-api/entities/interfaces#channelaware'>ChannelAware</a>`}   />

--- a/docs/docs/reference/typescript-api/services/customer-service.mdx
+++ b/docs/docs/reference/typescript-api/services/customer-service.mdx
@@ -103,6 +103,13 @@ Registers a new Customer account with the [NativeAuthenticationStrategy](/refere
 the email verification flow (unless [AuthOptions](/reference/typescript-api/auth/auth-options#authoptions) `requireVerification` is set to `false`)
 by publishing an [AccountRegistrationEvent](/reference/typescript-api/events/event-types#accountregistrationevent).
 
+If an account with the given email address already exists via another authentication method
+(for example an external/SSO strategy) and has no native credential yet, a native credential is
+added in an unactivated state (no password) and an [AccountRegistrationEvent](/reference/typescript-api/events/event-types#accountregistrationevent) is always
+published, even when `requireVerification` is `false`. The password can then only be set by
+whoever controls the email address, by completing the verification flow. This prevents an
+unauthenticated caller from taking over such an account by registering a password against it.
+
 This method is intended to be used in storefront Customer-creation flows.
 ### refreshVerificationToken
 

--- a/docs/docs/reference/typescript-api/services/fulfillment-service.mdx
+++ b/docs/docs/reference/typescript-api/services/fulfillment-service.mdx
@@ -2,7 +2,7 @@
 title: "FulfillmentService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/fulfillment.service.ts" sourceLine="34" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/fulfillment.service.ts" sourceLine="36" packageName="@vendure/core" />
 
 Contains methods relating to [Fulfillment](/reference/typescript-api/entities/fulfillment#fulfillment) entities.
 
@@ -37,7 +37,16 @@ Creates a new Fulfillment for the given Orders and OrderItems, using the specifi
 
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, id: <a href='/reference/typescript-api/common/id#id'>ID</a>) => Promise<<a href='/reference/typescript-api/entities/order-line-reference#fulfillmentline'>FulfillmentLine</a>[]>`}   />
 
+Loads the FulfillmentLines of a Fulfillment by id with no Channel check. Fulfillment is not
+ChannelAware, so its only Channel boundary is the parent Order, and a caller must load that
+Order in the current Channel first.
 
+This is safe for the core callers, the `Fulfillment.lines` and `Fulfillment.summary` field
+resolvers, because neither takes an id from the client: a Fulfillment is reachable only
+through `Order.fulfillments` or `FulfillmentLine.fulfillment`, and neither API has a root
+Fulfillment query. Scoping the read was considered and rejected, because it adds a joined
+Order query per Fulfillment per request on both APIs to guard a path no client can reach.
+Add the check here if a root Fulfillment query is introduced.
 ### getFulfillmentsLinesForOrderLine
 
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, orderLineId: <a href='/reference/typescript-api/common/id#id'>ID</a>, relations: RelationPaths<<a href='/reference/typescript-api/entities/order-line-reference#fulfillmentline'>FulfillmentLine</a>> = []) => Promise<<a href='/reference/typescript-api/entities/order-line-reference#fulfillmentline'>FulfillmentLine</a>[]>`}   />

--- a/docs/docs/reference/typescript-api/services/history-service.mdx
+++ b/docs/docs/reference/typescript-api/services/history-service.mdx
@@ -2,7 +2,7 @@
 title: "HistoryService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/history.service.ts" sourceLine="253" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/history.service.ts" sourceLine="256" packageName="@vendure/core" />
 
 Contains methods relating to [HistoryEntry](/reference/typescript-api/entities/history-entry#historyentry) entities. Histories are timelines of actions
 related to a particular Customer or Order, recording significant events such as creation, state changes,
@@ -109,9 +109,9 @@ class HistoryService {
     getHistoryForCustomer(ctx: RequestContext, customerId: ID, publicOnly: boolean, options?: HistoryEntryListOptions) => Promise<PaginatedList<CustomerHistoryEntry>>;
     createHistoryEntryForCustomer(args: CreateCustomerHistoryEntryArgs<T>, isPublic:  = false) => Promise<CustomerHistoryEntry>;
     updateOrderHistoryEntry(ctx: RequestContext, args: UpdateOrderHistoryEntryArgs<T>) => ;
-    deleteOrderHistoryEntry(ctx: RequestContext, id: ID) => Promise<void>;
+    deleteOrderHistoryEntry(ctx: RequestContext, id: ID, options?: { type?: HistoryEntryType }) => Promise<void>;
     updateCustomerHistoryEntry(ctx: RequestContext, args: UpdateCustomerHistoryEntryArgs<T>) => ;
-    deleteCustomerHistoryEntry(ctx: RequestContext, id: ID) => Promise<void>;
+    deleteCustomerHistoryEntry(ctx: RequestContext, id: ID, options?: { type?: HistoryEntryType }) => Promise<void>;
 }
 ```
 
@@ -144,9 +144,10 @@ class HistoryService {
 
 ### deleteOrderHistoryEntry
 
-<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, id: <a href='/reference/typescript-api/common/id#id'>ID</a>) => Promise<void>`}   />
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, id: <a href='/reference/typescript-api/common/id#id'>ID</a>, options?: { type?: HistoryEntryType }) => Promise<void>`}   />
 
-
+Deletes an OrderHistoryEntry. Pass `options.type` to restrict the deletion to entries of that
+type, which is how the `deleteOrderNote` mutation avoids deleting any other kind of entry.
 ### updateCustomerHistoryEntry
 
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, args: UpdateCustomerHistoryEntryArgs<T>) => `}   />
@@ -154,9 +155,10 @@ class HistoryService {
 
 ### deleteCustomerHistoryEntry
 
-<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, id: <a href='/reference/typescript-api/common/id#id'>ID</a>) => Promise<void>`}   />
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, id: <a href='/reference/typescript-api/common/id#id'>ID</a>, options?: { type?: HistoryEntryType }) => Promise<void>`}   />
 
-
+Deletes a CustomerHistoryEntry. Pass `options.type` to restrict the deletion to entries of that
+type, which is how the `deleteCustomerNote` mutation avoids deleting any other kind of entry.
 
 
 </div>

--- a/docs/docs/reference/typescript-api/services/order-service.mdx
+++ b/docs/docs/reference/typescript-api/services/order-service.mdx
@@ -2,7 +2,7 @@
 title: "OrderService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/order.service.ts" sourceLine="145" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/order.service.ts" sourceLine="149" packageName="@vendure/core" />
 
 Contains methods relating to [Order](/reference/typescript-api/entities/order#order) entities.
 

--- a/docs/docs/reference/typescript-api/services/payment-service.mdx
+++ b/docs/docs/reference/typescript-api/services/payment-service.mdx
@@ -2,7 +2,7 @@
 title: "PaymentService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/payment.service.ts" sourceLine="43" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/payment.service.ts" sourceLine="44" packageName="@vendure/core" />
 
 Contains methods relating to [Payment](/reference/typescript-api/entities/payment#payment) entities.
 
@@ -32,7 +32,11 @@ class PaymentService {
 
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, id: <a href='/reference/typescript-api/common/id#id'>ID</a>, relations: string[] = ['order']) => Promise<<a href='/reference/typescript-api/entities/payment#payment'>Payment</a>>`}   />
 
-
+Loads a Payment by id with no Channel check. Payment is not ChannelAware, so callers must first
+load the parent Order in the current Channel (or use a path which does, such as the private
+`getPaymentInChannelOrThrow` used by the payment mutations). The only core caller is the
+`Refund.lines` field resolver, which is reached from an Order already loaded in the current
+Channel.
 ### transitionToState
 
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, paymentId: <a href='/reference/typescript-api/common/id#id'>ID</a>, state: <a href='/reference/typescript-api/payment/payment-state#paymentstate'>PaymentState</a>) => Promise<<a href='/reference/typescript-api/entities/payment#payment'>Payment</a> | PaymentStateTransitionError>`}   />

--- a/docs/docs/reference/typescript-api/services/product-variant-service.mdx
+++ b/docs/docs/reference/typescript-api/services/product-variant-service.mdx
@@ -27,7 +27,7 @@ class ProductVariantService {
     update(ctx: RequestContext, input: UpdateProductVariantInput[]) => Promise<Array<Translated<ProductVariant>>>;
     createOrUpdateProductVariantPrice(ctx: RequestContext, productVariantId: ID, price: number, channelId: ID, currencyCode?: CurrencyCode, customFields?: CustomFieldsObject) => Promise<ProductVariantPrice>;
     deleteProductVariantPrice(ctx: RequestContext, variantId: ID, channelId: ID, currencyCode: CurrencyCode) => ;
-    softDelete(ctx: RequestContext, id: ID | ID[]) => Promise<DeletionResponse>;
+    softDelete(ctx: RequestContext, id: ID | ID[], checkChannel: boolean = true) => Promise<DeletionResponse>;
     hydratePriceFields(ctx: RequestContext, variant: ProductVariant, priceField: F) => Promise<ProductVariant[F]>;
     applyChannelPriceAndTax(variant: ProductVariant, ctx: RequestContext, order?: Order, throwIfNoPriceFound:  = false) => Promise<ProductVariant>;
     assignProductVariantsToChannel(ctx: RequestContext, input: AssignProductVariantsToChannelInput) => Promise<Array<Translated<ProductVariant>>>;
@@ -136,9 +136,13 @@ If the `currencyCode` is not specified, the default currency of the Channel will
 
 ### softDelete
 
-<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, id: <a href='/reference/typescript-api/common/id#id'>ID</a> | <a href='/reference/typescript-api/common/id#id'>ID</a>[]) => Promise<DeletionResponse>`}   />
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, id: <a href='/reference/typescript-api/common/id#id'>ID</a> | <a href='/reference/typescript-api/common/id#id'>ID</a>[], checkChannel: boolean = true) => Promise<DeletionResponse>`}   />
 
+Soft-deletes the ProductVariant(s) with the given id(s).
 
+The lookup is scoped to the active Channel, so an id which does not belong to
+`ctx.channelId` throws an [EntityNotFoundError](/reference/typescript-api/errors/error-types#entitynotfounderror). Previously an unknown or
+out-of-channel id was silently reported as deleted.
 ### hydratePriceFields
 
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, variant: <a href='/reference/typescript-api/entities/product-variant#productvariant'>ProductVariant</a>, priceField: F) => Promise<<a href='/reference/typescript-api/entities/product-variant#productvariant'>ProductVariant</a>[F]>`}   />

--- a/docs/docs/reference/typescript-api/services/role-service.mdx
+++ b/docs/docs/reference/typescript-api/services/role-service.mdx
@@ -12,6 +12,7 @@ class RoleService {
     initRoles() => ;
     findAll(ctx: RequestContext, options?: ListQueryOptions<Role>, relations?: RelationPaths<Role>) => Promise<PaginatedList<Role>>;
     findOne(ctx: RequestContext, roleId: ID, relations?: RelationPaths<Role>) => Promise<Role | undefined>;
+    activeUserHasPermissionsOfRoles(ctx: RequestContext, roleIds: ID[]) => Promise<boolean>;
     getChannelsForRole(ctx: RequestContext, roleId: ID) => Promise<Channel[]>;
     getSuperAdminRole(ctx?: RequestContext) => Promise<Role>;
     getCustomerRole(ctx?: RequestContext) => Promise<Role>;
@@ -43,6 +44,17 @@ class RoleService {
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, roleId: <a href='/reference/typescript-api/common/id#id'>ID</a>, relations?: RelationPaths<<a href='/reference/typescript-api/entities/role#role'>Role</a>>) => Promise<<a href='/reference/typescript-api/entities/role#role'>Role</a> | undefined>`}   />
 
 
+### activeUserHasPermissionsOfRoles
+
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, roleIds: <a href='/reference/typescript-api/common/id#id'>ID</a>[]) => Promise<boolean>`}  since="3.7.3"  />
+
+Returns `true` if the active user holds every Permission granted by the given Roles, on every
+Channel to which those Roles are assigned. This is the one rule which decides whether the active
+user may read a Role, grant it to an Administrator, or see an Administrator who holds it.
+
+The Roles are always read from the database, never from the Role cache. The answer authorises
+writes, and a Role missing from a stale cache would be treated as granting nothing, which is
+the wrong direction to fail in.
 ### getChannelsForRole
 
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, roleId: <a href='/reference/typescript-api/common/id#id'>ID</a>) => Promise<<a href='/reference/typescript-api/entities/channel#channel'>Channel</a>[]>`}   />

--- a/docs/docs/reference/typescript-api/services/user-service.mdx
+++ b/docs/docs/reference/typescript-api/services/user-service.mdx
@@ -13,6 +13,7 @@ class UserService {
     getUserByEmailAddress(ctx: RequestContext, emailAddress: string, userType?: 'administrator' | 'customer') => Promise<User | undefined>;
     createCustomerUser(ctx: RequestContext, identifier: string, password?: string) => Promise<User | PasswordValidationError>;
     addNativeAuthenticationMethod(ctx: RequestContext, user: User, identifier: string, password?: string) => Promise<User | PasswordValidationError>;
+    addUnactivatedNativeAuthenticationMethod(ctx: RequestContext, user: User, identifier: string, password?: string) => Promise<User | PasswordValidationError>;
     createAdminUser(ctx: RequestContext, identifier: string, password: string) => Promise<User>;
     createApiKeyUser(ctx: RequestContext, roles: Role[], identifier: string) => Promise<User>;
     softDelete(ctx: RequestContext, userId: ID) => ;
@@ -57,6 +58,30 @@ Creates a new User with the special `customer` Role and using the [NativeAuthent
 Adds a new [NativeAuthenticationMethod](/reference/typescript-api/entities/authentication-method#nativeauthenticationmethod) to the User. If the [AuthOptions](/reference/typescript-api/auth/auth-options#authoptions) `requireVerification`
 is set to `true` (as is the default), the User will be marked as unverified until the email verification
 flow is completed.
+### addUnactivatedNativeAuthenticationMethod
+
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, user: <a href='/reference/typescript-api/entities/user#user'>User</a>, identifier: string, password?: string) => Promise<<a href='/reference/typescript-api/entities/user#user'>User</a> | PasswordValidationError>`}   />
+
+Adds an unactivated [NativeAuthenticationMethod](/reference/typescript-api/entities/authentication-method#nativeauthenticationmethod) (empty password, pending
+`verificationToken`) to an existing User, without altering the User's `verified` state.
+
+If the User already carries a native credential with a pending `verificationToken`, a fresh one
+is issued for it instead. This lets the mailbox owner restart the flow when the first message
+was lost or its token has expired.
+
+The guarantee this method makes is that it never stores a password. A password already on the
+credential is left as it is, and the `password` argument is discarded.
+
+This is used when a native credential is being registered against an account that already
+exists via another authentication method (e.g. an external/SSO strategy). The credential is
+left without a password so that it can only be activated by whoever controls the email
+address, via the verification flow. Storing a caller-supplied password here would allow an
+unauthenticated account takeover (GHSA-wr5h-x3x6-4h23).
+
+If a `password` is supplied it is validated and hashed, but the hash is deliberately NOT
+stored. Doing the same work as a brand-new registration keeps this path indistinguishable from
+one, both in its error result and in how long it takes, so it does not become an
+account-existence oracle.
 ### createAdminUser
 
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, identifier: string, password: string) => Promise<<a href='/reference/typescript-api/entities/user#user'>User</a>>`}   />

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1068,7 +1068,7 @@
                   "title": "NativeAuthenticationStrategy",
                   "slug": "native-authentication-strategy",
                   "file": "docs/reference/typescript-api/auth/native-authentication-strategy.mdx",
-                  "lastModified": "2026-02-09T11:17:54+01:00"
+                  "lastModified": "2026-08-25T13:57:08Z"
                 },
                 {
                   "title": "NoopSessionCacheStrategy",
@@ -2766,7 +2766,7 @@
                   "title": "RequestContext",
                   "slug": "request-context",
                   "file": "docs/reference/typescript-api/request/request-context.mdx",
-                  "lastModified": "2026-08-17T12:00:11+02:00"
+                  "lastModified": "2026-08-25T13:57:08Z"
                 },
                 {
                   "title": "RequestContextService",
@@ -2892,7 +2892,7 @@
                   "title": "AdministratorService",
                   "slug": "administrator-service",
                   "file": "docs/reference/typescript-api/services/administrator-service.mdx",
-                  "lastModified": "2026-07-24T11:20:03+02:00"
+                  "lastModified": "2026-08-25T13:57:08Z"
                 },
                 {
                   "title": "AssetService",
@@ -2910,7 +2910,7 @@
                   "title": "ChannelService",
                   "slug": "channel-service",
                   "file": "docs/reference/typescript-api/services/channel-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-25T13:57:08Z"
                 },
                 {
                   "title": "CollectionService",
@@ -2940,7 +2940,7 @@
                   "title": "CustomerService",
                   "slug": "customer-service",
                   "file": "docs/reference/typescript-api/services/customer-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-25T13:57:08Z"
                 },
                 {
                   "title": "EntitySlugService",
@@ -2964,7 +2964,7 @@
                   "title": "FulfillmentService",
                   "slug": "fulfillment-service",
                   "file": "docs/reference/typescript-api/services/fulfillment-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-25T13:57:08Z"
                 },
                 {
                   "title": "GlobalSettingsService",
@@ -2976,7 +2976,7 @@
                   "title": "HistoryService",
                   "slug": "history-service",
                   "file": "docs/reference/typescript-api/services/history-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-25T13:57:08Z"
                 },
                 {
                   "title": "InitializerService",
@@ -2988,7 +2988,7 @@
                   "title": "OrderService",
                   "slug": "order-service",
                   "file": "docs/reference/typescript-api/services/order-service.mdx",
-                  "lastModified": "2026-08-17T12:00:11+02:00"
+                  "lastModified": "2026-08-25T13:57:08Z"
                 },
                 {
                   "title": "OrderTestingService",
@@ -3006,7 +3006,7 @@
                   "title": "PaymentService",
                   "slug": "payment-service",
                   "file": "docs/reference/typescript-api/services/payment-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-25T13:57:08Z"
                 },
                 {
                   "title": "ProductOptionGroupService",
@@ -3030,7 +3030,7 @@
                   "title": "ProductVariantService",
                   "slug": "product-variant-service",
                   "file": "docs/reference/typescript-api/services/product-variant-service.mdx",
-                  "lastModified": "2026-06-24T18:05:35+02:00"
+                  "lastModified": "2026-08-25T13:57:08Z"
                 },
                 {
                   "title": "PromotionService",
@@ -3048,7 +3048,7 @@
                   "title": "RoleService",
                   "slug": "role-service",
                   "file": "docs/reference/typescript-api/services/role-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-25T13:57:08Z"
                 },
                 {
                   "title": "SearchService",
@@ -3126,7 +3126,7 @@
                   "title": "UserService",
                   "slug": "user-service",
                   "file": "docs/reference/typescript-api/services/user-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-25T13:57:08Z"
                 },
                 {
                   "title": "ZoneService",
@@ -3798,7 +3798,7 @@
                   "title": "Mutations",
                   "slug": "mutations",
                   "file": "docs/reference/graphql-api/shop/mutations.mdx",
-                  "lastModified": "2026-03-05T15:08:55+01:00"
+                  "lastModified": "2026-08-25T13:57:08Z"
                 },
                 {
                   "title": "Queries",

--- a/packages/dashboard/e2e/tests/sales/orders.spec.ts
+++ b/packages/dashboard/e2e/tests/sales/orders.spec.ts
@@ -602,7 +602,13 @@ test.describe('Orders', () => {
             await expect(selectPaymentMethod).toBeVisible({ timeout: 10_000 });
             await selectPaymentMethod.click();
 
-            const standardPayment = dialog.getByRole('option', { name: /Test Payment/ });
+            // Options are labelled `${name} (${code})`. Match `test-payment` (created by
+            // `createNewOrder`) exactly: `payment-methods.spec.ts` creates "E2E Test Payment",
+            // and a substring match resolves to both until that spec renames or deletes it.
+            const standardPayment = dialog.getByRole('option', {
+                name: 'Test Payment (test-payment)',
+                exact: true,
+            });
             await expect(standardPayment).toBeVisible({ timeout: 10_000 });
             await standardPayment.click();
 
@@ -828,8 +834,12 @@ async function createFulfilledOrder(client: VendureAdminClient): Promise<string>
  * Admin API, and returns the order ID.
  */
 async function createNewOrder(client: VendureAdminClient) {
-    // Ensure a payment method exists
-    const { paymentMethods } = await client.gql(`query { paymentMethods { items { id } } }`);
+    // Ensure `test-payment` exists. Filter by code rather than checking for an empty
+    // list: `payment-methods.spec.ts` creates its own method, and specs run in parallel,
+    // so an unfiltered list can be non-empty without `test-payment` in it.
+    const { paymentMethods } = await client.gql(
+        `query { paymentMethods(options: { filter: { code: { eq: "test-payment" } } }) { items { id } } }`,
+    );
     if (paymentMethods.items.length === 0) {
         await client.gql(`
             mutation {


### PR DESCRIPTION
# Description

`dashboard e2e (3)` has been failing on unrelated PRs. Same signature every time:

```
strict mode violation: locator('[role="dialog"]').getByRole('option', { name: /Test Payment/ })
resolved to 2 elements
```

Payment method options are labelled `${name} (${code})` (`add-manual-payment-dialog.tsx:109`). `createNewOrder` creates `Test Payment (test-payment)` at runtime. `payment-methods.spec.ts` creates `E2E Test Payment (e2e-test-payment)`, so the unanchored `/Test Payment/` in `orders.spec.ts:605` matches both from that spec's create test until its update test renames the row. Specs run in parallel, so the window is real.

The knock-on effect is what took the shard down. `orders.spec.ts:12` sets `mode: 'serial'`, so the failure retried the whole `Orders` block from the top. On the retry `should create, configure, and complete a draft order` ran against a database the first pass had already populated and timed out after a minute, and the remaining 17 tests in the file were skipped.

Two changes:

- Match `Test Payment (test-payment)` exactly.
- Scope the guard in `createNewOrder` to `code: { eq: "test-payment" }`. It previously created the method only when the payment method list came back empty, which is the same race in reverse: if `payment-methods.spec.ts` creates its method first, the list is non-empty, `test-payment` is never created, and the exact locator matches nothing.

Observed on #5090, #5171 and #5173 within 24 hours, always shard 3, always tests 75 and 86. That shard matrix does not run on master pushes, which is why it went unnoticed.

# Breaking changes

None. Test-only.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed