### PR TITLE
perf(core): remove the per-request stock query stampede

### DIFF
--- a/packages/core/e2e/stock-control.e2e-spec.ts
+++ b/packages/core/e2e/stock-control.e2e-spec.ts
@@ -1352,7 +1352,40 @@ describe('Stock control', () => {
             );
         });
     });
+
+    // StockLevels are loaded through a DataLoader whose lifetime is one RequestContext and
+    // which batches without memoizing, so a stock read is never served from a value loaded
+    // before the write it follows. Mutation fields execute serially and each is completed
+    // before the next begins, so `before` resolves its stockOnHand, then `after` writes a new
+    // value and reads it back, both within one request. Widening the loader beyond a single
+    // RequestContext, or memoizing across one, makes this report 11 twice and oversell stock.
+    describe('reading stock back after writing it in the same request', () => {
+        const variantId = 'T_4';
+
+        it('reports the stockOnHand written earlier in the same request', async () => {
+            const { before, after } = await adminClient.query(adjustStockTwiceDocument, {
+                first: [{ id: variantId, stockOnHand: 11, trackInventory: GlobalFlag.TRUE }],
+                second: [{ id: variantId, stockOnHand: 13 }],
+            });
+
+            expect(before[0]!.stockOnHand).toBe(11);
+            expect(after[0]!.stockOnHand).toBe(13);
+        });
+    });
 });
