### PR TITLE
ci: automate dependency updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+
+# Scoping note: Dependabot security updates only raise pull requests for the
+# directories declared here. Test fixture manifests — packages/cli/e2e/fixtures
+# and packages/dashboard/vite/tests/**/fake_node_modules — are deliberately not
+# covered. They declare @vendure/core to exercise the CLI and Vite plugin, are
+# never installed, and are never published.
+updates:
+    # GitHub Actions are pinned by commit SHA. Dependabot updates the pin and
+    # the trailing version comment together.
+    #
+    # These pull requests modify .github/workflows/, which CODEOWNERS requires
+    # a listed maintainer to approve, so they are never auto-merged. They are
+    # grouped into a single weekly pull request to keep that review to one item.
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: weekly
+          day: monday
+      groups:
+          github-actions:
+              patterns:
+                  - '*'
+      commit-message:
+          prefix: chore
+          include: scope
+      labels:
+          - dependencies
+
+    # The docs site is a separate npm project with its own lockfile. It is not
+    # published to npm and is not part of the bun workspace.
+    - package-ecosystem: npm
+      directory: /docs
+      schedule:
+          interval: weekly
+          day: monday
+      open-pull-requests-limit: 3
+      groups:
+          docs:
+              patterns:
+                  - '*'
+              update-types:
+                  - minor
+                  - patch
+      commit-message:
+          prefix: chore
+          include: scope
+      labels:
+          - dependencies
+          - docs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,7 @@ updates:
           prefix: chore
           include: scope
       labels:
-          - dependencies
+          - 'type: chore 🧤'
 
     # The docs site is a separate npm project with its own lockfile. It is not
     # published to npm and is not part of the bun workspace.
@@ -55,8 +55,8 @@ updates:
           prefix: chore
           include: scope
       labels:
-          - dependencies
-          - docs
+          - 'type: chore 🧤'
+          - 'docs 📖'
 
     # The root bun workspace covers the published packages under packages/*.
     #
@@ -168,4 +168,4 @@ updates:
           prefix: chore
           include: scope
       labels:
-          - dependencies
+          - 'type: chore 🧤'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,3 +48,113 @@ updates:
       labels:
           - dependencies
           - docs
+
+    # The root bun workspace covers the published packages under packages/*.
+    #
+    # Note: Dependabot supports version updates for the bun ecosystem but NOT
+    # security updates. Vulnerabilities in these packages will not raise a pull
+    # request on their own — they are picked up by the weekly version update if
+    # the fix is within range, and otherwise need to be bumped deliberately.
+    - package-ecosystem: bun
+      directory: /
+      schedule:
+          interval: weekly
+          day: monday
+      open-pull-requests-limit: 10
+      # These packages are published, so the declared range is part of the
+      # public contract. Only widen it when the new version falls outside.
+      versioning-strategy: increase-if-necessary
+      ignore:
+          # Workspace-internal packages are versioned by the release process.
+          - dependency-name: '@vendure/*'
+      # Families that must move in lockstep are grouped so they land in one
+      # pull request. Groups cover minor and patch only; a major update arrives
+      # as its own pull request, because a major is a migration rather than a
+      # bump and should not hold a mergeable group hostage.
+      groups:
+          typescript:
+              patterns:
+                  - typescript
+              update-types:
+                  - minor
+                  - patch
+          types:
+              patterns:
+                  - '@types/*'
+              update-types:
+                  - minor
+                  - patch
+          dev-tooling:
+              patterns:
+                  - eslint
+                  - eslint-*
+                  - '@typescript-eslint/*'
+                  - prettier
+                  - prettier-*
+                  - vitest
+                  - '@vitest/*'
+                  - rimraf
+                  - concurrently
+                  - cross-env
+                  - ts-node
+              update-types:
+                  - minor
+                  - patch
+          nestjs:
+              patterns:
+                  - '@nestjs/*'
+              update-types:
+                  - minor
+                  - patch
+          graphql:
+              patterns:
+                  - graphql
+                  - graphql-*
+                  - '@graphql-tools/*'
+                  - '@apollo/*'
+                  - gql.tada
+              update-types:
+                  - minor
+                  - patch
+          typeorm:
+              patterns:
+                  - typeorm
+                  - mysql2
+                  - pg
+                  - better-sqlite3
+                  - sql.js
+              update-types:
+                  - minor
+                  - patch
+          opentelemetry:
+              patterns:
+                  - '@opentelemetry/*'
+              update-types:
+                  - minor
+                  - patch
+          angular:
+              patterns:
+                  - '@angular/*'
+                  - '@angular-devkit/*'
+                  - '@angular-eslint/*'
+              update-types:
+                  - minor
+                  - patch
+          dashboard:
+              patterns:
+                  - react
+                  - react-*
+                  - '@tanstack/*'
+                  - vite
+                  - '@vitejs/*'
+                  - tailwindcss
+                  - '@tailwindcss/*'
+                  - tailwind-merge
+              update-types:
+                  - minor
+                  - patch
+      commit-message:
+          prefix: chore
+          include: scope
+      labels:
+          - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,6 +74,14 @@ updates:
           default-days: 7
       # These packages are published, so the declared range is part of the
       # public contract. Only widen it when the new version falls outside.
