### PR TITLE
fix(dashboard): remove arbitrary 1000 max on promotion usage limits

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
@@ -211,7 +211,7 @@ function PromotionDetailPage() {
                             name="perCustomerUsageLimit"
                             label={<Trans>Per customer usage limit</Trans>}
                             render={({ field }) => (
-                                <NumberInput {...field} value={field.value ?? ''} min={0} max={1000} />
+                                <NumberInput {...field} value={field.value ?? ''} min={0} />
                             )}
                         />
                         <FormFieldWrapper
@@ -219,7 +219,7 @@ function PromotionDetailPage() {
                             name="usageLimit"
                             label={<Trans>Usage limit</Trans>}
                             render={({ field }) => (
-                                <NumberInput {...field} value={field.value ?? ''} min={0} max={1000} />
+                                <NumberInput {...field} value={field.value ?? ''} min={0} />
                             )}
                         />
                     </DetailFormGrid>


### PR DESCRIPTION
# Description

Removes the arbitrary `max={1000}` cap on the `usageLimit` and `perCustomerUsageLimit` fields in the Promotion detail page.

This cap existed only as a client-side HTML attribute in the Dashboard. The backend (`@vendure/core`) never enforced it — both fields are plain nullable `Int` columns, and a `null` value means "unlimited". This made the UI and backend inconsistent, and the limit could already be bypassed via the Admin API.

The 1000 cap was a real operational blocker for common always-on promotions (e.g. "free shipping over a threshold") which are auto-applied to most orders and reach 1000 uses quickly, forcing operators to recreate the promotion repeatedly. Both fields now keep `min={0}`; leaving them empty continues to mean unlimited.

Fixes #5225

# Breaking changes

None. This only removes a client-side input constraint; no API, schema, or persisted behavior changes.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790838110&installation_model_id=20193&pr_number=5226&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5226&signature=939b9bdc7c01f4769572c76f10bef82923479682ee5db02a57437157e8b85d20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->