### PR TITLE
ci: generate docs on the base branch instead of the PR branch

### DIFF
--- a/.github/actions/commit-and-push/action.yml
+++ b/.github/actions/commit-and-push/action.yml
@@ -1,0 +1,39 @@
+name: 'Commit and push'
+description: 'Commit the already-staged changes as the CI bot and push them to the checked-out branch'
+inputs:
+    token:
+        description: 'CI bot app token, used to push and to look up the bot user id'
+        required: true
+    app-slug:
+        description: 'CI bot app slug, used to build the commit author identity'
+        required: true
+    message:
+        description: 'Commit message subject'
+        required: true
+runs:
+    using: 'composite'
+    steps:
+        - name: Commit and push
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.token }}
+              APP_SLUG: ${{ inputs.app-slug }}
+              MESSAGE: ${{ inputs.message }}
+          run: |
+              user_id=$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)
+              git config user.name "${APP_SLUG}[bot]"
+              git config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
+              git commit -m "$MESSAGE"
+              # Other commits can land on the branch while the job runs, so rebase
+              # onto them and try again rather than failing the push outright.
+              for _ in 1 2 3; do
+                if git push; then
+                  exit 0
+                fi
+                if ! git pull --rebase; then
+                  echo "Could not rebase onto the updated branch, so the commit was not pushed" >&2
+                  exit 1
+                fi
+              done
+              echo "Could not push after 3 attempts" >&2
+              exit 1

--- a/.github/actions/generate-docs/action.yml
+++ b/.github/actions/generate-docs/action.yml
@@ -1,0 +1,24 @@
+name: 'Generate docs'
+description: 'Regenerate the TypeScript and GraphQL reference docs from source, then check the result is valid MDX'
+runs:
+    using: 'composite'
+    steps:
+        - uses: ./.github/actions/setup
+
+        - name: Generate TypeScript docs
+          shell: bash
+          run: bun run docs:generate-typescript-docs
+
+        - name: Generate GraphQL docs
+          shell: bash
+          run: bun run docs:generate-graphql-docs
+
+        - name: Install docs dependencies
+          shell: bash
+          working-directory: docs
+          run: npm install
+
+        - name: Validate generated docs
+          shell: bash
+          working-directory: docs
+          run: npm run test:mdx

--- a/.github/actions/generate-docs/action.yml
+++ b/.github/actions/generate-docs/action.yml
@@ -16,7 +16,9 @@ runs:
         - name: Install docs dependencies
           shell: bash
           working-directory: docs
-          run: npm install
+          # npm ci pins to docs/package-lock.json, and --ignore-scripts keeps a
+          # dependency's lifecycle script away from the CI bot token this job holds.
+          run: npm ci --ignore-scripts
 
         - name: Validate generated docs
           shell: bash

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -55,7 +55,8 @@ jobs:
               uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
             - name: Install dependencies
-              run: bun install
+              # npm ci pins to docs/package-lock.json, which bun install ignores.
+              run: npm ci --ignore-scripts
 
             - name: Validate MDX files
               run: bun run test:mdx
@@ -98,7 +99,9 @@ jobs:
 
             - name: Install docs dependencies
               working-directory: docs
-              run: bun install
+              # npm ci pins to docs/package-lock.json, and --ignore-scripts keeps a
+              # dependency's lifecycle script away from the CI bot token this job holds.
+              run: npm ci --ignore-scripts
 
             - name: Generate manifest
               run: bun run docs:compile-manifest

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -1,6 +1,14 @@
 name: Docs CI
 
+# docs/manifest.json is compiled from docs/src/manifest.ts, so like the generated
+# reference docs it is a build output that happens to be committed. It is compiled
+# and committed after merge, on the base branch, so that a PR touching the docs does
+# not carry a bot commit in its diff. A PR only checks that the compiler runs.
+
 on:
+    # Lets a maintainer regenerate the base branch by hand, for example after a
+    # run was skipped or failed.
+    workflow_dispatch:
     push:
         branches:
             - master