+      #
+      # bun is not on the documented list of ecosystems supporting this option
+      # (bundler, cargo, composer, helm, mix, npm, pip, pub, uv). It is kept
+      # anyway: it is either honoured, or ignored, and being ignored leaves the
+      # same default behaviour as omitting it. The auto-merge lane does not rely
+      # on it either way — every allowlisted dependency is declared as a caret
+      # range, so a patch update always falls inside the existing range and no
+      # strategy rewrites the manifest.
       versioning-strategy: increase-if-necessary
       ignore:
           # Workspace-internal packages are versioned by the release process.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,11 @@ updates:
       schedule:
           interval: weekly
           day: monday
+      # Wait a week before proposing a release. A compromised release is
+      # usually found and yanked within days, and this only delays version
+      # updates — security updates are never held back.
+      cooldown:
+          default-days: 7
       groups:
           github-actions:
               patterns:
@@ -35,6 +40,10 @@ updates:
           interval: weekly
           day: monday
       open-pull-requests-limit: 3
+      cooldown:
+          semver-patch-days: 7
+          semver-minor-days: 7
+          semver-major-days: 14
       groups:
           docs:
               patterns:
@@ -61,6 +70,8 @@ updates:
           interval: weekly
           day: monday
       open-pull-requests-limit: 10
+      cooldown:
+          default-days: 7
       # These packages are published, so the declared range is part of the
       # public contract. Only widen it when the new version falls outside.
       versioning-strategy: increase-if-necessary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,13 +95,21 @@ updates:
               update-types:
                   - minor
                   - patch
-          dev-tooling:
+          # Kept separate from dev-tooling because these are the packages the
+          # auto-merge workflow allowlists. Grouping them on their own means a
+          # group pull request contains only allowlisted names.
+          linting:
               patterns:
                   - eslint
                   - eslint-*
                   - '@typescript-eslint/*'
                   - prettier
                   - prettier-*
+              update-types:
+                  - minor
+                  - patch
+          dev-tooling:
+              patterns:
                   - vitest
                   - '@vitest/*'
                   - rimraf

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -159,7 +159,14 @@ jobs:
     sonarqube:
         name: SonarQube
         needs: detect-changes
