### PR TITLE
fix(dashboard): recover active channel after deleting the current one

### DIFF
--- a/packages/dashboard/e2e/tests/settings/channels.spec.ts
+++ b/packages/dashboard/e2e/tests/settings/channels.spec.ts
@@ -2,6 +2,7 @@ import { type Page, expect, test } from '@playwright/test';
 
 import { BaseDetailPage } from '../../page-objects/detail-page.base.js';
 import { BaseListPage } from '../../page-objects/list-page.base.js';
+import { VendureAdminClient } from '../../utils/vendure-admin-client.js';
 
 // Channels have dependent selectors: available languages/currencies must be set
 // before their respective defaults. Zone selectors are standard Base UI Selects.
@@ -163,6 +164,96 @@ test.describe('Channels CRUD', () => {
         const switcherMenu = page.locator('[data-slot="dropdown-menu-content"]');
         await expect(switcherMenu).toBeVisible();
         await expect(switcherMenu.getByText('e2e-test-channel')).toHaveCount(0);
+    });
+
+    // #5179 follow-up — deleting the channel you are currently switched into
+    // must recover the active channel without a full page reload. refreshChannels()
+    // refetches ['activeChannel'] while localStorage still holds the deleted
+    // channel's token (retry: false, so it is not retried); the provider then
+    // picks the first available channel and must re-invalidate ['activeChannel']
+    // so it refetches under the corrected token. No page.reload() below the
+    // initial load: a reload recreates the QueryClient and masks the bug.
+    test('should recover the active channel after deleting the current one', async ({ page }) => {
+        test.setTimeout(30_000);
+        const channelCode = `e2e-active-del-${Date.now()}`;
+
+        // Create the channel via the Admin API so the test can focus on the
+        // switch/delete/recover flow rather than the long create form.
+        const client = new VendureAdminClient(page);
+        await client.login();
+        const zones = await client.gql(
+            `query { zones(options: { filter: { name: { eq: "Europe" } } }) { items { id } } }`,
+        );
+        const zoneId = zones.zones.items[0]?.id as string;
+        expect(zoneId).toBeTruthy();
+        const created = await client.gql(
+            `mutation ($input: CreateChannelInput!) {
+                createChannel(input: $input) {
+                    ... on Channel { id }
+                    ... on ErrorResult { errorCode message }
+                }
+            }`,
+            {
+                input: {
+                    code: channelCode,
+                    token: channelCode,
+                    defaultLanguageCode: 'en',
+                    pricesIncludeTax: false,
+                    defaultCurrencyCode: 'USD',
+                    availableCurrencyCodes: ['USD'],
+                    defaultTaxZoneId: zoneId,
+                    defaultShippingZoneId: zoneId,
+                },
+            },
+        );
+        const createdChannelId = created.createChannel.id as string;
+
+        try {
+            // Initial (and only) full load.
+            await page.goto('/');
+            const sidebar = page.locator('[data-slot="sidebar"]');
+            const switcherTrigger = sidebar.getByRole('button').first();
+            await expect(switcherTrigger).toBeVisible({ timeout: 15_000 });
+
+            // Switch into the newly created channel.
+            await switcherTrigger.click();
+            const switcherMenu2 = page.locator('[data-slot="dropdown-menu-content"]');
+            await expect(switcherMenu2).toBeVisible();
+            await switcherMenu2.getByRole('menuitem').filter({ hasText: channelCode }).click();
+            await expect(switcherTrigger).toContainText(channelCode, { timeout: 10_000 });
+
+            // Delete the currently-active channel via the list (client-side nav).
+            // Channels lives under the Settings section, which may need expanding.
+            const channelsLink = sidebar.getByRole('link', { name: 'Channels', exact: true });
+            if (!(await channelsLink.isVisible().catch(() => false))) {
+                await sidebar.getByRole('button', { name: 'Settings' }).click();
+            }
+            await channelsLink.click();
+            const lp = listPage(page);
+            await lp.expectLoaded();
+            const row = lp.getRows().filter({ hasText: channelCode });
+            await row.getByRole('checkbox').click();
+            await page.getByRole('button', { name: /Actions/i }).click();
+            await page.locator('[role="menu"]').getByText('Delete', { exact: true }).click();
+            await page.locator('[role="alertdialog"]').getByRole('button', { name: 'Continue' }).click();
+            await lp.expectSuccessToast();
+            await expect(lp.getRows().filter({ hasText: channelCode })).toHaveCount(0);
+
+            // The active channel must recover to a valid channel on its own — the
+            // switcher trigger no longer shows the deleted channel and shows a
+            // real channel code instead. Without the fix this stays stuck on the
+            // deleted channel until a hard refresh.
+            await expect(switcherTrigger).not.toContainText(channelCode, { timeout: 10_000 });
+            await expect(switcherTrigger).toContainText(/[a-z]/i, { timeout: 10_000 });
+        } finally {
+            // Ensure the channel is gone even if an assertion above failed.
+            // The happy path already deletes it via the UI, so ignore "not found".
+            await client
+                .gql(`mutation ($id: ID!) { deleteChannel(id: $id) { result } }`, {
+                    id: createdChannelId,
+                })
+                .catch(() => {});
+        }
     });
 });
 

