### PR TITLE
fix(dashboard): make entity selectors refetch on mount

### DIFF
--- a/packages/dashboard/e2e/tests/regression/selector-stale-after-mutation.spec.ts
+++ b/packages/dashboard/e2e/tests/regression/selector-stale-after-mutation.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test';
 
+import { VendureAdminClient } from '../../utils/vendure-admin-client.js';
+
 // Regression: entity selector dropdowns must reflect newly created entities
 // without a full page reload.
 //
@@ -47,44 +49,48 @@ test.describe('Entity selectors refetch after mutation', () => {
         await page.goto('/tax-rates');
         await expect(page.getByTestId('page-heading')).toBeVisible({ timeout: 10_000 });
 
-        // Prime the ['zones'] cache and confirm the zone does not exist yet.
-        await openTaxRateZoneDropdown();
-        await expect(page.getByRole('option').first()).toBeVisible();
-        await expect(page.getByRole('option', { name: uniqueZoneName })).toHaveCount(0);
-        await page.keyboard.press('Escape');
+        try {
+            // Prime the ['zones'] cache and confirm the zone does not exist yet.
+            await openTaxRateZoneDropdown();
+            await expect(page.getByRole('option').first()).toBeVisible();
+            await expect(page.getByRole('option', { name: uniqueZoneName })).toHaveCount(0);
+            await page.keyboard.press('Escape');
 
-        // Create the new zone, navigating client-side via the sidebar.
-        await gotoViaSidebar('Zones');
-        await page.getByRole('button', { name: 'New Zone' }).click();
-        await expect(page).toHaveURL(/\/zones\/new$/);
-        const nameField = page.locator('[data-slot="field"]').filter({
-            has: page.locator('[data-slot="field-label"]').getByText('Name', { exact: true }),
-        });
-        await nameField.getByRole('textbox').fill(uniqueZoneName);
-        await page.getByRole('button', { name: 'Create', exact: true }).click();
-        await expect(page.locator('[data-sonner-toast]').filter({ hasText: /created/i })).toBeVisible({
-            timeout: 10_000,
-        });
+            // Create the new zone, navigating client-side via the sidebar.
+            await gotoViaSidebar('Zones');
+            await page.getByRole('button', { name: 'New Zone' }).click();
+            await expect(page).toHaveURL(/\/zones\/new$/);
+            const nameField = page.locator('[data-slot="field"]').filter({
+                has: page.locator('[data-slot="field-label"]').getByText('Name', { exact: true }),
+            });
+            await nameField.getByRole('textbox').fill(uniqueZoneName);
+            await page.getByRole('button', { name: 'Create', exact: true }).click();
+            await expect(page.locator('[data-sonner-toast]').filter({ hasText: /created/i })).toBeVisible({
+                timeout: 10_000,
+            });
 
-        // Re-open the Tax Rate page (client-side). ZoneSelector remounts and,
-        // with the staleTime opt-in removed, refetches ['zones'] — so the new
-        // zone appears without any reload.
-        await openTaxRateZoneDropdown();
-        await expect(page.getByRole('option', { name: uniqueZoneName })).toBeVisible({
-            timeout: 10_000,
-        });
-        await page.keyboard.press('Escape');
-
-        // Cleanup: delete the zone we created.
-        await gotoViaSidebar('Zones');
-        await expect(page.getByTestId('page-heading')).toBeVisible({ timeout: 10_000 });
-        const zoneRow = page.locator('table tbody tr').filter({ hasText: uniqueZoneName });
-        await zoneRow.getByRole('checkbox').click();
-        await page.getByRole('button', { name: /Actions/i }).click();
-        await page.locator('[role="menu"]').getByText('Delete', { exact: true }).click();
-        await page.locator('[role="alertdialog"]').getByRole('button', { name: 'Continue' }).click();
-        await expect(page.locator('table tbody tr').filter({ hasText: uniqueZoneName })).toHaveCount(0, {
-            timeout: 10_000,
-        });
+            // Re-open the Tax Rate page (client-side). ZoneSelector remounts and,
+            // with the staleTime opt-in removed, refetches ['zones'] — so the new
+            // zone appears without any reload.
+            await openTaxRateZoneDropdown();
+            await expect(page.getByRole('option', { name: uniqueZoneName })).toBeVisible({
+                timeout: 10_000,
+            });
+            await page.keyboard.press('Escape');
+        } finally {
+            // Always remove the created zone, even if an assertion above failed,
+            // so it does not leak into subsequent runs. Done via the Admin API so
+            // cleanup does not depend on the page being in a usable state.
+            const client = new VendureAdminClient(page);
+            await client.login();
+            const found = await client.gql(
+                `query ($options: ZoneListOptions) { zones(options: $options) { items { id } } }`,
+                { options: { filter: { name: { eq: uniqueZoneName } } } },
+            );
+            const zoneId = found?.zones?.items?.[0]?.id;
+            if (zoneId) {
+                await client.gql(`mutation ($id: ID!) { deleteZone(id: $id) { result } }`, { id: zoneId });
+            }
+        }
     });
 });