-        if: needs.detect-changes.outputs.packages == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+        # Dependabot pull requests read from the Dependabot secrets store, not
+        # from Actions secrets, so SONAR_TOKEN resolves empty and the scan
+        # fails. Skipping is safe: all-passed counts a skipped job as a pass,
+        # and the scan still runs on the push to master after the merge.
+        if: >-
+            needs.detect-changes.outputs.packages == 'true'
+            && github.actor != 'dependabot[bot]'
+            && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
         runs-on: ubuntu-latest
         permissions:
             contents: read

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -1,0 +1,101 @@
+name: Dependabot auto-merge
+
+# Uses pull_request_target rather than pull_request. Workflows that Dependabot
+# triggers via pull_request get a read-only GITHUB_TOKEN and read secrets from
+# the Dependabot secrets store, so the CI bot credentials would resolve empty.
+# pull_request_target is exempt from both restrictions.
+#
+# SECURITY: pull_request_target runs the workflow definition from the base
+# branch with access to Actions secrets. This workflow must never check out,
+# build, or execute anything from the pull request head. It only reads
+# Dependabot metadata and calls the GitHub API.
+on:
+    pull_request_target:
+        types: [opened, reopened, synchronize]
+
+permissions: {}
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+jobs:
+    metadata:
+        name: classify update
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: read
+        outputs:
+            eligible: ${{ steps.check.outputs.eligible }}
+        steps:
+            - name: Fetch Dependabot metadata
+              id: meta
+              uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            # Auto-merge is deliberately narrow: patch-level updates to
+            # development dependencies of the bun workspace. Those changes run
+            # the full build_and_test suite — build, unit tests and e2e against
+            # all four databases — so a green all-passed is real verification.
+            #
+            # Everything else is left for review:
+            #   - github-actions updates touch .github/workflows/, which
+            #     CODEOWNERS requires a listed maintainer to approve.
+            #   - docs updates produce a green all-passed without running
+            #     anything, because detect-changes skips every job for a
+            #     docs-only diff. Docs CI is not a required check, so
+            #     auto-merge would not wait for it.
+            #   - production dependencies and minor or major updates are a
+            #     compatibility judgement, not a bump.
+            - name: Check auto-merge eligibility
+              id: check
+              env:
+                  ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
+                  DEP_TYPE: ${{ steps.meta.outputs.dependency-type }}
+                  UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+              run: |
+                  echo "ecosystem=$ECOSYSTEM dependency-type=$DEP_TYPE update-type=$UPDATE_TYPE"
+                  if [ "$ECOSYSTEM" = "bun" ] \
+                     && [ "$DEP_TYPE" = "direct:development" ] \
+                     && [ "$UPDATE_TYPE" = "version-update:semver-patch" ]; then
+                    echo "eligible=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "eligible=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+    auto-merge:
+        name: approve and enable auto-merge
+        needs: metadata
+        if: needs.metadata.outputs.eligible == 'true'
+        runs-on: ubuntu-latest
+        permissions: {}
+        steps:
+            # The default GITHUB_TOKEN cannot approve a pull request, so the
+            # approval comes from the CI bot app. The app needs contents:write
+            # and pull-requests:write on this repository.
+            - name: Mint CI bot token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  app-id: ${{ secrets.CI_BOT_APP_ID }}
+                  private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
+
+            # Re-approving on every push is required, not redundant: the master
+            # ruleset sets require_last_push_approval, so an approval that
+            # predates Dependabot's latest rebase does not count.
+            - name: Approve
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+              run: gh pr review --approve "$PR_URL" --body "Patch-level development dependency update. Approved automatically; merging once all-passed is green."
+
+            # --auto merges only after the required status checks pass, so
+            # all-passed remains the gate.
+            - name: Enable auto-merge
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+              run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -36,40 +36,83 @@ jobs:
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
-            # Auto-merge is deliberately narrow: patch-level updates to
-            # development dependencies of the bun workspace. Those changes run
-            # the full build_and_test suite — build, unit tests and e2e against
-            # all four databases — so a green all-passed is real verification.
+            # Eligibility is an explicit allowlist of dependency names, not a
+            # dependency-type check.
             #
-            # Everything else is left for review:
+            # dependency-type looks like the natural gate, but it does not work
+            # here. fetch-metadata reports the highest-priority type across the
+            # whole pull request, ordered production, development, indirect. In
+            # this workspace every dependency family contains at least one
+            # production dependency of some published package — typescript is a
+            # production dependency of packages/cli, @types/express of
+            # asset-server-plugin, eslint of the root — so every grouped update
+            # reports direct:production and nothing would ever qualify.
+            #
+            # An allowlist says plainly what can merge without a human. These
+            # packages affect type checking and linting, both of which
+            # build_and_test verifies on every pull request, and a patch-level
+            # change to any of them cannot alter runtime behaviour.
+            #
+            # Excluded on purpose:
             #   - github-actions updates touch .github/workflows/, which
             #     CODEOWNERS requires a listed maintainer to approve.
