### PR TITLE
fix(dashboard): refresh tax category selector after mutations

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_tax-categories/components/tax-category-bulk-actions.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_tax-categories/components/tax-category-bulk-actions.tsx
@@ -8,6 +8,7 @@ export const DeleteTaxCategoriesBulkAction: BulkActionComponent<any> = ({ select
             mutationDocument={deleteTaxCategoriesDocument}
             entityName="tax categories"
             requiredPermissions={['DeleteTaxCategory']}
+            invalidateQueries={['taxCategories']}
             selection={selection}
             table={table}
         />

--- a/packages/dashboard/src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
@@ -16,6 +16,7 @@ import { ActionBarItem } from '@/vdb/framework/layout-engine/action-bar-item-wra
 import { detailPageRouteLoader } from '@/vdb/framework/page/detail-page-route-loader.js';
 import { useDetailPage } from '@/vdb/framework/page/use-detail-page.js';
 import { Trans, useLingui } from '@lingui/react/macro';
+import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { toast } from 'sonner';
 import {
@@ -46,6 +47,7 @@ function TaxCategoryDetailPage() {
     const navigate = useNavigate();
     const creatingNewEntity = params.id === NEW_ENTITY_PATH;
     const { t } = useLingui();
+    const queryClient = useQueryClient();
 
     const { form, submitHandler, entity, isPending, resetForm } = useDetailPage({
         pageId,
@@ -67,6 +69,7 @@ function TaxCategoryDetailPage() {
                     ? t`Successfully created tax category`
                     : t`Successfully updated tax category`,
             );
+            await queryClient.invalidateQueries({ queryKey: ['taxCategories'] });
             form.reset(form.getValues());
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });


### PR DESCRIPTION
Relates to #5177

# Description

The **Tax category** dropdown on the Tax Rate detail/create page in the dashboard was showing a stale list. `TaxCategorySelector` caches its options under the react-query key `['taxCategories']` with a 5-minute `staleTime`, but the tax category create/update and delete flows never invalidated that key. As a result, newly created tax categories were missing from the dropdown and deleted ones remained, until a full page refresh.

This PR invalidates `['taxCategories']` after the relevant mutations, following existing dashboard conventions:

- **Create/update** (`_tax-categories/tax-categories_.$id.tsx`): call `queryClient.invalidateQueries({ queryKey: ['taxCategories'] })` in the detail page `onSuccess`.
- **Delete** (`_tax-categories/components/tax-category-bulk-actions.tsx`): pass `invalidateQueries={['taxCategories']}` to the shared `DeleteBulkAction`.

The dropdown now reflects created and deleted tax categories immediately, without a page refresh.

# Breaking changes

None.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790260968&installation_model_id=20193&pr_number=5178&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5178&signature=cdb2f79f138593826a19a7d0bab57391a1ad100c7e1a41ba9787cf43104ab4de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->