--- a/packages/dashboard/e2e/tests/regression/selector-stale-after-mutation.spec.ts
+++ b/packages/dashboard/e2e/tests/regression/selector-stale-after-mutation.spec.ts
@@ -22,6 +22,17 @@ test.describe('Entity selectors refetch after mutation', () => {
     test.describe.configure({ mode: 'serial' });
 
     const uniqueZoneName = `E2E Selector Zone ${Date.now()}`;
+    let zoneId = '';
+
+    // Runs even if the test body throws, so the created zone never leaks into
+    // subsequent runs (the e2e seed data is cached).
+    test.afterEach(async ({ page }) => {
+        if (!zoneId) return;
+        const client = new VendureAdminClient(page);
+        await client.login();
+        await client.gql(`mutation ($id: ID!) { deleteZone(id: $id) { result } }`, { id: zoneId });
+        zoneId = '';
+    });
 
     // #5177, #5182 — a newly created zone must appear in the Tax Rate page's
     // zone selector without a page reload (the class of selector-staleness bug).
@@ -49,48 +60,36 @@ test.describe('Entity selectors refetch after mutation', () => {
         await page.goto('/tax-rates');
         await expect(page.getByTestId('page-heading')).toBeVisible({ timeout: 10_000 });
 
-        try {
-            // Prime the ['zones'] cache and confirm the zone does not exist yet.
-            await openTaxRateZoneDropdown();
-            await expect(page.getByRole('option').first()).toBeVisible();
-            await expect(page.getByRole('option', { name: uniqueZoneName })).toHaveCount(0);
-            await page.keyboard.press('Escape');
+        // Prime the ['zones'] cache and confirm the zone does not exist yet.
+        await openTaxRateZoneDropdown();
+        await expect(page.getByRole('option').first()).toBeVisible();
+        await expect(page.getByRole('option', { name: uniqueZoneName })).toHaveCount(0);
+        await page.keyboard.press('Escape');
 
-            // Create the new zone, navigating client-side via the sidebar.
-            await gotoViaSidebar('Zones');
-            await page.getByRole('button', { name: 'New Zone' }).click();
-            await expect(page).toHaveURL(/\/zones\/new$/);
-            const nameField = page.locator('[data-slot="field"]').filter({
-                has: page.locator('[data-slot="field-label"]').getByText('Name', { exact: true }),
-            });
-            await nameField.getByRole('textbox').fill(uniqueZoneName);
-            await page.getByRole('button', { name: 'Create', exact: true }).click();
-            await expect(page.locator('[data-sonner-toast]').filter({ hasText: /created/i })).toBeVisible({
-                timeout: 10_000,
-            });
+        // Create the new zone, navigating client-side via the sidebar.
+        await gotoViaSidebar('Zones');
+        await page.getByRole('button', { name: 'New Zone' }).click();
+        await expect(page).toHaveURL(/\/zones\/new$/);
+        const nameField = page.locator('[data-slot="field"]').filter({
+            has: page.locator('[data-slot="field-label"]').getByText('Name', { exact: true }),
+        });
+        await nameField.getByRole('textbox').fill(uniqueZoneName);
+        await page.getByRole('button', { name: 'Create', exact: true }).click();
+        await expect(page.locator('[data-sonner-toast]').filter({ hasText: /created/i })).toBeVisible({
+            timeout: 10_000,
+        });
 
-            // Re-open the Tax Rate page (client-side). ZoneSelector remounts and,
-            // with the staleTime opt-in removed, refetches ['zones'] — so the new
-            // zone appears without any reload.
-            await openTaxRateZoneDropdown();
-            await expect(page.getByRole('option', { name: uniqueZoneName })).toBeVisible({
-                timeout: 10_000,
-            });
-            await page.keyboard.press('Escape');
-        } finally {
-            // Always remove the created zone, even if an assertion above failed,
-            // so it does not leak into subsequent runs. Done via the Admin API so
-            // cleanup does not depend on the page being in a usable state.
-            const client = new VendureAdminClient(page);
-            await client.login();
-            const found = await client.gql(
-                `query ($options: ZoneListOptions) { zones(options: $options) { items { id } } }`,
-                { options: { filter: { name: { eq: uniqueZoneName } } } },
-            );
-            const zoneId = found?.zones?.items?.[0]?.id;
-            if (zoneId) {
-                await client.gql(`mutation ($id: ID!) { deleteZone(id: $id) { result } }`, { id: zoneId });
-            }
-        }
+        // Capture the created zone id from the URL for cleanup in afterEach.
+        await expect(page).toHaveURL(/\/zones\/(?!new$)[^/]+$/);
+        zoneId = new URL(page.url()).pathname.split('/').pop() ?? '';
+
+        // Re-open the Tax Rate page (client-side). ZoneSelector remounts and,
+        // with the staleTime opt-in removed, refetches ['zones'] — so the new
+        // zone appears without any reload.
+        await openTaxRateZoneDropdown();
+        await expect(page.getByRole('option', { name: uniqueZoneName })).toBeVisible({
+            timeout: 10_000,
+        });
+        await page.keyboard.press('Escape');
     });
 });

