### PR TITLE
feat(core): add auth options disable last login update property

### DIFF
--- a/docs/docs/reference/typescript-api/assets/asset-options.mdx
+++ b/docs/docs/reference/typescript-api/assets/asset-options.mdx
@@ -2,7 +2,7 @@
 title: "AssetOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="754" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="764" packageName="@vendure/core" />
 
 The AssetOptions define how assets (images and other files) are named and stored, and how preview images are generated.
 

--- a/docs/docs/reference/typescript-api/auth/auth-options.mdx
+++ b/docs/docs/reference/typescript-api/auth/auth-options.mdx
@@ -29,6 +29,7 @@ interface AuthOptions {
     verificationTokenStrategy?: VerificationTokenStrategy;
     entityAccessControlStrategy?: EntityAccessControlStrategy;
     customerChannelAssignmentStrategy?: CustomerChannelAssignmentStrategy;
+    disableLastLoginUpdate?: boolean;
 }
 ```
 
@@ -199,6 +200,13 @@ Allows you to define access control for entity queries at three levels:
 Determines whether an authenticated Customer is auto-assigned to the active Channel.
 This is skipped for the default channel, `disableAuth`, and registration/checkout flows.
 The default strategy always assigns.
+### disableLastLoginUpdate
+
+<MemberInfo kind="property" type={`boolean`} default={`false`}  since="3.8.0"  />
+
+When set to `true`, the `User.lastLogin` field is not updated when a user logs in.
+Each login otherwise writes to the `user` table, which can become a bottleneck for
+storefronts that authenticate on a large proportion of requests.
 
 
 </div>

--- a/docs/docs/reference/typescript-api/auth/superadmin-credentials.mdx
+++ b/docs/docs/reference/typescript-api/auth/superadmin-credentials.mdx
@@ -2,7 +2,7 @@
 title: "SuperadminCredentials"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="930" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="940" packageName="@vendure/core" />
 
 These credentials will be used to create the Superadmin user & administrator
 when Vendure first bootstraps.

--- a/docs/docs/reference/typescript-api/configuration/entity-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/entity-options.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## EntityOptions
 
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1128" packageName="@vendure/core" since="1.3.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1138" packageName="@vendure/core" since="1.3.0" />
 
 Options relating to the internal handling of entities.
 

--- a/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "RuntimeVendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1432" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1442" packageName="@vendure/core" />
 
 This interface represents the VendureConfig object available at run-time, i.e. the user-supplied
 config values have been merged with the [defaultConfig](/reference/typescript-api/configuration/default-config#defaultconfig) values.

--- a/docs/docs/reference/typescript-api/configuration/system-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/system-options.mdx
@@ -2,7 +2,7 @@
 title: "SystemOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1226" packageName="@vendure/core" since="1.6.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1236" packageName="@vendure/core" since="1.6.0" />
 
 Options relating to system functions.
 

--- a/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "VendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1285" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1295" packageName="@vendure/core" />
 
 All possible configuration options are defined by the
 [`VendureConfig`](https://github.com/vendurehq/vendure/blob/master/packages/core/src/config/vendure-config.ts) interface.

--- a/docs/docs/reference/typescript-api/import-export/import-export-options.mdx
+++ b/docs/docs/reference/typescript-api/import-export/import-export-options.mdx
@@ -2,7 +2,7 @@
 title: "ImportExportOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1028" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1038" packageName="@vendure/core" />
 
 Options related to importing & exporting data.
 

--- a/docs/docs/reference/typescript-api/job-queue/job-queue-options.mdx
+++ b/docs/docs/reference/typescript-api/job-queue/job-queue-options.mdx
@@ -2,7 +2,7 @@
 title: "JobQueueOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1052" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1062" packageName="@vendure/core" />
 
 Options related to the built-in job queue.
 

--- a/docs/docs/reference/typescript-api/orders/order-options.mdx
+++ b/docs/docs/reference/typescript-api/orders/order-options.mdx
@@ -2,7 +2,7 @@
 title: "OrderOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="577" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="587" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/payment/payment-options.mdx
+++ b/docs/docs/reference/typescript-api/payment/payment-options.mdx
@@ -2,7 +2,7 @@
 title: "PaymentOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="952" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="962" packageName="@vendure/core" />
 
 Defines payment-related options in the [VendureConfig](/reference/typescript-api/configuration/vendure-config#vendureconfig).
 

--- a/docs/docs/reference/typescript-api/products-stock/catalog-options.mdx
+++ b/docs/docs/reference/typescript-api/products-stock/catalog-options.mdx
@@ -2,7 +2,7 @@
 title: "CatalogOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="801" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="811" packageName="@vendure/core" />
 
 Options related to products and collections.
 

--- a/docs/docs/reference/typescript-api/promotions/promotion-options.mdx
+++ b/docs/docs/reference/typescript-api/promotions/promotion-options.mdx
@@ -2,7 +2,7 @@
 title: "PromotionOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="863" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="873" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx
+++ b/docs/docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx
@@ -2,7 +2,7 @@
 title: "SchedulerOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1091" packageName="@vendure/core" since="3.3.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1101" packageName="@vendure/core" since="3.3.0" />
 
 Options related to scheduled tasks..
 

--- a/docs/docs/reference/typescript-api/shipping/shipping-options.mdx
+++ b/docs/docs/reference/typescript-api/shipping/shipping-options.mdx
@@ -2,7 +2,7 @@
 title: "ShippingOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="879" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="889" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/tax/tax-options.mdx
+++ b/docs/docs/reference/typescript-api/tax/tax-options.mdx
@@ -2,7 +2,7 @@
 title: "TaxOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="992" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1002" packageName="@vendure/core" />
 
 
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -964,7 +964,7 @@
                   "title": "AssetOptions",
                   "slug": "asset-options",
                   "file": "docs/reference/typescript-api/assets/asset-options.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 },
                 {
                   "title": "AssetPreviewStrategy",
@@ -1014,7 +1014,7 @@
                   "title": "AuthOptions",
                   "slug": "auth-options",
                   "file": "docs/reference/typescript-api/auth/auth-options.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 },
                 {
                   "title": "BcryptPasswordHashingStrategy",
@@ -1110,7 +1110,7 @@
                   "title": "SuperadminCredentials",
                   "slug": "superadmin-credentials",
                   "file": "docs/reference/typescript-api/auth/superadmin-credentials.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 },
                 {
                   "title": "VerificationTokenStrategy",
@@ -1438,7 +1438,7 @@
                   "title": "EntityOptions",
                   "slug": "entity-options",
                   "file": "docs/reference/typescript-api/configuration/entity-options.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 },
                 {
                   "title": "MergeConfig",
@@ -1462,7 +1462,7 @@
                   "title": "RuntimeVendureConfig",
                   "slug": "runtime-vendure-config",
                   "file": "docs/reference/typescript-api/configuration/runtime-vendure-config.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 },
                 {
                   "title": "SecretAccessStrategy",
@@ -1486,7 +1486,7 @@
                   "title": "SystemOptions",
                   "slug": "system-options",
                   "file": "docs/reference/typescript-api/configuration/system-options.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 },
                 {
                   "title": "TrustProxyOptions",
@@ -1498,7 +1498,7 @@
                   "title": "VendureConfig",
                   "slug": "vendure-config",
                   "file": "docs/reference/typescript-api/configuration/vendure-config.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -2236,7 +2236,7 @@
                   "title": "ImportExportOptions",
                   "slug": "import-export-options",
                   "file": "docs/reference/typescript-api/import-export/import-export-options.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 },
                 {
                   "title": "ImportParser",
@@ -2316,7 +2316,7 @@
                   "title": "JobQueueOptions",
                   "slug": "job-queue-options",
                   "file": "docs/reference/typescript-api/job-queue/job-queue-options.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 },
                 {
                   "title": "JobQueueService",
@@ -2576,7 +2576,7 @@
                   "title": "OrderOptions",
                   "slug": "order-options",
                   "file": "docs/reference/typescript-api/orders/order-options.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 },
                 {
                   "title": "OrderPlacedStrategy",
@@ -2662,7 +2662,7 @@
                   "title": "PaymentOptions",
                   "slug": "payment-options",
                   "file": "docs/reference/typescript-api/payment/payment-options.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 },
                 {
                   "title": "PaymentProcess",
@@ -2756,7 +2756,7 @@
                   "title": "CatalogOptions",
                   "slug": "catalog-options",
                   "file": "docs/reference/typescript-api/products-stock/catalog-options.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 },
                 {
                   "title": "DefaultProductVariantPriceCalculationStrategy",
@@ -2830,7 +2830,7 @@
                   "title": "PromotionOptions",
                   "slug": "promotion-options",
                   "file": "docs/reference/typescript-api/promotions/promotion-options.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -2924,7 +2924,7 @@
                   "title": "SchedulerOptions",
                   "slug": "scheduler-options",
                   "file": "docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 },
                 {
                   "title": "SchedulerService",
@@ -3346,7 +3346,7 @@
                   "title": "ShippingOptions",
                   "slug": "shipping-options",
                   "file": "docs/reference/typescript-api/shipping/shipping-options.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 },
                 {
                   "title": "ShouldRunCheckFn",
@@ -3422,7 +3422,7 @@
                   "title": "TaxOptions",
                   "slug": "tax-options",
                   "file": "docs/reference/typescript-api/tax/tax-options.mdx",
-                  "lastModified": "2026-07-31T11:54:35+02:00"
+                  "lastModified": "2026-08-25T15:27:12Z"
                 },
                 {
                   "title": "TaxZoneStrategy",

--- a/packages/core/e2e/disable-last-login-update.e2e-spec.ts
+++ b/packages/core/e2e/disable-last-login-update.e2e-spec.ts
@@ -1,0 +1,75 @@
+import { mergeConfig } from '@vendure/core';
+import { createTestEnvironment } from '@vendure/testing';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { initialData } from '../../../e2e-common/e2e-initial-data';
+import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
+
+import { getCustomerDocument, getCustomerListDocument } from './graphql/shared-definitions';
+
+describe('authOptions.disableLastLoginUpdate (default false)', () => {
+    const { server, adminClient, shopClient } = createTestEnvironment(testConfig());
+
+    beforeAll(async () => {
+        await server.init({
+            initialData,
+            productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-minimal.csv'),
+            customerCount: 1,
+        });
+        await adminClient.asSuperAdmin();
+    }, TEST_SETUP_TIMEOUT_MS);
+
+    afterAll(async () => {
+        await server.destroy();
+    });
+
+    it('updates User.lastLogin on successful login', async () => {
+        const { customers } = await adminClient.query(getCustomerListDocument);
+        const customer = customers.items[0];
+
+        const before = await adminClient.query(getCustomerDocument, { id: customer.id });
+        expect(before.customer?.user?.lastLogin).toBeNull();
+
+        await shopClient.asUserWithCredentials(customer.emailAddress, 'test');
+
+        const after = await adminClient.query(getCustomerDocument, { id: customer.id });
+        expect(after.customer?.user?.lastLogin).not.toBeNull();
+    });
+});
+
+describe('authOptions.disableLastLoginUpdate (true)', () => {
+    const { server, adminClient, shopClient } = createTestEnvironment(
+        mergeConfig(testConfig(), {
+            authOptions: {
+                disableLastLoginUpdate: true,
+            },
+        }),
+    );
+
+    beforeAll(async () => {
+        await server.init({
+            initialData,
+            productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-minimal.csv'),
+            customerCount: 1,
+        });
+        await adminClient.asSuperAdmin();
+    }, TEST_SETUP_TIMEOUT_MS);
+
+    afterAll(async () => {
+        await server.destroy();
+    });
+
+    it('does not update User.lastLogin on successful login', async () => {
+        const { customers } = await adminClient.query(getCustomerListDocument);
+        const customer = customers.items[0];
+
+        const before = await adminClient.query(getCustomerDocument, { id: customer.id });
+        expect(before.customer?.user?.lastLogin).toBeNull();
+
+        await shopClient.asUserWithCredentials(customer.emailAddress, 'test');
+
+        const after = await adminClient.query(getCustomerDocument, { id: customer.id });
+        expect(after.customer?.user?.lastLogin).toBeNull();
+    });
+});

--- a/packages/core/e2e/disable-last-login-update.e2e-spec.ts
+++ b/packages/core/e2e/disable-last-login-update.e2e-spec.ts
@@ -31,10 +31,15 @@ describe('authOptions.disableLastLoginUpdate (default false)', () => {
         const before = await adminClient.query(getCustomerDocument, { id: customer.id });
         expect(before.customer?.user?.lastLogin).toBeNull();
 
-        await shopClient.asUserWithCredentials(customer.emailAddress, 'test');
+        // Allow 1s slack: some DBs store datetime with second precision.
+        const startOfTest = Date.now() - 1000;
+        const login = await shopClient.asUserWithCredentials(customer.emailAddress, 'test');
+        expect(login.identifier).toBe(customer.emailAddress);
 
         const after = await adminClient.query(getCustomerDocument, { id: customer.id });
-        expect(after.customer?.user?.lastLogin).not.toBeNull();
+        const lastLogin = after.customer!.user!.lastLogin;
+        expect(lastLogin).not.toBeNull();
+        expect(new Date(lastLogin as string).getTime()).toBeGreaterThanOrEqual(startOfTest);
     });
 });
 
@@ -67,9 +72,10 @@ describe('authOptions.disableLastLoginUpdate (true)', () => {
         const before = await adminClient.query(getCustomerDocument, { id: customer.id });
         expect(before.customer?.user?.lastLogin).toBeNull();
 
-        await shopClient.asUserWithCredentials(customer.emailAddress, 'test');
+        const login = await shopClient.asUserWithCredentials(customer.emailAddress, 'test');
+        expect(login.identifier).toBe(customer.emailAddress);
 
         const after = await adminClient.query(getCustomerDocument, { id: customer.id });
-        expect(after.customer?.user?.lastLogin).toBeNull();
+        expect(after.customer!.user!.lastLogin).toBeNull();
     });
 });

--- a/packages/core/src/config/default-config.ts
+++ b/packages/core/src/config/default-config.ts
@@ -116,6 +116,7 @@ export const defaultConfig: RuntimeVendureConfig = {
         sessionCacheStrategy: new DefaultSessionCacheStrategy(),
         sessionCacheTTL: 300,
         requireVerification: true,
+        disableLastLoginUpdate: false,
         verificationTokenDuration: '7d',
         superadminCredentials: {
             identifier: SUPER_ADMIN_USER_IDENTIFIER,

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -568,6 +568,16 @@ export interface AuthOptions {
      * @since 3.7.0
      */
     customerChannelAssignmentStrategy?: CustomerChannelAssignmentStrategy;
+    /**
+     * @description
+     * When set to `true`, the `User.lastLogin` field is not updated when a user logs in.
+     * Each login otherwise writes to the `user` table, which can become a bottleneck for
+     * storefronts that authenticate on a large proportion of requests.
+     *
+     * @default false
+     * @since 3.8.0
+     */
+    disableLastLoginUpdate?: boolean;
 }
 
 /**

--- a/packages/core/src/service/services/auth.service.ts
+++ b/packages/core/src/service/services/auth.service.ts
@@ -99,8 +99,10 @@ export class AuthService {
         if (ctx.session && ctx.session.activeOrderId) {
             await this.sessionService.deleteSessionsByActiveOrderId(ctx, ctx.session.activeOrderId);
         }
-        user.lastLogin = new Date();
-        await this.connection.getRepository(ctx, User).save(user);
+        if (!this.configService.authOptions.disableLastLoginUpdate) {
+            user.lastLogin = new Date();
+            await this.connection.getRepository(ctx, User).save(user);
+        }
         const session = await this.sessionService.createNewAuthenticatedSession(
             ctx,
             user,

--- a/packages/core/src/service/services/auth.service.ts
+++ b/packages/core/src/service/services/auth.service.ts
@@ -101,8 +101,11 @@ export class AuthService {
         }
         if (!this.configService.authOptions.disableLastLoginUpdate) {
             user.lastLogin = new Date();
-            await this.connection.getRepository(ctx, User).save(user);
         }
+        // The save is unconditional: an AuthenticationStrategy may have set fields on the
+        // User (e.g. `verified`, custom fields) which this is the only place to persist.
+        // With no changed columns, TypeORM issues no UPDATE, so the `user` row is not written.
+        await this.connection.getRepository(ctx, User).save(user);
         const session = await this.sessionService.createNewAuthenticatedSession(
             ctx,
             user,


### PR DESCRIPTION
# Description

Adds a new `authOptions.disableLastLoginUpdate` config option (default `false`). When set to `true`, Vendure skips the `User.lastLogin` write on every successful login.

On installations with high authentication traffic, that write causes lock contention on the `user` table (the original report cited 250k+ updates/day). This option lets those installations opt out of tracking `lastLogin`.

This is a take-over of #3253 by [@alexisvigoureux](https://github.com/alexisvigoureux), rebased onto current `minor`. The original author is credited via `Co-authored-by`, and #3253 has been closed in favour of this PR.

Changes made on top of the original PR, from the review feedback there:
- Removed the incorrect `user.roles` condition. Roles are loaded just above that check, so the flag never actually took effect.
- Set `@since 3.8.0` on the new option.
- Added e2e coverage for both the default and the disabled behaviour.

Relates to #3253

# Breaking changes

None. The option defaults to `false`, so existing behaviour is unchanged.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases (`packages/core/e2e/disable-last-login-update.e2e-spec.ts`: default updates `lastLogin`; with the flag set to `true`, login leaves it null)
- [ ] I have updated the README if needed (not needed; the option is documented via the generated `AuthOptions` reference docs)
