### PR TITLE
fix: publish OrderEvent when customer is assigned to order

### DIFF
--- a/packages/core/e2e/order-merge.e2e-spec.ts
+++ b/packages/core/e2e/order-merge.e2e-spec.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
+    EventBus,
     mergeConfig,
     MergedOrderLine,
     MergeOrdersStrategy,
     Order,
+    OrderEvent,
     OrderMergeStrategy,
     Product,
     RequestContext,
@@ -454,5 +456,21 @@ describe('Order merging', () => {
         expect(result.lines[0].productVariant.id).toBe('T_1');
         expect(result.lines[0].quantity).toBe(3);
         expect(result.lines[0].customFields.relationField?.id).toBe('T_4');
+    });
+
+    // #5189 — login with an existing active cart and no guest cart must not publish OrderEvent
+    it('login with existing cart and no guest cart publishes zero OrderEvents', async () => {
+        const eventBus = server.app.get(EventBus);
+        const events: OrderEvent[] = [];
+        const subscription = eventBus.ofType(OrderEvent).subscribe(event => events.push(event));
+
+        // Log in as a customer who already has an active order, with no guest cart
+        await shopClient.asUserWithCredentials(customers[0].emailAddress, 'test');
+
+        // Allow any async event delivery to settle
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(events).toHaveLength(0);
+        subscription.unsubscribe();
     });
 });

--- a/packages/core/e2e/order.e2e-spec.ts
+++ b/packages/core/e2e/order.e2e-spec.ts
@@ -12,12 +12,14 @@ import {
 import { omit } from '@vendure/common/lib/omit';
 import { pick } from '@vendure/common/lib/pick';
 import {
+    EventBus,
     OrderService,
     RequestContextService,
     defaultShippingCalculator,
     defaultShippingEligibilityChecker,
     manualFulfillmentHandler,
     mergeConfig,
+    OrderEvent,
 } from '@vendure/core';
 import {
     ErrorResultGuard,
@@ -2142,6 +2144,28 @@ describe('Orders resolver', () => {
                     type: HistoryEntryType.ORDER_CUSTOMER_UPDATED,
                 },
             ]);
+        });
+
+        it('setOrderCustomer publishes exactly one OrderEvent', async () => {
+            const eventBus = server.app.get(EventBus);
+            const events: OrderEvent[] = [];
+            const subscription = eventBus.ofType(OrderEvent).subscribe(event => events.push(event));
+
+            const { setOrderCustomer } = await adminClient.query(setOrderCustomerDocument, {
+                input: {
+                    orderId,
+                    customerId: customers[2].id,
+                    note: 'Event test',
+                },
+            });
+
+            // Allow any async event delivery to settle
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            expect(events).toHaveLength(1);
+            expect(events[0].type).toBe('updated');
+            expect(events[0].order.id).toBe(orderId);
+            subscription.unsubscribe();
         });
     });
 

--- a/packages/core/e2e/shop-order.e2e-spec.ts
+++ b/packages/core/e2e/shop-order.e2e-spec.ts
@@ -6,8 +6,10 @@ import {
     Asset,
     defaultShippingCalculator,
     defaultShippingEligibilityChecker,
+    EventBus,
     manualFulfillmentHandler,
     mergeConfig,
+    OrderEvent,
 } from '@vendure/core';
 import { createErrorResultGuard, createTestEnvironment, ErrorResultGuard } from '@vendure/testing';
 import { fail } from 'assert';