--- a/packages/dashboard/e2e/tests/regression/selector-stale-after-mutation.spec.ts
+++ b/packages/dashboard/e2e/tests/regression/selector-stale-after-mutation.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from '@playwright/test';
+
+// Regression: entity selector dropdowns must reflect newly created entities
+// without a full page reload.
+//
+// The shared selector components (ZoneSelector, TaxCategorySelector, etc.)
+// used to set a multi-minute `staleTime` on their list queries. The dashboard's
+// global QueryClient defaults to `staleTime: 0` (refetch-on-mount), so removing
+// those opt-ins is what makes the dropdowns pick up fresh data when a detail
+// page mounts. This test covers the whole class via the Zone selector on the Tax
+// Rate page (see #5177, #5182).
+//
+// It navigates entirely client-side (TanStack Router <Link>s in the sidebar)
+// after a single initial load, so the in-memory QueryClient — and therefore the
+// cached ['zones'] result — persists across page changes. A `page.goto()` or
+// `page.reload()` would spin up a fresh QueryClient and mask the very bug under
+// test, so there are deliberately none between priming the cache and the final
+// assertion.
+test.describe('Entity selectors refetch after mutation', () => {
+    test.describe.configure({ mode: 'serial' });
+
+    const uniqueZoneName = `E2E Selector Zone ${Date.now()}`;
+
+    // #5177, #5182 — a newly created zone must appear in the Tax Rate page's
+    // zone selector without a page reload (the class of selector-staleness bug).
+    test('zone selector on the tax rate page shows a newly created zone without reload', async ({
+        page,
+    }) => {
+        test.setTimeout(30_000);
+
+        const sidebar = page.locator('[data-slot="sidebar"]');
+        const gotoViaSidebar = (name: string) =>
+            sidebar.getByRole('link', { name, exact: true }).click();
+
+        const openTaxRateZoneDropdown = async () => {
+            await gotoViaSidebar('Tax Rates');
+            await page.getByRole('button', { name: 'New Tax Rate' }).click();
+            await expect(page).toHaveURL(/\/tax-rates\/new$/);
+            const zoneField = page.locator('[data-slot="field"]').filter({
+                has: page.locator('[data-slot="field-label"]').getByText('Zone', { exact: true }),
+            });
+            await zoneField.getByRole('combobox').click();
+        };
+
+        // Initial (and only) full load. Everything after this is client-side, so
+        // the QueryClient stays alive.
+        await page.goto('/tax-rates');
+        await expect(page.getByTestId('page-heading')).toBeVisible({ timeout: 10_000 });
+
+        // Prime the ['zones'] cache and confirm the zone does not exist yet.
+        await openTaxRateZoneDropdown();
+        await expect(page.getByRole('option').first()).toBeVisible();
+        await expect(page.getByRole('option', { name: uniqueZoneName })).toHaveCount(0);
+        await page.keyboard.press('Escape');
+
+        // Create the new zone, navigating client-side via the sidebar.
+        await gotoViaSidebar('Zones');
+        await page.getByRole('button', { name: 'New Zone' }).click();
+        await expect(page).toHaveURL(/\/zones\/new$/);
+        const nameField = page.locator('[data-slot="field"]').filter({
+            has: page.locator('[data-slot="field-label"]').getByText('Name', { exact: true }),
+        });
+        await nameField.getByRole('textbox').fill(uniqueZoneName);
+        await page.getByRole('button', { name: 'Create', exact: true }).click();
+        await expect(page.locator('[data-sonner-toast]').filter({ hasText: /created/i })).toBeVisible({
+            timeout: 10_000,
+        });
+
+        // Re-open the Tax Rate page (client-side). ZoneSelector remounts and,
+        // with the staleTime opt-in removed, refetches ['zones'] — so the new
+        // zone appears without any reload.
+        await openTaxRateZoneDropdown();
+        await expect(page.getByRole('option', { name: uniqueZoneName })).toBeVisible({
+            timeout: 10_000,
+        });
+        await page.keyboard.press('Escape');
+
+        // Cleanup: delete the zone we created.
+        await gotoViaSidebar('Zones');
+        await expect(page.getByTestId('page-heading')).toBeVisible({ timeout: 10_000 });
+        const zoneRow = page.locator('table tbody tr').filter({ hasText: uniqueZoneName });
+        await zoneRow.getByRole('checkbox').click();
+        await page.getByRole('button', { name: /Actions/i }).click();
+        await page.locator('[role="menu"]').getByText('Delete', { exact: true }).click();
+        await page.locator('[role="alertdialog"]').getByRole('button', { name: 'Continue' }).click();
+        await expect(page.locator('table tbody tr').filter({ hasText: uniqueZoneName })).toHaveCount(0, {
+            timeout: 10_000,
+        });
+    });
+});

--- a/packages/dashboard/e2e/tests/regression/selector-stale-after-mutation.spec.ts
+++ b/packages/dashboard/e2e/tests/regression/selector-stale-after-mutation.spec.ts
@@ -1,46 +1,36 @@
 import { expect, test } from '@playwright/test';
 
+import { BaseDetailPage } from '../../page-objects/detail-page.base.js';
+import { BaseListPage } from '../../page-objects/list-page.base.js';
 import { VendureAdminClient } from '../../utils/vendure-admin-client.js';
 
