### PR TITLE
ci: hold the MySQL e2e data directory in memory

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -251,14 +251,26 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
-        # MySQL is started by hand rather than as a service container because it needs server
-        # flags, and a service container has no way to pass them. MySQL 8 enables the binary
-        # log by default where MariaDB does not, so each commit costs two fsyncs instead of
-        # one. The e2e run drops and recreates the whole schema once per spec file, so it does
-        # enough commits for that to set the runtime: this job has averaged 22 minutes against
-        # 12 for the other databases, and passed 80 minutes when the runner disk was busy.
-        # A database that is thrown away at the end of the job has no use for a binary log.
         services:
+            mysql:
+                image: vendure/mysql-8-native-auth:latest
+                # Each spec file gets its own database, so the e2e run builds the full schema
+                # 122 times. MySQL 8 made DDL atomic, which made CREATE TABLE several times
+                # slower than it is on MariaDB, and Oracle closed that as working as intended
+                # (MySQL bug #106390). This job has therefore averaged 22 minutes against 12
+                # for the other databases, and reached 80 when the runner disk was busy.
+                # Holding the data directory in memory takes the disk out of that path. The
+                # binary log is switched off because a database that is deleted at the end of
+                # the job has no use for one, and it would otherwise grow in that same memory.
+                command: --skip-log-bin --performance-schema=OFF
+                env:
+                    MYSQL_ROOT_PASSWORD: password
+                ports:
+                    - 3306
+                options: >-
+                    --tmpfs /var/lib/mysql:rw,size=4g
+                    --health-cmd="mysqladmin ping --silent"
+                    --health-interval=10s --health-timeout=20s --health-retries=10
             redis:
                 image: redis:7.4.1
                 ports:
@@ -268,37 +280,15 @@ jobs:
             matrix:
                 node: ${{ github.event_name == 'pull_request' && fromJSON('["22.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
         steps:
-            - name: Start MySQL
-              run: |
-                  docker run --detach --name mysql \
-                      --publish 3306:3306 \
-                      --env MYSQL_ROOT_PASSWORD=password \
-                      vendure/mysql-8-native-auth:latest \
-                      --skip-log-bin \
-                      --performance-schema=OFF
             - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - uses: ./.github/actions/setup
               with:
                   node-version: ${{ matrix.node }}
             - name: Build
               run: bunx lerna run ci
-            # `mysqladmin ping` reports success while the entrypoint is still running its
-            # temporary server, so the readiness check runs a real query instead.
-            - name: Wait for MySQL
-              run: |
-                  for i in $(seq 1 60); do
-                      if docker exec mysql mysql --user=root --password=password --execute="SELECT 1" >/dev/null 2>&1; then
-                          echo "MySQL is ready"
-                          exit 0
-                      fi
-                      sleep 2
-                  done
-                  echo "MySQL did not become ready in time"
-                  docker logs mysql
-                  exit 1
             - name: e2e tests
               env:
-                  E2E_MYSQL_PORT: 3306
+                  E2E_MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
                   E2E_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
                   DB: mysql
               run: bun run e2e

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -251,14 +251,14 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+        # MySQL is started by hand rather than as a service container because it needs server
+        # flags, and a service container has no way to pass them. MySQL 8 enables the binary
+        # log by default where MariaDB does not, so each commit costs two fsyncs instead of
+        # one. The e2e run drops and recreates the whole schema once per spec file, so it does
+        # enough commits for that to set the runtime: this job has averaged 22 minutes against
+        # 12 for the other databases, and passed 80 minutes when the runner disk was busy.
+        # A database that is thrown away at the end of the job has no use for a binary log.
         services:
-            mysql:
-                image: vendure/mysql-8-native-auth:latest
-                env:
-                    MYSQL_ROOT_PASSWORD: password
-                ports:
-                    - 3306
-                options: --health-cmd="mysqladmin ping --silent" --health-interval=10s --health-timeout=20s --health-retries=10
             redis:
                 image: redis:7.4.1
                 ports:
@@ -268,15 +268,37 @@ jobs:
             matrix:
                 node: ${{ github.event_name == 'pull_request' && fromJSON('["22.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
         steps:
+            - name: Start MySQL
+              run: |
+                  docker run --detach --name mysql \
+                      --publish 3306:3306 \
+                      --env MYSQL_ROOT_PASSWORD=password \
+                      vendure/mysql-8-native-auth:latest \
+                      --skip-log-bin \
+                      --performance-schema=OFF
             - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - uses: ./.github/actions/setup
               with:
                   node-version: ${{ matrix.node }}
             - name: Build
               run: bunx lerna run ci
+            # `mysqladmin ping` reports success while the entrypoint is still running its
+            # temporary server, so the readiness check runs a real query instead.
+            - name: Wait for MySQL
+              run: |
+                  for i in $(seq 1 60); do
+                      if docker exec mysql mysql --user=root --password=password --execute="SELECT 1" >/dev/null 2>&1; then
+                          echo "MySQL is ready"
+                          exit 0
+                      fi
+                      sleep 2
+                  done
+                  echo "MySQL did not become ready in time"
+                  docker logs mysql
+                  exit 1
             - name: e2e tests
               env:
-                  E2E_MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
+                  E2E_MYSQL_PORT: 3306
                   E2E_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
                   DB: mysql
               run: bun run e2e


### PR DESCRIPTION
## Problem

The `e2e (mysql)` job is slower and much less predictable than the other three database jobs. Durations for the `22.x` job across 40 recent workflow runs:

| database | runs | mean | max | observed |
|---|---|---|---|---|
| mysql | 14 | **22.1 min** | **84 min** | 14, 44, 15, 15, 16, 14, 21, 16, 17, 31, 84, 16 |
| mariadb | 18 | 12.1 min | 27 min | 12, 12, 12, 12, 12, 12, 12, 11, 12, 12, 27, ... |
| postgres | 17 | 10.3 min | 12 min | 12, 12, 11, 12, 11, 11, 12, 11, 12, 11, ... |
| sqljs | 20 | 10.7 min | 13 min | 11, 13, 11, 11, 12, 10, 11, 11, 11, 11, ... |

## Cause

MySQL and MariaDB run the same code: both use `MysqlInitializer`, both run with `synchronize: true`. The difference is that MySQL 8 made DDL atomic, which made `CREATE TABLE` several times slower than it was in 5.7 and than it is in MariaDB. Oracle closed that as working as intended: *"table creation can cost more as MySQL 8.0 now is atomic in that process"* ([MySQL bug 106390](https://bugs.mysql.com/bug.php?id=106390), a duplicate of MySQL bugs 90209 and 92979; see also [MySQL bug 87827](https://bugs.mysql.com/bug.php?id=87827) and Percona's [One Million Tables in MySQL 8.0](https://www.percona.com/blog/one-million-tables-mysql-8-0/)).

That lands badly here because `MysqlInitializer` gives every spec file its own database, so the run builds the full ~100 table schema 122 times. The cost tracks the number of DDL statements, which is the axis MySQL 8 regressed on. Measured locally, 100 `CREATE TABLE` statements take 0.84s on MySQL 8.0.43 against 0.26s on MariaDB 11.5.

Someone hit [the same thing moving a test suite from MariaDB to MySQL 8](https://michilehr.de/reduce-integration-test-runtime-while-using-mysql/): schema setup went from 0.779s to 3.802s, adding about 25 minutes to a 500 test suite. Holding the data directory in memory recovered about half of it.

## Change

Two flags and a tmpfs mount on the existing service container:

- `--tmpfs /var/lib/mysql:rw,size=4g` takes the disk out of the DDL path. The data is deleted at the end of the job either way. An empty schema measures about 13MB, so 122 of them plus the base install come to roughly 2GB, inside the 4g cap and comfortable on a 16GB runner.
- `--skip-log-bin` because a throwaway database has no use for a binary log, and with tmpfs it would otherwise grow in the same memory.
- `--performance-schema=OFF`, which MariaDB also defaults to off.

Server flags are passed with the `command:` key, [added to service containers in April 2026](https://github.blog/changelog/2026-04-02-github-actions-early-april-2026-updates/).

## Measurements

`@vendure/core` vitest `Duration` for the `22.x` job. All runs have the same 12 job shape, and **the untouched `mariadb` job is used as a control** to show the runners were comparable.

| | run | mysql | mariadb (control) | ratio |
|---|---|---|---|---|
| baseline | 33491703673 | 801.25s | 577.93s | 1.39x |
| baseline | 33481706888 | 843.03s | 584.33s | 1.44x |
| baseline | 33377501134 | 843.16s | 574.22s | 1.47x |
| **baseline mean** | | **829.15s** | **578.83s** | **1.43x** |
| after | 33507241789 | 743.33s | 570.25s | 1.30x |
| after | 33509281677 | 720.72s | 584.32s | 1.23x |
| **after mean** | | **732.03s** | **577.29s** | **1.27x** |

MySQL is **11.7% faster** while the control moved 0.3%. The two groups do not overlap: the slowest run after the change (743.33s) is still faster than the quickest before it (801.25s).

The gap against MariaDB narrows from 1.43x to 1.27x. It does not close, and it will not: the remaining difference is the atomic DDL cost, which is inherent to MySQL 8 and not configurable.

## What did not work

The first version of this PR disabled only the binary log, on the theory that `log_bin=ON` plus `sync_binlog=1` (both off in MariaDB) meant two fsyncs per commit. A synthetic benchmark of 500 single row commits supported it, showing 0.68s against 0.21s.

It made no difference in CI: mysql 812.42s against a 801.25s baseline, with the control drifting in the same run. The benchmark measured raw commit rate on one connection, which is not the shape of this suite. [MySQL bug 106390](https://bugs.mysql.com/bug.php?id=106390) reports the same null result from the other direction, where disabling the redo log moved a schema import only from 3.008s to 2.785s.

The flag is kept because it stops the binary log consuming tmpfs, not for its own sake.

## Not addressed

This does nothing for the long tail, where the job has reached 44 and 84 minutes. In run 33492669124 every spec file was uniformly 3 to 6 times slower while `collect` was faster than baseline, so CPU was fine and only database time inflated. That looks like runner disk contention, and moving the data directory into memory may help it, but I have no measurement either way.

The larger win would be not rebuilding the schema for every spec file at all, which is what halved the runtime in the write-up linked above. That means reworking `MysqlInitializer` and changes test isolation for every database, so it is a separate discussion.
