### PR TITLE
fix(core): include Session custom fields in the cached session

### DIFF
--- a/packages/core/e2e/session-custom-fields.e2e-spec.ts
+++ b/packages/core/e2e/session-custom-fields.e2e-spec.ts
@@ -1,0 +1,143 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import {
+    CachedSession,
+    Ctx,
+    mergeConfig,
+    PluginCommonModule,
+    RequestContext,
+    Session,
+    SessionCacheStrategy,
+    TransactionalConnection,
+    VendurePlugin,
+} from '@vendure/core';
+import { createTestEnvironment } from '@vendure/testing';
+import gql from 'graphql-tag';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { initialData } from '../../../e2e-common/e2e-initial-data';
+import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
+
+declare module '@vendure/core/dist/entity/custom-entity-fields' {
+    interface CustomSessionFields {
+        testField?: string;
+        testDate?: Date;
+    }
+}
+
+const setSpy = vi.fn();
+
+class TestingSessionCacheStrategy implements SessionCacheStrategy {
+    private cache = new Map<string, CachedSession>();
+
+    get(sessionToken: string) {
+        return this.cache.get(sessionToken);
+    }
+
+    set(session: CachedSession) {
+        setSpy(session);
+        this.cache.set(session.token, session);
+    }
+
+    delete(sessionToken: string) {
+        this.cache.delete(sessionToken);
+    }
+
+    clear() {
+        this.cache.clear();
+    }
+}
+
+@Resolver()
+class SessionCustomFieldsTestResolver {
+    constructor(private connection: TransactionalConnection) {}
+
+    @Query()
+    sessionCustomFields(@Ctx() ctx: RequestContext) {
+        return ctx.session?.customFields;
+    }
+
+    @Mutation()
+    async setSessionCustomFields(@Ctx() ctx: RequestContext, @Args() args: { value: string; date: Date }) {
+        const sessionRepository = this.connection.rawConnection.getRepository(Session);
+        const session = await sessionRepository.findOneOrFail({ where: { id: ctx.session!.id } });
+        session.customFields = { ...session.customFields, testField: args.value, testDate: args.date };
+        await sessionRepository.save(session);
+        return true;
+    }
+}
+
+@VendurePlugin({
+    imports: [PluginCommonModule],
+    adminApiExtensions: {
+        schema: gql`
+            extend type Query {
+                sessionCustomFields: JSON
+            }
+            extend type Mutation {
+                setSessionCustomFields(value: String!, date: DateTime!): Boolean!
+            }
+        `,
+        resolvers: [SessionCustomFieldsTestResolver],
+    },
+})
+class SessionCustomFieldsTestPlugin {}
+
+describe('Session custom fields', () => {
+    const { server, adminClient } = createTestEnvironment(
+        mergeConfig(testConfig(), {
+            authOptions: {
+                sessionCacheStrategy: new TestingSessionCacheStrategy(),
+                sessionCacheTTL: 2,
+            },
+            customFields: {
+                Session: [
+                    { name: 'testField', type: 'string', nullable: true },
+                    { name: 'testDate', type: 'datetime', nullable: true },
+                ],
+            },
+            plugins: [SessionCustomFieldsTestPlugin],
+        }),
+    );
+
+    beforeAll(async () => {
+        await server.init({
+            initialData,
+            productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-minimal.csv'),
+            customerCount: 1,
+        });
+        await adminClient.asSuperAdmin();
+    }, TEST_SETUP_TIMEOUT_MS);
+
+    afterAll(async () => {
+        await server.destroy();
+    });
+
+    it('includes custom fields in the cached session', async () => {
+        await adminClient.query(gql`
+            mutation {
+                setSessionCustomFields(value: "hello", date: "2025-01-01T12:00:00.000Z")
+            }
+        `);
+
+        // Wait for the cache TTL to expire, so that the session gets
+        // reloaded from the database and cached again.
+        await pause(2100);
+        setSpy.mockClear();
+
+        const { sessionCustomFields } = await adminClient.query(gql`
+            query {
+                sessionCustomFields
+            }
+        `);
+
+        const expected = { testField: 'hello', testDate: '2025-01-01T12:00:00.000Z' };
+        expect(setSpy.mock.lastCall?.[0].customFields).toEqual(expected);
+        expect(sessionCustomFields).toEqual(expected);
+    });
+});
+
+function pause(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/core/src/config/session-cache/session-cache-strategy.ts
+++ b/packages/core/src/config/session-cache/session-cache-strategy.ts
@@ -2,7 +2,26 @@ import { ID } from '@vendure/common/lib/shared-types';
 
 import { ApiType } from '../../api/common/get-api-type';
 import { InjectableStrategy } from '../../common/types/injectable-strategy';
+import { CustomSessionFields } from '../../entity/custom-entity-fields';
 import { UserChannelPermissions } from '../../service/helpers/utils/get-user-channels-permissions';
+
+/**
+ * A `datetime` custom field is a Date on the Session entity, but an ISO string in the cache.
+ */
+type CachedValue<T> = T extends Date ? string : T;
+
+/**
+ * @description
+ * The custom fields of a Session as they are stored in the cache. Custom fields of type
+ * `relation` are not included, and `datetime` values are stored as ISO strings.
+ *
+ * @docsCategory auth
+ * @docsPage SessionCacheStrategy
+ * @since 3.8.0
+ */
+export type CachedSessionCustomFields = {
+    [K in keyof CustomSessionFields]: CachedValue<CustomSessionFields[K]>;
+};
 
 /**
  * @description
@@ -51,6 +70,13 @@ export type CachedSession = {
      * @since 3.8.0
      */
     apiType?: ApiType;
+    /**
+     * @description
+     * The custom fields defined on the Session entity, if any.
+     *
+     * @since 3.8.0
+     */
+    customFields?: CachedSessionCustomFields;
 };
 
 /**

--- a/packages/core/src/service/services/session.service.ts
+++ b/packages/core/src/service/services/session.service.ts
@@ -9,7 +9,11 @@ import { DeserializedCachedSession, RequestContext } from '../../api/common/requ
 import { Instrument } from '../../common/instrument-decorator';
 import { API_KEY_AUTH_STRATEGY_DEFAULT_DURATION_MS, API_KEY_AUTH_STRATEGY_NAME, Logger } from '../../config';
 import { ConfigService } from '../../config/config.service';
-import { CachedSession, SessionCacheStrategy } from '../../config/session-cache/session-cache-strategy';
+import {
+    CachedSession,
+    CachedSessionCustomFields,
+    SessionCacheStrategy,
+} from '../../config/session-cache/session-cache-strategy';
 import { findOptionsArrayToObject } from '../../connection/find-options-array-to-object';
 import { TransactionalConnection } from '../../connection/transactional-connection';
 import { ApiKey } from '../../entity/api-key/api-key.entity';
@@ -244,7 +248,34 @@ export class SessionService implements EntitySubscriberInterface, OnModuleInit {
                 channelPermissions: getUserChannelsPermissions(user),
             };
         }
+        const customFields = this.serializeSessionCustomFields(session);
+        if (customFields) {
+            serializedSession.customFields = customFields;
+        }
         return serializedSession;
+    }
+
+    /**
+     * Returns a plain copy of the custom fields defined on the Session entity, or undefined if there
+     * are none. Custom fields of type `relation` are left out, since the cached session should stay
+     * small and easy to store. `datetime` values are converted to ISO strings, so that they look the
+     * same whether the session comes fresh from the database or from a JSON-based cache.
+     */
+    private serializeSessionCustomFields(session: Session): CachedSessionCustomFields | undefined {
+        const customFieldConfigs = this.configService.customFields.Session;
+        if (customFieldConfigs.length === 0) {
+            return;
+        }
+        const sessionCustomFields = (session.customFields ?? {}) as Record<string, unknown>;
+        const customFields: Record<string, unknown> = {};
+        for (const config of customFieldConfigs) {
+            if (config.type === 'relation') {
+                continue;
+            }
+            const value = sessionCustomFields[config.name];
+            customFields[config.name] = value instanceof Date ? value.toISOString() : value;
+        }
+        return customFields as CachedSessionCustomFields;
     }
 
     /**


### PR DESCRIPTION
**⚠️Warning: vibecoded Fable 5.1 slop, but it works.** 

# Description

Custom fields defined on the `Session` entity were dropped by `SessionService.serializeSession()`, so they never reached the session cache and `ctx.session.customFields` was always `undefined`.

This copies them into `CachedSession.customFields`:

- `relation` custom fields are left out, to keep the cached session small and serializable.
- `datetime` values are converted to ISO strings, so they look the same whether the session came fresh from the database or from a JSON-based cache.
- Projects without Session custom fields see no change: the property is only added when some are configured.

Happy to adjust the relation / datetime rules if you'd rather handle those differently.

Closes #4018

# Breaking changes

None.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790887684&installation_model_id=20193&pr_number=5251&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5251&signature=47d273eec6b9ef12b7a6659d1a83c7d33f5fb8da7d3a16811db0e38ceb141e07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->