-            #   - docs updates produce a green all-passed without running
-            #     anything, because detect-changes skips every job for a
-            #     docs-only diff. Docs CI is not a required check, so
-            #     auto-merge would not wait for it.
-            #   - production dependencies and minor or major updates are a
-            #     compatibility judgement, not a bump.
+            #   - docs updates make detect-changes report no package changes,
+            #     which skips every job in build_and_test. all-passed then goes
+            #     green having verified nothing, and Docs CI is not a required
+            #     check, so auto-merge would not wait for it.
             - name: Check auto-merge eligibility
               id: check
               env:
                   ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
-                  DEP_TYPE: ${{ steps.meta.outputs.dependency-type }}
                   UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+                  DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
               run: |
-                  echo "ecosystem=$ECOSYSTEM dependency-type=$DEP_TYPE update-type=$UPDATE_TYPE"
-                  if [ "$ECOSYSTEM" = "bun" ] \
-                     && [ "$DEP_TYPE" = "direct:development" ] \
-                     && [ "$UPDATE_TYPE" = "version-update:semver-patch" ]; then
-                    echo "eligible=true" >> "$GITHUB_OUTPUT"
+                  set -euo pipefail
+                  echo "ecosystem=$ECOSYSTEM update-type=$UPDATE_TYPE names=$DEP_NAMES"
+
+                  eligible=true
+                  reason=""
+
+                  if [ "$ECOSYSTEM" != "bun" ]; then
+                    eligible=false
+                    reason="ecosystem is not bun"
+                  elif [ "$UPDATE_TYPE" != "version-update:semver-patch" ]; then
+                    eligible=false
+                    reason="not a patch update"
+                  elif [ -z "$DEP_NAMES" ]; then
+                    # Fail closed: an empty list means the metadata could not be
+                    # read, not that there is nothing to check.
+                    eligible=false
+                    reason="no dependency names reported"
                   else
