### PR TITLE
fix(dashboard): refresh customer group selector after mutations

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_customer-groups/components/customer-group-bulk-actions.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_customer-groups/components/customer-group-bulk-actions.tsx
@@ -8,6 +8,7 @@ export const DeleteCustomerGroupsBulkAction: BulkActionComponent<any> = ({ selec
             mutationDocument={deleteCustomerGroupsDocument}
             entityName="customer groups"
             requiredPermissions={['DeleteCustomerGroup']}
+            invalidateQueries={['customerGroups']}
             selection={selection}
             table={table}
         />

--- a/packages/dashboard/src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
@@ -15,6 +15,7 @@ import { ActionBarItem } from '@/vdb/framework/layout-engine/action-bar-item-wra
 import { detailPageRouteLoader } from '@/vdb/framework/page/detail-page-route-loader.js';
 import { useDetailPage } from '@/vdb/framework/page/use-detail-page.js';
 import { Trans, useLingui } from '@lingui/react/macro';
+import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { toast } from 'sonner';
 import { CustomerGroupMembersTable } from './components/customer-group-members-table.js';
@@ -44,6 +45,7 @@ function CustomerGroupDetailPage() {
     const navigate = useNavigate();
     const creatingNewEntity = params.id === NEW_ENTITY_PATH;
     const { t } = useLingui();
+    const queryClient = useQueryClient();
 
     const { form, submitHandler, entity, isPending, resetForm } = useDetailPage({
         pageId,
@@ -64,6 +66,7 @@ function CustomerGroupDetailPage() {
                     ? t`Successfully created customer group`
                     : t`Successfully updated customer group`,
             );
+            await queryClient.invalidateQueries({ queryKey: ['customerGroups'] });
             resetForm();
             if (creatingNewEntity && data?.id) {
                 await navigate({ to: `../$id`, params: { id: data.id } });


### PR DESCRIPTION
Relates to #5185

# Description

The **Customer group** dropdown (`CustomerGroupSelector`) in the dashboard was showing a stale list. It is used on the **Customer** detail page ("Customer groups" block) and by the customer-group **custom-field input**. `CustomerGroupSelector` caches its options under the react-query key `['customerGroups']` with a 5-minute `staleTime`, but the customer group create/update and delete flows never invalidated that key. As a result, newly created groups were missing from the dropdown and deleted ones remained, until a full page refresh.

This PR invalidates `['customerGroups']` after the relevant mutations, following existing dashboard conventions

- **Create/update** (`_customer-groups/customer-groups_.$id.tsx`): call `queryClient.invalidateQueries({ queryKey: ['customerGroups'] })` in the detail page `onSuccess`.
- **Delete** (`_customer-groups/components/customer-group-bulk-actions.tsx`): pass `invalidateQueries={['customerGroups']}` to the shared `DeleteBulkAction`.

The dropdown now reflects created and deleted customer groups immediately, without a page refresh.

# Breaking changes

None.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790264084&installation_model_id=20193&pr_number=5186&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5186&signature=9db78807e7c8f0a2d67be7e6494ba1021ac6a0affda1279448489d2c6fc69a30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->