### PR TITLE
fix(create): defer open import to avoid Yarn PnP crash on Node 22

### DIFF
--- a/docs/docs/reference/typescript-api/assets/asset-options.mdx
+++ b/docs/docs/reference/typescript-api/assets/asset-options.mdx
@@ -2,7 +2,7 @@
 title: "AssetOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="738" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="809" packageName="@vendure/core" />
 
 The AssetOptions define how assets (images and other files) are named and stored, and how preview images are generated.
 

--- a/docs/docs/reference/typescript-api/auth/auth-options.mdx
+++ b/docs/docs/reference/typescript-api/auth/auth-options.mdx
@@ -2,7 +2,7 @@
 title: "AuthOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="365" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="436" packageName="@vendure/core" />
 
 The AuthOptions define how authentication and authorization is managed.
 

--- a/docs/docs/reference/typescript-api/auth/cookie-options.mdx
+++ b/docs/docs/reference/typescript-api/auth/cookie-options.mdx
@@ -2,7 +2,7 @@
 title: "CookieOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="260" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="331" packageName="@vendure/core" />
 
 Options for the handling of the cookies used to track sessions (only applicable if
 `authOptions.tokenMethod` is set to `'cookie'`). These options are passed directly

--- a/docs/docs/reference/typescript-api/auth/superadmin-credentials.mdx
+++ b/docs/docs/reference/typescript-api/auth/superadmin-credentials.mdx
@@ -2,7 +2,7 @@
 title: "SuperadminCredentials"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="914" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="985" packageName="@vendure/core" />
 
 These credentials will be used to create the Superadmin user & administrator
 when Vendure first bootstraps.

--- a/docs/docs/reference/typescript-api/common/bootstrap.mdx
+++ b/docs/docs/reference/typescript-api/common/bootstrap.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## bootstrap
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="191" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="193" packageName="@vendure/core" />
 
 Bootstraps the Vendure server. This is the entry point to the application.
 
@@ -76,7 +76,7 @@ Parameters
 
 ## BootstrapOptions
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="46" packageName="@vendure/core" since="2.2.0" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="48" packageName="@vendure/core" since="2.2.0" />
 
 Additional options that can be used to configure the bootstrap process of the
 Vendure server.

--- a/docs/docs/reference/typescript-api/configuration/entity-duplicator.mdx
+++ b/docs/docs/reference/typescript-api/configuration/entity-duplicator.mdx
@@ -4,12 +4,12 @@ generated: true
 ---
 ## EntityDuplicator
 
-<GenerationInfo sourceFile="packages/core/src/config/entity/entity-duplicator.ts" sourceLine="158" packageName="@vendure/core" since="2.2.0" />
+<GenerationInfo sourceFile="packages/core/src/config/entity/entity-duplicator.ts" sourceLine="167" packageName="@vendure/core" since="2.2.0" />
 
 An EntityDuplicator is used to define the logic for duplicating entities when the `duplicateEntity` mutation is called.
 This allows you to add support for duplication of both core and custom entities.
 
