### PR TITLE
chore(ci): ignore Angular Admin UI dependency families in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,6 +86,34 @@ updates:
       ignore:
           # Workspace-internal packages are versioned by the release process.
           - dependency-name: '@vendure/*'
+          # The Angular Admin UI is deprecated in favour of the React dashboard
+          # in packages/dashboard, so its toolchain is not worth the review
+          # cost. Updates to it are noise in the queue.
+          #
+          # This entry has to be written as dependency names rather than a
+          # path, because this bun entry uses `directory: /` and covers the
+          # whole workspace, and Dependabot matches `ignore` on dependency
+          # name only. Every family below was checked against every
+          # packages/*/package.json and the root manifest: all of them appear
+          # only in packages/admin-ui, except @angular/* and @angular-devkit/*,
+          # which also appear in packages/ui-devkit. Nothing outside those two
+          # packages depends on any of them, so ignoring them workspace-wide
+          # does not stop updates for anything that still matters.
+          #
+          # ui-devkit is covered deliberately. It exists to compile Angular
+          # Admin UI extensions, so it shares the Admin UI's deprecation, and
+          # scripts/check-angular-versions.ts requires @angular/cli,
+          # @angular/compiler and @angular/compiler-cli to match exactly
+          # between the two packages. A name-based ignore cannot cover one and
+          # not the other in any case.
+          - dependency-name: '@angular/*'
+          - dependency-name: '@angular-devkit/*'
+          - dependency-name: '@angular-eslint/*'
+          - dependency-name: '@ngx-translate/*'
+          - dependency-name: '@types/jasmine*'
+          - dependency-name: 'jasmine*'
+          - dependency-name: 'karma*'
+          - dependency-name: 'zone.js'
       # Families that must move in lockstep are grouped so they land in one
       # pull request. Groups cover minor and patch only; a major update arrives
       # as its own pull request, because a major is a migration rather than a
@@ -156,14 +184,6 @@ updates:
           opentelemetry:
               patterns:
                   - '@opentelemetry/*'
-              update-types:
-                  - minor
-                  - patch
-          angular:
-              patterns:
-                  - '@angular/*'
-                  - '@angular-devkit/*'
-                  - '@angular-eslint/*'
               update-types:
                   - minor
                   - patch


### PR DESCRIPTION
## What this changes

Adds `ignore` entries to the bun ecosystem in `.github/dependabot.yml` for the dependency families used only by the Angular Admin UI, and removes the `angular` group.

## Why

The Angular Admin UI is deprecated in favour of the React dashboard. Admin UI work sits outside the normal classification system, so Dependabot pull requests against its toolchain are noise. Of the batch open when this was written, PR 5222 (`@angular/compiler` 19 to 22), PR 5221 (`@types/jasmine` 4 to 6) and PR 5220 (`@typescript-eslint/eslint-plugin`, which touches admin-ui among others) were all in this category.

The bun entry uses `directory: /` and covers the whole workspace, and Dependabot matches `ignore` on dependency name rather than path. There is no way to express "ignore this directory", so the families themselves have to be named.

## What I checked

A name-based ignore is workspace-wide, so an entry that also matches a package still in use would silently stop updates for it. I expanded each glob against the `dependencies`, `devDependencies`, `peerDependencies` and `optionalDependencies` of every `packages/*/package.json` and the root `package.json`. The eight globs match 31 dependency names:

| glob | matched names | packages |
| --- | --- | --- |
| `@angular/*` | 12 | admin-ui, ui-devkit |
| `@angular-devkit/*` | 1 | admin-ui, ui-devkit |
| `@angular-eslint/*` | 5 | admin-ui |
| `@ngx-translate/*` | 2 | admin-ui |
| `@types/jasmine*` | 2 | admin-ui |
| `jasmine*` | 2 | admin-ui |
| `karma*` | 6 | admin-ui |
| `zone.js` | 1 | admin-ui |

Nothing outside `packages/admin-ui` and `packages/ui-devkit` matches any of them. `packages/admin-ui-plugin` declares none of these families, so it needed no entry.

Two patterns are wider than the candidate list, on purpose. `@types/jasmine*` is needed because admin-ui also declares `@types/jasminewd2`. `karma*` covers the bare `karma` package as well as the six `karma-*` plugins.

## ui-devkit is covered too

`@angular/*` and `@angular-devkit/*` also appear in `packages/ui-devkit`, which is published and not itself deprecated. Covering it is still right, for two reasons.

`scripts/check-angular-versions.ts` requires `@angular/cli`, `@angular/compiler` and `@angular/compiler-cli` to match exactly between admin-ui and ui-devkit, because mismatched versions break Admin UI extension compilation. A Dependabot update that reached only one of the two packages would fail that check. Beyond that, ui-devkit's Angular dependencies exist to compile Angular Admin UI extensions, so they share the Admin UI's deprecation.

No entry could separate them in any case. `ignore` matches on dependency name, so anything covering admin-ui covers ui-devkit too.

## The angular group

With `@angular/*`, `@angular-devkit/*` and `@angular-eslint/*` all ignored, the `angular` group's three patterns can never match a dependency again. It is removed rather than left as configuration that reads as active.

## Notes

`.github/` is covered by CODEOWNERS, so this needs a listed maintainer to approve it.

This does not change `versioning-strategy`, and does not touch any other ecosystem entry. The `/docs` npm entry is unaffected, since `ignore` is scoped to the bun entry.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790848450&installation_model_id=20193&pr_number=5230&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5230&signature=520acfb1d26be2e9fafb1228e1a2461f95a8801dc71a8987f1b648698c5789db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->