### PR TITLE
docs(core): show per-channel customer accounts with EntityAccessContr…

### DIFF
--- a/packages/core/src/config/auth/entity-access-control-strategy.ts
+++ b/packages/core/src/config/auth/entity-access-control-strategy.ts
@@ -87,6 +87,43 @@ import { VendureEntity } from '../../entity/base/base.entity';
  * }
  * ```
  *
+ * @example
+ * ```ts
+ * // Per-channel customer accounts, so the same email address can hold a separate
+ * // account with a separate password at each Channel (#1705).
+ * //
+ * // Nothing in the schema prevents this: `User.identifier` and
+ * // `Customer.emailAddress` are not unique columns. What makes one address into
+ * // one platform-wide account is that `UserService.getUserByEmailAddress()`
+ * // applies no Channel filter - and every other identity check funnels through
+ * // it, so scoping `User` here reaches login, registration, password reset and
+ * // email change together.
+ * //
+ * // Filter rather than namespace the identifier: `user.identifier` is what the
+ * // email plugin passes to `setRecipient()` and what `currentUser.identifier`
+ * // returns, so a prefixed one makes verification mail undeliverable.
+ * class PerChannelCustomerIdentityStrategy extends DefaultEntityAccessControlStrategy {
+ *     applyAccessControl(qb, entityType, ctx) {
+ *         if (ctx.apiType !== 'shop') return;
+ *         if (entityType === Customer) {
+ *             qb.andWhere(
+ *                 `${qb.alias}.id IN (SELECT m."customerId" FROM customer_channels_channel m
+ *                                     WHERE m."channelId" = :aclChannelId)`,
+ *                 { aclChannelId: ctx.channelId },
+ *             );
+ *         }
+ *         if (entityType === User) {
+ *             qb.andWhere(
+ *                 `${qb.alias}.id IN (SELECT c."userId" FROM customer c
+ *                                     INNER JOIN customer_channels_channel m ON m."customerId" = c.id
+ *                                     WHERE m."channelId" = :aclChannelId AND c."userId" IS NOT NULL)`,
+ *                 { aclChannelId: ctx.channelId },
+ *             );
+ *         }
+ *     }
+ * }
+ * ```
+ *
  * :::info
  *
  * This is configured via the `authOptions.entityAccessControlStrategy` property

--- a/packages/core/src/config/auth/entity-access-control-strategy.ts
+++ b/packages/core/src/config/auth/entity-access-control-strategy.ts
@@ -94,31 +94,49 @@ import { VendureEntity } from '../../entity/base/base.entity';
  * //
  * // Nothing in the schema prevents this: `User.identifier` and
  * // `Customer.emailAddress` are not unique columns. What makes one address into
- * // one platform-wide account is that `UserService.getUserByEmailAddress()`
- * // applies no Channel filter - and every other identity check funnels through
- * // it, so scoping `User` here reaches login, registration, password reset and
- * // email change together.
+ * // one platform-wide account is that the lookups behind registration and login
+ * // apply no Channel filter. Scoping `User` here reaches all of them at once,
+ * // because `applyAccessControl()` runs for every `User` query built through
+ * // `getRepository(ctx, User)` - which is the email lookup, and also the
+ * // token-verification, password-reset and identifier-change queries that do not
+ * // go through it.
  * //
  * // Filter rather than namespace the identifier: `user.identifier` is what the
  * // email plugin passes to `setRecipient()` and what `currentUser.identifier`
  * // returns, so a prefixed one makes verification mail undeliverable.
+ * //
+ * // Note the subqueries are built with `qb.subQuery()` and relation property
+ * // paths rather than written as SQL, so TypeORM resolves the junction tables,
+ * // the `entityPrefix` and the driver's identifier quoting. Hand-written SQL
+ * // here silently ignores a configured prefix, and double-quoted identifiers
+ * // are rejected by MySQL unless ANSI_QUOTES is enabled.
  * class PerChannelCustomerIdentityStrategy extends DefaultEntityAccessControlStrategy {
  *     applyAccessControl(qb, entityType, ctx) {
  *         if (ctx.apiType !== 'shop') return;
  *         if (entityType === Customer) {
- *             qb.andWhere(
- *                 `${qb.alias}.id IN (SELECT m."customerId" FROM customer_channels_channel m
- *                                     WHERE m."channelId" = :aclChannelId)`,
- *                 { aclChannelId: ctx.channelId },
- *             );
+ *             qb.andWhere(sub => {
+ *                 const query = sub.subQuery()
+ *                     .select('aclCustomer.id')
+ *                     .from(Customer, 'aclCustomer')
+ *                     .innerJoin('aclCustomer.channels', 'aclChannel')
+ *                     .where('aclChannel.id = :aclChannelId')
+ *                     .getQuery();
+ *                 return `${qb.alias}.id IN ${query}`;
+ *             }).setParameter('aclChannelId', ctx.channelId);
  *         }
  *         if (entityType === User) {
- *             qb.andWhere(
- *                 `${qb.alias}.id IN (SELECT c."userId" FROM customer c
- *                                     INNER JOIN customer_channels_channel m ON m."customerId" = c.id
- *                                     WHERE m."channelId" = :aclChannelId AND c."userId" IS NOT NULL)`,
- *                 { aclChannelId: ctx.channelId },
- *             );
+ *             // The join to `aclCustomer.user` also confines this to
+ *             // customer-owned Users: an Administrator's User has no Customer.
+ *             qb.andWhere(sub => {
+ *                 const query = sub.subQuery()
+ *                     .select('aclUser.id')
+ *                     .from(Customer, 'aclCustomer')
+ *                     .innerJoin('aclCustomer.user', 'aclUser')
+ *                     .innerJoin('aclCustomer.channels', 'aclChannel')
+ *                     .where('aclChannel.id = :aclChannelId')
+ *                     .getQuery();
+ *                 return `${qb.alias}.id IN ${query}`;
+ *             }).setParameter('aclChannelId', ctx.channelId);
  *         }
  *     }
  * }


### PR DESCRIPTION
…olStrategy

Channel-aware customer accounts have been asked for since #1705 (2022), and the thread it was moved to has votes but no answer. The API to do it already shipped in 3.6 - it just is not documented as being able to, so nobody has found it.

Adds a third `@example` to the strategy's docs alongside the existing gate-level and seller-scoped ones. It is the shape people keep asking for: the same email address holding a separate account, with a separate password, at each Channel.

Two things the example is explicit about, because both are non-obvious and both cost time to rediscover:

- Nothing in the schema prevents two accounts for one address. `User.identifier` and `Customer.emailAddress` are plain columns with no unique index. What makes one address into one platform-wide account is that `getUserByEmailAddress()` applies no Channel filter, and every other identity check funnels through it - so scoping `User` here covers login, registration, password reset and email change together. This is the same trick `getUserByEmailAddress` already plays one level up, where it joins `customer` or `administrator` to tell a customer Alice from an administrator Alice (#2016).

- Filter, do not namespace the identifier. `user.identifier` is what the email plugin passes to `setRecipient()` and what `currentUser.identifier` returns, so a channel-prefixed identifier makes verification mail undeliverable.

Docs only - no behaviour change.

# Description

Please include a summary of the changes and the related issue.

# Breaking changes

Does this PR include any breaking changes we should be aware of?

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790271292&installation_model_id=20193&pr_number=5188&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5188&signature=10df12e04b3994be6d0b284e24e27983124227e2d1c888cc3d03cd9ca70d7354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->