-// Regression: entity selector dropdowns must reflect newly created entities
-// without a full page reload.
-//
-// The shared selector components (ZoneSelector, TaxCategorySelector, etc.)
-// used to set a multi-minute `staleTime` on their list queries. The dashboard's
-// global QueryClient defaults to `staleTime: 0` (refetch-on-mount), so removing
-// those opt-ins is what makes the dropdowns pick up fresh data when a detail
-// page mounts. This test covers the whole class via the Zone selector on the Tax
-// Rate page (see #5177, #5182).
-//
-// It navigates entirely client-side (TanStack Router <Link>s in the sidebar)
-// after a single initial load, so the in-memory QueryClient — and therefore the
-// cached ['zones'] result — persists across page changes. A `page.goto()` or
-// `page.reload()` would spin up a fresh QueryClient and mask the very bug under
-// test, so there are deliberately none between priming the cache and the final
-// assertion.
+// #5177, #5182 — selector dropdowns must reflect created and deleted entities
+// without a reload. Do not add a page.goto() or page.reload() below the first
+// one: either creates a fresh QueryClient and masks the bug under test.
 test.describe('Entity selectors refetch after mutation', () => {
-    test.describe.configure({ mode: 'serial' });
+    const zoneName = `E2E Selector Zone ${Date.now()}`;
 
-    const uniqueZoneName = `E2E Selector Zone ${Date.now()}`;
-    let zoneId = '';
-
-    // Runs even if the test body throws, so the created zone never leaks into
-    // subsequent runs (the e2e seed data is cached).
+    // By name, so a failure anywhere still cleans up.
     test.afterEach(async ({ page }) => {
-        if (!zoneId) return;
         const client = new VendureAdminClient(page);
         await client.login();
-        await client.gql(`mutation ($id: ID!) { deleteZone(id: $id) { result } }`, { id: zoneId });
-        zoneId = '';
+        const { zones } = await client.gql(
+            `query ($name: String!) {
+                zones(options: { filter: { name: { eq: $name } } }) { items { id } }
+            }`,
+            { name: zoneName },
+        );
+        for (const zone of zones.items) {
+            await client.gql(`mutation ($id: ID!) { deleteZone(id: $id) { result } }`, { id: zone.id });
+        }
     });
 
-    // #5177, #5182 — a newly created zone must appear in the Tax Rate page's
-    // zone selector without a page reload (the class of selector-staleness bug).
-    test('zone selector on the tax rate page shows a newly created zone without reload', async ({
-        page,
-    }) => {
-        test.setTimeout(30_000);
-
+    test('shows a created zone and drops a deleted one, without reload', async ({ page }) => {
+        const detail = new BaseDetailPage(page, {
+            newPath: '/zones/new',
+            pathPrefix: '/zones/',
+            newTitle: 'New zone',
+        });
         const sidebar = page.locator('[data-slot="sidebar"]');
         const gotoViaSidebar = (name: string) =>
             sidebar.getByRole('link', { name, exact: true }).click();
@@ -49,47 +39,50 @@ test.describe('Entity selectors refetch after mutation', () => {
             await gotoViaSidebar('Tax Rates');
             await page.getByRole('button', { name: 'New Tax Rate' }).click();
             await expect(page).toHaveURL(/\/tax-rates\/new$/);
-            const zoneField = page.locator('[data-slot="field"]').filter({
-                has: page.locator('[data-slot="field-label"]').getByText('Zone', { exact: true }),
-            });
-            await zoneField.getByRole('combobox').click();
+            await detail.formItem('Zone').getByRole('combobox').click();
+            // Guard: without this, toHaveCount(0) also passes if it never opened.
+            await expect(page.getByRole('option').first()).toBeVisible();
         };
 
-        // Initial (and only) full load. Everything after this is client-side, so
-        // the QueryClient stays alive.
         await page.goto('/tax-rates');
         await expect(page.getByTestId('page-heading')).toBeVisible({ timeout: 10_000 });
 
-        // Prime the ['zones'] cache and confirm the zone does not exist yet.
+        // Prime the ['zones'] cache while the zone does not exist.
         await openTaxRateZoneDropdown();
-        await expect(page.getByRole('option').first()).toBeVisible();
-        await expect(page.getByRole('option', { name: uniqueZoneName })).toHaveCount(0);
+        await expect(page.getByRole('option', { name: zoneName })).toHaveCount(0);
         await page.keyboard.press('Escape');
 
-        // Create the new zone, navigating client-side via the sidebar.
         await gotoViaSidebar('Zones');
         await page.getByRole('button', { name: 'New Zone' }).click();
-        await expect(page).toHaveURL(/\/zones\/new$/);
-        const nameField = page.locator('[data-slot="field"]').filter({
-            has: page.locator('[data-slot="field-label"]').getByText('Name', { exact: true }),
-        });
-        await nameField.getByRole('textbox').fill(uniqueZoneName);
-        await page.getByRole('button', { name: 'Create', exact: true }).click();
-        await expect(page.locator('[data-sonner-toast]').filter({ hasText: /created/i })).toBeVisible({
-            timeout: 10_000,
-        });
+        await detail.fillInput('Name', zoneName);
+        await detail.clickCreate();
+        await detail.expectSuccessToast(/created/i);
+        await detail.expectNavigatedToExisting();
 
-        // Capture the created zone id from the URL for cleanup in afterEach.
-        await expect(page).toHaveURL(/\/zones\/(?!new$)[^/]+$/);
-        zoneId = new URL(page.url()).pathname.split('/').pop() ?? '';
-
-        // Re-open the Tax Rate page (client-side). ZoneSelector remounts and,
-        // with the staleTime opt-in removed, refetches ['zones'] — so the new
-        // zone appears without any reload.
+        // Create case.
         await openTaxRateZoneDropdown();
-        await expect(page.getByRole('option', { name: uniqueZoneName })).toBeVisible({
-            timeout: 10_000,
-        });
+        await expect(page.getByRole('option', { name: zoneName })).toBeVisible();
         await page.keyboard.press('Escape');
+
+        // BaseListPage.goto() would reload, so arrive via the sidebar. The zones
+        // list has no search box, so select the row by its unique name.
+        await gotoViaSidebar('Zones');
+        const list = new BaseListPage(page, {
+            path: '/zones',
+            title: 'Zones',
+            newButtonLabel: 'New Zone',
+        });
+        await list.expectLoaded();
+        const zoneRow = list.getRows().filter({ hasText: zoneName });
+        await zoneRow.getByRole('checkbox').click();
+        await page.getByRole('button', { name: /Actions/i }).click();
+        await page.locator('[role="menu"]').getByText('Delete', { exact: true }).click();
+        await page.locator('[role="alertdialog"]').getByRole('button', { name: 'Continue' }).click();
+        await list.expectSuccessToast();
+        await expect(list.getRows().filter({ hasText: zoneName })).toHaveCount(0);
+
+        // Delete case: covers the invalidateQueries removed from the bulk actions.
+        await openTaxRateZoneDropdown();
+        await expect(page.getByRole('option', { name: zoneName })).toHaveCount(0);
     });
 });

--- a/packages/dashboard/src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
@@ -55,7 +55,6 @@ export function AssetTagFilter({ selectedTags, onTagsChange }: Readonly<AssetTag
             return totalFetched < lastPage.totalItems ? allPages.length : undefined;
         },
         initialPageParam: 0,
-        staleTime: 1000 * 60 * 5,
     });
 
     const availableTags = data?.pages.flatMap(page => page?.items ?? []) ?? [];

--- a/packages/dashboard/src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
@@ -41,7 +41,6 @@ export function AssetTagsEditor({
     const { data: tagsData } = useQuery({
         queryKey: ['tags'],
         queryFn: () => api.query(tagListDocument, { options: { take: 100 } }),
-        staleTime: 1000 * 60 * 5, // 5 minutes
     });
 
     // Create new tag mutation

--- a/packages/dashboard/src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
@@ -33,7 +33,6 @@ export function ManageTagsDialog({ open, onOpenChange, onTagsUpdated }: Readonly
     const { data: tagsData, isLoading } = useQuery({
         queryKey: ['tags'],
         queryFn: () => api.query(tagListDocument, { options: { take: 100 } }),
-        staleTime: 1000 * 60 * 5,
     });
 
     // Update tag mutation

--- a/packages/dashboard/src/app/routes/_authenticated/_collections/collections.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_collections/collections.tsx
@@ -102,12 +102,13 @@ function CollectionListPage() {
         });
     }, [navigate]);
 
-    // NOTE: queryFn must be pure (no setState side effects) because TanStack Query
-    // skips queryFn entirely when data is served from cache. If we
-    // called setAccumulatedChildren inside queryFn, a re-mounted component would get
-    // cache hits but accumulatedChildren would never be populated, so children wouldn't
-    // render. Instead we sync via useEffect below, which fires for both cache hits and
-    // fresh fetches.
+    // NOTE: queryFn must be pure (no setState side effects). With the global
+    // `keepPreviousData`, a re-mounted component is served the cached data on its
+    // first render before the refetch lands, and TanStack Query skips the queryFn
+    // entirely for that cached render. If we called setAccumulatedChildren inside
+    // queryFn, those cache-hit renders would never populate accumulatedChildren,
+    // so children wouldn't render. Instead we sync via the useEffect below, which
+    // fires for both cache hits and fresh fetches.
     const firstPageChildQueries = useQueries({
         queries: expanded === true ? [] : Object.entries(expanded)
             .filter(([collectionId]) => !accumulatedChildren[collectionId])

--- a/packages/dashboard/src/app/routes/_authenticated/_collections/collections.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_collections/collections.tsx
@@ -103,7 +103,7 @@ function CollectionListPage() {
     }, [navigate]);
 
     // NOTE: queryFn must be pure (no setState side effects) because TanStack Query
-    // skips queryFn entirely when data is served from cache (staleTime: 5min). If we
+    // skips queryFn entirely when data is served from cache. If we
     // called setAccumulatedChildren inside queryFn, a re-mounted component would get
     // cache hits but accumulatedChildren would never be populated, so children wouldn't
     // render. Instead we sync via useEffect below, which fires for both cache hits and
@@ -130,7 +130,6 @@ function CollectionListPage() {
                             totalItems: result.collections.totalItems,
                         };
                     },
-                    staleTime: 1000 * 60 * 5,
                 } satisfies FetchQueryOptions;
             }),
     });