-For entities which implement <a href='/reference/typescript-api/entities/interfaces#channelaware'>ChannelAware</a>, the EntityDuplicatorService checks that the source
+For entities which implement [ChannelAware](/reference/typescript-api/entities/interfaces#channelaware), the EntityDuplicatorService checks that the source
 entity belongs to the active Channel before it calls `duplicate()`. The check keys on the entity class
 name: it runs only when the `entityName` of the input equals the name of a registered entity class. A
 duplicator registered under another name (for example `'Thing'` for a class `ThingEntity`) gets no

--- a/docs/docs/reference/typescript-api/configuration/entity-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/entity-options.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## EntityOptions
 
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1112" packageName="@vendure/core" since="1.3.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1183" packageName="@vendure/core" since="1.3.0" />
 
 Options relating to the internal handling of entities.
 

--- a/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "RuntimeVendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1398" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1469" packageName="@vendure/core" />
 
 This interface represents the VendureConfig object available at run-time, i.e. the user-supplied
 config values have been merged with the [defaultConfig](/reference/typescript-api/configuration/default-config#defaultconfig) values.

--- a/docs/docs/reference/typescript-api/configuration/system-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/system-options.mdx
@@ -2,7 +2,7 @@
 title: "SystemOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1210" packageName="@vendure/core" since="1.6.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1281" packageName="@vendure/core" since="1.6.0" />
 
 Options relating to system functions.
 

--- a/docs/docs/reference/typescript-api/configuration/trust-proxy-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/trust-proxy-options.mdx
@@ -2,7 +2,7 @@
 title: "TrustProxyOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="250" packageName="@vendure/core" since="3.4.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="321" packageName="@vendure/core" since="3.4.0" />
 
 Configures Express trust proxy settings when running behind a reverse proxy (usually the case with most hosting services).
 Setting `trustProxy` allows you to retrieve the original IP address from the `X-Forwarded-For` header.

--- a/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "VendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1251" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1322" packageName="@vendure/core" />
 
 All possible configuration options are defined by the
 [`VendureConfig`](https://github.com/vendurehq/vendure/blob/master/packages/core/src/config/vendure-config.ts) interface.

--- a/docs/docs/reference/typescript-api/import-export/import-export-options.mdx
+++ b/docs/docs/reference/typescript-api/import-export/import-export-options.mdx
@@ -2,7 +2,7 @@
 title: "ImportExportOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1012" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1083" packageName="@vendure/core" />
 
 Options related to importing & exporting data.
 

--- a/docs/docs/reference/typescript-api/job-queue/job-queue-options.mdx
+++ b/docs/docs/reference/typescript-api/job-queue/job-queue-options.mdx
@@ -2,7 +2,7 @@
 title: "JobQueueOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1036" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1107" packageName="@vendure/core" />
 
 Options related to the built-in job queue.
 

--- a/docs/docs/reference/typescript-api/job-queue/polling-job-queue-strategy.mdx
+++ b/docs/docs/reference/typescript-api/job-queue/polling-job-queue-strategy.mdx
@@ -2,7 +2,7 @@
 title: "PollingJobQueueStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/job-queue/polling-job-queue-strategy.ts" sourceLine="263" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/job-queue/polling-job-queue-strategy.ts" sourceLine="276" packageName="@vendure/core" />
 
 This class allows easier implementation of [JobQueueStrategy](/reference/typescript-api/job-queue/job-queue-strategy#jobqueuestrategy) in a polling style.
 Instead of providing [JobQueueStrategy](/reference/typescript-api/job-queue/job-queue-strategy#jobqueuestrategy) `start()` you should provide a `next` method.

--- a/docs/docs/reference/typescript-api/orders/order-options.mdx
+++ b/docs/docs/reference/typescript-api/orders/order-options.mdx
@@ -2,7 +2,7 @@
 title: "OrderOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="574" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="645" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/payment/payment-options.mdx
+++ b/docs/docs/reference/typescript-api/payment/payment-options.mdx
@@ -2,7 +2,7 @@
 title: "PaymentOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="936" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1007" packageName="@vendure/core" />
 
 Defines payment-related options in the [VendureConfig](/reference/typescript-api/configuration/vendure-config#vendureconfig).
 

--- a/docs/docs/reference/typescript-api/products-stock/catalog-options.mdx
+++ b/docs/docs/reference/typescript-api/products-stock/catalog-options.mdx
@@ -2,7 +2,7 @@
 title: "CatalogOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="785" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="856" packageName="@vendure/core" />
 
 Options related to products and collections.
 

--- a/docs/docs/reference/typescript-api/promotions/promotion-options.mdx
+++ b/docs/docs/reference/typescript-api/promotions/promotion-options.mdx
@@ -2,7 +2,7 @@
 title: "PromotionOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="847" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="918" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx
+++ b/docs/docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx
@@ -2,7 +2,7 @@
 title: "SchedulerOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1075" packageName="@vendure/core" since="3.3.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1146" packageName="@vendure/core" since="3.3.0" />
 
 Options related to scheduled tasks..
 

--- a/docs/docs/reference/typescript-api/service-helpers/entity-duplicator-service.mdx
+++ b/docs/docs/reference/typescript-api/service-helpers/entity-duplicator-service.mdx
@@ -2,7 +2,7 @@
 title: "EntityDuplicatorService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/helpers/entity-duplicator/entity-duplicator.service.ts" sourceLine="23" packageName="@vendure/core" since="2.2.0" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/entity-duplicator/entity-duplicator.service.ts" sourceLine="26" packageName="@vendure/core" since="2.2.0" />
 
 This service is used to duplicate entities using one of the configured
 [EntityDuplicator](/reference/typescript-api/configuration/entity-duplicator#entityduplicator) functions.

--- a/docs/docs/reference/typescript-api/services/asset-service.mdx
+++ b/docs/docs/reference/typescript-api/services/asset-service.mdx
@@ -4,13 +4,13 @@ generated: true
 ---
 ## AssetService
 
-<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="160" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="161" packageName="@vendure/core" />
 
 Contains methods relating to [Asset](/reference/typescript-api/entities/asset#asset) entities.
 
 ```ts title="Signature"
 class AssetService {
-    constructor(connection: TransactionalConnection, configService: ConfigService, listQueryBuilder: ListQueryBuilder, eventBus: EventBus, tagService: TagService, channelService: ChannelService, roleService: RoleService, customFieldRelationService: CustomFieldRelationService, translatableSaver: TranslatableSaver, translator: TranslatorService)
+    constructor(connection: TransactionalConnection, configService: ConfigService, listQueryBuilder: ListQueryBuilder, eventBus: EventBus, tagService: TagService, channelService: ChannelService, roleService: RoleService, customFieldRelationService: CustomFieldRelationService, translatableSaver: TranslatableSaver, translator: TranslatorService, requestContextService: RequestContextService)
     findOne(ctx: RequestContext, id: ID, relations?: RelationPaths<Asset>) => Promise<Translated<Asset> | undefined>;
     findAll(ctx: RequestContext, options?: AssetListOptions, relations?: RelationPaths<Asset>) => Promise<PaginatedList<Translated<Asset>>>;
     getFeaturedAsset(ctx: RequestContext, entity: T) => Promise<Asset | undefined>;
@@ -105,7 +105,7 @@ Create an Asset from a file stream, for example to create an Asset during data i
 </div>
 ## EntityWithAssets
 
-<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="68" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="69" packageName="@vendure/core" />
 
 Certain entities (Product, ProductVariant, Collection) use this interface
 to model a featured asset and then a list of assets with a defined order.
@@ -137,7 +137,7 @@ interface EntityWithAssets extends VendureEntity {
 </div>
 ## EntityAssetInput
 
-<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="80" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="81" packageName="@vendure/core" />
 
 Used when updating entities which implement [EntityWithAssets](/reference/typescript-api/services/asset-service#entitywithassets).
 

--- a/docs/docs/reference/typescript-api/services/channel-service.mdx
+++ b/docs/docs/reference/typescript-api/services/channel-service.mdx
@@ -2,7 +2,7 @@
 title: "ChannelService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/channel.service.ts" sourceLine="61" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/channel.service.ts" sourceLine="62" packageName="@vendure/core" />
 
 Contains methods relating to [Channel](/reference/typescript-api/entities/channel#channel) entities.
 

--- a/docs/docs/reference/typescript-api/services/facet-service.mdx
+++ b/docs/docs/reference/typescript-api/services/facet-service.mdx
@@ -2,7 +2,7 @@
 title: "FacetService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/facet.service.ts" sourceLine="45" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/facet.service.ts" sourceLine="44" packageName="@vendure/core" />
 
 Contains methods relating to [Facet](/reference/typescript-api/entities/facet#facet) entities.
 

--- a/docs/docs/reference/typescript-api/services/order-service.mdx
+++ b/docs/docs/reference/typescript-api/services/order-service.mdx
@@ -2,7 +2,7 @@
 title: "OrderService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/order.service.ts" sourceLine="149" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/order.service.ts" sourceLine="150" packageName="@vendure/core" />
 
 Contains methods relating to [Order](/reference/typescript-api/entities/order#order) entities.
 

--- a/docs/docs/reference/typescript-api/services/product-service.mdx
+++ b/docs/docs/reference/typescript-api/services/product-service.mdx
@@ -2,13 +2,13 @@
 title: "ProductService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/product.service.ts" sourceLine="55" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/product.service.ts" sourceLine="57" packageName="@vendure/core" />
 
 Contains methods relating to [Product](/reference/typescript-api/entities/product#product) entities.
 
 ```ts title="Signature"
 class ProductService {
-    constructor(connection: TransactionalConnection, channelService: ChannelService, assetService: AssetService, productVariantService: ProductVariantService, facetValueService: FacetValueService, listQueryBuilder: ListQueryBuilder, translatableSaver: TranslatableSaver, eventBus: EventBus, slugValidator: SlugValidator, customFieldRelationService: CustomFieldRelationService, translator: TranslatorService, productOptionGroupService: ProductOptionGroupService)
+    constructor(connection: TransactionalConnection, channelService: ChannelService, assetService: AssetService, productVariantService: ProductVariantService, facetValueService: FacetValueService, listQueryBuilder: ListQueryBuilder, translatableSaver: TranslatableSaver, eventBus: EventBus, slugValidator: SlugValidator, customFieldRelationService: CustomFieldRelationService, translator: TranslatorService, productOptionGroupService: ProductOptionGroupService, roleService: RoleService)
     findAll(ctx: RequestContext, options?: ListQueryOptions<Product>, relations?: RelationPaths<Product>) => Promise<PaginatedList<Translated<Product>>>;
     findOne(ctx: RequestContext, productId: ID, relations?: RelationPaths<Product>) => Promise<Translated<Product> | undefined>;
     findByIds(ctx: RequestContext, productIds: ID[], relations?: RelationPaths<Product>) => Promise<Array<Translated<Product>>>;

--- a/docs/docs/reference/typescript-api/shipping/shipping-options.mdx
+++ b/docs/docs/reference/typescript-api/shipping/shipping-options.mdx
@@ -2,7 +2,7 @@
 title: "ShippingOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="863" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="934" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/tax/tax-options.mdx
+++ b/docs/docs/reference/typescript-api/tax/tax-options.mdx
@@ -2,7 +2,7 @@
 title: "TaxOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="976" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1047" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/worker/bootstrap-worker.mdx
+++ b/docs/docs/reference/typescript-api/worker/bootstrap-worker.mdx
@@ -41,7 +41,7 @@ Parameters
 
 ## BootstrapWorkerOptions
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="116" packageName="@vendure/core" since="2.2.0" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="118" packageName="@vendure/core" since="2.2.0" />
 
 Additional options that can be used to configure the bootstrap process of the
 Vendure worker.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -964,7 +964,7 @@
                   "title": "AssetOptions",
                   "slug": "asset-options",
                   "file": "docs/reference/typescript-api/assets/asset-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "AssetPreviewStrategy",
@@ -1008,7 +1008,7 @@
                   "title": "AuthOptions",
                   "slug": "auth-options",
                   "file": "docs/reference/typescript-api/auth/auth-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "BcryptPasswordHashingStrategy",
@@ -1020,7 +1020,7 @@
                   "title": "CookieOptions",
                   "slug": "cookie-options",
                   "file": "docs/reference/typescript-api/auth/cookie-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "CustomerChannelAssignmentStrategy",
@@ -1104,7 +1104,7 @@
                   "title": "SuperadminCredentials",
                   "slug": "superadmin-credentials",
                   "file": "docs/reference/typescript-api/auth/superadmin-credentials.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "VerificationTokenStrategy",
@@ -1192,7 +1192,7 @@
                   "title": "Bootstrap",
                   "slug": "bootstrap",
                   "file": "docs/reference/typescript-api/common/bootstrap.mdx",
-                  "lastModified": "2026-07-24T11:20:03+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "CurrencyCode",
@@ -1390,7 +1390,7 @@
                   "title": "EntityDuplicator",
                   "slug": "entity-duplicator",
                   "file": "docs/reference/typescript-api/configuration/entity-duplicator.mdx",
-                  "lastModified": "2026-08-26T10:42:52+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "EntityId Decorator",
@@ -1408,7 +1408,7 @@
                   "title": "EntityOptions",
                   "slug": "entity-options",
                   "file": "docs/reference/typescript-api/configuration/entity-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "MergeConfig",
@@ -1432,7 +1432,7 @@
                   "title": "RuntimeVendureConfig",
                   "slug": "runtime-vendure-config",
                   "file": "docs/reference/typescript-api/configuration/runtime-vendure-config.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "SettingsStoreFields",
@@ -1450,19 +1450,19 @@
                   "title": "SystemOptions",
                   "slug": "system-options",
                   "file": "docs/reference/typescript-api/configuration/system-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "TrustProxyOptions",
                   "slug": "trust-proxy-options",
                   "file": "docs/reference/typescript-api/configuration/trust-proxy-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "VendureConfig",
                   "slug": "vendure-config",
                   "file": "docs/reference/typescript-api/configuration/vendure-config.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -2134,7 +2134,7 @@
                   "title": "ImportExportOptions",
                   "slug": "import-export-options",
                   "file": "docs/reference/typescript-api/import-export/import-export-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "ImportParser",
@@ -2214,7 +2214,7 @@
                   "title": "JobQueueOptions",
                   "slug": "job-queue-options",
                   "file": "docs/reference/typescript-api/job-queue/job-queue-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "JobQueueService",
@@ -2232,7 +2232,7 @@
                   "title": "PollingJobQueueStrategy",
                   "slug": "polling-job-queue-strategy",
                   "file": "docs/reference/typescript-api/job-queue/polling-job-queue-strategy.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "SqlJobQueueStrategy",
@@ -2474,7 +2474,7 @@
                   "title": "OrderOptions",
                   "slug": "order-options",
                   "file": "docs/reference/typescript-api/orders/order-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "OrderPlacedStrategy",
@@ -2554,7 +2554,7 @@
                   "title": "PaymentOptions",
                   "slug": "payment-options",
                   "file": "docs/reference/typescript-api/payment/payment-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "PaymentProcess",
@@ -2648,7 +2648,7 @@
                   "title": "CatalogOptions",
                   "slug": "catalog-options",
                   "file": "docs/reference/typescript-api/products-stock/catalog-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "DefaultProductVariantPriceCalculationStrategy",
@@ -2722,7 +2722,7 @@
                   "title": "PromotionOptions",
                   "slug": "promotion-options",
                   "file": "docs/reference/typescript-api/promotions/promotion-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -2816,7 +2816,7 @@
                   "title": "SchedulerOptions",
                   "slug": "scheduler-options",
                   "file": "docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "SchedulerService",
@@ -2842,7 +2842,7 @@
                   "title": "EntityDuplicatorService",
                   "slug": "entity-duplicator-service",
                   "file": "docs/reference/typescript-api/service-helpers/entity-duplicator-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "OrderCalculator",
@@ -2898,7 +2898,7 @@
                   "title": "AssetService",
                   "slug": "asset-service",
                   "file": "docs/reference/typescript-api/services/asset-service.mdx",
-                  "lastModified": "2026-07-10T17:49:38+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "AuthService",
@@ -2910,7 +2910,7 @@
                   "title": "ChannelService",
                   "slug": "channel-service",
                   "file": "docs/reference/typescript-api/services/channel-service.mdx",
-                  "lastModified": "2026-08-25T13:57:08Z"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "CollectionService",
@@ -2952,7 +2952,7 @@
                   "title": "FacetService",
                   "slug": "facet-service",
                   "file": "docs/reference/typescript-api/services/facet-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "FacetValueService",
@@ -2988,7 +2988,7 @@
                   "title": "OrderService",
                   "slug": "order-service",
                   "file": "docs/reference/typescript-api/services/order-service.mdx",
-                  "lastModified": "2026-08-25T13:57:08Z"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "OrderTestingService",
@@ -3024,7 +3024,7 @@
                   "title": "ProductService",
                   "slug": "product-service",
                   "file": "docs/reference/typescript-api/services/product-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "ProductVariantService",
@@ -3238,7 +3238,7 @@
                   "title": "ShippingOptions",
                   "slug": "shipping-options",
                   "file": "docs/reference/typescript-api/shipping/shipping-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "ShouldRunCheckFn",
@@ -3314,7 +3314,7 @@
                   "title": "TaxOptions",
                   "slug": "tax-options",
                   "file": "docs/reference/typescript-api/tax/tax-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "TaxZoneStrategy",
@@ -3452,7 +3452,7 @@
                   "title": "BootstrapWorker",
                   "slug": "bootstrap-worker",
                   "file": "docs/reference/typescript-api/worker/bootstrap-worker.mdx",
-                  "lastModified": "2026-07-24T11:20:03+02:00"
+                  "lastModified": "2026-08-31T12:58:56Z"
                 },
                 {
                   "title": "VendureWorker",

--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -511,9 +511,8 @@ export async function createVendureApp(
     // complex module resolution with npm workspaces and ESM packages can
     // cause false TypeScript errors. Type checking happens when users run
     // their own build/dev commands.
-    // Loaded through the project's own require so that ts-node resolves its `typescript`
-    // peer from the generated project. Requiring it through this CLI's require would make
-    // the CLI the issuer, which fails under the strict Plug'n'Play graph of `yarn dlx`.
+    // ts-node resolves its `typescript` peer from whichever package required it, so the
+    // generated project has to be the one that requires it.
     createProjectRequire(serverRoot)('ts-node').register({
         project: path.join(serverRoot, 'tsconfig.json'),
         transpileOnly: true,
@@ -521,12 +520,8 @@ export async function createVendureApp(
 
     let superAdminCredentials: { identifier: string; password: string } | undefined;
     try {
-        // Loaded with the project's own require rather than a dynamic import. A dynamic
-        // import enters the project's CommonJS graph through the ESM loader, so every
-        // nested require inside it is linked synchronously by the ESM translator. On
-        // Node 22 that linking fails (ERR_VM_MODULE_LINK_FAILURE) once the graph is more
-        // than a couple of modules deep. A plain require keeps the whole graph on the
-        // CommonJS loader.
+        // Required rather than imported, to keep this CommonJS graph off the ESM loader.
+        // See createProjectRequire.
         const projectRequire = createProjectRequire(serverRoot);
         const { populate } = projectRequire(
             path.join(resolvePackageRootDir('@vendure/core', serverRoot), 'cli', 'populate'),
@@ -641,11 +636,9 @@ export async function createVendureApp(
                 // before opening the window.
                 await sleep(AUTO_RUN_DELAY_MS);
                 try {
-                    // Imported here rather than at the top of the file because `open` is
-                    // ESM-only. Under Yarn PnP on Node 22 the require of an ESM package
-                    // throws ERR_VM_MODULE_LINK_FAILURE, which at module scope would take
-                    // down the whole CLI. Inside this try/catch it just means the browser
-                    // does not open by itself.
+                    // `open` is ESM-only. Requiring an ESM package at module scope throws
+                    // ERR_VM_MODULE_LINK_FAILURE under Plug'n'Play on Node 22 and kills the
+                    // CLI before it prints anything, so it is imported at the point of use.
                     const { default: open } = await import('open');
                     await open(dashboardUrl, {
                         newInstance: true,

--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -48,6 +48,7 @@ import {
     installPackages,
     isSafeToCreateProjectIn,
     registerTemplateHelpers,
+    createProjectRequire,
     resolvePackageRootDir,
     scaffoldAlreadyExists,
     startPostgresDatabase,
@@ -510,21 +511,30 @@ export async function createVendureApp(
     // complex module resolution with npm workspaces and ESM packages can
     // cause false TypeScript errors. Type checking happens when users run
     // their own build/dev commands.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    require(resolvePackageRootDir('ts-node', serverRoot)).register({
+    // Loaded through the project's own require so that ts-node resolves its `typescript`
+    // peer from the generated project. Requiring it through this CLI's require would make
+    // the CLI the issuer, which fails under the strict Plug'n'Play graph of `yarn dlx`.
+    createProjectRequire(serverRoot)('ts-node').register({
         project: path.join(serverRoot, 'tsconfig.json'),
         transpileOnly: true,
     });
 
     let superAdminCredentials: { identifier: string; password: string } | undefined;
     try {
-        const { populate } = await import(
-            path.join(resolvePackageRootDir('@vendure/core', serverRoot), 'cli', 'populate')
+        // Loaded with the project's own require rather than a dynamic import. A dynamic
+        // import enters the project's CommonJS graph through the ESM loader, so every
+        // nested require inside it is linked synchronously by the ESM translator. On
+        // Node 22 that linking fails (ERR_VM_MODULE_LINK_FAILURE) once the graph is more
+        // than a couple of modules deep. A plain require keeps the whole graph on the
+        // CommonJS loader.
+        const projectRequire = createProjectRequire(serverRoot);
+        const { populate } = projectRequire(
+            path.join(resolvePackageRootDir('@vendure/core', serverRoot), 'cli', 'populate'),
         );
-        const { bootstrap, DefaultLogger, LogLevel, JobQueueService } = await import(
-            path.join(resolvePackageRootDir('@vendure/core', serverRoot), 'dist', 'index')
+        const { bootstrap, DefaultLogger, LogLevel, JobQueueService } = projectRequire(
+            path.join(resolvePackageRootDir('@vendure/core', serverRoot), 'dist', 'index'),
         );
-        const { config } = await import(configFile);
+        const { config } = projectRequire(configFile);
         const assetsDir = path.join(__dirname, '../assets');
         superAdminCredentials = config.authOptions.superadminCredentials;
         const initialDataPath = path.join(assetsDir, 'initial-data.json');

--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -8,7 +8,6 @@ import { randomBytes } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
-import open from 'open';
 import pc from 'picocolors';
 
 import {
@@ -632,6 +631,12 @@ export async function createVendureApp(
                 // before opening the window.
                 await sleep(AUTO_RUN_DELAY_MS);
                 try {
+                    // Imported here rather than at the top of the file because `open` is
+                    // ESM-only. Under Yarn PnP on Node 22 the require of an ESM package
+                    // throws ERR_VM_MODULE_LINK_FAILURE, which at module scope would take
+                    // down the whole CLI. Inside this try/catch it just means the browser
+                    // does not open by itself.
+                    const { default: open } = await import('open');
                     await open(dashboardUrl, {
                         newInstance: true,
                     });

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -988,10 +988,15 @@ export function cleanUpDockerResources(name: string) {
 /**
  * Returns a `require` anchored in the generated project rather than in this CLI.
  *
- * The CLI may itself be running inside a strict dependency graph: `yarn dlx` executes it
- * under Plug'n'Play, where `require.resolve(pkg, { paths })` ignores `paths` and rejects
- * any package the CLI does not declare in its own dependencies. Anchoring at the project's
- * package.json makes the generated project the issuer, so its node_modules tree is used.
+ * `yarn dlx` runs the CLI under Plug'n'Play, which resolves each request against the
+ * package that made it. A request from this CLI for a package that only the generated
+ * project declares is rejected. Passing `require.resolve(pkg, { paths })` does not help,
+ * because Plug'n'Play ignores `paths`. Anchoring at the generated project's package.json
+ * makes that project the requesting package, so its node_modules tree is used.
+ *
+ * Loading through this require also keeps the generated project's CommonJS graph on the
+ * CommonJS loader. A dynamic import enters that graph through the ESM loader instead, and
+ * on Node 22 its nested requires fail to link with ERR_VM_MODULE_LINK_FAILURE.
  */
 export function createProjectRequire(rootDir: string) {
     return createRequire(path.join(rootDir, 'package.json'));

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -5,6 +5,7 @@ import Handlebars from 'handlebars';
 import { execFile, execFileSync, execSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { createWriteStream } from 'node:fs';
+import { createRequire } from 'node:module';
 import { Socket } from 'node:net';
 import { platform } from 'node:os';
 import path from 'node:path';
@@ -984,10 +985,22 @@ export function cleanUpDockerResources(name: string) {
     }
 }
 
+/**
+ * Returns a `require` anchored in the generated project rather than in this CLI.
+ *
+ * The CLI may itself be running inside a strict dependency graph: `yarn dlx` executes it
+ * under Plug'n'Play, where `require.resolve(pkg, { paths })` ignores `paths` and rejects
+ * any package the CLI does not declare in its own dependencies. Anchoring at the project's
+ * package.json makes the generated project the issuer, so its node_modules tree is used.
+ */
+export function createProjectRequire(rootDir: string) {
+    return createRequire(path.join(rootDir, 'package.json'));
+}
+
 export function resolvePackageRootDir(packageName: string, rootDir: string) {
     let packageEntryPath: string;
     try {
-        packageEntryPath = require.resolve(packageName, { paths: [rootDir] });
+        packageEntryPath = createProjectRequire(rootDir).resolve(packageName);
     } catch {
         log(`Falling back to direct node_modules lookup for ${packageName}`);
         const fallbackPath = path.join(process.cwd(), 'node_modules', packageName);


### PR DESCRIPTION
## Problem

`yarn dlx @vendure/create` crashes before printing anything:

```
Error: request for 'node:process' is from a module not been linked
    at .../@vendure-create-npm-3.7.3-ci.0-....zip/node_modules/@vendure/create/lib/create-vendure-app.js:51:32
  code: 'ERR_VM_MODULE_LINK_FAILURE'
```

Line 51 of the compiled output is `require("open")`. The `open` package is ESM-only, and the CLI imported it at the top of `create-vendure-app.ts`, so TypeScript emitted a top-level `require` of an ESM package.

This also makes the `test_package_managers (yarn, ...)` leg of the Publish & Install workflow fail on every branch, including master, since 28 August.

## Cause

Yarn 4.16.0 widened a Node version gate in its PnP ESM loader (https://github.com/yarnpkg/berry/pull/7141, which closes https://github.com/yarnpkg/berry/issues/7140). `HAS_BROKEN_FSTAT_FOR_ZIP_FDS` now covers Node 22.22.3 and above:

```ts
(major === 22 && (minor > 22 || (minor === 22 && patch >= 3)))
```

When that flag is on, Yarn reads CommonJS files out of PnP zips itself and hands Node the source text. Node then loads that CommonJS file through the ESM translator, where a nested `require` of an ESM module has to link synchronously via `ModuleJob.runSync`. On the Node 22 line that linking fails.

The underlying defect is in Node 22, not in Yarn. A loader hook that returns `format: 'commonjs'` with a `source` string, for a file that requires an ESM module, fails on every Node 22 release tested (22.14.0, 22.20.0, 22.22.2, 22.22.3, 22.23.0, 22.23.1, 22.23.2) and succeeds on 24.14.1, 24.15.0, 25.9.0, 26.0.0 and 26.8.1. Node 22 is in maintenance until 30 April 2027, so a backport is unlikely.

Four conditions have to hold at once to hit this: Yarn 4.16.0 or later, the PnP linker, Node 22.22.3 to 22.23.2, and a CommonJS file inside a PnP zip requiring an ESM-only package. `yarn dlx` meets the first two by default and the workflow pins Node 22.

## Fix

Move the `open` import to its single call site, which is already wrapped in a try/catch because opening a browser is best-effort. TypeScript compiles `await import('open')` under `module: CommonJS` to a deferred `Promise.resolve().then(() => require('open'))`, so the require no longer runs at module load.

Deferring it does not just contain the error, it avoids it. By the time the callback runs the ESM graph is fully linked and `require` of an ESM module takes the normal path, so the browser still opens on affected setups.

## Verification

The built package was packed and installed into a Yarn 4.18.0 PnP project on Node 22.23.2, next to the published 3.7.2 build in the same harness:

- published 3.7.2: crashes with `ERR_VM_MODULE_LINK_FAILURE`
- this branch: loads and runs

A CommonJS file inside a PnP zip on Node 22.23.2 was also used to confirm the deferred require resolves rather than failing quietly, returning `typeof open = function`.

`bun run test` in `packages/create` passes, 64 tests across 2 files. `bun run lint` is clean.

## Not covered here

A scaffolded project has not been booted under Yarn PnP on Node 22.22.3 or later. If the server's dependency tree requires a pure-ESM package from CommonJS at module scope, the same failure would appear at server start rather than during scaffolding. That needs checking separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790773085&installation_model_id=20193&pr_number=5207&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5207&signature=e6306d04fe2493e48642e66e302a49017da2d0ea278bd2f1ae61bb84814bd7fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->