### PR TITLE
ci: label dependency pull requests by published contract impact

### DIFF
--- a/.github/workflows/dependency_impact.yml
+++ b/.github/workflows/dependency_impact.yml
@@ -1,0 +1,57 @@
+name: Dependency impact
+
+# Labels each dependency pull request with what it does to the published contract, because a
+# lockfile refresh and a widened published range look identical in the pull request list and mean
+# different things.
+#
+# Uses pull_request_target for the reason given in dependabot_auto_merge.yml: a workflow that
+# Dependabot triggers via pull_request gets a read-only GITHUB_TOKEN, so it could not apply a
+# label or post a comment.
+#
+# SECURITY: pull_request_target runs the workflow definition from the base branch with write
+# access to the base repository. This workflow must never check out, install, or build the pull
+# request head. It checks out the base commit to get its own script, and reads the head's
+# package.json files as data through the GitHub API. Parsing JSON never executes anything from the
+# pull request. It takes no secret beyond the automatic GITHUB_TOKEN.
+#
+# This is deliberately not a required status check and must not become one. It reports a fact
+# about a pull request; it does not judge it. It is a separate workflow rather than a job in
+# build_and_test.yml so that it stays out of the all-passed needs list.
+on:
+    pull_request_target:
+        types: [opened, reopened, synchronize]
+        paths:
+            - '**/package.json'
+            - 'bun.lock'
+
+permissions: {}
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+jobs:
+    classify:
+        name: classify dependency impact
+        runs-on: ubuntu-latest
+        permissions:
+            # contents: read is for checking out this repository's base commit.
+            # pull-requests: read is for listing the files the pull request changes.
+            # issues: write covers labels and the report comment, both of which are issue APIs.
+            contents: read
+            pull-requests: read
+            issues: write
+        steps:
+            - name: Check out base commit
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+              with:
+                  # Explicit, so that this can never be read as checking out the head. The default
+                  # for pull_request_target is already the base branch; naming the base commit
+                  # makes the intent auditable.
+                  ref: ${{ github.event.pull_request.base.sha }}
+                  persist-credentials: false
+
+            - name: Classify and report
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: node .github/workflows/scripts/dependency-impact.js

--- a/.github/workflows/dependency_impact.yml
+++ b/.github/workflows/dependency_impact.yml
@@ -20,9 +20,6 @@ name: Dependency impact
 on:
     pull_request_target:
         types: [opened, reopened, synchronize]
-        paths:
-            - '**/package.json'
-            - 'bun.lock'
 
 permissions: {}
 
@@ -50,6 +47,9 @@ jobs:
                   # makes the intent auditable.
                   ref: ${{ github.event.pull_request.base.sha }}
                   persist-credentials: false
+
+            - name: Test classifier
+              run: node --test .github/workflows/scripts/dependency-impact.test.js
 
             - name: Classify and report
               env:

--- a/.github/workflows/dependency_impact.yml
+++ b/.github/workflows/dependency_impact.yml
@@ -39,13 +39,12 @@ jobs:
             pull-requests: read
             issues: write
         steps:
-            - name: Check out base commit
+            - name: Check out trusted workflow code
               uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
               with:
-                  # Explicit, so that this can never be read as checking out the head. The default
-                  # for pull_request_target is already the base branch; naming the base commit
-                  # makes the intent auditable.
-                  ref: ${{ github.event.pull_request.base.sha }}
+                  # Do not override ref or repository here. For pull_request_target, checkout's
+                  # protected default resolves trusted code from the base repository, never the
+                  # pull request head or merge commit.
                   persist-credentials: false
 
             - name: Test classifier