@@ -23,13 +31,16 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-    cancel-in-progress: true
+    # A superseded PR run tells us nothing, so cancel it. A push run commits to the
+    # base branch, so let it finish: cancelling it would leave the manifest stale
+    # until the next docs change happened to come along.
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
     validate:
         name: Validate MDX
         # Skip draft PRs
-        if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
         permissions:
             contents: read
         runs-on: ubuntu-latest
@@ -49,10 +60,17 @@ jobs:
             - name: Validate MDX files
               run: bun run test:mdx
 
+            # The manifest is committed after merge. Compiling it here without
+            # committing catches a docs change that breaks the compiler, which would
+            # otherwise only surface once it had landed on the base branch.
+            - name: Compile manifest
+              if: ${{ github.event_name == 'pull_request' }}
+              working-directory: .
+              run: bun run docs:compile-manifest
+
     generate-manifest:
         name: Generate & commit manifest
-        # Skip fork PRs (can't push back to fork branches) and draft PRs
-        if: ${{ github.event_name == 'push' || (!github.event.pull_request.head.repo.fork && !github.event.pull_request.draft) }}
+        if: ${{ github.event_name != 'pull_request' }}
         runs-on: ubuntu-latest
         permissions:
             contents: write
@@ -70,7 +88,9 @@ jobs:
               uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
               with:
                   token: ${{ steps.app-token.outputs.token }}
-                  ref: ${{ github.head_ref || github.ref }}
+                  # Check out the branch by name rather than the pushed SHA so the
+                  # commit below has an upstream to rebase onto and push to.
+                  ref: ${{ github.ref_name }}
                   fetch-depth: 0
 
             - name: Setup Bun
@@ -81,7 +101,7 @@ jobs:
               run: bun install
 
             - name: Generate manifest
-              run: bun run docs/scripts/compile-manifest.ts
+              run: bun run docs:compile-manifest
 
             - name: Check for changes
               id: diff
@@ -93,19 +113,10 @@ jobs:
                     echo "changed=true" >> "$GITHUB_OUTPUT"
                   fi
 
-            - name: Get CI Bot user info
-              if: steps.diff.outputs.changed == 'true'
-              id: get-user
-              env:
-                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
-              run: |
-                  user_id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}%5Bbot%5D" --jq .id)
-                  echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
-
             - name: Commit and push manifest
               if: steps.diff.outputs.changed == 'true'
-              run: |
-                  git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
-                  git config user.email "${{ steps.get-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
-                  git commit -m "docs: Regenerate manifest.json"
-                  git push
+              uses: ./.github/actions/commit-and-push
+              with:
+                  token: ${{ steps.app-token.outputs.token }}
+                  app-slug: ${{ steps.app-token.outputs.app-slug }}
+                  message: 'docs: Regenerate manifest.json'

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -1,6 +1,24 @@
 name: Generate Docs
 
+# The reference docs under docs/docs/reference are generated from the package
+# sources, so they are a build output that happens to be committed. Generation
+# happens after merge, on the base branch, because the generator always emits the
+# full current state: run it on a PR branch and it pulls in every change that
+# earlier merges left ungenerated, filling the PR diff with unrelated files. A PR
+# only checks that the generators run and produce valid MDX.
+
 on:
+    # Lets a maintainer regenerate the base branch by hand, for example after a
+    # run was skipped or failed.
+    workflow_dispatch:
+    push:
+        branches:
+            - master
+            - minor
+            - major
+        paths:
+            - 'packages/**/*.ts'
+            - 'packages/**/*.tsx'
     pull_request:
         types: [opened, synchronize, reopened, ready_for_review]
         branches:
@@ -13,17 +31,33 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-    cancel-in-progress: true
+    # A superseded PR run tells us nothing, so cancel it. A push run commits to the
+    # base branch, so let it finish: cancelling it would leave the branch's docs
+    # stale until the next source change happened to come along.
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-    generate:
+    validate:
+        name: Validate generated docs
+        # Nothing is committed here, so this needs no write access and no secrets,
+        # which means it also covers PRs from forks.
+        if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+            - name: Generate and validate docs
+              uses: ./.github/actions/generate-docs
+
+    commit:
         name: Generate & commit docs