--- a/packages/dashboard/e2e/tests/settings/channels.spec.ts
+++ b/packages/dashboard/e2e/tests/settings/channels.spec.ts
@@ -166,7 +166,7 @@ test.describe('Channels CRUD', () => {
         await expect(switcherMenu.getByText('e2e-test-channel')).toHaveCount(0);
     });
 
-    // #5179 follow-up — deleting the channel you are currently switched into
+    // #5179 — Follow-up: deleting the channel you are currently switched into
     // must recover the active channel without a full page reload. refreshChannels()
     // refetches ['activeChannel'] while localStorage still holds the deleted
     // channel's token (retry: false, so it is not retried); the provider then

--- a/packages/dashboard/e2e/tests/settings/channels.spec.ts
+++ b/packages/dashboard/e2e/tests/settings/channels.spec.ts
@@ -217,9 +217,9 @@ test.describe('Channels CRUD', () => {
 
             // Switch into the newly created channel.
             await switcherTrigger.click();
-            const switcherMenu2 = page.locator('[data-slot="dropdown-menu-content"]');
-            await expect(switcherMenu2).toBeVisible();
-            await switcherMenu2.getByRole('menuitem').filter({ hasText: channelCode }).click();
+            const switcherMenu = page.locator('[data-slot="dropdown-menu-content"]');
+            await expect(switcherMenu).toBeVisible();
+            await switcherMenu.getByRole('menuitem').filter({ hasText: channelCode }).click();
             await expect(switcherTrigger).toContainText(channelCode, { timeout: 10_000 });
 
             // Delete the currently-active channel via the list (client-side nav).
@@ -239,15 +239,16 @@ test.describe('Channels CRUD', () => {
             await lp.expectSuccessToast();
             await expect(lp.getRows().filter({ hasText: channelCode })).toHaveCount(0);
 
-            // The active channel must recover to a valid channel on its own — the
-            // switcher trigger no longer shows the deleted channel and shows a
-            // real channel code instead. Without the fix this stays stuck on the
-            // deleted channel until a hard refresh.
+            // The active channel must recover to a valid channel on its own. This
+            // suite runs in serial mode and the default channel is the only one
+            // left at this point, so the switcher must land on it. Without the fix
+            // this stays stuck on the deleted channel until a hard refresh.
             await expect(switcherTrigger).not.toContainText(channelCode, { timeout: 10_000 });
-            await expect(switcherTrigger).toContainText(/[a-z]/i, { timeout: 10_000 });
+            await expect(switcherTrigger).toContainText('Default channel', { timeout: 10_000 });
         } finally {
-            // Ensure the channel is gone even if an assertion above failed.
-            // The happy path already deletes it via the UI, so ignore "not found".
+            // Ensure the channel is gone even if an assertion above failed. On the
+            // happy path the UI already deleted it, so this call is expected to
+            // fail with "not found" and the rejection is discarded.
             await client
                 .gql(`mutation ($id: ID!) { deleteChannel(id: $id) { result } }`, {
                     id: createdChannelId,

--- a/packages/dashboard/src/lib/providers/channel-provider.tsx
+++ b/packages/dashboard/src/lib/providers/channel-provider.tsx
@@ -222,16 +222,19 @@ export function ChannelProvider({ children }: Readonly<{ children: React.ReactNo
             // If no selected channel is set, use the first available channel
             const defaultChannel = channels[0];
             setSelectedChannelId(defaultChannel.id);
-            setChannelTokenInLocalStorage(defaultChannel.token);
-            // The active channel query may have been refetched (e.g. by
-            // refreshChannels() after deleting the current channel) while
-            // localStorage still held the now-deleted channel's token, and it
-            // is not retried (retry: false). Invalidate it now that the token
-            // points at a valid channel so the active channel recovers without
-            // requiring a full page reload.
-            queryClient.invalidateQueries({
-                queryKey: ['activeChannel', isAuthenticated],
-            });
+            const currentToken = getChannelTokenFromLocalStorage();
+            if (currentToken !== defaultChannel.token) {
+                setChannelTokenInLocalStorage(defaultChannel.token);
+                // The active channel query may have been refetched (e.g. by
+                // refreshChannels() after deleting the current channel) while
+                // localStorage still held the now-deleted channel's token, and
+                // it is not retried (retry: false). Invalidate it now that the
+                // token points at a valid channel so the active channel
+                // recovers without requiring a full page reload.
+                queryClient.invalidateQueries({
+                    queryKey: ['activeChannel', isAuthenticated],
+                });
+            }
         }
     }, [selectedChannelId, channels, queryClient, isAuthenticated]);
 

--- a/packages/dashboard/src/lib/providers/channel-provider.tsx
+++ b/packages/dashboard/src/lib/providers/channel-provider.tsx
@@ -223,6 +223,15 @@ export function ChannelProvider({ children }: Readonly<{ children: React.ReactNo
             const defaultChannel = channels[0];
             setSelectedChannelId(defaultChannel.id);
             setChannelTokenInLocalStorage(defaultChannel.token);
+            // The active channel query may have been refetched (e.g. by
+            // refreshChannels() after deleting the current channel) while
+            // localStorage still held the now-deleted channel's token, and it
+            // is not retried (retry: false). Invalidate it now that the token
+            // points at a valid channel so the active channel recovers without
+            // requiring a full page reload.
+            queryClient.invalidateQueries({
+                queryKey: ['activeChannel', isAuthenticated],
+            });
         }
     }, [selectedChannelId, channels, queryClient, isAuthenticated]);
 


### PR DESCRIPTION
Fixes #5227
Relates to #5179

# Description

Deleting the channel you're currently switched into left the dashboard on a broken active channel until a hard refresh — it didn't self-recover. This is a follow-up surfaced by #5179 / #5181 (which refresh the switcher after a channel delete).

**Cause:** the active-channel query (`['activeChannel']` in `channel-provider.tsx`) uses `retry: false`. On delete, `refreshChannels()` invalidates and refetches `['activeChannel']` while `localStorage` still holds the deleted channel's token (the recovery effect runs later, after `me.channels` updates). That request fails under the dead token and, with `retry: false`, is never retried. The recovery effect then falls into the "pick first available channel" branch, which fixes the token but — unlike the token-out-of-sync branch — does **not** re-invalidate `['activeChannel']`, so it stays stuck on the failed response.

**Fix:** in the "pick first available channel" recovery branch, re-invalidate `['activeChannel']` after correcting the token (mirroring the sibling token-out-of-sync branch), so it refetches under the valid token and the active channel recovers without a reload.

Adds an e2e test in the existing channels suite: switch into a newly created channel, delete it while active, and assert the switcher recovers to a valid channel — with no `page.reload()` (a reload recreates the QueryClient and masks the bug). Verified to fail without the fix (the switcher stays stuck on the deleted channel).

# Breaking changes

None.

# Screenshots
https://www.loom.com/share/459f4e04931948619e3f0a73585e139d

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790842269&installation_model_id=20193&pr_number=5228&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5228&signature=33ea0406b0d16bc292bdb14e77fcdd85d11e066c89d8439c0149e4542af7dec7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->