### PR TITLE
fix(core): allow external auth to set an Administrator avatar

### DIFF
--- a/packages/core/e2e/authentication-strategy.e2e-spec.ts
+++ b/packages/core/e2e/authentication-strategy.e2e-spec.ts
@@ -13,6 +13,7 @@ import {
     TestAuthenticationStrategy,
     TestAuthenticationStrategy2,
     TestSSOStrategyAdmin,
+    TestSSOStrategyAdminAvatarSync,
     TestSSOStrategyShop,
     TestUnverifiedEmailStrategy,
     VALID_AUTH_TOKEN,
@@ -54,7 +55,11 @@ describe('AuthenticationStrategy', () => {
                     new TestSSOStrategyShop(),
                     new TestUnverifiedEmailStrategy(),
                 ],
-                adminAuthenticationStrategy: [new NativeAuthenticationStrategy(), new TestSSOStrategyAdmin()],
+                adminAuthenticationStrategy: [
+                    new NativeAuthenticationStrategy(),
+                    new TestSSOStrategyAdmin(),
+                    new TestSSOStrategyAdminAvatarSync(),
+                ],
             },
         }),
     );
@@ -313,6 +318,48 @@ describe('AuthenticationStrategy', () => {
             currentUserGuard.assertSuccess(shopAuth);
 
             expect(adminAuth.id).not.toBe(shopAuth.id);
+        });
+
+        // A strategy runs while the request is still anonymous, so setAdministratorAvatar() cannot
+        // read the Administrator through a permission-scoped lookup.
+        it('a strategy can synchronize the Administrator avatar during authentication', async () => {
+            const emailAddress = 'avatar-sync@test-domain.com';
+            await adminClient.asAnonymousUser();
+            const { authenticate: firstLogin } = await adminClient.query(authenticateDocument, {
+                input: {
+                    test_sso_strategy_admin_avatar_sync: {
+                        email: emailAddress,
+                        avatarFilename: 'first-profile.png',
+                    },
+                },
+            });
+            currentUserGuard.assertSuccess(firstLogin);
+
+            const { activeAdministrator: afterFirstLogin } = await adminClient.query(
+                getActiveAdministratorAvatarDocument,
+            );
+            expect(afterFirstLogin?.avatar).toMatchObject({
+                mimeType: 'image/png',
+            });
+            expect(afterFirstLogin?.avatar?.source).toContain('first-profile.png');
+
+            // Logging in again syncs a new image, which replaces the one already stored.
+            await adminClient.asAnonymousUser();
+            const { authenticate: secondLogin } = await adminClient.query(authenticateDocument, {
+                input: {
+                    test_sso_strategy_admin_avatar_sync: {
+                        email: emailAddress,
+                        avatarFilename: 'second-profile.png',
+                    },
+                },
+            });
+            currentUserGuard.assertSuccess(secondLogin);
+
+            const { activeAdministrator: afterSecondLogin } = await adminClient.query(
+                getActiveAdministratorAvatarDocument,
+            );
+            expect(afterSecondLogin?.avatar?.source).toContain('second-profile.png');
+            expect(afterSecondLogin?.avatar?.id).not.toBe(afterFirstLogin?.avatar?.id);
         });
     });
 