-        # Skip fork PRs (can't push back to fork branches) and draft PRs
-        if: ${{ !github.event.pull_request.head.repo.fork && !github.event.pull_request.draft }}
+        if: ${{ github.event_name != 'pull_request' }}
         runs-on: ubuntu-latest
         permissions:
             contents: write
-            pull-requests: write
             models: read
         steps:
             - name: Generate CI Bot Token
@@ -32,40 +66,20 @@ jobs:
               with:
                   app-id: ${{ secrets.CI_BOT_APP_ID }}
                   private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
-                  # Least privilege: token is only used to commit & push regenerated docs to the PR branch.
+                  # Least privilege: token is only used to commit & push regenerated docs.
                   permission-contents: write
 
-            - name: Checkout PR branch
+            - name: Checkout
               uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
               with:
                   token: ${{ steps.app-token.outputs.token }}
-                  ref: ${{ github.head_ref }}
+                  # Check out the branch by name rather than the pushed SHA so the
+                  # commit below has an upstream to rebase onto and push to.
+                  ref: ${{ github.ref_name }}
+                  fetch-depth: 0
 
-            - name: Setup Node.js
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-              with:
-                  node-version: '22'
-
-            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-              with:
-                  bun-version: '1.3.10'
-
-            - name: Install root dependencies
-              run: bun install --frozen-lockfile
-
-            - name: Generate TypeScript docs
-              run: bun run docs:generate-typescript-docs
-
-            - name: Generate GraphQL docs
-              run: bun run docs:generate-graphql-docs
-
-            - name: Install docs dependencies
-              working-directory: docs
-              run: npm install
-
-            - name: Validate generated docs
-              working-directory: docs
-              run: npm run test:mdx
+            - name: Generate and validate docs
+              uses: ./.github/actions/generate-docs
 
             - name: Check for changes
               id: diff
@@ -104,22 +118,10 @@ jobs:
 
                       ${{ steps.diff.outputs.summary }}
 
-            - name: Get CI Bot user info
-              if: steps.diff.outputs.changed == 'true'
-              id: get-user
-              env:
-                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
-              run: |
-                  user_id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}%5Bbot%5D" --jq .id)
-                  echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
-
             - name: Commit and push generated docs
               if: steps.diff.outputs.changed == 'true'
-              env:
-                  AI_MESSAGE: ${{ steps.ai-message.outputs.response }}
-              run: |
-                  git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
-                  git config user.email "${{ steps.get-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
-                  message="${AI_MESSAGE:-docs: Generate docs for source changes}"
-                  git commit -m "$message"
-                  git push
+              uses: ./.github/actions/commit-and-push
+              with:
+                  token: ${{ steps.app-token.outputs.token }}
+                  app-slug: ${{ steps.app-token.outputs.app-slug }}
+                  message: "${{ steps.ai-message.outputs.response || 'docs: Generate docs for source changes' }}"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint --fix",
     "format": "prettier --write --html-whitespace-sensitivity ignore",
     "docs:generate-typescript-docs": "ts-node scripts/docs/generate-typescript-docs.ts",
+    "docs:compile-manifest": "bun run docs/scripts/compile-manifest.ts",
     "docs:generate-graphql-docs": "ts-node scripts/docs/generate-graphql-docs.ts --api=shop && ts-node scripts/docs/generate-graphql-docs.ts --api=admin",
     "docs:build": "bun run docs:generate-typescript-docs && bun run docs:generate-graphql-docs",
     "codegen": "tsc -p scripts/codegen/plugins && ts-node scripts/codegen/generate-graphql-types.ts && bun run codegen:gql-tada",


### PR DESCRIPTION
## Problem

PR #5207 changed two files in `packages/create`. Its diff contains 31.

The other 29 came from two bot commits, `docs: Generate docs for source changes` and `docs: Regenerate manifest.json`, and none of them relate to the change under review.

