### PR TITLE
ci: build against a fresh resolve of the declared ranges weekly

### DIFF
--- a/.github/workflows/floating_deps_check.yml
+++ b/.github/workflows/floating_deps_check.yml
@@ -1,0 +1,114 @@
+name: Floating dependency check
+
+# Builds the published packages against a fresh resolve of their declared dependency ranges,
+# with no lockfile.
+#
+# build_and_test.yml installs with --frozen-lockfile, so it verifies the one version combination
+# recorded in bun.lock. No consumer installs that combination. packages/dashboard, for one, sets
+# "main" and "module" to ./src/lib/index.ts, so consumers compile its TypeScript source against
+# their own resolution of the ranges it declares. This job checks the thing consumers actually do.
+#
+# It is deliberately not a required check, runs on a schedule rather than on pull requests, and
+# gates nothing. It fails whenever a third party ships a release inside a declared range that does
+# not compile, which is information rather than a reason to block other people's work.
+on:
+    schedule:
+        # Wednesday 04:00 UTC. Offset from the Monday Dependabot run so a failure here is not read
+        # as being caused by that morning's pull requests, and away from the 02:00 jobs.
+        - cron: '0 4 * * 3'
+    workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
+
+jobs:
+    resolve-and-build:
+        name: resolve declared ranges and build
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            issues: write
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+              with:
+                  # No push credentials are left on disk. This job must never write to the
+                  # repository, and the throwaway resolve must never be committed.
+                  persist-credentials: false
+
+            # .github/actions/setup is not used here because it installs with --frozen-lockfile,
+            # which is the thing this job exists to avoid. The Node and Bun pins below are kept in
+            # step with that action.
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version: '22.x'
+            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+              with:
+                  bun-version: '1.3.10'
+
+            - name: Resolve declared ranges with no lockfile
+              shell: bash
+              run: |
+                  # Deleting the lockfile is what forces a fresh resolve. Without this, bun installs
+                  # the pinned versions and the job verifies the same thing build_and_test already
+                  # does.
+                  rm -f bun.lock
+
+                  # bunfig.toml sets install.minimumReleaseAge to seven days, so a resolve in this
+                  # repository skips anything published in the last week. A consumer installing
+                  # with npm, pnpm or yarn has no such gate and gets the newest matching version
+                  # straight away. Passing --minimum-release-age=0 on the command line overrides
+                  # the bunfig value for this run only, without editing the committed file. The
+                  # committed value stays at seven days for everyone else.
+                  #
+                  # --no-save stops bun writing a replacement bun.lock. A later step asserts that.
+                  bun install --minimum-release-age=0 --no-save 2>&1 | tee /tmp/floating-deps.log
+
+            - name: Record resolved versions
+              if: always()
+              shell: bash
+              run: node .github/workflows/scripts/floating-deps-report.js resolved | tee /tmp/resolved.md
+
+            - name: Build and type check
+              shell: bash
+              run: bun run build 2>&1 | tee -a /tmp/floating-deps.log
+
+            - name: Confirm no lockfile was written
+              if: always()
+              shell: bash
+              run: |
+                  if [ -f bun.lock ]; then
+                    echo "bun.lock was regenerated, so --no-save did not take effect."
+                    echo "The file is not committed from here, but the flag is meant to prevent it existing at all."
+                    exit 1
+                  fi
+                  echo "No lockfile was written."
+
+            # The issue body truncates both files to fit GitHub's 65536 character limit. Keeping
+            # them whole here means a truncated report still has somewhere to point.
+            - name: Upload the resolved versions and the build output
+              if: always()
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              with:
+                  name: floating-deps-${{ github.run_id }}
+                  path: |
+                      /tmp/resolved.md
+                      /tmp/floating-deps.log
+                  if-no-files-found: warn
+                  retention-days: 30
+
+            - name: Open or update the failure issue
+              if: failure()
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  RESOLVED_FILE: /tmp/resolved.md
+                  LOG_FILE: /tmp/floating-deps.log
+              run: node .github/workflows/scripts/floating-deps-report.js report
+
+            - name: Close the failure issue
+              if: success()
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: node .github/workflows/scripts/floating-deps-report.js resolve-issue