+
+const adjustStockTwiceDocument = graphql(`
+    mutation AdjustStockTwice($first: [UpdateProductVariantInput!]!, $second: [UpdateProductVariantInput!]!) {
+        before: updateProductVariants(input: $first) {
+            id
+            stockOnHand
+        }
+        after: updateProductVariants(input: $second) {
+            id
+            stockOnHand
+        }
+    }
+`);
 
 const updateStockOnHandDocument = graphql(
     `

--- a/packages/core/src/config/catalog/multi-channel-stock-location-strategy.spec.ts
+++ b/packages/core/src/config/catalog/multi-channel-stock-location-strategy.spec.ts
@@ -4,6 +4,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { RequestContext } from '../../api/common/request-context';
 import { Cache } from '../../cache/cache';
+import { RequestContextCacheService } from '../../cache/request-context-cache.service';
 import { Channel } from '../../entity/channel/channel.entity';
 import { Product } from '../../entity/product/product.entity';
 import { StockLevel } from '../../entity/stock-level/stock-level.entity';
@@ -52,11 +53,16 @@ const mockEventBus = {
 let channelsInDb: Channel[];
 const getEntityOrThrow = vi.fn(() => Promise.resolve(new StockLocation({ id: 1, channels: channelsInDb })));
 
+// The real service is used: the strategy relies on it storing the un-awaited promise to
+// collapse concurrent lookups, which a stub would not reproduce.
+let requestContextCache: RequestContextCacheService;
+
 const mockInjector = {
     get: (token: unknown) => {
         const name = (token as { name?: string })?.name;
         if (name === 'EventBus') return mockEventBus;
         if (name === 'CacheService') return mockCacheService;
+        if (name === 'RequestContextCacheService') return requestContextCache;
         if (name === 'TransactionalConnection') return { getEntityOrThrow };
         return {};
     },
@@ -75,8 +81,10 @@ function contextForChannel(channel: Channel): RequestContext {
     } as any);
 }
 
-const ctxChannel1 = contextForChannel(channel1);
-const ctxChannel2 = contextForChannel(channel2);
+// Re-created for each test: the strategy caches channel ids against the RequestContext
+// instance, so a shared context would carry a lookup from one test into the next.
+let ctxChannel1: RequestContext;
+let ctxChannel2: RequestContext;
 
 const stockLevel = new StockLevel({
     stockLocationId: 1,
@@ -105,6 +113,9 @@ describe('MultiChannelStockLocationStrategy', () => {
         eventStream = new Subject<any>();
         channelsInDb = [channel1];
         getEntityOrThrow.mockClear();
+        requestContextCache = new RequestContextCacheService();
+        ctxChannel1 = contextForChannel(channel1);
+        ctxChannel2 = contextForChannel(channel2);
         // Dynamic import to avoid vitest circular dependency issue
         const { MultiChannelStockLocationStrategy } =
             await import('./multi-channel-stock-location-strategy.js');
@@ -121,6 +132,34 @@ describe('MultiChannelStockLocationStrategy', () => {
         expect(getEntityOrThrow).toHaveBeenCalledTimes(1);
     });
 
+    it('loads a StockLocation once when its stock levels are resolved concurrently', async () => {
+        const stockLevels = [1, 2, 3, 4, 5].map(
+            productVariantId =>
+                new StockLevel({
+                    stockLocationId: 1,
+                    stockOnHand: 100,
+                    stockAllocated: 0,
+                    productVariantId,
+                }),
+        );
+
+        const results = await Promise.all(
+            stockLevels.map(level => strategy.getAvailableStock(ctxChannel1, level.productVariantId, [level])),
+        );
+
+        expect(results.map(r => r.stockOnHand)).toEqual([100, 100, 100, 100, 100]);
+        expect(getEntityOrThrow).toHaveBeenCalledTimes(1);
+    });
+
+    it('loads a StockLocation once per request, not once per request-scoped read', async () => {
+        await strategy.getAvailableStock(ctxChannel1, 1, [stockLevel]);
+        expect(getEntityOrThrow).toHaveBeenCalledTimes(1);
+
+        // A different RequestContext still finds the value in the cross-request cache
+        await strategy.getAvailableStock(contextForChannel(channel1), 1, [stockLevel]);
+        expect(getEntityOrThrow).toHaveBeenCalledTimes(1);
+    });
+
     it('invalidates the cache when a StockLocation is updated', async () => {
         // Cache the channel ids while the location belongs to channel1 only
         const stale = await strategy.getAvailableStock(ctxChannel2, 1, [stockLevel]);
@@ -130,7 +169,9 @@ describe('MultiChannelStockLocationStrategy', () => {
         eventStream.next(new StockLocationEvent(ctxChannel1, stockLocation, 'updated'));
         await flushEventHandlers();
 
-        const fresh = await strategy.getAvailableStock(ctxChannel2, 1, [stockLevel]);
+        // Invalidation clears the cross-request cache, so the read that observes it belongs
+        // to a later request and therefore a new RequestContext.
+        const fresh = await strategy.getAvailableStock(contextForChannel(channel2), 1, [stockLevel]);
         expect(fresh.stockOnHand).toBe(100);
     });
 
@@ -140,7 +181,10 @@ describe('MultiChannelStockLocationStrategy', () => {
         eventStream.next(new StockLocationEvent(ctxChannel1, stockLocation, 'created'));
         await flushEventHandlers();
 
-        await strategy.getAvailableStock(ctxChannel1, 1, [stockLevel]);
+        // Read through a new context, as the positive invalidation tests do: reusing
+        // ctxChannel1 would be answered by the request-scoped cache and never reach the
+        // cross-request cache this test is about.
+        await strategy.getAvailableStock(contextForChannel(channel1), 1, [stockLevel]);
         expect(getEntityOrThrow).toHaveBeenCalledTimes(1);
     });
 
@@ -153,7 +197,7 @@ describe('MultiChannelStockLocationStrategy', () => {
         eventStream.next(new ChangeChannelEvent(ctxChannel1, stockLocation, [2], 'assigned', StockLocation));
         await flushEventHandlers();
 
-        const fresh = await strategy.getAvailableStock(ctxChannel2, 1, [stockLevel]);
+        const fresh = await strategy.getAvailableStock(contextForChannel(channel2), 1, [stockLevel]);
         expect(fresh.stockOnHand).toBe(100);
     });
 
@@ -166,7 +210,7 @@ describe('MultiChannelStockLocationStrategy', () => {
         eventStream.next(new ChangeChannelEvent(ctxChannel1, stockLocation, [2], 'removed', StockLocation));
         await flushEventHandlers();
 
-        const fresh = await strategy.getAvailableStock(ctxChannel2, 1, [stockLevel]);
+        const fresh = await strategy.getAvailableStock(contextForChannel(channel2), 1, [stockLevel]);
         expect(fresh.stockOnHand).toBe(0);
     });
 
@@ -190,7 +234,7 @@ describe('MultiChannelStockLocationStrategy', () => {
         );
         await flushEventHandlers();
 
-        await strategy.getAvailableStock(ctxChannel1, 1, [stockLevel]);
+        await strategy.getAvailableStock(contextForChannel(channel1), 1, [stockLevel]);
         expect(getEntityOrThrow).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/core/src/config/catalog/multi-channel-stock-location-strategy.ts
+++ b/packages/core/src/config/catalog/multi-channel-stock-location-strategy.ts
@@ -157,22 +157,29 @@ export class MultiChannelStockLocationStrategy extends BaseStockLocationStrategy
         ctx: RequestContext,
         stockLevel: StockLevel,
     ): Promise<boolean> {
-        const channelIds = await this.channelIdCache.get(stockLevel.stockLocationId, async () => {
-            const stockLocation = await this.connection.getEntityOrThrow(
-                ctx,
-                StockLocation,
-                stockLevel.stockLocationId,
-                {
-                    relations: {
-                        channels: true,
-                    },
-                },
-            );
-            return stockLocation.channels.map(c => c.id);
-        });
+        const channelIds = await this.getChannelIdsForStockLocation(ctx, stockLevel.stockLocationId);
         return channelIds.includes(ctx.channelId);
     }
 
+    private getChannelIdsForStockLocation(ctx: RequestContext, stockLocationId: ID): Promise<ID[]> {
+        return this.requestContextCache.get(ctx, this.getCacheKey(stockLocationId), () =>
+            this.channelIdCache.get(stockLocationId, async () => {
+                const stockLocation = await this.connection.getEntityOrThrow(
+                    ctx,
+                    StockLocation,
+                    stockLocationId,
+                    {
+                        relations: {
+                            channels: true,
+                        },
+                    },
+                );
+                return stockLocation.channels.map(c => c.id);
+            }),
+        );
+    }
+
+    // Shared by both caches. They are separate stores, so the key does not collide in either.
     private getCacheKey(stockLocationId: ID) {
         return `MultiChannelStockLocationStrategy:StockLocationChannelIds:${stockLocationId}`;
     }

--- a/packages/core/src/service/services/stock-level.service.spec.ts
+++ b/packages/core/src/service/services/stock-level.service.spec.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RequestContext } from '../../api/common/request-context';
+import { RequestContextCacheService } from '../../cache/request-context-cache.service';
+import { Channel } from '../../entity/channel/channel.entity';
+import { StockLevel } from '../../entity/stock-level/stock-level.entity';
+
+import { StockLevelService } from './stock-level.service';
+
+/**
+ * Unit tests for the request-scoped batching of StockLevel lookups. Resolving the stock of a
+ * list of ProductVariants used to issue one query per variant, and two per variant on the
+ * Admin API, where `stockOnHand` and `stockAllocated` are separate field resolvers.
+ */
+
+/** One row per variant 1-5, all at stock location 1. */
+const allStockLevels = [1, 2, 3, 4, 5].map(
+    productVariantId =>
+        new StockLevel({
+            id: productVariantId,
+            stockLocationId: 1,
+            stockOnHand: productVariantId * 10,
+            stockAllocated: 1,
+            productVariantId,
+        }),
+);
+
+const find = vi.fn(({ where }: any) => {
+    const requestedIds: Array<string | number> = where.productVariantId._value;
+    const ids = requestedIds.map(id => String(id));
+    return Promise.resolve(allStockLevels.filter(sl => ids.includes(String(sl.productVariantId))));
+});
+
+const mockConnection = {
+    getRepository: () => ({ find }),
+} as any;
+
+// Sums the levels it is given, as DefaultStockLocationStrategy does, so the assertions are
+// about which rows reach the strategy rather than about channel filtering.
+const mockConfigService = {
+    catalogOptions: {
+        stockLocationStrategy: {
+            getAvailableStock: (ctx: RequestContext, productVariantId: any, stockLevels: StockLevel[]) => ({
+                stockOnHand: stockLevels.reduce((sum, sl) => sum + sl.stockOnHand, 0),
+                stockAllocated: stockLevels.reduce((sum, sl) => sum + sl.stockAllocated, 0),
+            }),
+        },
+    },
+} as any;
+
+function newCtx(): RequestContext {
+    return new RequestContext({
+        apiType: 'shop',
+        channel: new Channel({ id: 1 }),
+        authorizedAsOwnerOnly: false,
+        isAuthorized: true,
+        session: {} as any,
+    } as any);
+}
+
+describe('StockLevelService', () => {
+    let service: StockLevelService;
+    let ctx: RequestContext;
+
+    beforeEach(() => {
+        find.mockClear();
+        ctx = newCtx();
+        service = new StockLevelService(
+            mockConnection,
+            {} as any,
+            mockConfigService,
+            new RequestContextCacheService(),
+        );
+    });
+
+    describe('getAvailableStock', () => {
+        it('batches concurrent lookups into a single query', async () => {
+            const results = await Promise.all(
+                [1, 2, 3, 4, 5].map(id => service.getAvailableStock(ctx, id)),
+            );
+
+            expect(find).toHaveBeenCalledTimes(1);
+            expect(results.map(r => r.stockOnHand)).toEqual([10, 20, 30, 40, 50]);
+            expect(results.map(r => r.stockAllocated)).toEqual([1, 1, 1, 1, 1]);
+        });
+
+        it('batches repeated lookups of the same variant into a single query', async () => {
+            // The Admin API resolves `stockOnHand` and `stockAllocated` separately, so the same
+            // variant is loaded twice in one tick.
+            const [first, second] = await Promise.all([
+                service.getAvailableStock(ctx, 1),
+                service.getAvailableStock(ctx, 1),
+            ]);
+
+            expect(find).toHaveBeenCalledTimes(1);
+            expect(first).toEqual(second);
+        });
+
+        it('returns zero stock for a variant with no StockLevel rows', async () => {
+            const result = await service.getAvailableStock(ctx, 99);
+
+            expect(result).toEqual({ stockOnHand: 0, stockAllocated: 0 });
+        });
+
+        it('re-reads on a later tick, so stock changed within a request is not stale', async () => {
+            await service.getAvailableStock(ctx, 1);
+            await service.getAvailableStock(ctx, 1);
+
+            expect(find).toHaveBeenCalledTimes(2);
+        });
+
+        it('does not share a batch across RequestContexts', async () => {
+            await Promise.all([
+                service.getAvailableStock(ctx, 1),
+                service.getAvailableStock(newCtx(), 2),
+            ]);
+
+            expect(find).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/packages/core/src/service/services/stock-level.service.ts
+++ b/packages/core/src/service/services/stock-level.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { ID } from '@vendure/common/lib/shared-types';
+import DataLoader from 'dataloader';
+import { In } from 'typeorm';
 
 import { RequestContext } from '../../api/common/request-context';
+import { RequestContextCacheService } from '../../cache/request-context-cache.service';
 import { Instrument } from '../../common/instrument-decorator';
 import { AvailableStock } from '../../config/catalog/stock-location-strategy';
 import { ConfigService } from '../../config/config.service';
@@ -27,6 +30,7 @@ export class StockLevelService {
         private connection: TransactionalConnection,
         private stockLocationService: StockLocationService,
         private configService: ConfigService,
+        private requestCache: RequestContextCacheService,
     ) {}
 
     /**
@@ -71,12 +75,44 @@ export class StockLevelService {
      */
     async getAvailableStock(ctx: RequestContext, productVariantId: ID): Promise<AvailableStock> {
         const { stockLocationStrategy } = this.configService.catalogOptions;
+        const stockLevels = await this.getStockLevelLoader(ctx).load(productVariantId);
+        return stockLocationStrategy.getAvailableStock(ctx, productVariantId, stockLevels);
+    }
+
+    /**
+     * Resolving a list of ProductVariants costs one query per variant otherwise, and the Admin
+     * API doubles that because `stockOnHand` and `stockAllocated` are separate field resolvers.
+     * `cache: false` batches without memoizing, so a write earlier in the request is not masked.
+     */
+    private getStockLevelLoader(ctx: RequestContext): DataLoader<ID, StockLevel[]> {
+        return this.requestCache.get(
+            ctx,
+            'StockLevelService.stockLevelsByVariantId',
+            () =>
+                new DataLoader<ID, StockLevel[]>(ids => this.batchLoadStockLevels(ctx, ids as ID[]), {
+                    cache: false,
+                }),
+        );
+    }
+
+    private async batchLoadStockLevels(ctx: RequestContext, ids: ID[]): Promise<StockLevel[][]> {
+        const uniqueIds = [...new Map(ids.map(id => [String(id), id])).values()];
         const stockLevels = await this.connection.getRepository(ctx, StockLevel).find({
             where: {
-                productVariantId,
+                productVariantId: In(uniqueIds),
             },
         });
-        return stockLocationStrategy.getAvailableStock(ctx, productVariantId, stockLevels);
+        const byVariantId = new Map<string, StockLevel[]>();
+        for (const stockLevel of stockLevels) {
+            const key = String(stockLevel.productVariantId);
+            const existing = byVariantId.get(key);
+            if (existing) {
+                existing.push(stockLevel);
+            } else {
+                byVariantId.set(key, [stockLevel]);
+            }
+        }
+        return ids.map(id => byVariantId.get(String(id)) ?? []);
     }
 
     /**


### PR DESCRIPTION
`MultiChannelStockLocationStrategy` is the default `stockLocationStrategy` since 3.1.0, so this sits on the read path every storefront hits. Two independent causes made a single shop-API product query issue far more statements than it needed.

### 1. The channel id cache stampeded itself

`stockLevelAppliesToActiveChannel` reads a StockLocation's channel ids through a `CacheService` cache with a 7-day TTL. `Cache.get()` awaits the backend read and has no in-flight de-duplication, so every stock level on a page misses before any of them has populated the entry, and each issues its own query for the same StockLocation row. The cache was correct across requests and useless within one.

Fixed by layering the request cache in front of it. `RequestContextCacheService.get()` stores the promise *before* it resolves, so the second and subsequent callers await the first load rather than starting their own. No new mechanism, no new dependency, no change to the query shape, and the cross-request cache and both its `EventBus` invalidation subscriptions are untouched.

Accepted limitation, documented in the code: a `ChangeChannelEvent` raised during the same request does not clear the request-scoped entry. The event carries the `RequestContext` which published it, but `EventBus.ofType()` defers delivery until that transaction settles, so an eviction keyed on that context would race the reads it means to protect. The stale window is one request, against the 7 days the cross-request cache already tolerates.

### 2. StockLevel rows were fetched one variant at a time

`StockLevelService.getAvailableStock` issued its own `find` per variant, and the Admin API doubled that because `stockOnHand` and `stockAllocated` are separate `@ResolveField`s. An admin list of N variants ran 2N queries.

Fixed with a request-scoped `DataLoader` keyed on `productVariantId`, held on `RequestContextCacheService` the same way `CustomFieldRelationResolverService` holds its own. `dataloader` was already a direct dependency of `@vendure/core`.

The loader is created with `cache: false`, so it batches without memoizing. `getAvailableStock` is also on mutation paths (`OrderService`, `OrderModifier`, `defaultOrderProcess`) where stock is being changed in the same request; memoizing there would risk overselling. Batching alone is tick-scoped, so sequential awaits in a mutation each get a fresh read while the concurrent field resolves of a GraphQL list still collapse into one query.

## Measurements

Shop `product` query returning two tracked variants, measured with a TypeORM logger on the same throwaway harness both sides:

| | statements | `stock_level` queries |
|---|---|---|
| before | 7 | 2 — `productVariantId = 5`, `productVariantId = 6` |
| after | 6 | 1 — `productVariantId IN (5, 6)` |

The stampede fix is counted in the unit spec: a strategy resolving five stock levels at one StockLocation concurrently loads that location 5 times on `master` and once with this change.

## Testing

- New in `multi-channel-stock-location-strategy.spec.ts`: `loads a StockLocation once when its stock levels are resolved concurrently`, and a per-context isolation test. The spec now builds a real `RequestContextCacheService` and a fresh `RequestContext` per test, and every test that observes the cross-request cache reads through a new context, since the request-scoped entry would otherwise answer the second read.
- New: `stock-level.service.spec.ts` — batching, duplicate-variant collapse, the empty-rows case, the `cache: false` guarantee, and per-context isolation. All five fail on `master`.
- New e2e in `stock-control.e2e-spec.ts`: `reports the stockOnHand written earlier in the same request`. Mutation fields execute serially and each is completed before the next begins, so two aliased `updateProductVariants` fields write and read the same variant within one request. Widening the loader beyond a single `RequestContext`, or memoizing across one, makes the second read report the first value and oversell stock; both were confirmed to fail the test.
- 1230 core unit tests pass.
- 351 e2e pass across `stock-control` (37), `stock-control-multi-location` (10), `stock-location` (18), and the order suites matched by `order`/`order-modification` (286).
