### PR TITLE
fix(core): correct inverse side of CustomerGroup.taxRates relation

### DIFF
--- a/packages/core/src/entity/customer-group/customer-group.entity.ts
+++ b/packages/core/src/entity/customer-group/customer-group.entity.ts
@@ -28,6 +28,6 @@ export class CustomerGroup extends VendureEntity implements HasCustomFields {
     @Column(type => CustomCustomerGroupFields)
     customFields: CustomCustomerGroupFields;
 
-    @OneToMany(type => TaxRate, taxRate => taxRate.zone)
+    @OneToMany(type => TaxRate, taxRate => taxRate.customerGroup)
     taxRates: TaxRate[];
 }


### PR DESCRIPTION
`CustomerGroup.taxRates` declared its inverse side as `taxRate => taxRate.zone`, while `TaxRate.customerGroup` declares its own as
`customerGroup => customerGroup.taxRates`. The two halves of the relation therefore disagree, and TypeORM resolves `CustomerGroup.taxRates` through `TaxRate.zoneId` - so the property returns tax rates whose *zone* id happens to match the group id, rather than the tax rates belonging to that customer group.

It looks like a copy-paste from `Zone.taxRates` directly above it, which is correctly `taxRate => taxRate.zone`.

No behaviour change in core: nothing currently reads `CustomerGroup.taxRates`, so this is latent rather than user-visible. It does affect anyone loading the relation from a plugin or custom query.

# Description

Please include a summary of the changes and the related issue.

# Breaking changes

Does this PR include any breaking changes we should be aware of?

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790260598&installation_model_id=20193&pr_number=5176&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5176&signature=0be453f1ab0ee39ac7eb7e11fc7642d4d74ec4d86d75c05beab9d0ec7281be69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->