--- a/packages/core/e2e/fixtures/test-authentication-strategies.ts
+++ b/packages/core/e2e/fixtures/test-authentication-strategies.ts
@@ -116,6 +116,63 @@ export class TestSSOStrategyAdmin implements AuthenticationStrategy<{ email: str
 }
 
 /**
+ * Synchronizes the provider profile image on every login through
+ * ExternalAuthenticationService.setAdministratorAvatar(), which is the flow that method's
+ * documentation describes. The Administrator is deliberately created without an avatar, so an avatar
+ * which is present afterwards can only have been set by the synchronization.
+ */
+export class TestSSOStrategyAdminAvatarSync implements AuthenticationStrategy<{
+    email: string;
+    avatarFilename: string;
+}> {
+    readonly name = 'test_sso_strategy_admin_avatar_sync';
+    private externalAuthenticationService: ExternalAuthenticationService;
+    private roleService: RoleService;
+
+    init(injector: Injector) {
+        this.externalAuthenticationService = injector.get(ExternalAuthenticationService);
+        this.roleService = injector.get(RoleService);
+    }
+
+    defineInputType(): DocumentNode {
+        return gql`
+            input TestSSOInputAdminAvatarSync {
+                email: String!
+                avatarFilename: String!
+            }
+        `;
+    }
+
+    async authenticate(
+        ctx: RequestContext,
+        data: { email: string; avatarFilename: string },
+    ): Promise<User | false | string> {
+        const { email, avatarFilename } = data;
+        let user = await this.externalAuthenticationService.findUser(ctx, this.name, email);
+        if (!user) {
+            const superAdminRole = await this.roleService.getSuperAdminRole();
+            user = await this.externalAuthenticationService.createAdministratorAndUser(ctx, {
+                strategy: this.name,
+                externalIdentifier: email,
+                emailAddress: email,
+                firstName: 'Avatar Sync SSO Admin First Name',
+                lastName: 'Avatar Sync SSO Admin Last Name',
+                identifier: email,
+                roles: [superAdminRole],
+            });
+        }
+        // The request is still anonymous here, because the session is only minted once this method
+        // has returned the User.
+        await this.externalAuthenticationService.setAdministratorAvatar(ctx, user.id, {
+            filename: avatarFilename,
+            mimetype: 'image/png',
+            createReadStream: () => Readable.from([TEST_ADMIN_AVATAR]),
+        });
+        return user;
+    }
+}
+
+/**
  * The same as TestSSOStrategyAdmin under a different name, so that a test can register it on the
  * Shop API only. The Admin API then has no input field for it, and a Shop-minted session is the only
  * route to the administrator's permissions on the Admin API.

--- a/packages/core/src/service/helpers/external-authentication/external-authentication.service.spec.ts
+++ b/packages/core/src/service/helpers/external-authentication/external-authentication.service.spec.ts
@@ -31,13 +31,15 @@ describe('ExternalAuthenticationService', () => {
         const administrator = new Administrator({ id: 42 });
         const administratorService = {
             findOneByUserId: vi.fn().mockResolvedValue(administrator),
-            setAvatar: vi.fn().mockResolvedValue(administrator),
+            setAvatarWithoutVisibilityCheck: vi.fn().mockResolvedValue(administrator),
         };
         const service = createService(administratorService);
 
         await expect(service.setAdministratorAvatar(ctx, 7, avatar)).resolves.toBe(administrator);
         expect(administratorService.findOneByUserId).toHaveBeenCalledWith(ctx, 7);
-        expect(administratorService.setAvatar).toHaveBeenCalledWith(ctx, 42, avatar);
+        // The visibility-scoped setAvatar() is not used, because a strategy calls this while the
+        // request is still anonymous.
+        expect(administratorService.setAvatarWithoutVisibilityCheck).toHaveBeenCalledWith(ctx, 42, avatar);
     });
 
     it('fails when the User is not associated with an Administrator', async () => {

--- a/packages/core/src/service/helpers/external-authentication/external-authentication.service.ts
+++ b/packages/core/src/service/helpers/external-authentication/external-authentication.service.ts
@@ -225,7 +225,13 @@ export class ExternalAuthenticationService {
         );
 
         if (config.avatar) {
-            await this.administratorService.setAvatar(ctx, administrator.id, config.avatar);
+            // The request is still anonymous at this point, so the visibility-scoped setAvatar()
+            // would not find the Administrator which has just been created above.
+            await this.administratorService.setAvatarWithoutVisibilityCheck(
+                ctx,
+                administrator.id,
+                config.avatar,
+            );
         }
 
         return savedUser;
@@ -259,7 +265,9 @@ export class ExternalAuthenticationService {
         if (!administrator) {
             throw new EntityNotFoundError('Administrator', userId);
         }
-        return this.administratorService.setAvatar(ctx, administrator.id, avatar);
+        // An authentication strategy calls this while the request is still anonymous, which the
+        // visibility rule applied by setAvatar() would reject.
+        return this.administratorService.setAvatarWithoutVisibilityCheck(ctx, administrator.id, avatar);
     }
 
     async findUser(

--- a/packages/core/src/service/services/administrator.service.ts
+++ b/packages/core/src/service/services/administrator.service.ts
@@ -67,9 +67,10 @@ export class AdministratorService {
     ) {}
 
     /**
-     * Replaces or removes profile-owned media for an Administrator. The new files are
-     * persisted before the old files are deleted so a failed upload never destroys the
-     * currently-visible avatar.
+     * Replaces or removes profile-owned media for an Administrator.
+     *
+     * The Administrator is read through {@link AdministratorService.findOne}, so an Administrator
+     * which is not visible to the active user cannot have their avatar changed.
      */
     async setAvatar(
         ctx: RequestContext,
@@ -80,6 +81,51 @@ export class AdministratorService {
         if (!administrator) {
             throw new EntityNotFoundError('Administrator', administratorId);
         }
+        return this.writeAvatar(ctx, administrator, upload);
+    }
+
+    /**
+     * Replaces or removes profile-owned media for an Administrator without applying the visibility
+     * rule that {@link AdministratorService.setAvatar} applies.
+     *
+     * External authentication runs while the request is still anonymous: the session is minted only
+     * once the strategy has returned a User. An anonymous active user holds no permissions, so the
+     * visibility rule hides every Administrator from it, including the one the strategy has just
+     * created. A strategy which synchronizes a provider profile image therefore cannot go through
+     * the visibility-scoped read.
+     *
+     * The caller is responsible for establishing that it may write to this Administrator. Do not
+     * use this method to serve a request whose Administrator id comes from the client.
+     *
+     * @internal
+     */
+    async setAvatarWithoutVisibilityCheck(
+        ctx: RequestContext,
+        administratorId: ID,
+        upload: Promise<StoredMediaUpload> | StoredMediaUpload | null,
+    ): Promise<Administrator> {
+        const administrator = await this.connection.getRepository(ctx, Administrator).findOne({
+            relations: { avatar: true },
+            where: {
+                id: administratorId,
+                deletedAt: IsNull(),
+            },
+        });
+        if (!administrator) {
+            throw new EntityNotFoundError('Administrator', administratorId);
+        }
+        return this.writeAvatar(ctx, administrator, upload);
+    }
+
+    /**
+     * Writes the avatar of an already-loaded Administrator. The new files are persisted before the
+     * old files are deleted so a failed upload never destroys the currently-visible avatar.
+     */
+    private async writeAvatar(
+        ctx: RequestContext,
+        administrator: Administrator,
+        upload: Promise<StoredMediaUpload> | StoredMediaUpload | null,
+    ): Promise<Administrator> {
         const previousAvatar = administrator.avatar;
 
         if (upload == null) {


### PR DESCRIPTION
## What this fixes

The e2e tests for `@vendure/core` have been failing on `minor` since the back-merge in
PR 5150, on every database. Two test files fail, four tests in total:

```
FAIL  e2e/authentication-strategy.e2e-spec.ts
FAIL  e2e/session-api-type-binding.e2e-spec.ts
```

The whole job looks worse than it is, because Nx does not honour the `--no-bail` flag in the
root `e2e` script and stops the other five packages from running once core fails. That is a
separate problem and is not addressed here.

## Root cause

The failures all come from one bug, and it is a case where neither side of the back-merge was
wrong on its own.

`minor` added the Administrator avatar feature. An authentication strategy can now pass an
`avatar` to `ExternalAuthenticationService.createAdministratorAndUser()`, which calls
`AdministratorService.setAvatar()`. That method reads the Administrator back through
`AdministratorService.findOne()`.

`master` hardened `findOne()` with the Administrator visibility rule: it returns `undefined`
unless `roleService.activeUserHasPermissionsOfRoles()` passes for the active user.

External authentication runs while the request is still anonymous, because the session is only
minted once the strategy has returned a User. An anonymous active user holds no permissions, so
the visibility rule hides every Administrator from it, including the one the strategy has just
created. `findOne()` returns `undefined` and `setAvatar()` throws:

```
No Administrator with the id "2" could be found
```

Id 2 is the Administrator the SSO strategy creates during the test; the seed SuperAdmin is id 1.

The two `FORBIDDEN` failures in `authentication-strategy.e2e-spec.ts` are collateral. The test at
line 291 calls `adminClient.asAnonymousUser()`, the SSO login then throws, and the shared
`adminClient` is left anonymous for the rest of the file, so every later `createCustomer` is
rejected.

`ExternalAuthenticationService.setAdministratorAvatar()` had the same bug. It is public API for
strategy authors and its documented use is during authentication, so it runs under the same
anonymous context. No e2e test covered it, and its unit test mocked `setAvatar()`, so the failure
was invisible.

## The change

`AdministratorService` now separates the read policy from the write:

- `setAvatar()` keeps its current behaviour. It still reads through the visibility-scoped
  `findOne()`, so an Administrator who is not visible to the active user cannot have their avatar
  changed. Its only caller is the `setActiveAdministratorAvatar` resolver.
- `setAvatarWithoutVisibilityCheck()` is new and marked `@internal`. It loads the Administrator
  directly from the repository, with the `avatar` relation and the same `deletedAt: IsNull()`
  filter, and applies no permission check. The caller is responsible for establishing that it may
  write to that Administrator.
- `writeAvatar()` is a private method holding the body both variants share, including the ordering
  that persists the new files before deleting the old ones so a failed upload never destroys the
  currently-visible avatar.

`ExternalAuthenticationService` calls the unchecked variant from both places that run under an
anonymous request: `createAdministratorAndUser()` and `setAdministratorAvatar()`.

The visibility check is kept on `setAvatar()` even though its one caller resolves the Administrator
from `ctx.activeUserId` and so can never fail the check. It costs nothing and it stops a future
resolver which takes a client-supplied Administrator id from inheriting an unchecked write.

## Verification

The failure was reproduced locally before the fix, with the same message and the same id:

```
→ No Administrator with the id "2" could be found
Tests  2 failed | 11 passed | 3 skipped (16)
```

After the fix, on sqljs:

| Suite | Result |
| --- | --- |
| `authentication-strategy`, `session-api-type-binding`, `administrator`, `administrator-visibility`, `administrator-update-privesc-guard`, `role` e2e | 133 passed |
| `@vendure/core` unit tests | 108 files, 1511 passed |

ESLint, Prettier and `tsc` are clean on the changed files. Only sqljs was run locally; the CI
failure was identical on postgres and mariadb and the fix is not dialect-specific.

## Test coverage for `setAdministratorAvatar()`

The first version of this branch verified `setAdministratorAvatar()` only with a mock, which is the
same class of test that let the original bug through. It now has a real e2e test.

`TestSSOStrategyAdminAvatarSync` is a new fixture strategy which synchronizes a profile image on
every login by calling `setAdministratorAvatar()`, which is the flow that method's documentation
describes. It creates the Administrator without an avatar, so an avatar which is present afterwards
can only have been set by the synchronization. The test logs in twice with different filenames and
asserts that the first image is stored and that the second replaces it, which also exercises the
path that deletes the previous Asset.

The test was confirmed to fail without the service fix, with the same error as the original
failure:

```
FAIL  e2e/authentication-strategy.e2e-spec.ts > AuthenticationStrategy > external auth > a strategy can synchronize the Administrator avatar during authentication
Error: No Administrator with the id "2" could be found
```

The unit test for `setAdministratorAvatar()` still asserts that the unchecked method is the one
called. That covers the wiring; the e2e test covers the behaviour against a real database.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790860362&installation_model_id=20193&pr_number=5243&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5243&signature=d48adad2099964a8407d7cc1a92cb96f79de1c15e75ec0a2571afde29acae8d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