--- a/.github/workflows/scripts/dependency-impact.js
+++ b/.github/workflows/scripts/dependency-impact.js
@@ -1,0 +1,268 @@
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+
+/**
+ * Classifies a pull request that touches a package.json or bun.lock, and reports what it does to
+ * the published dependency contract.
+ *
+ * A pull request changes the contract when it edits a `dependencies`, `peerDependencies` or
+ * `optionalDependencies` range in the package.json of a published package. Everything else —
+ * devDependencies, bun.lock, and the manifests of private packages — leaves the contract alone.
+ * Both look the same in the pull request list, and they mean different things: a widened range is
+ * a new promise to every consumer, whereas a lockfile edit only records what this repository
+ * installs.
+ *
+ * A package counts as published when its path is packages/<name>/package.json and its manifest
+ * does not set `"private": true`. The root manifest and docs/package.json both set it, so the
+ * same test excludes them without naming them.
+ *
+ * SECURITY: this runs from a pull_request_target workflow with write access to the base
+ * repository. It reads the pull request head's package.json files as data through the GitHub API
+ * and parses them with JSON.parse. It never checks out, installs, resolves or executes anything
+ * from the head. Do not add a step here that does.
+ */
+
+const MARKER = '<!-- dependency-impact -->';
+const CONTRACT_LABEL = 'deps: contract change';
+const LOCKFILE_LABEL = 'deps: lockfile only';
+const CONTRACT_SECTIONS = ['dependencies', 'peerDependencies', 'optionalDependencies'];
+const PUBLISHED_PATH = /^packages\/[^/]+\/package\.json$/;
+
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+const repo = process.env.GITHUB_REPOSITORY;
+const prNumber = event.pull_request.number;
+const baseSha = event.pull_request.base.sha;
+const headSha = event.pull_request.head.sha;
+
+main().catch(err => {
+    console.error(err.message);
+    process.exit(1);
+});
+
+async function main() {
+    const changedFiles = gh([`repos/${repo}/pulls/${prNumber}/files`, '--paginate', '--jq', '.[].filename'])
+        .split('\n')
+        .filter(Boolean);
+
+    const manifests = changedFiles.filter(f => f === 'package.json' || f.endsWith('/package.json'));
+    const lockfileChanged = changedFiles.includes('bun.lock');
+
+    const contractChanges = [];
+    const otherChanges = [];
+
+    for (const path of manifests) {
+        const base = readManifest(path, baseSha);
+        const head = readManifest(path, headSha);
+        // A manifest present at neither ref cannot be compared. This happens when a pull request
+        // adds and then removes the same file across pushes.
+        if (!base && !head) {
+            continue;
+        }
+        const published = isPublished(path, head || base);
+        for (const section of [
+            'dependencies',
+            'peerDependencies',
+            'optionalDependencies',
+            'devDependencies',
+        ]) {
+            for (const change of diffSection(base, head, section)) {
+                const entry = { ...change, path, section };
+                const isContract = published && CONTRACT_SECTIONS.includes(section);
+                (isContract ? contractChanges : otherChanges).push(entry);
+            }
+        }
+    }
+
+    const label = contractChanges.length ? CONTRACT_LABEL : LOCKFILE_LABEL;
+    const remove = label === CONTRACT_LABEL ? LOCKFILE_LABEL : CONTRACT_LABEL;
+
+    ensureLabels();
+    applyLabel(label, remove);
+    upsertComment(buildComment({ label, contractChanges, otherChanges, lockfileChanged, manifests }));
+
+    console.log(`applied "${label}" (${contractChanges.length} contract, ${otherChanges.length} other)`);
+}
+
+/**
+ * A package is published when it lives directly under packages/ and does not opt out with
+ * `"private": true`. Deriving it this way means a new package is classified correctly without
+ * anyone remembering to update a list here.
+ */
+function isPublished(path, manifest) {
+    return PUBLISHED_PATH.test(path) && manifest.private !== true;
+}
+
+function diffSection(base, head, section) {
+    const before = (base && base[section]) || {};
+    const after = (head && head[section]) || {};
+    const changes = [];
+    for (const name of new Set([...Object.keys(before), ...Object.keys(after)])) {
+        if (before[name] !== after[name]) {
+            changes.push({ name, from: before[name], to: after[name] });
+        }
+    }
+    return changes.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Reads a manifest at a given commit and parses it. Returns null when the file does not exist at
+ * that commit, which is the normal case for a manifest the pull request adds or deletes.
+ */
+function readManifest(path, ref) {
+    let raw;
+    try {
+        // ref goes in the query string. Passing it with -f makes gh send it as a request body,
+        // which the contents API ignores, and every lookup then resolves against the default
+        // branch or 404s.
+        raw = gh([`repos/${repo}/contents/${path}?ref=${ref}`, '-H', 'Accept: application/vnd.github.raw']);
+    } catch (e) {
+        const stderr = String(e.stderr || '');
+        if (stderr.includes('HTTP 404')) {
+            return null;
+        }
+        // Any other failure means the classification would be wrong rather than absent, so stop
+        // instead of reporting a contract change as a lockfile refresh.
+        throw new Error(`could not read ${path} at ${ref}: ${stderr.trim() || e.message}`);
+    }
+    try {
+        return JSON.parse(raw);
+    } catch (e) {
+        // Returning null here would make diffSection read the manifest as empty and report every
+        // dependency in it as removed. A manifest that does not parse is a broken pull request,
+        // so say so instead of publishing a wrong report.
+        throw new Error(`could not parse ${path} at ${ref}: ${e.message}`);
+    }
+}
+
+function ensureLabels() {
+    const wanted = [
+        {
+            name: CONTRACT_LABEL,
+            color: 'B60205',
+            description: 'Changes a dependency range in a published package',
+        },
+        {
+            name: LOCKFILE_LABEL,
+            color: '0E8A16',
+            description: 'Leaves every published dependency range unchanged',
+        },
+    ];
+    for (const label of wanted) {
+        try {
+            gh([`repos/${repo}/labels/${encodeURIComponent(label.name)}`]);
+        } catch (e) {
+            gh([
+                `repos/${repo}/labels`,
+                '-X',
+                'POST',
+                '-f',
+                `name=${label.name}`,
+                '-f',
+                `color=${label.color}`,
+                '-f',
+                `description=${label.description}`,
+            ]);
+        }
+    }
+}
+
+function applyLabel(add, remove) {
+    gh([`repos/${repo}/issues/${prNumber}/labels`, '-X', 'POST', '-f', `labels[]=${add}`]);
+    // Removing the opposite label matters when a push changes the classification. Without it a
+    // pull request that drops a manifest edit keeps both labels and reads as ambiguous.
+    try {
+        gh([`repos/${repo}/issues/${prNumber}/labels/${encodeURIComponent(remove)}`, '-X', 'DELETE']);
+    } catch (e) {
+        // Not present, which is the common case.
+    }
+}
+
+/**
+ * Posts the report, or edits the report already on the pull request. Dependabot force-pushes this
+ * branch on every rebase, so posting a new comment each time would bury the pull request.
+ */
+function upsertComment(body) {
+    const existing = gh([
+        `repos/${repo}/issues/${prNumber}/comments`,
+        '--paginate',
+        '--jq',
+        `[.[] | select(.body | contains("${MARKER}")) | .id] | first // empty`,
+    ]).trim();
+
+    if (existing) {
+        gh([`repos/${repo}/issues/comments/${existing}`, '-X', 'PATCH', '-f', `body=${body}`]);
+    } else {
+        gh([`repos/${repo}/issues/${prNumber}/comments`, '-X', 'POST', '-f', `body=${body}`]);
+    }
+}
+
+function buildComment({ label, contractChanges, otherChanges, lockfileChanged, manifests }) {
+    const lines = [MARKER, '', `### Dependency impact: ${label}`, ''];
+
+    if (contractChanges.length) {
+        lines.push(
+            'This pull request changes a dependency range in a published package, so it changes what',
+            'consumers resolve. Review the new range rather than the resolved version.',
+            '',
+            '| package | section | range |',
+            '| --- | --- | --- |',
+        );
+        for (const c of contractChanges) {
+            lines.push(`| \`${c.name}\` | ${packageOf(c.path)} / ${c.section} | ${formatRange(c)} |`);
+        }
+        lines.push('');
+    } else {
+        lines.push(
+            'No published dependency range changes. Consumers resolve exactly what they did before.',
+            '',
+        );
+    }
+
+    if (otherChanges.length) {
+        lines.push(
+            `<details><summary>${otherChanges.length} change(s) that do not affect the contract</summary>`,
+            '',
+        );
+        lines.push('| package | section | range |', '| --- | --- | --- |');
+        for (const c of otherChanges) {
+            lines.push(`| \`${c.name}\` | ${packageOf(c.path)} / ${c.section} | ${formatRange(c)} |`);
+        }
+        lines.push('', '</details>', '');
+    }
+
+    if (lockfileChanged) {
+        lines.push(
+            '`bun.lock` changed. The lockfile records what this repository installs, and CI verifies',
+            'only that combination. It is not what a consumer installing the published packages gets.',
+            '',
+        );
+    }
+    if (!manifests.length && !lockfileChanged) {
+        lines.push('No manifest or lockfile changes found.', '');
+    }
+
+    lines.push('<sub>Reported by `dependency_impact.yml`. Not a required check.</sub>');
+    return lines.join('\n');
+}
+
+function packageOf(path) {
+    return path === 'package.json' ? '(root)' : path.replace(/\/package\.json$/, '');
+}
+
+function formatRange({ from, to }) {
+    if (from === undefined) {
+        return `added \`${to}\``;
+    }
+    if (to === undefined) {
+        return `removed \`${from}\``;
+    }
+    return `\`${from}\` -> \`${to}\``;
+}
+
+function gh(args) {
+    return execFileSync('gh', ['api', ...args], {
+        encoding: 'utf8',
+        maxBuffer: 32 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+}

--- a/.github/workflows/scripts/dependency-impact.js
+++ b/.github/workflows/scripts/dependency-impact.js
@@ -351,20 +351,18 @@ function formatRange({ from, to }) {
 /**
  * Renders one value inside a table cell code span. GFM treats an HTML entity inside a code span as
  * literal text, so entity-escaping a range would display `&gt;=16.0.0 &#124;&#124; ^17.0.0` rather
- * than `>=16.0.0 || ^17.0.0`, and `||` is ordinary in a peer range. Inside a code span the only
- * hazards are the table's own pipe, which escapes with a backslash, and the span's own backtick,
- * which cannot be escaped at all. A value carrying a backtick falls back to entity-escaped plain
- * text so it cannot create links, images, mentions or other active Markdown in the bot's report.
+ * than `>=16.0.0 || ^17.0.0`, and `||` is ordinary in a peer range. Values containing a pipe,
+ * backslash or backtick use an HTML code element with fully entity-escaped text. This avoids a
+ * partial Markdown-escaping path while preserving both the displayed value and code styling.
  */
 function codeCell(value) {
     const text = String(value).replace(/\r?\n/g, ' ');
-    // A backtick cannot be escaped inside a code span at all. A backslash cannot be escaped inside
-    // one either, so it would survive to sit in front of the pipe escape below and consume it,
-    // putting a bare pipe back into the row. Either character falls back to escaped plain text.
-    if (text.includes('`') || text.includes('\\')) {
-        return escapeMarkdown(text);
+    // A backtick cannot be escaped inside a code span. Pipes and backslashes interact with the
+    // table parser, so all three take the fully entity-escaped HTML route.
+    if (/[|`\\]/.test(text)) {
+        return `<code>${escapeMarkdown(text)}</code>`;
     }
-    return `\`${text.replace(/\|/g, '\\|')}\``;
+    return `\`${text}\``;
 }
 
 function escapeMarkdown(value) {

--- a/.github/workflows/scripts/dependency-impact.js
+++ b/.github/workflows/scripts/dependency-impact.js
@@ -268,6 +268,8 @@ function findReportComment() {
         '--paginate',
         // gh applies --jq per page, so an aggregating filter over a default 30-item page can
         // return one id per page, and a two-line result makes the PATCH URL unusable.
+        '-X',
+        'GET',
         '-F',
         'per_page=100',
         '--jq',

--- a/.github/workflows/scripts/dependency-impact.js
+++ b/.github/workflows/scripts/dependency-impact.js
@@ -355,7 +355,10 @@ function formatRange({ from, to }) {
  */
 function codeCell(value) {
     const text = String(value).replace(/\r?\n/g, ' ');
-    if (text.includes('`')) {
+    // A backtick cannot be escaped inside a code span at all. A backslash cannot be escaped inside
+    // one either, so it would survive to sit in front of the pipe escape below and consume it,
+    // putting a bare pipe back into the row. Either character falls back to escaped plain text.
+    if (text.includes('`') || text.includes('\\')) {
         return escapeMarkdown(text);
     }
     return `\`${text.replace(/\|/g, '\\|')}\``;

--- a/.github/workflows/scripts/dependency-impact.js
+++ b/.github/workflows/scripts/dependency-impact.js
@@ -269,19 +269,26 @@ function findReportComment() {
 }
 
 function buildComment({ label, contractChanges, otherChanges, lockfileChanged, manifests }) {
-    const lines = [MARKER, '', `### Dependency impact: ${label}`, ''];
+    const lines = [
+        MARKER,
+        '',
+        contractChanges.length
+            ? '### This pull request changes the published dependency contract'
+            : '### This pull request leaves the published dependency contract unchanged',
+        '',
+    ];
 
     if (contractChanges.length) {
         lines.push(
             'This pull request changes a dependency range in a published package, so it changes what',
             'consumers resolve. Review the new range rather than the resolved version.',
             '',
-            '| package | section | range |',
+            '| dependency | declared in | range |',
             '| --- | --- | --- |',
         );
         for (const c of contractChanges) {
             lines.push(
-                `| \`${escapeMarkdown(c.name)}\` | ${escapeMarkdown(packageOf(c.path))} / ${escapeMarkdown(c.section)} | ${formatRange(c)} |`,
+                `| ${codeCell(c.name)} | ${escapeMarkdown(packageOf(c.path))} / ${c.section} | ${formatRange(c)} |`,
             );
         }
         lines.push('');
@@ -297,10 +304,10 @@ function buildComment({ label, contractChanges, otherChanges, lockfileChanged, m
             `<details><summary>${otherChanges.length} change(s) that do not affect the contract</summary>`,
             '',
         );
-        lines.push('| package | section | range |', '| --- | --- | --- |');
+        lines.push('| dependency | declared in | range |', '| --- | --- | --- |');
         for (const c of otherChanges) {
             lines.push(
-                `| \`${escapeMarkdown(c.name)}\` | ${escapeMarkdown(packageOf(c.path))} / ${escapeMarkdown(c.section)} | ${formatRange(c)} |`,
+                `| ${codeCell(c.name)} | ${escapeMarkdown(packageOf(c.path))} / ${c.section} | ${formatRange(c)} |`,
             );
         }
         lines.push('', '</details>', '');
@@ -327,12 +334,27 @@ function packageOf(path) {
 
 function formatRange({ from, to }) {
     if (from === undefined) {
-        return `added \`${escapeMarkdown(to)}\``;
+        return `added ${codeCell(to)}`;
     }
     if (to === undefined) {
-        return `removed \`${escapeMarkdown(from)}\``;
+        return `removed ${codeCell(from)}`;
     }
-    return `\`${escapeMarkdown(from)}\` -> \`${escapeMarkdown(to)}\``;
+    return `${codeCell(from)} -> ${codeCell(to)}`;
+}
+
+/**
+ * Renders one value inside a table cell code span. GFM treats an HTML entity inside a code span as
+ * literal text, so entity-escaping a range would display `&gt;=16.0.0 &#124;&#124; ^17.0.0` rather
+ * than `>=16.0.0 || ^17.0.0`, and `||` is ordinary in a peer range. Inside a code span the only
+ * hazards are the table's own pipe, which escapes with a backslash, and the span's own backtick,
+ * which cannot be escaped at all — a value carrying one falls back to escaped plain text.
+ */
+function codeCell(value) {
+    const text = String(value).replace(/\r?\n/g, ' ');
+    if (text.includes('`')) {
+        return escapeMarkdown(text);
+    }
+    return `\`${text.replace(/\|/g, '\\|')}\``;
 }
 
 function escapeMarkdown(value) {

--- a/.github/workflows/scripts/dependency-impact.js
+++ b/.github/workflows/scripts/dependency-impact.js
@@ -353,7 +353,8 @@ function formatRange({ from, to }) {
  * literal text, so entity-escaping a range would display `&gt;=16.0.0 &#124;&#124; ^17.0.0` rather
  * than `>=16.0.0 || ^17.0.0`, and `||` is ordinary in a peer range. Inside a code span the only
  * hazards are the table's own pipe, which escapes with a backslash, and the span's own backtick,
- * which cannot be escaped at all. A value carrying a backtick falls back to escaped plain text.
+ * which cannot be escaped at all. A value carrying a backtick falls back to entity-escaped plain
+ * text so it cannot create links, images, mentions or other active Markdown in the bot's report.
  */
 function codeCell(value) {
     const text = String(value).replace(/\r?\n/g, ' ');
@@ -368,12 +369,10 @@ function codeCell(value) {
 
 function escapeMarkdown(value) {
     return String(value)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/\|/g, '&#124;')
-        .replace(/`/g, '&#96;')
-        .replace(/\r?\n/g, '<br>');
+        .replace(/\r?\n/g, ' ')
+        .replace(/[!"#$%&'()*+,./:;<=>?@[\\\]^_`{|}~-]/g, character => {
+            return `&#${character.codePointAt(0)};`;
+        });
 }
 
 function isHttpError(error, status) {

--- a/.github/workflows/scripts/dependency-impact.js
+++ b/.github/workflows/scripts/dependency-impact.js
@@ -47,11 +47,32 @@ async function main() {
     const manifests = changedFiles.filter(f => f === 'package.json' || f.endsWith('/package.json'));
     const lockfileChanged = changedFiles.includes('bun.lock');
 
+    // Run on every pull request synchronization so a push which removes the last dependency file
+    // can clear the classification left by an earlier run.
+    if (!manifests.length && !lockfileChanged) {
+        removeLabel(CONTRACT_LABEL);
+        removeLabel(LOCKFILE_LABEL);
+        deleteReportComment();
+        console.log('cleared dependency impact classification (no dependency files changed)');
+        return;
+    }
+
+    const mergeBaseSha = gh([
+        `repos/${repo}/compare/${baseSha}...${headSha}`,
+        '--jq',
+        '.merge_base_commit.sha',
+    ]).trim();
+    if (!mergeBaseSha) {
+        throw new Error(`could not determine merge base for ${baseSha}...${headSha}`);
+    }
+
     const contractChanges = [];
     const otherChanges = [];
 
     for (const path of manifests) {
-        const base = readManifest(path, baseSha);
+        // Compare the pull request head with its merge base, not the current base tip. Otherwise a
+        // change made only on the target branch can be misreported as a reversal by a stale head.
+        const base = readManifest(path, mergeBaseSha);
         const head = readManifest(path, headSha);
         // A manifest present at neither ref cannot be compared. This happens when a pull request
         // adds and then removes the same file across pushes.
@@ -151,17 +172,29 @@ function ensureLabels() {
         try {
             gh([`repos/${repo}/labels/${encodeURIComponent(label.name)}`]);
         } catch (e) {
-            gh([
-                `repos/${repo}/labels`,
-                '-X',
-                'POST',
-                '-f',
-                `name=${label.name}`,
-                '-f',
-                `color=${label.color}`,
-                '-f',
-                `description=${label.description}`,
-            ]);
+            if (!isHttpError(e, 404)) {
+                throw e;
+            }
+            try {
+                gh([
+                    `repos/${repo}/labels`,
+                    '-X',
+                    'POST',
+                    '-f',
+                    `name=${label.name}`,
+                    '-f',
+                    `color=${label.color}`,
+                    '-f',
+                    `description=${label.description}`,
+                ]);
+            } catch (createError) {
+                if (!isHttpError(createError, 422)) {
+                    throw createError;
+                }
+                // A concurrent run can create the label after our lookup. Confirm that this is the
+                // race we expected rather than suppressing an unrelated validation failure.
+                gh([`repos/${repo}/labels/${encodeURIComponent(label.name)}`]);
+            }
         }
     }
 }
@@ -170,10 +203,16 @@ function applyLabel(add, remove) {
     gh([`repos/${repo}/issues/${prNumber}/labels`, '-X', 'POST', '-f', `labels[]=${add}`]);
     // Removing the opposite label matters when a push changes the classification. Without it a
     // pull request that drops a manifest edit keeps both labels and reads as ambiguous.
+    removeLabel(remove);
+}
+
+function removeLabel(label) {
     try {
-        gh([`repos/${repo}/issues/${prNumber}/labels/${encodeURIComponent(remove)}`, '-X', 'DELETE']);
+        gh([`repos/${repo}/issues/${prNumber}/labels/${encodeURIComponent(label)}`, '-X', 'DELETE']);
     } catch (e) {
-        // Not present, which is the common case.
+        if (!isHttpError(e, 404)) {
+            throw e;
+        }
     }
 }
 
@@ -182,18 +221,29 @@ function applyLabel(add, remove) {
  * branch on every rebase, so posting a new comment each time would bury the pull request.
  */
 function upsertComment(body) {
-    const existing = gh([
-        `repos/${repo}/issues/${prNumber}/comments`,
-        '--paginate',
-        '--jq',
-        `[.[] | select(.body | contains("${MARKER}")) | .id] | first // empty`,
-    ]).trim();
+    const existing = findReportComment();
 
     if (existing) {
         gh([`repos/${repo}/issues/comments/${existing}`, '-X', 'PATCH', '-f', `body=${body}`]);
     } else {
         gh([`repos/${repo}/issues/${prNumber}/comments`, '-X', 'POST', '-f', `body=${body}`]);
     }
+}
+
+function deleteReportComment() {
+    const existing = findReportComment();
+    if (existing) {
+        gh([`repos/${repo}/issues/comments/${existing}`, '-X', 'DELETE']);
+    }
+}
+
+function findReportComment() {
+    return gh([
+        `repos/${repo}/issues/${prNumber}/comments`,
+        '--paginate',
+        '--jq',
+        `[.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("${MARKER}")) | .id] | first // empty`,
+    ]).trim();
 }
 
 function buildComment({ label, contractChanges, otherChanges, lockfileChanged, manifests }) {
@@ -208,7 +258,9 @@ function buildComment({ label, contractChanges, otherChanges, lockfileChanged, m
             '| --- | --- | --- |',
         );
         for (const c of contractChanges) {
-            lines.push(`| \`${c.name}\` | ${packageOf(c.path)} / ${c.section} | ${formatRange(c)} |`);
+            lines.push(
+                `| \`${escapeMarkdown(c.name)}\` | ${escapeMarkdown(packageOf(c.path))} / ${escapeMarkdown(c.section)} | ${formatRange(c)} |`,
+            );
         }
         lines.push('');
     } else {
@@ -225,7 +277,9 @@ function buildComment({ label, contractChanges, otherChanges, lockfileChanged, m
         );
         lines.push('| package | section | range |', '| --- | --- | --- |');
         for (const c of otherChanges) {
-            lines.push(`| \`${c.name}\` | ${packageOf(c.path)} / ${c.section} | ${formatRange(c)} |`);
+            lines.push(
+                `| \`${escapeMarkdown(c.name)}\` | ${escapeMarkdown(packageOf(c.path))} / ${escapeMarkdown(c.section)} | ${formatRange(c)} |`,
+            );
         }
         lines.push('', '</details>', '');
     }
@@ -251,12 +305,26 @@ function packageOf(path) {
 
 function formatRange({ from, to }) {
     if (from === undefined) {
-        return `added \`${to}\``;
+        return `added \`${escapeMarkdown(to)}\``;
     }
     if (to === undefined) {
-        return `removed \`${from}\``;
+        return `removed \`${escapeMarkdown(from)}\``;
     }
-    return `\`${from}\` -> \`${to}\``;
+    return `\`${escapeMarkdown(from)}\` -> \`${escapeMarkdown(to)}\``;
+}
+
+function escapeMarkdown(value) {
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/\|/g, '&#124;')
+        .replace(/`/g, '&#96;')
+        .replace(/\r?\n/g, '<br>');
+}
+
+function isHttpError(error, status) {
+    return `${String(error.stderr || '')}\n${String(error.stdout || '')}`.includes(`HTTP ${status}`);
 }
 
 function gh(args) {

--- a/.github/workflows/scripts/dependency-impact.js
+++ b/.github/workflows/scripts/dependency-impact.js
@@ -114,8 +114,8 @@ function isPublished(path, manifest) {
 }
 
 function diffSection(base, head, section) {
-    const before = (base && base[section]) || {};
-    const after = (head && head[section]) || {};
+    const before = readSection(base, section);
+    const after = readSection(head, section);
     const changes = [];
     for (const name of new Set([...Object.keys(before), ...Object.keys(after)])) {
         if (before[name] !== after[name]) {
@@ -123,6 +123,17 @@ function diffSection(base, head, section) {
         }
     }
     return changes.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Reads one dependency section from a manifest. A manifest is only valid JSON, not valid npm, so a
+ * section can be a string or an array. Object.keys would then read a string as one entry per
+ * character and report a row per character, so anything that is not a plain object is read as
+ * absent. The section's real entries at the other ref still show up, as removed or added.
+ */
+function readSection(manifest, section) {
+    const value = manifest && manifest[section];
+    return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
 }
 
 /**

--- a/.github/workflows/scripts/dependency-impact.js
+++ b/.github/workflows/scripts/dependency-impact.js
@@ -80,12 +80,10 @@ async function main() {
             continue;
         }
         const published = isPublished(path, head || base);
-        for (const section of [
-            'dependencies',
-            'peerDependencies',
-            'optionalDependencies',
-            'devDependencies',
-        ]) {
+        // devDependencies is reported but never counts as a contract change, so the scanned list
+        // is the contract sections plus that one. Restating the contract sections here instead
+        // would let the two lists drift, and the drift would be silent.
+        for (const section of [...CONTRACT_SECTIONS, 'devDependencies']) {
             for (const change of diffSection(base, head, section)) {
                 const entry = { ...change, path, section };
                 const isContract = published && CONTRACT_SECTIONS.includes(section);

--- a/.github/workflows/scripts/dependency-impact.js
+++ b/.github/workflows/scripts/dependency-impact.js
@@ -137,6 +137,15 @@ function readSection(manifest, section) {
 }
 
 /**
+ * Percent-encodes a repository path for use in a contents API URL. The path comes from the pull
+ * request's changed-file list, and git permits `?`, `#` and `%` in a filename. Left raw, such a
+ * name would change which endpoint and which ref the request asks for.
+ */
+function encodePath(path) {
+    return path.split('/').map(encodeURIComponent).join('/');
+}
+
+/**
  * Reads a manifest at a given commit and parses it. Returns null when the file does not exist at
  * that commit, which is the normal case for a manifest the pull request adds or deletes.
  */
@@ -146,7 +155,11 @@ function readManifest(path, ref) {
         // ref goes in the query string. Passing it with -f makes gh send it as a request body,
         // which the contents API ignores, and every lookup then resolves against the default
         // branch or 404s.
-        raw = gh([`repos/${repo}/contents/${path}?ref=${ref}`, '-H', 'Accept: application/vnd.github.raw']);
+        raw = gh([
+            `repos/${repo}/contents/${encodePath(path)}?ref=${ref}`,
+            '-H',
+            'Accept: application/vnd.github.raw',
+        ]);
     } catch (e) {
         const stderr = String(e.stderr || '');
         if (stderr.includes('HTTP 404')) {

--- a/.github/workflows/scripts/dependency-impact.js
+++ b/.github/workflows/scripts/dependency-impact.js
@@ -34,12 +34,16 @@ const prNumber = event.pull_request.number;
 const baseSha = event.pull_request.base.sha;
 const headSha = event.pull_request.head.sha;
 
-main().catch(err => {
-    console.error(err.message);
+try {
+    main();
+} catch (err) {
+    // Every call in here is execFileSync, so there is nothing to await and nothing to unhandle.
+    // Print the stack: this runs unattended, and a message alone loses where it came from.
+    console.error(err.stack || err.message);
     process.exit(1);
-});
+}
 
-async function main() {
+function main() {
     const changedFiles = gh([`repos/${repo}/pulls/${prNumber}/files`, '--paginate', '--jq', '.[].filename'])
         .split('\n')
         .filter(Boolean);
@@ -97,7 +101,7 @@ async function main() {
 
     ensureLabels();
     applyLabel(label, remove);
-    upsertComment(buildComment({ label, contractChanges, otherChanges, lockfileChanged, manifests }));
+    upsertComment(buildComment({ contractChanges, otherChanges, lockfileChanged }));
 
     console.log(`applied "${label}" (${contractChanges.length} contract, ${otherChanges.length} other)`);
 }
@@ -159,13 +163,12 @@ function readManifest(path, ref) {
             'Accept: application/vnd.github.raw',
         ]);
     } catch (e) {
-        const stderr = String(e.stderr || '');
-        if (stderr.includes('HTTP 404')) {
+        if (isHttpError(e, 404)) {
             return null;
         }
         // Any other failure means the classification would be wrong rather than absent, so stop
         // instead of reporting a contract change as a lockfile refresh.
-        throw new Error(`could not read ${path} at ${ref}: ${stderr.trim() || e.message}`);
+        throw new Error(`could not read ${path} at ${ref}: ${String(e.stderr || '').trim() || e.message}`);
     }
     try {
         return JSON.parse(raw);
@@ -263,12 +266,16 @@ function findReportComment() {
     return gh([
         `repos/${repo}/issues/${prNumber}/comments`,
         '--paginate',
+        // gh applies --jq per page, so an aggregating filter over a default 30-item page can
+        // return one id per page, and a two-line result makes the PATCH URL unusable.
+        '-F',
+        'per_page=100',
         '--jq',
         `[.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("${MARKER}")) | .id] | first // empty`,
     ]).trim();
 }
 
-function buildComment({ label, contractChanges, otherChanges, lockfileChanged, manifests }) {
+function buildComment({ contractChanges, otherChanges, lockfileChanged }) {
     const lines = [
         MARKER,
         '',
@@ -320,9 +327,6 @@ function buildComment({ label, contractChanges, otherChanges, lockfileChanged, m
             '',
         );
     }
-    if (!manifests.length && !lockfileChanged) {
-        lines.push('No manifest or lockfile changes found.', '');
-    }
 
     lines.push('<sub>Reported by `dependency_impact.yml`. Not a required check.</sub>');
     return lines.join('\n');
@@ -347,7 +351,7 @@ function formatRange({ from, to }) {
  * literal text, so entity-escaping a range would display `&gt;=16.0.0 &#124;&#124; ^17.0.0` rather
  * than `>=16.0.0 || ^17.0.0`, and `||` is ordinary in a peer range. Inside a code span the only
  * hazards are the table's own pipe, which escapes with a backslash, and the span's own backtick,
- * which cannot be escaped at all — a value carrying one falls back to escaped plain text.
+ * which cannot be escaped at all. A value carrying a backtick falls back to escaped plain text.
  */
 function codeCell(value) {
     const text = String(value).replace(/\r?\n/g, ' ');

--- a/.github/workflows/scripts/dependency-impact.test.js
+++ b/.github/workflows/scripts/dependency-impact.test.js
@@ -208,7 +208,8 @@ test('does not suppress a failure while removing the opposite label', () => {
                     'repos/vendurehq/vendure/issues/42/labels/deps%3A%20contract%20change': 500,
                 },
             }),
-        /classifier failed with status 1/,
+        // Naming the endpoint and the status, so an unrelated TypeError cannot satisfy this.
+        /issues\/42\/labels\/deps%3A%20contract%20change[\s\S]*HTTP 500/,
     );
 });
 

--- a/.github/workflows/scripts/dependency-impact.test.js
+++ b/.github/workflows/scripts/dependency-impact.test.js
@@ -140,6 +140,13 @@ test('labels a published dependency range edit as a contract change', () => {
 
     assert.deepEqual(appliedLabels(calls), ['deps: contract change']);
     assert.match(output, /1 contract, 0 other/);
+    const body = calls
+        .find(args => args[1] === 'repos/vendurehq/vendure/issues/42/comments' && args.includes('POST'))
+        .find(arg => arg.startsWith('body='));
+    assert.match(
+        body,
+        /\| `graphql` \| packages&#47;core \/ dependencies \| `\^16\.0\.0` -> `\^17\.0\.0` \|/,
+    );
 });
 
 test('labels lockfile and private manifest edits as having no contract change', () => {
@@ -265,12 +272,10 @@ test('escapes untrusted dependency names and ranges in the report table', () => 
     );
     const body = commentCall.find(arg => arg.startsWith('body='));
 
-    // A backtick cannot be escaped inside a code span, so a name carrying one drops out of the
-    // span and is entity-escaped as plain text instead.
-    assert.match(body, /unsafe&#124;&#96;name/);
-    // A range without a backtick keeps its code span, where a pipe escapes with a backslash and
-    // an entity would only render as itself.
-    assert.match(body, /`\^2\.0\.0 \\\| forged \\\| row \\\|`/);
+    // Pipes and backticks take the fully entity-escaped HTML route, preserving code styling
+    // without leaving any partial Markdown escaping.
+    assert.match(body, /<code>unsafe&#124;&#96;name<\/code>/);
+    assert.match(body, /<code>&#94;2&#46;0&#46;0 &#124; forged &#124; row &#124;<\/code>/);
     assert.doesNotMatch(body, /\n\| forged \| row \|/);
 });
 
@@ -305,10 +310,11 @@ test('takes a range carrying a backslash out of the code span', () => {
     assert.match(body, /&#91;maintainer&#93;&#40;https&#58;&#47;&#47;example&#46;com&#41;/);
     assert.match(body, /&#33;&#91;tracker&#93;&#40;https&#58;&#47;&#47;example&#46;com&#47;pixel&#46;png&#41;/);
     assert.match(body, /&#64;michaelbromley &#35;123/);
+    assert.match(body, /<code>.*<\/code>/);
     assert.doesNotMatch(body, /\[maintainer\]\(|!\[tracker\]\(|@michaelbromley|#123/);
 });
 
-test('renders a comparator range as written rather than as HTML entities', () => {
+test('renders a comparator range through fully escaped HTML code', () => {
     const filePath = 'packages/dashboard/package.json';
     const { calls } = runClassifier({
         files: [filePath],
@@ -327,9 +333,11 @@ test('renders a comparator range as written rather than as HTML entities', () =>
         .find(args => args[1] === 'repos/vendurehq/vendure/issues/42/comments' && args.includes('POST'))
         .find(arg => arg.startsWith('body='));
 
-    // GFM does not decode an entity inside a code span, so any of these would display verbatim.
-    assert.doesNotMatch(body, /&#124;|&gt;|&lt;|&#96;/);
-    assert.match(body, /`\^3\.25\.0 \\\|\\\| \^4\.0\.0` -> `>=3\.25\.0 <5`/);
+    assert.match(
+        body,
+        /<code>&#94;3&#46;25&#46;0 &#124;&#124; &#94;4&#46;0&#46;0<\/code> -> `>=3\.25\.0 <5`/,
+    );
+    assert.doesNotMatch(body, /\\\|/);
 });
 
 test('counts a peerDependencies change in a published package as a contract change', () => {

--- a/.github/workflows/scripts/dependency-impact.test.js
+++ b/.github/workflows/scripts/dependency-impact.test.js
@@ -1,0 +1,255 @@
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const classifierPath = path.join(__dirname, 'dependency-impact.js');
+
+function runClassifier({ files, manifests = {}, comments = [], failures = {} }) {
+    assert.ok(
+        fs.existsSync(classifierPath),
+        'dependency impact classifier is missing, so dependency pull requests cannot be categorized',
+    );
+
+    const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'dependency-impact-test-'));
+    const callsPath = path.join(temporaryDirectory, 'calls.jsonl');
+    const ghPath = path.join(temporaryDirectory, 'gh');
+    fs.writeFileSync(
+        ghPath,
+        `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.MOCK_GH_CALLS_PATH, JSON.stringify(args) + '\\n');
+const endpoint = args[1] || '';
+const failures = JSON.parse(process.env.MOCK_FAILURES);
+const configuredFailure = failures[endpoint];
+const calls = fs.readFileSync(process.env.MOCK_GH_CALLS_PATH, 'utf8').trim().split('\\n').map(line => JSON.parse(line));
+const endpointCallCount = calls.filter(call => call[1] === endpoint).length;
+const failure = Array.isArray(configuredFailure)
+    ? configuredFailure[endpointCallCount - 1]
+    : configuredFailure;
+if (failure) {
+    process.stderr.write('gh: mock failure (HTTP ' + failure + ')\\n');
+    process.exit(1);
+} else if (endpoint.includes('/pulls/') && endpoint.endsWith('/files')) {
+    process.stdout.write(JSON.parse(process.env.MOCK_CHANGED_FILES).join('\\n'));
+} else if (endpoint.includes('/compare/')) {
+    process.stdout.write('merge-base');
+} else if (endpoint.includes('/contents/')) {
+    const value = JSON.parse(process.env.MOCK_MANIFESTS)[endpoint];
+    if (value === undefined) {
+        process.stderr.write('gh: Not Found (HTTP 404)\\n');
+        process.exit(1);
+    }
+    process.stdout.write(JSON.stringify(value));
+} else if (endpoint.includes('/comments') && args.includes('--paginate')) {
+    const comments = JSON.parse(process.env.MOCK_COMMENTS);
+    const botComment = comments.find(comment => comment.user.login === 'github-actions[bot]' && comment.body.includes('<!-- dependency-impact -->'));
+    process.stdout.write(botComment ? String(botComment.id) : '');
+} else {
+    process.stdout.write('{}');
+}
+`,
+        { mode: 0o755 },
+    );
+
+    const eventPath = path.join(temporaryDirectory, 'event.json');
+    fs.writeFileSync(
+        eventPath,
+        JSON.stringify({ pull_request: { number: 42, base: { sha: 'base' }, head: { sha: 'head' } } }),
+    );
+
+    try {
+        const result = spawnSync(process.execPath, [classifierPath], {
+            encoding: 'utf8',
+            env: {
+                ...process.env,
+                PATH: `${temporaryDirectory}${path.delimiter}${process.env.PATH}`,
+                GITHUB_EVENT_PATH: eventPath,
+                GITHUB_REPOSITORY: 'vendurehq/vendure',
+                MOCK_CHANGED_FILES: JSON.stringify(files),
+                MOCK_MANIFESTS: JSON.stringify(manifests),
+                MOCK_COMMENTS: JSON.stringify(comments),
+                MOCK_FAILURES: JSON.stringify(failures),
+                MOCK_GH_CALLS_PATH: callsPath,
+            },
+        });
+        if (result.status !== 0) {
+            const error = new Error(
+                `classifier failed with status ${result.status}: ${result.stderr.trim()}`,
+            );
+            error.stdout = result.stdout;
+            error.stderr = result.stderr;
+            throw error;
+        }
+        const calls = fs
+            .readFileSync(callsPath, 'utf8')
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .map(line => JSON.parse(line));
+        return { output: result.stdout, calls };
+    } finally {
+        fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+}
+
+function manifestEndpoint(filePath, ref) {
+    return `repos/vendurehq/vendure/contents/${filePath}?ref=${ref}`;
+}
+
+function appliedLabels(calls) {
+    return calls
+        .filter(args => args[1] === 'repos/vendurehq/vendure/issues/42/labels' && args.includes('POST'))
+        .flatMap(args => args.filter(arg => arg.startsWith('labels[]=')))
+        .map(arg => arg.slice('labels[]='.length));
+}
+
+test('labels a published dependency range edit as a contract change', () => {
+    const filePath = 'packages/core/package.json';
+    const { output, calls } = runClassifier({
+        files: [filePath, 'bun.lock'],
+        manifests: {
+            [manifestEndpoint(filePath, 'merge-base')]: {
+                name: '@vendure/core',
+                dependencies: { graphql: '^16.0.0' },
+            },
+            [manifestEndpoint(filePath, 'head')]: {
+                name: '@vendure/core',
+                dependencies: { graphql: '^17.0.0' },
+            },
+        },
+    });
+
+    assert.deepEqual(appliedLabels(calls), ['deps: contract change']);
+    assert.match(output, /1 contract, 0 other/);
+});
+
+test('labels lockfile and private manifest edits as having no contract change', () => {
+    const filePath = 'packages/dev-server/package.json';
+    const { output, calls } = runClassifier({
+        files: [filePath, 'bun.lock'],
+        manifests: {
+            [manifestEndpoint(filePath, 'merge-base')]: {
+                name: '@vendure/dev-server',
+                private: true,
+                devDependencies: { vite: '^6.0.0' },
+            },
+            [manifestEndpoint(filePath, 'head')]: {
+                name: '@vendure/dev-server',
+                private: true,
+                devDependencies: { vite: '^7.0.0' },
+            },
+        },
+    });
+
+    assert.deepEqual(appliedLabels(calls), ['deps: lockfile only']);
+    assert.match(output, /0 contract, 1 other/);
+});
+
+test('compares a stale pull request head with its merge base', () => {
+    const filePath = 'packages/core/package.json';
+    const { output, calls } = runClassifier({
+        files: [filePath],
+        manifests: {
+            [manifestEndpoint(filePath, 'merge-base')]: {
+                name: '@vendure/core',
+                dependencies: { graphql: '^16.0.0' },
+                devDependencies: { vitest: '^3.0.0' },
+            },
+            [manifestEndpoint(filePath, 'head')]: {
+                name: '@vendure/core',
+                dependencies: { graphql: '^16.0.0' },
+                devDependencies: { vitest: '^4.0.0' },
+            },
+        },
+    });
+
+    assert.deepEqual(appliedLabels(calls), ['deps: lockfile only']);
+    assert.match(output, /0 contract, 1 other/);
+});
+
+test('clears both labels and the bot report when no dependency files remain', () => {
+    const { output, calls } = runClassifier({
+        files: ['README.md'],
+        comments: [
+            { id: 12, user: { login: 'contributor' }, body: '<!-- dependency-impact -->' },
+            { id: 34, user: { login: 'github-actions[bot]' }, body: '<!-- dependency-impact -->' },
+        ],
+    });
+
+    const deletedEndpoints = calls.filter(args => args.includes('DELETE')).map(args => args[1]);
+    assert.deepEqual(deletedEndpoints, [
+        'repos/vendurehq/vendure/issues/42/labels/deps%3A%20contract%20change',
+        'repos/vendurehq/vendure/issues/42/labels/deps%3A%20lockfile%20only',
+        'repos/vendurehq/vendure/issues/comments/34',
+    ]);
+    assert.match(output, /cleared dependency impact classification/);
+});
+
+test('does not suppress a failure while removing the opposite label', () => {
+    assert.throws(
+        () =>
+            runClassifier({
+                files: ['bun.lock'],
+                failures: {
+                    'repos/vendurehq/vendure/issues/42/labels/deps%3A%20contract%20change': 500,
+                },
+            }),
+        /classifier failed with status 1/,
+    );
+});
+
+test('accepts a concurrent label creation only after confirming the label exists', () => {
+    const labelEndpoint = 'repos/vendurehq/vendure/labels/deps%3A%20contract%20change';
+    const { calls } = runClassifier({
+        files: ['bun.lock'],
+        failures: {
+            [labelEndpoint]: [404, null],
+            'repos/vendurehq/vendure/labels': [422],
+        },
+    });
+
+    assert.equal(calls.filter(args => args[1] === labelEndpoint).length, 2);
+    assert.equal(calls.filter(args => args[1] === 'repos/vendurehq/vendure/labels').length, 1);
+});
+
+test('updates only a report owned by github-actions', () => {
+    const { calls } = runClassifier({
+        files: ['bun.lock'],
+        comments: [
+            { id: 12, user: { login: 'contributor' }, body: '<!-- dependency-impact -->' },
+            { id: 34, user: { login: 'github-actions[bot]' }, body: '<!-- dependency-impact -->' },
+        ],
+    });
+
+    assert.ok(calls.some(args => args[1] === 'repos/vendurehq/vendure/issues/comments/34'));
+    assert.ok(!calls.some(args => args[1] === 'repos/vendurehq/vendure/issues/comments/12'));
+});
+
+test('escapes untrusted dependency names and ranges in the report table', () => {
+    const filePath = 'packages/core/package.json';
+    const { calls } = runClassifier({
+        files: [filePath],
+        manifests: {
+            [manifestEndpoint(filePath, 'merge-base')]: {
+                name: '@vendure/core',
+                dependencies: { 'unsafe|`name': '^1.0.0' },
+            },
+            [manifestEndpoint(filePath, 'head')]: {
+                name: '@vendure/core',
+                dependencies: { 'unsafe|`name': '^2.0.0\n| forged | row |' },
+            },
+        },
+    });
+    const commentCall = calls.find(
+        args => args[1] === 'repos/vendurehq/vendure/issues/42/comments' && args.includes('POST'),
+    );
+    const body = commentCall.find(arg => arg.startsWith('body='));
+
+    assert.match(body, /unsafe&#124;&#96;name/);
+    assert.match(body, /\^2\.0\.0<br>&#124; forged &#124; row &#124;/);
+    assert.doesNotMatch(body, /\n\| forged \| row \|/);
+});

--- a/.github/workflows/scripts/dependency-impact.test.js
+++ b/.github/workflows/scripts/dependency-impact.test.js
@@ -55,6 +55,11 @@ if (failure) {
     }
     process.stdout.write(JSON.stringify(value));
 } else if (endpoint.includes('/comments') && args.includes('--paginate')) {
+    const methodIndex = args.indexOf('-X');
+    if (methodIndex === -1 || args[methodIndex + 1] !== 'GET') {
+        process.stderr.write('gh: paginated comment lookup must use GET\\n');
+        process.exit(1);
+    }
     const comments = JSON.parse(process.env.MOCK_COMMENTS);
     const botComment = comments.find(comment => comment.user.login === 'github-actions[bot]' && comment.body.includes('<!-- dependency-impact -->'));
     process.stdout.write(botComment ? String(botComment.id) : '');

--- a/.github/workflows/scripts/dependency-impact.test.js
+++ b/.github/workflows/scripts/dependency-impact.test.js
@@ -263,3 +263,45 @@ test('escapes untrusted dependency names and ranges in the report table', () => 
     assert.match(body, /\^2\.0\.0<br>&#124; forged &#124; row &#124;/);
     assert.doesNotMatch(body, /\n\| forged \| row \|/);
 });
+
+test('reads a dependency section that is not an object as absent', () => {
+    const filePath = 'packages/core/package.json';
+    const { output, calls } = runClassifier({
+        files: [filePath],
+        manifests: {
+            [manifestEndpoint(filePath, 'merge-base')]: {
+                name: '@vendure/core',
+                dependencies: { graphql: '^16.0.0' },
+            },
+            // Valid JSON, invalid npm. Object.keys on the string would report one change per
+            // character and flip the label on nonsense.
+            [manifestEndpoint(filePath, 'head')]: {
+                name: '@vendure/core',
+                dependencies: 'graphql',
+            },
+        },
+    });
+
+    assert.deepEqual(appliedLabels(calls), ['deps: contract change']);
+    assert.match(output, /1 contract, 0 other/);
+    const body = calls
+        .find(args => args[1] === 'repos/vendurehq/vendure/issues/42/comments' && args.includes('POST'))
+        .find(arg => arg.startsWith('body='));
+    assert.match(body, /`graphql` \| packages\/core \/ dependencies \| removed `\^16\.0\.0`/);
+    assert.doesNotMatch(body, /\| `0` \|/);
+});
+
+test('percent-encodes a manifest path before asking the contents API for it', () => {
+    const filePath = 'packages/core/we?ref=master#/package.json';
+    const encoded = 'packages/core/we%3Fref%3Dmaster%23/package.json';
+    const { calls } = runClassifier({
+        files: [filePath],
+        manifests: {
+            [manifestEndpoint(encoded, 'merge-base')]: { dependencies: { a: '^1.0.0' } },
+            [manifestEndpoint(encoded, 'head')]: { dependencies: { a: '^2.0.0' } },
+        },
+    });
+
+    assert.ok(calls.some(args => args[1] === manifestEndpoint(encoded, 'head')));
+    assert.ok(!calls.some(args => args[1] === manifestEndpoint(filePath, 'head')));
+});

--- a/.github/workflows/scripts/dependency-impact.test.js
+++ b/.github/workflows/scripts/dependency-impact.test.js
@@ -259,9 +259,37 @@ test('escapes untrusted dependency names and ranges in the report table', () => 
     );
     const body = commentCall.find(arg => arg.startsWith('body='));
 
+    // A backtick cannot be escaped inside a code span, so a name carrying one drops out of the
+    // span and is entity-escaped as plain text instead.
     assert.match(body, /unsafe&#124;&#96;name/);
-    assert.match(body, /\^2\.0\.0<br>&#124; forged &#124; row &#124;/);
+    // A range without a backtick keeps its code span, where a pipe escapes with a backslash and
+    // an entity would only render as itself.
+    assert.match(body, /`\^2\.0\.0 \\\| forged \\\| row \\\|`/);
     assert.doesNotMatch(body, /\n\| forged \| row \|/);
+});
+
+test('renders a comparator range as written rather than as HTML entities', () => {
+    const filePath = 'packages/dashboard/package.json';
+    const { calls } = runClassifier({
+        files: [filePath],
+        manifests: {
+            [manifestEndpoint(filePath, 'merge-base')]: {
+                name: '@vendure/dashboard',
+                dependencies: { zod: '^3.25.0 || ^4.0.0' },
+            },
+            [manifestEndpoint(filePath, 'head')]: {
+                name: '@vendure/dashboard',
+                dependencies: { zod: '>=3.25.0 <5' },
+            },
+        },
+    });
+    const body = calls
+        .find(args => args[1] === 'repos/vendurehq/vendure/issues/42/comments' && args.includes('POST'))
+        .find(arg => arg.startsWith('body='));
+
+    // GFM does not decode an entity inside a code span, so any of these would display verbatim.
+    assert.doesNotMatch(body, /&#124;|&gt;|&lt;|&#96;/);
+    assert.match(body, /`\^3\.25\.0 \\\|\\\| \^4\.0\.0` -> `>=3\.25\.0 <5`/);
 });
 
 test('counts a peerDependencies change in a published package as a contract change', () => {

--- a/.github/workflows/scripts/dependency-impact.test.js
+++ b/.github/workflows/scripts/dependency-impact.test.js
@@ -285,7 +285,10 @@ test('takes a range carrying a backslash out of the code span', () => {
             },
             [manifestEndpoint(filePath, 'head')]: {
                 name: '@vendure/core',
-                dependencies: { graphql: '^17.0.0 \\| forged | row |' },
+                dependencies: {
+                    graphql:
+                        '^17.0.0 \\| forged | row | [maintainer](https://example.com) ![tracker](https://example.com/pixel.png) @michaelbromley #123',
+                },
             },
         },
     });
@@ -294,9 +297,15 @@ test('takes a range carrying a backslash out of the code span', () => {
         .find(arg => arg.startsWith('body='));
 
     // Escaping only the pipe would leave the backslash in front of it, so the row would carry a
-    // bare pipe and split into extra cells. Plain text entity-escapes the pipe instead.
+    // bare pipe and split into extra cells. Entity-escaping every Markdown punctuation character
+    // also prevents an untrusted range from creating bot-authored links, images, mentions or issue
+    // references while preserving the rendered text.
     assert.match(body, /&#124; forged &#124; row &#124;/);
     assert.doesNotMatch(body, /\\\\\|/);
+    assert.match(body, /&#91;maintainer&#93;&#40;https&#58;&#47;&#47;example&#46;com&#41;/);
+    assert.match(body, /&#33;&#91;tracker&#93;&#40;https&#58;&#47;&#47;example&#46;com&#47;pixel&#46;png&#41;/);
+    assert.match(body, /&#64;michaelbromley &#35;123/);
+    assert.doesNotMatch(body, /\[maintainer\]\(|!\[tracker\]\(|@michaelbromley|#123/);
 });
 
 test('renders a comparator range as written rather than as HTML entities', () => {
@@ -368,7 +377,7 @@ test('reads a dependency section that is not an object as absent', () => {
     const body = calls
         .find(args => args[1] === 'repos/vendurehq/vendure/issues/42/comments' && args.includes('POST'))
         .find(arg => arg.startsWith('body='));
-    assert.match(body, /`graphql` \| packages\/core \/ dependencies \| removed `\^16\.0\.0`/);
+    assert.match(body, /`graphql` \| packages&#47;core \/ dependencies \| removed `\^16\.0\.0`/);
     assert.doesNotMatch(body, /\| `0` \|/);
 });
 

--- a/.github/workflows/scripts/dependency-impact.test.js
+++ b/.github/workflows/scripts/dependency-impact.test.js
@@ -6,6 +6,16 @@ const path = require('node:path');
 const test = require('node:test');
 
 const classifierPath = path.join(__dirname, 'dependency-impact.js');
+const workflowPath = path.join(__dirname, '..', 'dependency_impact.yml');
+
+test('does not override the protected pull_request_target checkout', () => {
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+    const checkoutStep = workflow.match(/- name: Check out trusted workflow code[\s\S]*?(?=\n\s+- name:)/);
+
+    assert.ok(checkoutStep, 'trusted checkout step is missing');
+    assert.doesNotMatch(checkoutStep[0], /^\s+(?:ref|repository|allow-unsafe-pr-checkout):/m);
+    assert.match(checkoutStep[0], /^\s+persist-credentials: false$/m);
+});
 
 function runClassifier({ files, manifests = {}, comments = [], failures = {} }) {
     assert.ok(

--- a/.github/workflows/scripts/dependency-impact.test.js
+++ b/.github/workflows/scripts/dependency-impact.test.js
@@ -269,6 +269,31 @@ test('escapes untrusted dependency names and ranges in the report table', () => 
     assert.doesNotMatch(body, /\n\| forged \| row \|/);
 });
 
+test('takes a range carrying a backslash out of the code span', () => {
+    const filePath = 'packages/core/package.json';
+    const { calls } = runClassifier({
+        files: [filePath],
+        manifests: {
+            [manifestEndpoint(filePath, 'merge-base')]: {
+                name: '@vendure/core',
+                dependencies: { graphql: '^16.0.0' },
+            },
+            [manifestEndpoint(filePath, 'head')]: {
+                name: '@vendure/core',
+                dependencies: { graphql: '^17.0.0 \\| forged | row |' },
+            },
+        },
+    });
+    const body = calls
+        .find(args => args[1] === 'repos/vendurehq/vendure/issues/42/comments' && args.includes('POST'))
+        .find(arg => arg.startsWith('body='));
+
+    // Escaping only the pipe would leave the backslash in front of it, so the row would carry a
+    // bare pipe and split into extra cells. Plain text entity-escapes the pipe instead.
+    assert.match(body, /&#124; forged &#124; row &#124;/);
+    assert.doesNotMatch(body, /\\\\\|/);
+});
+
 test('renders a comparator range as written rather than as HTML entities', () => {
     const filePath = 'packages/dashboard/package.json';
     const { calls } = runClassifier({

--- a/.github/workflows/scripts/dependency-impact.test.js
+++ b/.github/workflows/scripts/dependency-impact.test.js
@@ -264,6 +264,28 @@ test('escapes untrusted dependency names and ranges in the report table', () => 
     assert.doesNotMatch(body, /\n\| forged \| row \|/);
 });
 
+test('counts a peerDependencies change in a published package as a contract change', () => {
+    const filePath = 'packages/core/package.json';
+    const { output, calls } = runClassifier({
+        files: [filePath],
+        manifests: {
+            [manifestEndpoint(filePath, 'merge-base')]: {
+                name: '@vendure/core',
+                peerDependencies: { graphql: '^16.0.0' },
+                optionalDependencies: { bufferutil: '^4.0.0' },
+            },
+            [manifestEndpoint(filePath, 'head')]: {
+                name: '@vendure/core',
+                peerDependencies: { graphql: '^17.0.0' },
+                optionalDependencies: { bufferutil: '^5.0.0' },
+            },
+        },
+    });
+
+    assert.deepEqual(appliedLabels(calls), ['deps: contract change']);
+    assert.match(output, /2 contract, 0 other/);
+});
+
 test('reads a dependency section that is not an object as absent', () => {
     const filePath = 'packages/core/package.json';
     const { output, calls } = runClassifier({


### PR DESCRIPTION
## What this changes

Adds `.github/workflows/dependency_impact.yml` and its script, `.github/workflows/scripts/dependency-impact.js`. Together they label every pull request that touches a `package.json` or `bun.lock` with what it does to the published dependency contract, and post one comment naming each changed range.

## Why

A lockfile refresh and a widened published range look identical in the pull request list, and they mean different things. A range in a published `package.json` is a promise to every consumer about what they may resolve. `bun.lock` only records what this repository installs, and no consumer installs it.

PR 5219 is the case that prompted this. It changes no `package.json` at all, only `bun.lock`, so it reads as a routine refresh. Nothing in the queue distinguishes it from PR 5217, which widens twelve `@opentelemetry/*` ranges in the published `@vendure/telemetry-plugin`.

## The rule

A pull request changes the contract when it edits a `dependencies`, `peerDependencies` or `optionalDependencies` range in the `package.json` of a published package. Changes to `devDependencies`, to `bun.lock`, or to a private package's manifest do not.

A package counts as published when its path matches `packages/<name>/package.json` and its manifest does not set `"private": true`. Deriving it from the flag rather than a hardcoded list means a new package is classified correctly without anyone remembering to update this script. `packages/dev-server`, the root manifest and `docs/package.json` all set the flag, so the same test excludes all three without naming them.

## What I verified

I ran the classifier against five open Dependabot pull requests, reading the real diffs through the API. The write calls were stubbed out, so nothing was posted:

| PR | changes | label | reported |
| --- | --- | --- | --- |
| 5219 | `bun.lock` only | `deps: lockfile only` | no range changes |
| 5220 | root and admin-ui manifests | `deps: lockfile only` | 2 non-contract changes; root is `private: true`, admin-ui's is `devDependencies` |
| 5222 | admin-ui and ui-devkit manifests | `deps: contract change` | `@angular/compiler` `^19.2.4` to `^22.1.3` in ui-devkit `dependencies` |
| 5217 | telemetry-plugin manifest | `deps: contract change` | 12 `@opentelemetry/*` ranges |
| 5214 | core manifest | `deps: contract change` | `@nestjs/apollo` and `@nestjs/graphql`, `~13.1.0` to `~13.4.5` |

5222 is the case worth checking. The same package moves in both manifests, but only ui-devkit declares it under `dependencies`, so only that one is a contract change.

I also verified that this cannot affect the auto-merge lane. `dependabot_auto_merge.yml` decides eligibility from `dependabot/fetch-metadata` outputs (`package-ecosystem`, `update-type`, `dependency-names`) and the `DEPENDABOT_AUTO_MERGE_DISABLED` variable. It reads no label and no comment, so nothing here changes which pull requests qualify. `gh pr merge --auto` waits on required status checks, and this workflow is not one.

Adding a label also cannot re-trigger anything. No workflow in `.github/workflows/` subscribes to `labeled` or `unlabeled`. `cla.yml` is the only workflow listening to `issue_comment`, and its job runs only when the comment body is exactly `recheck` or the CLA signature sentence, neither of which this comment can be.

## What I did not verify

The read and classify path is verified against real pull requests. The write path — creating the two labels, applying one and removing the other, and creating or editing the comment — is not exercised here, because it needs write scope against a live pull request. The API shapes are the documented ones, but the first real run is the first time those calls execute.

## Security

This uses `pull_request_target` for the reason `dependabot_auto_merge.yml` documents: a workflow that Dependabot triggers via `pull_request` gets a read-only `GITHUB_TOKEN` and could not apply a label.

The property that workflow depends on is preserved. The job checks out `github.event.pull_request.base.sha`, named explicitly rather than left to the default, and only to get the script. It reads the head's `package.json` files as data through the contents API and parses them with `JSON.parse`. It never checks out, installs, resolves or builds anything from the head. It takes no secret beyond the automatic `GITHUB_TOKEN`, and holds `contents: read`, `pull-requests: read` and `issues: write`.

## Not a gate

This is a separate workflow rather than a job in `build_and_test.yml`, so it stays out of the `all-passed` `needs` list and cannot gate a merge. It must not be added to the required checks.

## One thing worth a second opinion

The two label names are the ones suggested in the brief. `deps: lockfile only` is slightly wrong for a pull request like 5220, which edits manifests but changes no published range. The comment says exactly what changed in each case, so the detail is never lost, but `deps: no contract change` would be the more accurate name for the negative label. Happy to rename if you prefer.

`.github/` is covered by CODEOWNERS, so this needs a listed maintainer to approve it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790848457&installation_model_id=20193&pr_number=5231&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5231&signature=63459253a996d8c3af62853ba763af9ede62a7db6f949b21c8af872414a9c9d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->