@@ -174,7 +173,6 @@ function CollectionListPage() {
                             totalItems: result.collections.totalItems,
                         };
                     },
-                    staleTime: 1000 * 60 * 5,
                 } satisfies FetchQueryOptions;
             }),
     });

--- a/packages/dashboard/src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
@@ -237,7 +237,6 @@ export function MoveCollectionsDialog({
                     }),
                 },
             }),
-        staleTime: 1000 * 60 * 5,
         enabled: open,
     });
 
@@ -257,7 +256,6 @@ export function MoveCollectionsDialog({
                             },
                         },
                     }),
-                staleTime: 1000 * 60 * 5,
             };
         }),
     });

--- a/packages/dashboard/src/app/routes/_authenticated/_countries/components/country-bulk-actions.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_countries/components/country-bulk-actions.tsx
@@ -8,6 +8,7 @@ export const DeleteCountriesBulkAction: BulkActionComponent<any> = ({ selection,
             mutationDocument={deleteCountriesDocument}
             entityName="countries"
             requiredPermissions={['DeleteCountry']}
+            invalidateQueries={['availableCountries']}
             selection={selection}
             table={table}
         />

--- a/packages/dashboard/src/app/routes/_authenticated/_countries/countries_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_countries/countries_.$id.tsx
@@ -16,7 +16,9 @@ import {    CustomFieldsPageBlock,
 import { ActionBarItem } from '@/vdb/framework/layout-engine/action-bar-item-wrapper.js';
 import { detailPageRouteLoader } from '@/vdb/framework/page/detail-page-route-loader.js';
 import { useDetailPage } from '@/vdb/framework/page/use-detail-page.js';
+import { availableCountriesQueryKey } from '@/vdb/hooks/use-available-countries.js';
 import { Trans, useLingui } from '@lingui/react/macro';
+import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { toast } from 'sonner';
 import { countryDetailDocument, createCountryDocument, updateCountryDocument } from './countries.graphql.js';
@@ -41,6 +43,7 @@ function CountryDetailPage() {
     const navigate = useNavigate();
     const creatingNewEntity = params.id === NEW_ENTITY_PATH;
     const { t } = useLingui();
+    const queryClient = useQueryClient();
 
     const { form, submitHandler, entity, isPending, resetForm } = useDetailPage({
         pageId,
@@ -60,6 +63,7 @@ function CountryDetailPage() {
         params: { id: params.id },
         onSuccess: async data => {
             toast(creatingNewEntity ? t`Successfully created country` : t`Successfully updated country`);
+            await queryClient.invalidateQueries({ queryKey: availableCountriesQueryKey });
             form.reset(form.getValues());
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });

--- a/packages/dashboard/src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
@@ -222,7 +222,6 @@ function OptionGroupSearch({
                         : undefined,
                 },
             }),
-        staleTime: 1000 * 60,
     });
 
     const items = data?.productOptionGroups?.items ?? [];

--- a/packages/dashboard/src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
@@ -4,25 +4,10 @@ import { Form } from '@/vdb/components/ui/form.js';
 import { Input } from '@/vdb/components/ui/input.js';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/vdb/components/ui/select.js';
 import { LS_KEY_SHIPPING_TEST_ADDRESS } from '@/vdb/constants.js';
-import { api } from '@/vdb/graphql/api.js';
-import { graphql } from '@/vdb/graphql/graphql.js';
+import { useAvailableCountries } from '@/vdb/hooks/use-available-countries.js';
 import { Trans } from '@lingui/react/macro';
-import { useQuery } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
-
-// Query document to fetch available countries
-const getAvailableCountriesDocument = graphql(`
-    query GetAvailableCountries {
-        countries(options: { filter: { enabled: { eq: true } } }) {
-            items {
-                id
-                code
-                name
-            }
-        }
-    }
-`);
 
 export interface TestAddress {
     fullName: string;
@@ -75,10 +60,7 @@ export function TestAddressForm({ onAddressChange }: Readonly<TestAddressFormPro
     });
 
     // Fetch available countries
-    const { data: countriesData, isLoading: isLoadingCountries } = useQuery({
-        queryKey: ['availableCountries'],
-        queryFn: () => api.query(getAvailableCountriesDocument),
-    });
+    const { data: countriesData, isLoading: isLoadingCountries } = useAvailableCountries();
 
     const previousValuesRef = useRef<string>('');
 

--- a/packages/dashboard/src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
@@ -78,7 +78,6 @@ export function TestAddressForm({ onAddressChange }: Readonly<TestAddressFormPro
     const { data: countriesData, isLoading: isLoadingCountries } = useQuery({
         queryKey: ['availableCountries'],
         queryFn: () => api.query(getAvailableCountriesDocument),
-        staleTime: 1000 * 60 * 60 * 24, // 24 hours
     });
 
     const previousValuesRef = useRef<string>('');

--- a/packages/dashboard/src/app/routes/_authenticated/_tax-categories/components/tax-category-bulk-actions.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_tax-categories/components/tax-category-bulk-actions.tsx
@@ -8,7 +8,6 @@ export const DeleteTaxCategoriesBulkAction: BulkActionComponent<any> = ({ select
             mutationDocument={deleteTaxCategoriesDocument}
             entityName="tax categories"
             requiredPermissions={['DeleteTaxCategory']}
-            invalidateQueries={['taxCategories']}
             selection={selection}
             table={table}
         />

--- a/packages/dashboard/src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
@@ -16,7 +16,6 @@ import { ActionBarItem } from '@/vdb/framework/layout-engine/action-bar-item-wra
 import { detailPageRouteLoader } from '@/vdb/framework/page/detail-page-route-loader.js';
 import { useDetailPage } from '@/vdb/framework/page/use-detail-page.js';
 import { Trans, useLingui } from '@lingui/react/macro';
-import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { toast } from 'sonner';
 import {
@@ -47,7 +46,6 @@ function TaxCategoryDetailPage() {
     const navigate = useNavigate();
     const creatingNewEntity = params.id === NEW_ENTITY_PATH;
     const { t } = useLingui();
-    const queryClient = useQueryClient();
 
     const { form, submitHandler, entity, isPending, resetForm } = useDetailPage({
         pageId,
@@ -69,7 +67,6 @@ function TaxCategoryDetailPage() {
                     ? t`Successfully created tax category`
                     : t`Successfully updated tax category`,
             );
-            await queryClient.invalidateQueries({ queryKey: ['taxCategories'] });
             form.reset(form.getValues());
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });

--- a/packages/dashboard/src/lib/components/shared/channel-selector.tsx
+++ b/packages/dashboard/src/lib/components/shared/channel-selector.tsx
@@ -29,7 +29,6 @@ export function ChannelSelector<T extends boolean>(props: ChannelSelectorProps<T
     const { data: channelsData } = useQuery({
         queryKey: ['channels'],
         queryFn: () => api.query(channelsDocument, {}),
-        staleTime: 1000 * 60 * 5,
     });
 
     const items = (channelsData?.channels.items ?? []).map(channel => ({

--- a/packages/dashboard/src/lib/components/shared/country-selector.tsx
+++ b/packages/dashboard/src/lib/components/shared/country-selector.tsx
@@ -11,6 +11,7 @@ import { api } from '@/vdb/graphql/api.js';
 import { graphql } from '@/vdb/graphql/graphql.js';
 import { Trans } from '@lingui/react/macro';
 import { useQuery } from '@tanstack/react-query';
+import { useDebounce } from '@uidotdev/usehooks';
 import { Plus, Search } from 'lucide-react';
 import { useState } from 'react';
 
@@ -42,20 +43,21 @@ export interface CountrySelectorProps {
 export function CountrySelector(props: CountrySelectorProps) {
     const [open, setOpen] = useState(false);
     const [searchTerm, setSearchTerm] = useState('');
+    const debouncedSearchTerm = useDebounce(searchTerm, 300);
 
     const { data, isLoading } = useQuery({
-        queryKey: ['countries', searchTerm],
+        queryKey: ['countries', debouncedSearchTerm],
         queryFn: () =>
             api.query(countryListDocument, {
                 options: {
                     sort: { name: 'ASC' },
-                    filter: searchTerm
+                    filter: debouncedSearchTerm
                         ? {
-                              name: { contains: searchTerm },
-                              code: { contains: searchTerm },
+                              name: { contains: debouncedSearchTerm },
+                              code: { contains: debouncedSearchTerm },
                           }
                         : undefined,
-                    filterOperator: searchTerm ? 'OR' : undefined,
+                    filterOperator: debouncedSearchTerm ? 'OR' : undefined,
                 },
             }),
     });

--- a/packages/dashboard/src/lib/components/shared/country-selector.tsx
+++ b/packages/dashboard/src/lib/components/shared/country-selector.tsx
@@ -58,7 +58,6 @@ export function CountrySelector(props: CountrySelectorProps) {
                     filterOperator: searchTerm ? 'OR' : undefined,
                 },
             }),
-        staleTime: 1000 * 60 * 60, // 1 hour
     });
 
     const handleSearch = (value: string) => {

--- a/packages/dashboard/src/lib/components/shared/customer-address-form.tsx
+++ b/packages/dashboard/src/lib/components/shared/customer-address-form.tsx
@@ -1,8 +1,6 @@
-import { api } from '@/vdb/graphql/api.js';
-import { graphql } from '@/vdb/graphql/graphql.js';
 import { z, zodResolver } from '@/vdb/lib/zod.js';
+import { useAvailableCountries } from '@/vdb/hooks/use-available-countries.js';
 import { Trans, useLingui } from '@lingui/react/macro';
-import { useQuery } from '@tanstack/react-query';
 import { Controller, useForm } from 'react-hook-form';
 import { Button } from '../ui/button.js';
 import { Checkbox } from '../ui/checkbox.js';
@@ -12,19 +10,6 @@ import { Input } from '../ui/input.js';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select.js';
 import { FormFieldWrapper } from './form-field-wrapper.js';
 import { CustomFieldsForm } from './custom-fields-form.js';
-
-// Query document to fetch available countries
-const getAvailableCountriesDocument = graphql(`
-    query GetAvailableCountries {
-        countries(options: { filter: { enabled: { eq: true } } }) {
-            items {
-                id
-                code
-                name
-            }
-        }
-    }
-`);
 
 const addressFormSchema = z.object({
     id: z.string(),
@@ -73,10 +58,7 @@ export function CustomerAddressForm<T>({
     const { t } = useLingui();
 
     // Fetch available countries
-    const { data: countriesData, isLoading: isLoadingCountries } = useQuery({
-        queryKey: ['availableCountries'],
-        queryFn: () => api.query(getAvailableCountriesDocument),
-    });
+    const { data: countriesData, isLoading: isLoadingCountries } = useAvailableCountries();
 
     const form = useForm<AddressFormValues>({
         resolver: zodResolver(addressFormSchema),

--- a/packages/dashboard/src/lib/components/shared/customer-address-form.tsx
+++ b/packages/dashboard/src/lib/components/shared/customer-address-form.tsx
@@ -76,7 +76,6 @@ export function CustomerAddressForm<T>({
     const { data: countriesData, isLoading: isLoadingCountries } = useQuery({
         queryKey: ['availableCountries'],
         queryFn: () => api.query(getAvailableCountriesDocument),
-        staleTime: 1000 * 60 * 60 * 24, // 24 hours
     });
 
     const form = useForm<AddressFormValues>({

--- a/packages/dashboard/src/lib/components/shared/customer-group-selector.tsx
+++ b/packages/dashboard/src/lib/components/shared/customer-group-selector.tsx
@@ -35,7 +35,6 @@ export function CustomerGroupSelector(props: CustomerGroupSelectorProps) {
                     sort: { name: 'ASC' },
                 },
             }),
-        staleTime: 1000 * 60 * 5,
     });
 
     return (

--- a/packages/dashboard/src/lib/components/shared/customer-selector.tsx
+++ b/packages/dashboard/src/lib/components/shared/customer-selector.tsx
@@ -90,7 +90,6 @@ function CustomerSearch({ onSelect }: Readonly<{ onSelect: (value: Customer) => 
                     filterOperator: debouncedSearchTerm ? 'OR' : undefined,
                 },
             }),
-        staleTime: 1000 * 60, // 1 minute
     });
 
     return (

--- a/packages/dashboard/src/lib/components/shared/language-selector.tsx
+++ b/packages/dashboard/src/lib/components/shared/language-selector.tsx
@@ -25,7 +25,6 @@ export function LanguageSelector<T extends boolean>(props: LanguageSelectorProps
     const { data } = useQuery({
         queryKey: ['availableGlobalLanguages'],
         queryFn: () => api.query(availableGlobalLanguages),
-        staleTime: 1000 * 60 * 5, // 5 minutes
     });
     const { value, onChange, multiple, availableLanguageCodes } = props;
     const { t } = useLingui();

--- a/packages/dashboard/src/lib/components/shared/product-variant-selector.tsx
+++ b/packages/dashboard/src/lib/components/shared/product-variant-selector.tsx
@@ -62,7 +62,6 @@ export function ProductVariantSelector({ onProductVariantSelect }: Readonly<Prod
 
     const { data } = useQuery({
         queryKey: ['productVariants', debouncedSearch],
-        staleTime: 1000 * 60 * 5,
         enabled: debouncedSearch.length > 0,
         queryFn: () =>
             api.query(productVariantListDocument, {

--- a/packages/dashboard/src/lib/components/shared/tax-category-selector.tsx
+++ b/packages/dashboard/src/lib/components/shared/tax-category-selector.tsx
@@ -32,7 +32,6 @@ export interface TaxCategorySelectorProps {
 export function TaxCategorySelector({ value, onChange }: Readonly<TaxCategorySelectorProps>) {
     const { data, isLoading, isPending, status } = useQuery({
         queryKey: ['taxCategories'],
-        staleTime: 1000 * 60 * 5,
         queryFn: () =>
             api.query(taxCategoriesDocument, {
                 options: {

--- a/packages/dashboard/src/lib/components/shared/zone-selector.tsx
+++ b/packages/dashboard/src/lib/components/shared/zone-selector.tsx
@@ -31,7 +31,6 @@ export interface ZoneSelectorProps {
 export function ZoneSelector({ value, onChange }: Readonly<ZoneSelectorProps>) {
     const { data, isLoading, isPending } = useQuery({
         queryKey: ['zones'],
-        staleTime: 1000 * 60 * 5,
         queryFn: () =>
             api.query(zonesDocument, {
                 options: {

--- a/packages/dashboard/src/lib/hooks/use-available-countries.ts
+++ b/packages/dashboard/src/lib/hooks/use-available-countries.ts
@@ -1,0 +1,34 @@
+import { api } from '@/vdb/graphql/api.js';
+import { graphql } from '@/vdb/graphql/graphql.js';
+import { useQuery } from '@tanstack/react-query';
+
+export const availableCountriesQueryKey = ['availableCountries'];
+
+const availableCountriesDocument = graphql(`
+    query GetAvailableCountries {
+        countries(options: { filter: { enabled: { eq: true } } }) {
+            items {
+                id
+                code
+                name
+            }
+        }
+    }
+`);
+
+/**
+ * @description
+ * Fetches the enabled countries (sorted by name) used to populate country
+ * dropdowns in the address forms. Shared so the query is defined once and its
+ * cache is reused across the customer address form and the shipping-method test
+ * address form. A modest `staleTime` avoids refetching the full list every time
+ * a dialog that renders it mounts; the country admin pages invalidate
+ * `availableCountriesQueryKey` after mutations so the list stays fresh.
+ */
+export function useAvailableCountries() {
+    return useQuery({
+        queryKey: availableCountriesQueryKey,
+        queryFn: () => api.query(availableCountriesDocument),
+        staleTime: 1000 * 60 * 5, // 5 minutes
+    });
+}


### PR DESCRIPTION
Fixes #5177
Fixes #5182

# Description

Shared selector dropdowns in the dashboard (zone, tax category, channel, customer group, language, country, customer, product variant, etc.) each opted into a multi-minute `staleTime` on their list query. Because the dashboard's global `QueryClient` uses the default `staleTime` of `0` (refetch-on-mount, `packages/dashboard/src/app/app-providers.tsx`), each opt-in meant every mutation site anywhere in the app was silently obliged to invalidate a cache key it neither owns nor can see. When it forgot, the dropdown showed a newly created entity as missing, or kept a deleted one, until a full page refresh. This is the class of bug behind #5177 and #5182 (and the same shape as the per-site fixes in #5178 / the closed #5183).

Rather than adding yet another per-site `invalidateQueries` for each entity, this removes the `staleTime` opt-ins from the queries backing mutable entities so the dropdowns refetch when their detail page mounts. These are `take: 100`-style dropdown queries that fire once on mount, so the cache bought nothing. Fixing the cause removes the unbounded obligation instead of documenting it.

Why some invalidateQueries are removed and others kept: refetch-on-mount only makes an invalidation redundant when the component reading the data actually unmounts and remounts. Dropdowns like tax categories and zones unmount when you navigate away and back, so they refetch on remount — their per-site invalidations were dead code and are removed. Components that stay mounted while their data is mutated on the same page still need an explicit invalidation: the collection tree (invalidateQueries={['childCollections']} in collection-bulk-actions.tsx:88) and the asset tags list (['tags'] in asset-tags-editor.tsx / manage-tags-dialog.tsx) are kept for exactly this reason. So this PR both removes and keeps invalidations, deliberately.

### Removed `staleTime` (mutable-entity queries)

- `lib/components/shared/channel-selector.tsx` (`['channels']`)
- `lib/components/shared/tax-category-selector.tsx` (`['taxCategories']`)
- `lib/components/shared/zone-selector.tsx` (`['zones']`)
- `lib/components/shared/customer-group-selector.tsx` (`['customerGroups']`)
- `lib/components/shared/language-selector.tsx` (`['availableGlobalLanguages']`)
- `lib/components/shared/country-selector.tsx` (`['countries', search]`)
- `lib/components/shared/customer-address-form.tsx` (`['availableCountries']`, was 24h)
- `app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx` (`['availableCountries']`, was 24h)
- `lib/components/shared/product-variant-selector.tsx`
- `lib/components/shared/customer-selector.tsx`
- `app/routes/_authenticated/_products/components/add-option-group-dialog.tsx`
- `app/routes/_authenticated/_collections/components/move-collections-dialog.tsx` (x2)
- `app/routes/_authenticated/_collections/collections.tsx` (x2, plus the now-inaccurate comment)

### Reverted the now-redundant per-site invalidation

- Removed the `['taxCategories']` invalidations added for tax categories in #5178 (create/update `onSuccess` and the delete bulk action). Once the selector refetches on mount, they are dead code. (#5183, which did the same for zones, was closed and never merged, so there was nothing to revert there.)

### Left in place (intentionally)

- `configurable-operation-selector.tsx`, `configurable-operation-multi-selector.tsx`, `fulfillment-handler-selector.tsx`, `fulfill-order-dialog.tsx`, `duplicate-entity-dialog.tsx` — server config, immutable until the server restarts.
- `lib/providers/auth.tsx`, `lib/providers/server-config.tsx` (`Infinity`).
- `lib/components/shared/asset/asset-gallery.tsx` — the heaviest query in the set; refetch-on-mount would be noticeable, so its `staleTime` is kept (per the reviewer's judgement-call note).

### Test

Adds `packages/dashboard/e2e/tests/regression/selector-stale-after-mutation.spec.ts`, covering the whole class via the Zone selector on the Tax Rate page. It navigates entirely client-side (TanStack Router `<Link>`s) after a single initial load so the in-memory `QueryClient` — and therefore the cached `['zones']` result — persists across page changes; there is deliberately no `page.goto()` / `page.reload()` between priming the cache and the final assertion, since a reload would spin up a fresh `QueryClient` and mask the bug. Verified to fail when the `staleTime` opt-in is restored.

# Breaking changes

None.

# Screenshots
https://www.loom.com/share/9d0f38162ea24a539c94baf96a8dba3a

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790333628&installation_model_id=20193&pr_number=5190&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5190&signature=52eb4495332d38d12342893eb357bcb06dba5e5b63f4aeca1013f1d608a96720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->