### PR TITLE
fix(dashboard): fix country dropdown in address forms

### DIFF
--- a/packages/dashboard/e2e/tests/customers/customers.spec.ts
+++ b/packages/dashboard/e2e/tests/customers/customers.spec.ts
@@ -53,55 +53,77 @@ test('should show new history entries after updating the customer', async ({ pag
     await expect(page.getByText('Customer details updated').first()).toBeVisible();
 });
 
-// #5191 — the country dropdown on the customer address form must include every
-// enabled country, sorted by name. The query returned countries unsorted, and
-// Base UI's Select drops items whose order does not match its own collation, so
-// a country whose name sorted between two existing ones was missing from the
-// dropdown.
-test('address form country dropdown includes a newly created country', async ({ page }) => {
-    const client = new VendureAdminClient(page);
-    await client.login();
+// #5191 — the country dropdown on the customer address form.
+test.describe('Address form country dropdown', () => {
+    let countryId = '';
+    let customerId = '';
 
-    // A name that sorts in the middle of the list (between the seeded "Austria"
-    // and "Canada"), which is exactly where the unsorted-order bug dropped items.
-    const suffix = Date.now();
-    const countryName = `Belgium E2E ${suffix}`;
-    const countryCode = `QE${suffix.toString().slice(-4)}`;
+    // Runs even if the test body throws, so created entities never leak.
+    test.afterEach(async ({ page }) => {
+        if (!countryId && !customerId) return;
+        const client = new VendureAdminClient(page);
+        await client.login();
+        if (customerId) {
+            await client.gql(`mutation ($id: ID!) { deleteCustomer(id: $id) { result } }`, {
+                id: customerId,
+            });
+            customerId = '';
+        }
+        if (countryId) {
+            await client.gql(`mutation ($id: ID!) { deleteCountry(id: $id) { result } }`, {
+                id: countryId,
+            });
+            countryId = '';
+        }
+    });
 
-    const countryResult = await client.gql(
-        `mutation CreateCountryForAddressTest($input: CreateCountryInput!) {
-            createCountry(input: $input) { id }
-        }`,
-        {
-            input: {
-                code: countryCode,
-                enabled: true,
-                translations: [{ languageCode: 'en', name: countryName }],
+    // The dropdown must include every enabled country, sorted by name. The query
+    // returned countries unsorted, and Base UI's Select drops items whose order
+    // does not match its own collation, so a country whose name sorted between
+    // two existing ones was missing from the dropdown.
+    test('includes a newly created country in sorted order', async ({ page }) => {
+        const client = new VendureAdminClient(page);
+        await client.login();
+
+        // A name that sorts in the middle of the list (between the seeded "Austria"
+        // and "Canada"), which is exactly where the unsorted-order bug dropped items.
+        const suffix = Date.now();
+        const countryName = `Belgium E2E ${suffix}`;
+        const countryCode = `QE${suffix.toString().slice(-4)}`;
+
+        const countryResult = await client.gql(
+            `mutation CreateCountryForAddressTest($input: CreateCountryInput!) {
+                createCountry(input: $input) { id }
+            }`,
+            {
+                input: {
+                    code: countryCode,
+                    enabled: true,
+                    translations: [{ languageCode: 'en', name: countryName }],
+                },
             },
-        },
-    );
-    const countryId = countryResult.createCountry.id as string;
-    expect(countryId).toBeTruthy();
+        );
+        countryId = countryResult.createCountry.id as string;
+        expect(countryId).toBeTruthy();
 
-    const customerResult = await client.gql(
-        `mutation CreateCustomerForAddressTest($input: CreateCustomerInput!) {
-            createCustomer(input: $input) {
-                ... on Customer { id }
-                ... on ErrorResult { errorCode message }
-            }
-        }`,
-        {
-            input: {
-                firstName: 'Address',
-                lastName: 'CountryTest',
-                emailAddress: `address-country-test-${suffix}@example.com`,
+        const customerResult = await client.gql(
+            `mutation CreateCustomerForAddressTest($input: CreateCustomerInput!) {
+                createCustomer(input: $input) {
+                    ... on Customer { id }
+                    ... on ErrorResult { errorCode message }
+                }
+            }`,
+            {
+                input: {
+                    firstName: 'Address',
+                    lastName: 'CountryTest',
+                    emailAddress: `address-country-test-${suffix}@example.com`,
+                },
             },
-        },
-    );
-    const customerId = customerResult.createCustomer.id as string;
-    expect(customerId).toBeTruthy();
+        );
+        customerId = customerResult.createCustomer.id as string;
+        expect(customerId).toBeTruthy();
 
-    try {
         await page.goto(`/customers/${customerId}`);
         await expect(page.getByRole('heading', { name: 'Address CountryTest' })).toBeVisible();
 
@@ -121,40 +143,43 @@ test('address form country dropdown includes a newly created country', async ({ 
         const optionLabels = await page.getByRole('option').allInnerTexts();
         const sorted = [...optionLabels].sort((a, b) => a.localeCompare(b));
         expect(optionLabels).toEqual(sorted);
-    } finally {
-        // Cleanup.
-        await client.gql(`mutation ($id: ID!) { deleteCustomer(id: $id) { result } }`, {
-            id: customerId,
-        });
-        await client.gql(`mutation ($id: ID!) { deleteCountry(id: $id) { result } }`, {
-            id: countryId,
-        });
-    }
-});
+    });
 
-// #5191 (symptom 2) — editing an existing address must pre-select its country
-// in the Country dropdown, rather than falling back to the placeholder.
-test('editing an existing address pre-selects its country', async ({ page }) => {
-    const client = new VendureAdminClient(page);
-    await client.login();
-    const suffix = Date.now();
-    const countryName = `Belgium E2E ${suffix}`;
-    const countryCode = `QE${suffix.toString().slice(-4)}`;
-    const country = await client.gql(
-        `mutation ($input: CreateCountryInput!) { createCountry(input: $input) { id } }`,
-        { input: { code: countryCode, enabled: true, translations: [{ languageCode: 'en', name: countryName }] } },
-    );
-    const countryId = country.createCountry.id as string;
-    const cust = await client.gql(
-        `mutation ($input: CreateCustomerInput!) { createCustomer(input: $input) { ... on Customer { id } } }`,
-        { input: { firstName: 'Edit', lastName: 'CountryTest', emailAddress: `edit-country-${suffix}@example.com` } },
-    );
-    const customerId = cust.createCustomer.id as string;
-    await client.gql(
-        `mutation ($customerId: ID!, $input: CreateAddressInput!) { createCustomerAddress(customerId: $customerId, input: $input) { id } }`,
-        { customerId, input: { streetLine1: '1 Test St', city: 'Testville', countryCode } },
-    );
-    try {
+    // Editing an existing address must pre-select its country in the Country
+    // dropdown, rather than falling back to the placeholder.
+    test('pre-selects an existing address country when editing', async ({ page }) => {
+        const client = new VendureAdminClient(page);
+        await client.login();
+        const suffix = Date.now();
+        const countryName = `Belgium E2E ${suffix}`;
+        const countryCode = `QE${suffix.toString().slice(-4)}`;
+        const country = await client.gql(
+            `mutation ($input: CreateCountryInput!) { createCountry(input: $input) { id } }`,
+            {
+                input: {
+                    code: countryCode,
+                    enabled: true,
+                    translations: [{ languageCode: 'en', name: countryName }],
+                },
+            },
+        );
+        countryId = country.createCountry.id as string;
+        const cust = await client.gql(
+            `mutation ($input: CreateCustomerInput!) { createCustomer(input: $input) { ... on Customer { id } } }`,
+            {
+                input: {
+                    firstName: 'Edit',
+                    lastName: 'CountryTest',
+                    emailAddress: `edit-country-${suffix}@example.com`,
+                },
+            },
+        );
+        customerId = cust.createCustomer.id as string;
+        await client.gql(
+            `mutation ($customerId: ID!, $input: CreateAddressInput!) { createCustomerAddress(customerId: $customerId, input: $input) { id } }`,
+            { customerId, input: { streetLine1: '1 Test St', city: 'Testville', countryCode } },
+        );
+
         await page.goto(`/customers/${customerId}`);
         await expect(page.getByRole('heading', { name: 'Edit CountryTest' })).toBeVisible();
         await page.locator('[data-slot="dialog-trigger"]').first().click();
@@ -163,10 +188,9 @@ test('editing an existing address pre-selects its country', async ({ page }) => 
         const editCountryField = editDialog.locator('[data-slot="field"]').filter({
             has: page.locator('[data-slot="field-label"]').getByText('Country', { exact: true }),
         });
-        await expect(editCountryField.getByRole('combobox')).toContainText(countryName, { timeout: 10_000 });
-    } finally {
-        await client.gql(`mutation ($id: ID!) { deleteCustomer(id: $id) { result } }`, { id: customerId });
-        await client.gql(`mutation ($id: ID!) { deleteCountry(id: $id) { result } }`, { id: countryId });
-    }
+        await expect(editCountryField.getByRole('combobox')).toContainText(countryName, {
+            timeout: 10_000,
+        });
+    });
 });
 

--- a/packages/dashboard/e2e/tests/customers/customers.spec.ts
+++ b/packages/dashboard/e2e/tests/customers/customers.spec.ts
@@ -52,3 +52,121 @@ test('should show new history entries after updating the customer', async ({ pag
 
     await expect(page.getByText('Customer details updated').first()).toBeVisible();
 });
+
+// #5191 — the country dropdown on the customer address form must include every
+// enabled country, sorted by name. The query returned countries unsorted, and
+// Base UI's Select drops items whose order does not match its own collation, so
+// a country whose name sorted between two existing ones was missing from the
+// dropdown.
+test('address form country dropdown includes a newly created country', async ({ page }) => {
+    const client = new VendureAdminClient(page);
+    await client.login();
+
+    // A name that sorts in the middle of the list (between the seeded "Austria"
+    // and "Canada"), which is exactly where the unsorted-order bug dropped items.
+    const suffix = Date.now();
+    const countryName = `Belgium E2E ${suffix}`;
+    const countryCode = `QE${suffix.toString().slice(-4)}`;
+
+    const countryResult = await client.gql(
+        `mutation CreateCountryForAddressTest($input: CreateCountryInput!) {
+            createCountry(input: $input) { id }
+        }`,
+        {
+            input: {
+                code: countryCode,
+                enabled: true,
+                translations: [{ languageCode: 'en', name: countryName }],
+            },
+        },
+    );
+    const countryId = countryResult.createCountry.id as string;
+    expect(countryId).toBeTruthy();
+
+    const customerResult = await client.gql(
+        `mutation CreateCustomerForAddressTest($input: CreateCustomerInput!) {
+            createCustomer(input: $input) {
+                ... on Customer { id }
+                ... on ErrorResult { errorCode message }
+            }
+        }`,
+        {
+            input: {
+                firstName: 'Address',
+                lastName: 'CountryTest',
+                emailAddress: `address-country-test-${suffix}@example.com`,
+            },
+        },
+    );
+    const customerId = customerResult.createCustomer.id as string;
+    expect(customerId).toBeTruthy();
+
+    try {
+        await page.goto(`/customers/${customerId}`);
+        await expect(page.getByRole('heading', { name: 'Address CountryTest' })).toBeVisible();
+
+        // Open the "Add new address" dialog and its Country select.
+        await page.getByRole('button', { name: 'Add new address' }).click();
+        const countryField = page.locator('[data-slot="field"]').filter({
+            has: page.locator('[data-slot="field-label"]').getByText('Country', { exact: true }),
+        });
+        await countryField.getByRole('combobox').click();
+
+        // The newly created country is present in the list.
+        await expect(page.getByRole('option', { name: countryName })).toBeVisible({ timeout: 10_000 });
+
+        // ...and the options are rendered in ascending name order. This is the
+        // real guarantee of the fix: the query now sorts by name, so the order
+        // matches Base UI's collation and no items are dropped from the popup.
+        const optionLabels = await page.getByRole('option').allInnerTexts();
+        const sorted = [...optionLabels].sort((a, b) => a.localeCompare(b));
+        expect(optionLabels).toEqual(sorted);
+    } finally {
+        // Cleanup.
+        await client.gql(`mutation ($id: ID!) { deleteCustomer(id: $id) { result } }`, {
+            id: customerId,
+        });
+        await client.gql(`mutation ($id: ID!) { deleteCountry(id: $id) { result } }`, {
+            id: countryId,
+        });
+    }
+});
+
+// #5191 (symptom 2) — editing an existing address must pre-select its country
+// in the Country dropdown, rather than falling back to the placeholder.
+test('editing an existing address pre-selects its country', async ({ page }) => {
+    const client = new VendureAdminClient(page);
+    await client.login();
+    const suffix = Date.now();
+    const countryName = `Belgium E2E ${suffix}`;
+    const countryCode = `QE${suffix.toString().slice(-4)}`;
+    const country = await client.gql(
+        `mutation ($input: CreateCountryInput!) { createCountry(input: $input) { id } }`,
+        { input: { code: countryCode, enabled: true, translations: [{ languageCode: 'en', name: countryName }] } },
+    );
+    const countryId = country.createCountry.id as string;
+    const cust = await client.gql(
+        `mutation ($input: CreateCustomerInput!) { createCustomer(input: $input) { ... on Customer { id } } }`,
+        { input: { firstName: 'Edit', lastName: 'CountryTest', emailAddress: `edit-country-${suffix}@example.com` } },
+    );
+    const customerId = cust.createCustomer.id as string;
+    await client.gql(
+        `mutation ($customerId: ID!, $input: CreateAddressInput!) { createCustomerAddress(customerId: $customerId, input: $input) { id } }`,
+        { customerId, input: { streetLine1: '1 Test St', city: 'Testville', countryCode } },
+    );
+    try {
+        await page.goto(`/customers/${customerId}`);
+        await expect(page.getByRole('heading', { name: 'Edit CountryTest' })).toBeVisible();
+        await page.locator('[data-slot="dialog-trigger"]').first().click();
+        const editDialog = page.getByRole('dialog').filter({ hasText: 'Edit Address' });
+        await expect(editDialog).toBeVisible();
+        const editCountryField = editDialog.locator('[data-slot="field"]').filter({
+            has: page.locator('[data-slot="field-label"]').getByText('Country', { exact: true }),
+        });
+        await expect(editCountryField.getByRole('combobox')).toContainText(countryName, { timeout: 10_000 });
+    } finally {
+        await client.gql(`mutation ($id: ID!) { deleteCustomer(id: $id) { result } }`, { id: customerId });
+        await client.gql(`mutation ($id: ID!) { deleteCountry(id: $id) { result } }`, { id: countryId });
+    }
+});
+

--- a/packages/dashboard/src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
@@ -2,7 +2,7 @@ import { FormFieldWrapper } from '@/vdb/components/shared/form-field-wrapper.js'
 import { AccordionContent, AccordionItem, AccordionTrigger } from '@/vdb/components/ui/accordion.js';
 import { Form } from '@/vdb/components/ui/form.js';
 import { Input } from '@/vdb/components/ui/input.js';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/vdb/components/ui/select.js';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/vdb/components/ui/select.js';
 import { LS_KEY_SHIPPING_TEST_ADDRESS } from '@/vdb/constants.js';
 import { useAvailableCountries } from '@/vdb/hooks/use-available-countries.js';
 import { Trans } from '@lingui/react/macro';
@@ -200,19 +200,29 @@ export function TestAddressForm({ onAddressChange }: Readonly<TestAddressFormPro
                                 render={({ field }) => (
                                     <Select
                                         items={countriesData ? Object.fromEntries(countriesData.countries.items.map(c => [c.code, c.name])) : {}}
-                                        onValueChange={field.onChange}
-                                        value={field.value}
+                                        onValueChange={value => value && field.onChange(value)}
+                                        value={field.value ?? ''}
                                         disabled={isLoadingCountries}
                                     >
                                         <SelectTrigger>
-                                            <SelectValue placeholder="Select a country" />
+                                            <SelectValue placeholder="Select a country">
+                                                {(value: string) =>
+                                                    countriesData?.countries.items.find(
+                                                        c => c.code === value,
+                                                    )?.name
+                                                }
+                                            </SelectValue>
                                         </SelectTrigger>
                                         <SelectContent>
-                                            {countriesData?.countries.items.map(country => (
-                                                <SelectItem key={country.code} value={country.code}>
-                                                    {country.name}
-                                                </SelectItem>
-                                            ))}
+                                            {countriesData && (
+                                                <SelectGroup>
+                                                    {countriesData.countries.items.map(country => (
+                                                        <SelectItem key={country.code} value={country.code}>
+                                                            {country.name}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectGroup>
+                                            )}
                                         </SelectContent>
                                     </Select>
                                 )}

--- a/packages/dashboard/src/lib/components/shared/customer-address-form.tsx
+++ b/packages/dashboard/src/lib/components/shared/customer-address-form.tsx
@@ -7,7 +7,7 @@ import { Checkbox } from '../ui/checkbox.js';
 import { FieldDescription, FieldLabel } from '../ui/field.js';
 import { Form } from '../ui/form.js';
 import { Input } from '../ui/input.js';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select.js';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '../ui/select.js';
 import { FormFieldWrapper } from './form-field-wrapper.js';
 import { CustomFieldsForm } from './custom-fields-form.js';
 
@@ -168,21 +168,34 @@ export function CustomerAddressForm<T>({
                         renderFormControl={false}
                         render={({ field }) => (
                             <Select
-                                items={countriesData ? Object.fromEntries(countriesData.countries.items.map(c => [c.code, c.name])) : {}}
-                                onValueChange={field.onChange}
-                                defaultValue={field.value || undefined}
-                                value={field.value || undefined}
+                                items={
+                                    countriesData
+                                        ? Object.fromEntries(
+                                              countriesData.countries.items.map(c => [c.code, c.name]),
+                                          )
+                                        : {}
+                                }
+                                value={field.value ?? ''}
+                                onValueChange={value => value && field.onChange(value)}
                                 disabled={isLoadingCountries}
                             >
                                 <SelectTrigger>
-                                    <SelectValue placeholder={t`Select a country`} />
+                                    <SelectValue placeholder={t`Select a country`}>
+                                        {(value: string) =>
+                                            countriesData?.countries.items.find(c => c.code === value)?.name
+                                        }
+                                    </SelectValue>
                                 </SelectTrigger>
                                 <SelectContent>
-                                    {countriesData?.countries.items.map(country => (
-                                        <SelectItem key={country.code} value={country.code}>
-                                            {country.name}
-                                        </SelectItem>
-                                    ))}
+                                    {countriesData && (
+                                        <SelectGroup>
+                                            {countriesData.countries.items.map(country => (
+                                                <SelectItem key={country.code} value={country.code}>
+                                                    {country.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectGroup>
+                                    )}
                                 </SelectContent>
                             </Select>
                         )}

--- a/packages/dashboard/src/lib/hooks/use-available-countries.ts
+++ b/packages/dashboard/src/lib/hooks/use-available-countries.ts
@@ -6,7 +6,7 @@ export const availableCountriesQueryKey = ['availableCountries'];
 
 const availableCountriesDocument = graphql(`
     query GetAvailableCountries {
-        countries(options: { filter: { enabled: { eq: true } } }) {
+        countries(options: { filter: { enabled: { eq: true } }, sort: { name: ASC } }) {
             items {
                 id
                 code


### PR DESCRIPTION
Fixes #5191

# Description

The **Country** dropdown on the customer address form had two problems:

1. **Countries could be missing from the list.** A country that existed and was returned by the API was absent from the dropdown (verified: the API returned all countries including the "missing" one, but it wasn't in the rendered options).
2. **Editing an existing address didn't pre-select its country.** Opening an existing address for editing showed the placeholder instead of the saved country.

Both came down to the country `<Select>` not following the pattern used by the other entity selectors in the dashboard:

- The `GetAvailableCountries` query fetched countries **unsorted**, unlike `country-selector.tsx` / `customer-group-selector.tsx` which sort by name. Adding `sort: { name: ASC }` makes all countries render in a predictable order.
- The `<Select>` used `value={field.value || undefined}` with no `SelectValue` label resolver, so a value set before the item list loaded was discarded and never re-applied. Aligning it with the working selectors (`value={field.value ?? ''}`, `onValueChange={value => value && field.onChange(value)}`, and a `<SelectValue>` children function that resolves the label from the loaded data) fixes the pre-selection.

Applied in both places that use this dropdown:
- `packages/dashboard/src/lib/components/shared/customer-address-form.tsx` (customer address add/edit, draft-order addresses)
- `packages/dashboard/src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx` (shipping-method test address)

Adds e2e tests covering both: the dropdown includes a newly created country in sorted order, and editing an existing address pre-selects its country.

# Breaking changes

None.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790340275&installation_model_id=20193&pr_number=5192&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5192&signature=01ee875eff4a9c6b50061de507e3ccce7952b7d713a64653faff3922e9fa9f76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->