--- a/.github/workflows/scripts/floating-deps-report.js
+++ b/.github/workflows/scripts/floating-deps-report.js
@@ -1,0 +1,246 @@
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Support script for floating_deps_check.yml.
+ *
+ * `node floating-deps-report.js resolved` prints a table of every dependency range the published
+ * packages declare, next to the version a fresh resolve picked for it.
+ *
+ * `node floating-deps-report.js report` opens an issue describing a failed run, or edits the
+ * issue an earlier failed run already opened. `node floating-deps-report.js resolve-issue` closes
+ * that issue once a run passes again.
+ *
+ * A package counts as published when its path is packages/<name>/package.json and its manifest
+ * does not set `"private": true`, which is the same test dependency-impact.js uses.
+ */
+
+const MARKER = '<!-- floating-deps-check -->';
+const LABEL = 'ci: floating deps';
+const TITLE = 'Scheduled floating dependency check is failing';
+const CONTRACT_SECTIONS = ['dependencies', 'peerDependencies', 'optionalDependencies'];
+// GitHub rejects an issue body over 65536 characters, and the body carries both the resolved
+// versions and the build output. These two caps leave headroom for the surrounding text. The
+// workflow also uploads both files whole as a run artifact, so truncation here loses nothing.
+const MAX_RESOLVED_CHARS = 20000;
+const MAX_LOG_CHARS = 20000;
+
+const repo = process.env.GITHUB_REPOSITORY;
+const mode = process.argv[2];
+
+if (mode === 'resolved') {
+    process.stdout.write(resolvedTable());
+} else if (mode === 'report') {
+    report();
+} else if (mode === 'resolve-issue') {
+    resolveIssue();
+} else {
+    console.error(`unknown mode "${mode}", expected resolved, report or resolve-issue`);
+    process.exit(1);
+}
+
+function publishedPackages() {
+    return fs
+        .readdirSync('packages', { withFileTypes: true })
+        .filter(entry => entry.isDirectory())
+        .map(entry => path.join('packages', entry.name, 'package.json'))
+        .filter(manifestPath => fs.existsSync(manifestPath))
+        .map(manifestPath => ({ manifestPath, manifest: JSON.parse(fs.readFileSync(manifestPath, 'utf8')) }))
+        .filter(({ manifest }) => manifest.private !== true);
+}
+
+/**
+ * Finds the version actually installed for a dependency of a given package. bun hoists most
+ * packages to the root node_modules but can nest one under the package that needs it, so check
+ * the nested location first.
+ */
+function installedVersion(packageDir, name) {
+    const candidates = [
+        path.join(packageDir, 'node_modules', name, 'package.json'),
+        path.join('node_modules', name, 'package.json'),
+    ];
+    for (const candidate of candidates) {
+        if (fs.existsSync(candidate)) {
+            try {
+                return JSON.parse(fs.readFileSync(candidate, 'utf8')).version;
+            } catch (e) {
+                return `unreadable (${e.message})`;
+            }
+        }
+    }
+    return null;
+}
+
+function resolvedTable() {
+    const rows = [];
+    for (const { manifestPath, manifest } of publishedPackages()) {
+        const packageDir = path.dirname(manifestPath);
+        for (const section of CONTRACT_SECTIONS) {
+            for (const [name, range] of Object.entries(manifest[section] || {})) {
+                // Workspace packages resolve to the checkout, so their version says nothing about
+                // what a consumer would get.
+                if (typeof range === 'string' && range.startsWith('workspace:')) {
+                    continue;
+                }
+                rows.push({
+                    pkg: manifest.name,
+                    section,
+                    name,
+                    range,
+                    resolved: installedVersion(packageDir, name),
+                });
+            }
+        }
+    }
+    rows.sort((a, b) => a.pkg.localeCompare(b.pkg) || a.name.localeCompare(b.name));
+
+    const lines = ['| package | dependency | declared range | resolved |', '| --- | --- | --- | --- |'];
+    for (const row of rows) {
+        const section = row.section === 'dependencies' ? '' : ` _(${row.section})_`;
+        lines.push(
+            `| \`${row.pkg}\` | \`${row.name}\`${section} | \`${row.range}\` | ${
+                row.resolved ? `\`${row.resolved}\`` : 'not installed'
+            } |`,
+        );
+    }
+    return lines.join('\n') + '\n';
+}
+
+/**
+ * Reads a file, keeping the end when it is too long. The end of a build log holds the error that
+ * stopped it, which is the part worth reading.
+ */
+function readTail(file, limit) {
+    if (!file || !fs.existsSync(file)) {
+        return '(no output captured)';
+    }
+    const text = fs.readFileSync(file, 'utf8');
+    if (text.length <= limit) {
+        return text || '(empty)';
+    }
+    return `... truncated to the last ${limit} characters, see the run artifact for the whole file ...\n${text.slice(
+        -limit,
+    )}`;
+}
+
+function buildBody() {
+    const runUrl = `${process.env.GITHUB_SERVER_URL}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+    return [
+        MARKER,
+        '',
+        'The scheduled floating dependency check failed. This job resolves the published packages',
+        'declared dependency ranges with no lockfile and builds the result, so it reports what a',
+        'consumer installing these packages today would get. It is not a required check and blocks',
+        'nothing.',
+        '',
+        'A failure here usually means a third party shipped a release that is inside a declared',
+        'range and does not compile against this source. The fix is either to correct the range or',
+        'to update the code that uses it. Failing on its own is not a reason to revert anything.',
+        '',
+        `Run: ${runUrl}`,
+        `Commit: \`${process.env.GITHUB_SHA}\``,
+        '',
+        '## Resolved versions',
+        '',
+        '<details><summary>Every declared range and what it resolved to</summary>',
+        '',
+        readTail(process.env.RESOLVED_FILE, MAX_RESOLVED_CHARS),
+        '',
+        '</details>',
+        '',
+        '## Output',
+        '',
+        '```',
+        readTail(process.env.LOG_FILE, MAX_LOG_CHARS),
+        '```',
+        '',
+        `<sub>Updated automatically by \`floating_deps_check.yml\`. Edits to this body are overwritten on the next failure.</sub>`,
+    ].join('\n');
+}
+
+function ensureLabel() {
+    try {
+        gh([`repos/${repo}/labels/${encodeURIComponent(LABEL)}`]);
+    } catch (e) {
+        gh([
+            `repos/${repo}/labels`,
+            '-X',
+            'POST',
+            '-f',
+            `name=${LABEL}`,
+            '-f',
+            'color=D93F0B',
+            '-f',
+            'description=Raised by the scheduled floating dependency check',
+        ]);
+    }
+}
+
+function findOpenIssue() {
+    // The filters go in the query string. Passing them with -f makes gh send a request body,
+    // which turns this GET into a write attempt against the issues endpoint.
+    const query = `state=open&labels=${encodeURIComponent(LABEL)}`;
+    const found = gh([
+        `repos/${repo}/issues?${query}`,
+        '--paginate',
+        '--jq',
+        `[.[] | select(.pull_request == null) | select(.body | contains("${MARKER}")) | .number] | first // empty`,
+    ]).trim();
+    return found || null;
+}
+
+function report() {
+    ensureLabel();
+    const body = buildBody();
+    const existing = findOpenIssue();
+    if (existing) {
+        gh([`repos/${repo}/issues/${existing}`, '-X', 'PATCH', '-f', `body=${body}`]);
+        console.log(`updated issue #${existing}`);
+    } else {
+        const created = gh([
+            `repos/${repo}/issues`,
+            '-X',
+            'POST',
+            '-f',
+            `title=${TITLE}`,
+            '-f',
+            `body=${body}`,
+            '-f',
+            `labels[]=${LABEL}`,
+            '--jq',
+            '.number',
+        ]).trim();
+        console.log(`opened issue #${created}`);
+    }
+}
+
+/**
+ * Closes the issue a previous failure opened. Only an issue carrying this workflow's marker is
+ * touched, so a run passing can never close something a person filed.
+ */
+function resolveIssue() {
+    const existing = findOpenIssue();
+    if (!existing) {
+        console.log('no open issue to close');
+        return;
+    }
+    const runUrl = `${process.env.GITHUB_SERVER_URL}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+    gh([
+        `repos/${repo}/issues/${existing}/comments`,
+        '-X',
+        'POST',
+        '-f',
+        `body=The floating dependency check passed on \`${process.env.GITHUB_SHA}\`. Closing.\n\nRun: ${runUrl}`,
+    ]);
+    gh([`repos/${repo}/issues/${existing}`, '-X', 'PATCH', '-f', 'state=closed']);
+    console.log(`closed issue #${existing}`);
+}
+
+function gh(args) {
+    return execFileSync('gh', ['api', ...args], {
+        encoding: 'utf8',
+        maxBuffer: 32 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+}


### PR DESCRIPTION
## What this changes

Adds `.github/workflows/floating_deps_check.yml` and `.github/workflows/scripts/floating-deps-report.js`. A scheduled job deletes `bun.lock`, resolves the published packages' declared dependency ranges from scratch, and runs the build and type check. On failure it opens an issue with the resolved versions and the output, or edits the issue an earlier failure already opened, and closes that issue once a run passes again.

## Why

`build_and_test.yml` installs with `--frozen-lockfile`, so every job verifies the one version combination recorded in `bun.lock`. No consumer installs that combination. Consumers resolve the declared ranges fresh.

The gap is not theoretical. `packages/dashboard` sets `"main"` and `"module"` to `./src/lib/index.ts` and ships TypeScript source rather than built output, so consumers compile that source against their own resolution of the ranges it declares. It declares `"react-hook-form": "^7.71.0"`, the lockfile pins 7.71.2, and the range resolves to 7.87.0 today.

## What the first run finds

I ran the job's steps locally against a real lockfile-free resolve. It fails, and it finds four separate things. All of them are pre-existing, and none is fixed here.

**1. `http-proxy-middleware`, a breaking change inside a declared range.** `packages/core` declares `^3.0.3`; a fresh resolve gives 3.0.7. The `Logger` type no longer accepts a `log` member, so `packages/core/src/plugin/plugin-utils.ts:47` fails with `'log' does not exist in type 'Logger'`. This is exactly the class of break the job exists to catch, and it is in core rather than the dashboard.

**2 and 3. Two undeclared imports in `packages/core`.** `src/api/config/generate-resolvers.ts` imports `@graphql-tools/utils` and `src/config/vendure-config.ts` imports `@apollographql/graphql-playground-html`. Neither is declared in any manifest in this repository. They resolve today only because some other package happens to hoist them into the tree, and a fresh resolve does not place them where core can see them.

These two are less severe than they look, because `@vendure/core` ships built output from `dist/` rather than source, so a consumer never compiles the files that import them. The exposure is to this repository's own build being reproducible from what it declares, not to consumers.

**4. `react-hook-form`, already tracked on issue 5142.** Against the fresh resolve the dashboard produces the `Control<T, any>` is not assignable to `Control<any, any>` errors described there.

That last one is older than the triage review believed. The review put the break at 7.86.0. The `ValidateForm` type that causes it is absent from 7.71.2 and present in 7.72.0, published 2026-03-22, and 7.72.0 produces the same 32 errors as 7.87.0. Isolating react-hook-form alone against an otherwise locked tree gives 32 `TS2322` errors across 31 files. I have recorded the detail on issue 5142.

So the job's first scheduled run is expected to fail and open an issue. That is the intended behaviour, not a reason to hold this back.

## The two things that would have made this useless

**`minimumReleaseAge`.** `bunfig.toml` sets it to 604800. A resolve in this repository therefore skips anything published in the last seven days. A consumer installing with npm, pnpm or yarn has no such gate and gets the newest matching version straight away. A job that inherited the gate would miss the case it exists to catch.

The job passes `bun install --minimum-release-age=0`. That is the documented command-line form of the setting, and it overrides the `bunfig.toml` value for one run without editing the committed file, which stays at seven days for everyone else. I checked this against the version CI pins rather than the one on my machine. `.github/actions/setup` pins bun 1.3.10, and on 1.3.10 a package with a `bunfig.toml` gate of ten years fails to resolve without the flag and resolves to the newest matching version with it.

**The throwaway lockfile.** The job deletes `bun.lock` and passes `--no-save`, so bun writes no replacement. A later step fails the run if `bun.lock` exists afterwards. The checkout sets `persist-credentials: false`, so no push credentials are left on disk, and there is no commit or push step.

## What I verified

- A fresh lockfile-free resolve of this workspace with `--minimum-release-age=0` succeeds and installs 2799 packages.
- It resolves `react-hook-form` to 7.87.0 and `react` to 19.2.8, the newest versions matching the declared ranges rather than the pinned ones.
- `--no-save` writes no lockfile, and a default install does write one, so the flag is required rather than a precaution.
- The `--minimum-release-age` flag exists and overrides `bunfig.toml` on bun 1.3.10.
- The resolved-versions script reports 238 rows, and finds versions in nested `packages/<name>/node_modules` as well as the hoisted root. That matters: bun installs `react-hook-form` under `packages/dashboard/node_modules`, not at the root, and a root-only lookup reports it as missing.
- The build then fails, with the four findings above.

## What I did not verify

The issue-filing path — creating the label, opening an issue, editing an existing one and closing it on recovery — is not exercised here, because it needs write scope on the live repository. The first scheduled run is the first time those calls execute.

I also did not run a full `bun run build` across every package locally. I ran the core and common build and the dashboard type check, which is where all four findings surfaced. Packages later in the topological order may hold more.

## Not a gate

The workflow triggers on `schedule` and `workflow_dispatch` only, never on pull requests. It is a separate workflow rather than a job in `build_and_test.yml`, so it stays out of the `all-passed` `needs` list. It must not be added to the required checks. It fails whenever a third party ships a breaking release inside a declared range, which is information, not a reason to block other people's work.

It runs Wednesday at 04:00 UTC, away from the Monday Dependabot run so a failure is not read as being caused by that morning's pull requests, and away from the 02:00 nightly jobs.

`.github/` is covered by CODEOWNERS, so this needs a listed maintainer to approve it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790848459&installation_model_id=20193&pr_number=5232&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5232&signature=1202b5e68193bd13f1ecb05507cc5bb10dcc20bc76b1d97ca752c2e488d37f12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->