@@ -999,6 +1001,29 @@ describe('Shop orders', () => {
             expect(customer.lastName).toBe('Person');
             expect(customer.emailAddress).toBe('test@test.com');
             expect(customer.id).toBe(createdCustomerId);
+        });
+
+        it('setCustomerForOrder publishes exactly one OrderEvent', async () => {
+            const eventBus = server.app.get(EventBus);
+            const events: OrderEvent[] = [];
+            const subscription = eventBus.ofType(OrderEvent).subscribe(event => events.push(event));
+
+            const { setCustomerForOrder } = await shopClient.query(setCustomerDocument, {
+                input: {
+                    emailAddress: 'event-test@test.com',
+                    firstName: 'Event',
+                    lastName: 'Test',
+                },
+            });
+            orderResultGuard.assertSuccess(setCustomerForOrder);
+
+            // Allow any async event delivery to settle
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            expect(events).toHaveLength(1);
+            expect(events[0].type).toBe('updated');
+            expect(events[0].order.id).toBe(setCustomerForOrder.id);
+            subscription.unsubscribe();
         });
 
         describe('address handling', () => {

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -573,7 +573,6 @@ export class OrderService implements OnApplicationBootstrap {
         }
 
         const updatedOrder = await this.addCustomerToOrder(ctx, order.id, targetCustomer);
-        await this.eventBus.publish(new OrderEvent(ctx, updatedOrder, 'updated', targetCustomer));
         await this.historyService.createHistoryEntryForOrder({
             ctx,
             orderId,
@@ -2059,6 +2058,7 @@ export class OrderService implements OnApplicationBootstrap {
                 }
             }
         }
+        await this.eventBus.publish(new OrderEvent(ctx, updatedOrder, 'updated', customer));
         return updatedOrder;
     }
 
@@ -2254,8 +2254,7 @@ export class OrderService implements OnApplicationBootstrap {
                 }
                 const customer = await this.customerService.findOneByUserId(txCtx, user.id);
                 if (order && customer) {
-                    order.customer = customer;
-                    await this.connection.getRepository(txCtx, Order).save(order, { reload: false });
+                    order = await this.addCustomerToOrder(txCtx, order, customer);
                 }
                 return order;
             });

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -2031,7 +2031,13 @@ export class OrderService implements OnApplicationBootstrap {
 
     /**
      * @description
-     * Associates a Customer with the Order.
+     * Associates a Customer with the Order. If the customer is already assigned,
+     * the order is returned unchanged.
+     *
+     * Publishes an {@link OrderEvent} with type `'updated'` and the assigned Customer
+     * as the event input whenever a new customer association is made.
+     *
+     * @since 3.7.2
      */
     async addCustomerToOrder(
         ctx: RequestContext,
@@ -2042,6 +2048,9 @@ export class OrderService implements OnApplicationBootstrap {
             orderIdOrOrder instanceof Order
                 ? orderIdOrOrder
                 : await this.getOrderOrThrow(ctx, orderIdOrOrder);
+        if (idsAreEqual(order.customer?.id, customer.id)) {
+            return order;
+        }
         order.customer = customer;
         await this.connection.getRepository(ctx, Order).save(order, { reload: false });
         let updatedOrder = order;


### PR DESCRIPTION
closes #5189.

# Description

`addCustomerToOrder` now publishes `OrderEvent(ctx, order, 'updated', customer)` internally. This ensures all code paths — admin (`updateOrderCustomer`), shop (`setCustomerForOrder`), draft order (`setCustomerForDraftOrder`), and login-merge — emit the event when a customer is associated with an order.

The duplicate event publish in `updateOrderCustomer` was removed. The raw `save()` in `mergeOrders` was replaced with a call to `addCustomerToOrder`, which also gains coupon code revalidation.

# Note

# Breaking changes

The new code delegates to addCustomerToOrder, which also validates coupon codes (lines 2049-2059) and removes any that are invalid for the newly assigned customer. This means if a guest had coupon codes that don't apply to their registered account, they'll be silently stripped during merge.

This is arguably the correct behavior — but it's a behavioral change beyond the scope of "fire an OrderEvent."

# Screenshots



# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [x] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790422988&installation_model_id=20193&pr_number=5196&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5196&signature=6d4e67ad1161c2e8f15411aa9ae681ebb8bea70325ee3dbe066969e6957c0f47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->