They are not caused by that PR. PR #4662 merged earlier the same day and added a constructor parameter to `AssetService`, which shifted source line numbers across the reference docs. It came from a fork, and `generate_docs.yml` skipped fork PRs because the CI bot cannot push to a fork's branch:

```yaml
if: ${{ !github.event.pull_request.head.repo.fork && ... }}
```

So `master` went stale. PR #5207 was the next non-fork PR to touch `packages/**/*.ts`, the bot regenerated the docs on its branch, and the whole backlog landed in its diff.

This is not a one-off. The generator always emits the full current state of the docs, so it cannot produce only the changes a given PR caused. Any staleness on the base branch lands in whichever PR happens to run next, and Vendure takes enough fork contributions that staleness is the normal state rather than the exception.

## Change

Generation moves off the PR branch and onto the base branch, after merge.

**`generate_docs.yml`** splits into two jobs:

- `validate`, on `pull_request`: regenerates the docs and runs `test:mdx`, and commits nothing. It needs no write access and no secrets, so it also runs for fork PRs. Those previously got no docs check at all.
- `commit`, on `push` to `master`/`minor`/`major`: regenerates and commits to the base branch, with the same bot identity and AI-generated commit message as before.

**`docs_ci.yml`** gets the same treatment for `manifest.json`. The `generate-manifest` job is push-only. The PR side gains a `Compile manifest` step that runs the compiler without committing, so a docs change that breaks it still fails the PR.

Both workflows gain `workflow_dispatch` so a maintainer can regenerate a base branch by hand.

Two composite actions hold the shared steps:

- `.github/actions/generate-docs` — setup, TypeScript docs, GraphQL docs, MDX validation. Used by both jobs in `generate_docs.yml`. It reuses the existing `.github/actions/setup` in place of the hand-rolled Node and Bun blocks the workflow declared inline.
- `.github/actions/commit-and-push` — bot identity lookup, commit, and push. Used by both workflows. The bot user id lookup was already duplicated across the two files before this change.

## Supporting changes

`cancel-in-progress` becomes `${{ github.event_name == 'pull_request' }}`. Cancelling a superseded PR run is free, but cancelling a push run would leave the branch stale until the next source change came along.

The push is wrapped in a rebase-and-retry loop, three attempts, with an explicit check on the rebase result. `master` takes frequent pushes and these jobs run for several minutes, so a plain `git push` loses the race eventually.

`docs:compile-manifest` is added to the root `package.json`, so both call sites go through a named script like the sibling `docs:generate-*` scripts rather than repeating the path to the file.

## Effects

The same two bot commits still get made. They land on the base branch afterwards instead of on a contributor's branch beforehand, so the net commit count is roughly unchanged.

The chain terminates. A `Generate Docs` push touches `docs/**`, which triggers `Docs CI`; the manifest push touches only `docs/manifest.json`, which `Docs CI` excludes via `'!docs/manifest.json'`. Neither retriggers `Generate Docs`, which only listens on `packages/**/*.ts` and `.tsx`. The path filters are what stop this looping, and they matter because pushes made with a GitHub App token do trigger workflows, unlike pushes made with the default `GITHUB_TOKEN`.

Direct pushes to `master` are not new here. `docs_ci.yml` already does this, and the master ruleset lists an `Integration` bypass actor for the CI bot app. Commit `1c008346b` is a bot manifest commit on master with zero associated pull requests.

## Trade-off

Reviewers no longer see the generated docs diff in the PR. The output is mechanical and still MDX-validated on every PR, including fork PRs for the first time, but it is a real reduction in what review covers.

## Follow-up

`master` is stale right now, from PR #4662. It will clear on the next merge that touches `packages/**/*.ts`, or immediately by running `Generate Docs` via `workflow_dispatch`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790847101&installation_model_id=20193&pr_number=5229&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5229&signature=aeffa002f31721353e9e5800edeb84473f10397f6e0bdcaaa6745641ea91c644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->