### PR TITLE
fix(dashboard): refresh channel switcher after deleting channels

### DIFF
--- a/packages/dashboard/e2e/tests/settings/channels.spec.ts
+++ b/packages/dashboard/e2e/tests/settings/channels.spec.ts
@@ -151,6 +151,18 @@ test.describe('Channels CRUD', () => {
         await lp.expectSuccessToast();
 
         await expect(lp.getRows().filter({ hasText: 'e2e-test-channel' })).toHaveCount(0);
+
+        // #5179 — the deleted channel must also disappear from the channel
+        // switcher in the sidebar, not just the list. The switcher renders from
+        // the channel provider (me.channels), which the delete bulk action
+        // refreshes via refreshChannels(). Crucially there is no page.reload()
+        // here: a reload would repopulate the switcher from scratch and mask the
+        // bug this asserts.
+        const sidebar = page.locator('[data-slot="sidebar"]');
+        await sidebar.getByRole('button').first().click();
+        const switcherMenu = page.locator('[data-slot="dropdown-menu-content"]');
+        await expect(switcherMenu).toBeVisible();
+        await expect(switcherMenu.getByText('e2e-test-channel')).toHaveCount(0);
     });
 });
 

--- a/packages/dashboard/src/app/routes/_authenticated/_channels/components/channel-bulk-actions.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_channels/components/channel-bulk-actions.tsx
@@ -1,13 +1,16 @@
 import { DeleteBulkAction } from '../../../../common/delete-bulk-action.js';
 import { deleteChannelsDocument } from '../channels.graphql.js';
 import { BulkActionComponent } from '@/vdb/framework/extension-api/types/index.js';
+import { useChannel } from '@/vdb/hooks/use-channel.js';
 
 export const DeleteChannelsBulkAction: BulkActionComponent<any> = ({ selection, table }) => {
+    const { refreshChannels } = useChannel();
     return (
         <DeleteBulkAction
             mutationDocument={deleteChannelsDocument}
             entityName="channels"
             requiredPermissions={['DeleteChannel']}
+            onSuccess={refreshChannels}
             selection={selection}
             table={table}
         />


### PR DESCRIPTION
Relates to #5179

# Description

The **channel switcher** at the top of the dashboard did not update when a channel was deleted — the deleted channel stayed in the switcher dropdown until a full page refresh. (Creating a channel already updated the switcher correctly; only delete was affected.)

The switcher renders its list from `ChannelProvider`, which is built primarily from the auth provider's `me.channels` (`staleTime: Infinity`). Create/update channel flows call `refreshChannels()` in their `onSuccess`, which invalidates `['currentUser']`, `['channels']` and `['activeChannel']`, so the switcher updates. The delete flow went through the generic `DeleteBulkAction` with no `onSuccess`, so it only refetched the Channels list-page table and never invalidated the queries the switcher depends on.

This PR wires `refreshChannels()` into the channel delete bulk action via the `DeleteBulkAction` `onSuccess` prop, reusing the exact same refresh path as create/update. The deleted channel now disappears from the switcher immediately, without a page refresh.

# Breaking changes

None.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790261400&installation_model_id=20193&pr_number=5181&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5181&signature=edc23c22dad5a6d68da07203782e436793e78453c67ae71bc700b379511124f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->