-                    echo "eligible=false" >> "$GITHUB_OUTPUT"
+                    IFS=',' read -ra names <<< "$DEP_NAMES"
+                    for raw in "${names[@]}"; do
+                      name="$(echo "$raw" | xargs)"
+                      [ -z "$name" ] && continue
+                      case "$name" in
+                        @types/* | @typescript-eslint/* | eslint | eslint-* | prettier | prettier-*) ;;
+                        *)
+                          eligible=false
+                          reason="$name is not on the allowlist"
+                          ;;
+                      esac
+                    done
                   fi
+
+                  if [ "$eligible" = "true" ]; then
+                    echo "eligible for auto-merge"
+                  else
+                    echo "not eligible: $reason"
+                  fi
+                  echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
 
     auto-merge:
         name: approve and enable auto-merge
         needs: metadata
-        if: needs.metadata.outputs.eligible == 'true'
+        # DEPENDABOT_AUTO_MERGE_DISABLED is a manual pause. Auto-merge is on
+        # by default; set the repository variable to 'true' to stop it without
+        # reverting this workflow.
+        if: needs.metadata.outputs.eligible == 'true' && vars.DEPENDABOT_AUTO_MERGE_DISABLED != 'true'
         runs-on: ubuntu-latest
         permissions: {}
         steps:


### PR DESCRIPTION
Sets up Dependabot so dependency updates arrive as pull requests, and auto-merges the narrow slice of them that carries real CI verification.

Dependabot security updates were disabled on this repository, so the alerts on the security tab produced no pull requests. That setting is now enabled (done directly on the repository, not in this diff). This PR adds the configuration that goes with it.

## What is here

- `.github/dependabot.yml` covering three ecosystems: `github-actions` at the root, `npm` for `docs/`, and `bun` for the workspace.
- A SonarQube skip for Dependabot pull requests.
- `.github/workflows/dependabot_auto_merge.yml`, which approves and enables auto-merge for an allowlisted set of patch updates.

## Bun has no security update support

Dependabot supports version updates for the bun ecosystem but not security updates. The three open alerts against shipped packages — `sharp`, `@opentelemetry/sdk-node` and `@apollo/server` — all live in the bun workspace, so enabling security updates does not reach them. They will be picked up by a weekly version update when the fix is within range, and otherwise need bumping deliberately.

The `js-yaml` alerts in `docs/` are unaffected by this. That project uses npm, and the fix at 3.15.1 sits inside the `^3.13.1` range that `gray-matter` declares, so it resolves as a lockfile bump.

## Auto-merge is gated on a name allowlist, not on dependency type

Gating on `dependency-type == direct:development` is the obvious approach and it does not work in this repository.

`dependabot/fetch-metadata` reports the highest-priority dependency type across the whole pull request, ordered production, development, indirect. In this workspace every dependency family contains at least one production dependency of some published package: `typescript` is a production dependency of `packages/cli`, `@types/express` of `asset-server-plugin`, `eslint` of the root, `typeorm` and `sql.js` of `packages/core` and `packages/testing`. Every grouped update would therefore report `direct:production`, and no pull request would ever qualify. The gate would have been silently dead rather than merely conservative.

So eligibility is an explicit allowlist of dependency names instead:

```
@types/*  @typescript-eslint/*  eslint  eslint-*  prettier  prettier-*
```

combined with `package-ecosystem == bun` and `update-type == version-update:semver-patch`. Every name in the pull request must match, and an empty name list fails closed. These packages affect type checking and linting, both of which `build_and_test` verifies on every pull request, and a patch-level change to any of them cannot alter runtime behaviour.

The `linting` group is kept separate from `dev-tooling` in `dependabot.yml` so that a grouped pull request contains only allowlisted names.

Two categories are excluded on purpose:

- `github-actions` updates modify files under `.github/workflows/`, which CODEOWNERS requires a listed maintainer to approve. They are grouped into one weekly pull request so that review stays a single item.
- `docs/` updates make `detect-changes` report no package changes, which skips every job in `build_and_test`. `all-passed` then goes green having verified nothing. Docs CI does validate the MDX but is not a required status check, so auto-merge would not wait for it. Promoting a docs aggregate job to a required check would make this lane safe to widen later.

Setting the repository variable `DEPENDABOT_AUTO_MERGE_DISABLED` to `true` pauses auto-merge without reverting the workflow.

## Trigger choice

The auto-merge workflow uses `pull_request_target` rather than `pull_request`. Workflows that Dependabot triggers via `pull_request` get a read-only token and read secrets from the Dependabot secrets store, so the CI bot credentials would resolve empty. `pull_request_target` is exempt from both restrictions.

That trigger runs with access to Actions secrets, so the workflow never checks out, builds or executes anything from the pull request head. It only reads Dependabot metadata and calls the GitHub API.

Approval comes from the `vendure-ci-automation-bot` app, which already has the `contents: write` and `pull_requests: write` permissions this needs. It does not have `workflows: write`, which means it cannot merge a change to a workflow file even if the eligibility check were wrong. The approval step re-runs on every push because the master ruleset sets `require_last_push_approval`, so an approval predating a Dependabot rebase does not count.

## Cooldown

Version updates wait seven days before being proposed, and docs majors wait fourteen. A compromised release is usually found and yanked within days. Cooldown applies to version updates only and never delays a security update.

## Worth watching on the first runs

- This repository's `bun.lock` carries a `configVersion` key. There is a known dependabot-core issue where it gets stripped, and CI runs `bun install --frozen-lockfile`. If that happens, every bun pull request fails the same way. Merging the `github-actions` and `docs` lanes first would surface it cheaply.
- The master ruleset sets `require_extra_approval_for_unattributed_changes`. Dependabot commits are attributed, so this should be fine, but it is worth confirming on the first pull request.

## Follow-up not in this PR

The three bun-ecosystem vulnerabilities still need bumping by hand or by an agent, since Dependabot will not raise them.

The two alerts against test fixture manifests have been dismissed as not used. The directory scoping in `dependabot.yml` stops equivalents being raised again.
