### PR TITLE
fix(dashboard): refresh zone selector after mutations

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
@@ -14,6 +14,7 @@ export const DeleteZonesBulkAction: BulkActionComponent<any> = ({ selection, tab
             mutationDocument={deleteZonesDocument}
             entityName="zones"
             requiredPermissions={['DeleteZone']}
+            invalidateQueries={['zones']}
             selection={selection}
             table={table}
         />

--- a/packages/dashboard/src/app/routes/_authenticated/_zones/zones_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_zones/zones_.$id.tsx
@@ -16,6 +16,7 @@ import {
 import { detailPageRouteLoader } from '@/vdb/framework/page/detail-page-route-loader.js';
 import { useDetailPage } from '@/vdb/framework/page/use-detail-page.js';
 import { Trans, useLingui } from '@lingui/react/macro';
+import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { toast } from 'sonner';
 import { ZoneCountriesTable } from './components/zone-countries-table.js';
@@ -43,6 +44,7 @@ function ZoneDetailPage() {
     const navigate = useNavigate();
     const creatingNewEntity = params.id === NEW_ENTITY_PATH;
     const { t } = useLingui();
+    const queryClient = useQueryClient();
 
     const { form, submitHandler, entity, isPending, resetForm } = useDetailPage({
         pageId,
@@ -59,6 +61,7 @@ function ZoneDetailPage() {
         params: { id: params.id },
         onSuccess: async data => {
             toast.success(creatingNewEntity ? t`Successfully created zone` : t`Successfully updated zone`);
+            await queryClient.invalidateQueries({ queryKey: ['zones'] });
             resetForm();
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });


### PR DESCRIPTION
Relates to #5182

# Description

The **Zone** dropdown (`ZoneSelector`) in the dashboard was showing a stale list. It is used on the **Tax Rate** detail/create page (zone selection) and on the **Channel** detail page (default tax zone / default shipping zone). `ZoneSelector` caches its options under the react-query key `['zones']` with a 5-minute `staleTime`, but the zone create/update and delete flows never invalidated that key. As a result, newly created zones were missing from the dropdown and deleted ones remained, until a full page refresh.

This PR invalidates `['zones']` after the relevant mutations, following existing dashboard conventions 

- **Create/update** (`_zones/zones_.$id.tsx`): call `queryClient.invalidateQueries({ queryKey: ['zones'] })` in the detail page `onSuccess`.
- **Delete** (`_zones/components/zone-bulk-actions.tsx`): pass `invalidateQueries={['zones']}` to the shared `DeleteBulkAction`.

The dropdown now reflects created and deleted zones immediately, without a page refresh.

# Breaking changes

None.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790262618&installation_model_id=20193&pr_number=5183&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5183&signature=efc6da394f3723513b1633656163b9881a7cc7eb0b3d5a7c42c6d0f1a40ab130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->