### PR TITLE
test(core): Add role-escalation authorization regression test (GHSA-rcgx-8gc8-92v7)

### DIFF
--- a/packages/core/e2e/administrator-role-escalation.e2e-spec.ts
+++ b/packages/core/e2e/administrator-role-escalation.e2e-spec.ts
@@ -8,10 +8,10 @@ import { initialData } from '../../../e2e-common/e2e-initial-data';
 import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
 
 import {
-    CREATE_ADMINISTRATOR,
-    CREATE_CHANNEL,
-    CREATE_ROLE,
-    UPDATE_ADMINISTRATOR,
+    createAdministratorDocument,
+    createChannelDocument,
+    createRoleDocument,
+    updateAdministratorDocument,
 } from './graphql/shared-definitions';
 
 const SECOND_CHANNEL_TOKEN = 'second_channel_token';
@@ -22,7 +22,7 @@ const SECOND_CHANNEL_TOKEN = 'second_channel_token';
  *
  * Reported as GHSA-rcgx-8gc8-92v7 (privilege escalation via `assignRoleToAdministrator`)
  * and closed as not reproducible: `assignRole` has no explicit authorization check, but it
- * calls `roleService.findOne`, whose `activeUserCanReadRole` requires the caller to already
+ * calls `roleService.findOne`, whose `activeUserHasPermissionsOnChannelsOf` requires the caller to already
  * hold every permission in the role, so the SuperAdmin grant is refused. This suite pins
  * that guarantee from five attack angles with a maximally-privileged attacker (every
  * admin/role management permission short of SuperAdmin), verifying persisted roles in the
@@ -99,8 +99,6 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
     let superAdminRoleId: string;
     let subsetRoleId: string;
 
-    const log = (m: string) => console.log(`[role-escalation] ${m}`);
-
     async function loginAsAttacker() {
         await adminClient.asUserWithCredentials(attacker.emailAddress, attacker.password);
     }
@@ -125,7 +123,7 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
         const { roles } = await adminClient.query<any>(GET_ROLES);
         superAdminRoleId = roles.items.find((r: any) => r.code === SUPER_ADMIN_ROLE_CODE).id;
 
-        const { createRole } = await adminClient.query<any>(CREATE_ROLE, {
+        const { createRole } = await adminClient.query<any>(createRoleDocument, {
             input: {
                 code: 'attacker-role',
                 description: 'Everything short of SuperAdmin',
@@ -133,7 +131,7 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
                 channelIds: ['1'],
             },
         });
-        const { createRole: subset } = await adminClient.query<any>(CREATE_ROLE, {
+        const { createRole: subset } = await adminClient.query<any>(createRoleDocument, {
             input: {
                 code: 'catalog-reader',
                 description: 'A subset of what the attacker holds',
@@ -143,7 +141,7 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
         });
         subsetRoleId = subset.id;
 
-        const { createAdministrator } = await adminClient.query<any>(CREATE_ADMINISTRATOR, {
+        const { createAdministrator } = await adminClient.query<any>(createAdministratorDocument, {
             input: {
                 emailAddress: attacker.emailAddress,
                 firstName: 'Attacker',
@@ -154,7 +152,7 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
         });
         attackerAdminId = createAdministrator.id;
 
-        const { createAdministrator: victim } = await adminClient.query<any>(CREATE_ADMINISTRATOR, {
+        const { createAdministrator: victim } = await adminClient.query<any>(createAdministratorDocument, {
             input: {
                 emailAddress: 'victim-admin@test.com',
                 firstName: 'Victim',
@@ -167,7 +165,7 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
 
         // A second channel, and an attacker scoped ONLY to it, to test that a channel-scoped
         // admin cannot reach the global SuperAdmin role from a different channel context.
-        const { createChannel } = await adminClient.query<any>(CREATE_CHANNEL, {
+        const { createChannel } = await adminClient.query<any>(createChannelDocument, {
             input: {
                 code: 'second-channel',
                 token: SECOND_CHANNEL_TOKEN,
@@ -178,7 +176,7 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
                 defaultTaxZoneId: '1',
             },
         });
-        const { createRole: channelBRole } = await adminClient.query<any>(CREATE_ROLE, {
+        const { createRole: channelBRole } = await adminClient.query<any>(createRoleDocument, {
             input: {
                 code: 'channel-b-admin',
                 description: 'Admin management on channel B only',
@@ -186,19 +184,19 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
                 channelIds: [createChannel.id],
             },
         });
-        const { createAdministrator: attackerBAdmin } = await adminClient.query<any>(CREATE_ADMINISTRATOR, {
-            input: {
-                emailAddress: attackerB.emailAddress,
-                firstName: 'AttackerB',
-                lastName: 'Admin',
-                password: attackerB.password,
-                roleIds: [channelBRole.id],
+        const { createAdministrator: attackerBAdmin } = await adminClient.query<any>(
+            createAdministratorDocument,
+            {
+                input: {
+                    emailAddress: attackerB.emailAddress,
+                    firstName: 'AttackerB',
+                    lastName: 'Admin',
+                    password: attackerB.password,
+                    roleIds: [channelBRole.id],
+                },
             },
-        });
+        );
         attackerBAdminId = attackerBAdmin.id;
-
-        log(`SuperAdmin role id (enumerable): ${superAdminRoleId}`);
-        log(`Attacker perms: ${ATTACKER_PERMISSIONS.join(', ')}`);
     }, TEST_SETUP_TIMEOUT_MS);
 
     afterAll(async () => {
@@ -208,18 +206,11 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
 
     it('control: attacker CAN assign a role whose permissions it already holds', async () => {
         await loginAsAttacker();
-        let ok = false;
-        try {
-            await adminClient.query<any>(ASSIGN_ROLE, {
-                administratorId: attackerAdminId,
-                roleId: subsetRoleId,
-            });
-            ok = true;
-        } catch (e: any) {
-            log(`control unexpectedly failed: ${e.message ?? e}`);
-        }
-        log(`Control (assign held role): ${ok ? 'SUCCEEDED (mutation is reachable)' : 'FAILED'}`);
-        expect(ok).toBe(true);
+        const { assignRoleToAdministrator } = await adminClient.query<any>(ASSIGN_ROLE, {
+            administratorId: attackerAdminId,
+            roleId: subsetRoleId,
+        });
+        expect(assignRoleToAdministrator.id).toBe(attackerAdminId);
     });
 
     it('vector 1: cannot self-escalate to SuperAdmin via assignRoleToAdministrator', async () => {
@@ -233,7 +224,6 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
         } catch (e: any) {
             err = e.message ?? String(e);
         }
-        log(`Vector 1 (assignRole self -> SuperAdmin): ${err ? `REJECTED (${err})` : 'RETURNED OK'}`);
         expect(err).toBeDefined();
         expect(await adminDbRoles(attackerAdminId)).not.toContain(SUPER_ADMIN_ROLE_CODE);
     });
@@ -242,13 +232,12 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
         await loginAsAttacker();
         let err: string | undefined;
         try {
-            await adminClient.query<any>(UPDATE_ADMINISTRATOR, {
+            await adminClient.query<any>(updateAdministratorDocument, {
                 input: { id: attackerAdminId, roleIds: [superAdminRoleId] },
             });
         } catch (e: any) {
             err = e.message ?? String(e);
         }
-        log(`Vector 2 (updateAdministrator self -> SuperAdmin): ${err ? `REJECTED (${err})` : 'RETURNED OK'}`);
         expect(err).toBeDefined();
         expect(await adminDbRoles(attackerAdminId)).not.toContain(SUPER_ADMIN_ROLE_CODE);
     });
@@ -257,7 +246,7 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
         await loginAsAttacker();
         let err: string | undefined;
         try {
-            await adminClient.query<any>(CREATE_ROLE, {
+            await adminClient.query<any>(createRoleDocument, {
                 input: {
                     code: 'sneaky-superadmin',
                     description: 'attempt to mint a superadmin-equivalent role',
@@ -268,7 +257,6 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
         } catch (e: any) {
             err = e.message ?? String(e);
         }
-        log(`Vector 3 (createRole with SuperAdmin perm): ${err ? `REJECTED (${err})` : 'RETURNED OK'}`);
         expect(err).toBeDefined();
     });
 
@@ -283,7 +271,6 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
         } catch (e: any) {
             err = e.message ?? String(e);
         }
-        log(`Vector 4 (assignRole victim -> SuperAdmin): ${err ? `REJECTED (${err})` : 'RETURNED OK'}`);
         expect(err).toBeDefined();
 
         await adminClient.asSuperAdmin();
@@ -303,7 +290,6 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
         } catch (e: any) {
             err = e.message ?? String(e);
         }
-        log(`Vector 5 (channel-B attacker -> SuperAdmin): ${err ? `REJECTED (${err})` : 'RETURNED OK'}`);
         expect(err).toBeDefined();
         expect(await adminDbRoles(attackerBAdminId)).not.toContain(SUPER_ADMIN_ROLE_CODE);
     });
@@ -314,15 +300,6 @@ describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', ()
         const active = await adminClient.query<any>(ACTIVE_ADMIN);
         const sessionRoles = active.activeAdministrator.user.roles.map((r: any) => r.code);
         const dbRoles = await adminDbRoles(attackerAdminId);
-        log('======================================================================');
-        log(`Attacker session roles: [${sessionRoles.join(', ')}]`);
-        log(`Attacker DB roles:      [${dbRoles.join(', ')}]`);
-        log(
-            dbRoles.includes(SUPER_ADMIN_ROLE_CODE)
-                ? 'VULNERABLE: attacker holds SuperAdmin.'
-                : 'BLOCKED: attacker never obtained SuperAdmin. Advisory does not reproduce.',
-        );
-        log('======================================================================');
         expect(sessionRoles).not.toContain(SUPER_ADMIN_ROLE_CODE);
         expect(dbRoles).not.toContain(SUPER_ADMIN_ROLE_CODE);
     });

--- a/packages/core/e2e/administrator-role-escalation.e2e-spec.ts
+++ b/packages/core/e2e/administrator-role-escalation.e2e-spec.ts
@@ -1,0 +1,329 @@
+import { SUPER_ADMIN_ROLE_CODE } from '@vendure/common/lib/shared-constants';
+import { createTestEnvironment, E2E_DEFAULT_CHANNEL_TOKEN } from '@vendure/testing';
+import gql from 'graphql-tag';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { initialData } from '../../../e2e-common/e2e-initial-data';
+import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
+
+import {
+    CREATE_ADMINISTRATOR,
+    CREATE_CHANNEL,
+    CREATE_ROLE,
+    UPDATE_ADMINISTRATOR,
+} from './graphql/shared-definitions';
+
+const SECOND_CHANNEL_TOKEN = 'second_channel_token';
+
+/**
+ * Regression guard: a non-SuperAdmin administrator must not be able to escalate to
+ * SuperAdmin by assigning roles it does not have the permissions for.
+ *
+ * Reported as GHSA-rcgx-8gc8-92v7 (privilege escalation via `assignRoleToAdministrator`)
+ * and closed as not reproducible: `assignRole` has no explicit authorization check, but it
+ * calls `roleService.findOne`, whose `activeUserCanReadRole` requires the caller to already
+ * hold every permission in the role, so the SuperAdmin grant is refused. This suite pins
+ * that guarantee from five attack angles with a maximally-privileged attacker (every
+ * admin/role management permission short of SuperAdmin), verifying persisted roles in the
+ * DB rather than trusting the session cache. If any vector starts succeeding, the
+ * authorization has regressed.
+ *
+ * Run: cd packages/core && DB=sqljs PACKAGE=core ../../node_modules/.bin/vitest \
+ *   --config ../../e2e-common/vitest.config.mts --run administrator-role-escalation
+ */
+
+const ACTIVE_ADMIN = gql`
+    query {
+        activeAdministrator {
+            id
+            user {
+                roles {
+                    code
+                }
+            }
+        }
+    }
+`;
+
+const GET_ADMIN_ROLES = gql`
+    query ($id: ID!) {
+        administrator(id: $id) {
+            id
+            user {
+                roles {
+                    code
+                }
+            }
+        }
+    }
+`;
+
+const GET_ROLES = gql`
+    query {
+        roles(options: { take: 100 }) {
+            items {
+                id
+                code
+            }
+        }
+    }
+`;
+
+const ASSIGN_ROLE = gql`
+    mutation ($administratorId: ID!, $roleId: ID!) {
+        assignRoleToAdministrator(administratorId: $administratorId, roleId: $roleId) {
+            id
+        }
+    }
+`;
+
+// The maximal admin/role-management set short of SuperAdmin. Role CRUD is gated by the
+// Administrator permissions; there are no separate Role permissions in Vendure.
+const ATTACKER_PERMISSIONS = [
+    'ReadAdministrator',
+    'CreateAdministrator',
+    'UpdateAdministrator',
+    'DeleteAdministrator',
+    'ReadCatalog',
+];
+
+describe('Administrator role-escalation authorization (GHSA-rcgx-8gc8-92v7)', () => {
+    const { server, adminClient } = createTestEnvironment(testConfig());
+
+    const attacker = { emailAddress: 'attacker-admin@test.com', password: 'test-password' };
+    const attackerB = { emailAddress: 'attacker-channel-b@test.com', password: 'test-password' };
+    let attackerAdminId: string;
+    let attackerBAdminId: string;
+    let victimAdminId: string;
+    let superAdminRoleId: string;
+    let subsetRoleId: string;
+
+    const log = (m: string) => console.log(`[role-escalation] ${m}`);
+
+    async function loginAsAttacker() {
+        await adminClient.asUserWithCredentials(attacker.emailAddress, attacker.password);
+    }
+
+    // Reads an admin's persisted roles from the DB perspective (as SuperAdmin on the
+    // default channel), the ground truth independent of session caching.
+    async function adminDbRoles(adminId: string): Promise<string[]> {
+        adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+        await adminClient.asSuperAdmin();
+        const { administrator } = await adminClient.query<any>(GET_ADMIN_ROLES, { id: adminId });
+        return administrator.user.roles.map((r: any) => r.code);
+    }
+
+    beforeAll(async () => {
+        await server.init({
+            initialData,
+            productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-minimal.csv'),
+            customerCount: 1,
+        });
+        await adminClient.asSuperAdmin();
+
+        const { roles } = await adminClient.query<any>(GET_ROLES);
+        superAdminRoleId = roles.items.find((r: any) => r.code === SUPER_ADMIN_ROLE_CODE).id;
+
+        const { createRole } = await adminClient.query<any>(CREATE_ROLE, {
+            input: {
+                code: 'attacker-role',
+                description: 'Everything short of SuperAdmin',
+                permissions: ATTACKER_PERMISSIONS,
+                channelIds: ['1'],
+            },
+        });
+        const { createRole: subset } = await adminClient.query<any>(CREATE_ROLE, {
+            input: {
+                code: 'catalog-reader',
+                description: 'A subset of what the attacker holds',
+                permissions: ['ReadCatalog'],
+                channelIds: ['1'],
+            },
+        });
+        subsetRoleId = subset.id;
+
+        const { createAdministrator } = await adminClient.query<any>(CREATE_ADMINISTRATOR, {
+            input: {
+                emailAddress: attacker.emailAddress,
+                firstName: 'Attacker',
+                lastName: 'Admin',
+                password: attacker.password,
+                roleIds: [createRole.id],
+            },
+        });
+        attackerAdminId = createAdministrator.id;
+
+        const { createAdministrator: victim } = await adminClient.query<any>(CREATE_ADMINISTRATOR, {
+            input: {
+                emailAddress: 'victim-admin@test.com',
+                firstName: 'Victim',
+                lastName: 'Admin',
+                password: 'victim-password',
+                roleIds: [subsetRoleId],
+            },
+        });
+        victimAdminId = victim.id;
+
+        // A second channel, and an attacker scoped ONLY to it, to test that a channel-scoped
+        // admin cannot reach the global SuperAdmin role from a different channel context.
+        const { createChannel } = await adminClient.query<any>(CREATE_CHANNEL, {
+            input: {
+                code: 'second-channel',
+                token: SECOND_CHANNEL_TOKEN,
+                defaultLanguageCode: 'en',
+                currencyCode: 'GBP',
+                pricesIncludeTax: true,
+                defaultShippingZoneId: '1',
+                defaultTaxZoneId: '1',
+            },
+        });
+        const { createRole: channelBRole } = await adminClient.query<any>(CREATE_ROLE, {
+            input: {
+                code: 'channel-b-admin',
+                description: 'Admin management on channel B only',
+                permissions: ATTACKER_PERMISSIONS,
+                channelIds: [createChannel.id],
+            },
+        });
+        const { createAdministrator: attackerBAdmin } = await adminClient.query<any>(CREATE_ADMINISTRATOR, {
+            input: {
+                emailAddress: attackerB.emailAddress,
+                firstName: 'AttackerB',
+                lastName: 'Admin',
+                password: attackerB.password,
+                roleIds: [channelBRole.id],
+            },
+        });
+        attackerBAdminId = attackerBAdmin.id;
+
+        log(`SuperAdmin role id (enumerable): ${superAdminRoleId}`);
+        log(`Attacker perms: ${ATTACKER_PERMISSIONS.join(', ')}`);
+    }, TEST_SETUP_TIMEOUT_MS);
+
+    afterAll(async () => {
+        await adminClient.asSuperAdmin();
+        await server.destroy();
+    });
+
+    it('control: attacker CAN assign a role whose permissions it already holds', async () => {
+        await loginAsAttacker();
+        let ok = false;
+        try {
+            await adminClient.query<any>(ASSIGN_ROLE, {
+                administratorId: attackerAdminId,
+                roleId: subsetRoleId,
+            });
+            ok = true;
+        } catch (e: any) {
+            log(`control unexpectedly failed: ${e.message ?? e}`);
+        }
+        log(`Control (assign held role): ${ok ? 'SUCCEEDED (mutation is reachable)' : 'FAILED'}`);
+        expect(ok).toBe(true);
+    });
+
+    it('vector 1: cannot self-escalate to SuperAdmin via assignRoleToAdministrator', async () => {
+        await loginAsAttacker();
+        let err: string | undefined;
+        try {
+            await adminClient.query<any>(ASSIGN_ROLE, {
+                administratorId: attackerAdminId,
+                roleId: superAdminRoleId,
+            });
+        } catch (e: any) {
+            err = e.message ?? String(e);
+        }
+        log(`Vector 1 (assignRole self -> SuperAdmin): ${err ? `REJECTED (${err})` : 'RETURNED OK'}`);
+        expect(err).toBeDefined();
+        expect(await adminDbRoles(attackerAdminId)).not.toContain(SUPER_ADMIN_ROLE_CODE);
+    });
+
+    it('vector 2: cannot self-escalate via updateAdministrator roleIds (sibling path)', async () => {
+        await loginAsAttacker();
+        let err: string | undefined;
+        try {
+            await adminClient.query<any>(UPDATE_ADMINISTRATOR, {
+                input: { id: attackerAdminId, roleIds: [superAdminRoleId] },
+            });
+        } catch (e: any) {
+            err = e.message ?? String(e);
+        }
+        log(`Vector 2 (updateAdministrator self -> SuperAdmin): ${err ? `REJECTED (${err})` : 'RETURNED OK'}`);
+        expect(err).toBeDefined();
+        expect(await adminDbRoles(attackerAdminId)).not.toContain(SUPER_ADMIN_ROLE_CODE);
+    });
+
+    it('vector 3: cannot create a SuperAdmin-permission role to then assign', async () => {
+        await loginAsAttacker();
+        let err: string | undefined;
+        try {
+            await adminClient.query<any>(CREATE_ROLE, {
+                input: {
+                    code: 'sneaky-superadmin',
+                    description: 'attempt to mint a superadmin-equivalent role',
+                    permissions: ['SuperAdmin'],
+                    channelIds: ['1'],
+                },
+            });
+        } catch (e: any) {
+            err = e.message ?? String(e);
+        }
+        log(`Vector 3 (createRole with SuperAdmin perm): ${err ? `REJECTED (${err})` : 'RETURNED OK'}`);
+        expect(err).toBeDefined();
+    });
+
+    it('vector 4: cannot push SuperAdmin onto another administrator', async () => {
+        await loginAsAttacker();
+        let err: string | undefined;
+        try {
+            await adminClient.query<any>(ASSIGN_ROLE, {
+                administratorId: victimAdminId,
+                roleId: superAdminRoleId,
+            });
+        } catch (e: any) {
+            err = e.message ?? String(e);
+        }
+        log(`Vector 4 (assignRole victim -> SuperAdmin): ${err ? `REJECTED (${err})` : 'RETURNED OK'}`);
+        expect(err).toBeDefined();
+
+        await adminClient.asSuperAdmin();
+        const { administrator } = await adminClient.query<any>(GET_ADMIN_ROLES, { id: victimAdminId });
+        expect(administrator.user.roles.map((r: any) => r.code)).not.toContain(SUPER_ADMIN_ROLE_CODE);
+    });
+
+    it('vector 5: a channel-scoped admin cannot reach the global SuperAdmin role', async () => {
+        adminClient.setChannelToken(SECOND_CHANNEL_TOKEN);
+        await adminClient.asUserWithCredentials(attackerB.emailAddress, attackerB.password);
+        let err: string | undefined;
+        try {
+            await adminClient.query<any>(ASSIGN_ROLE, {
+                administratorId: attackerBAdminId,
+                roleId: superAdminRoleId,
+            });
+        } catch (e: any) {
+            err = e.message ?? String(e);
+        }
+        log(`Vector 5 (channel-B attacker -> SuperAdmin): ${err ? `REJECTED (${err})` : 'RETURNED OK'}`);
+        expect(err).toBeDefined();
+        expect(await adminDbRoles(attackerBAdminId)).not.toContain(SUPER_ADMIN_ROLE_CODE);
+    });
+
+    it('summary: attacker never became SuperAdmin by any vector', async () => {
+        adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+        await loginAsAttacker();
+        const active = await adminClient.query<any>(ACTIVE_ADMIN);
+        const sessionRoles = active.activeAdministrator.user.roles.map((r: any) => r.code);
+        const dbRoles = await adminDbRoles(attackerAdminId);
+        log('======================================================================');
+        log(`Attacker session roles: [${sessionRoles.join(', ')}]`);
+        log(`Attacker DB roles:      [${dbRoles.join(', ')}]`);
+        log(
+            dbRoles.includes(SUPER_ADMIN_ROLE_CODE)
+                ? 'VULNERABLE: attacker holds SuperAdmin.'
+                : 'BLOCKED: attacker never obtained SuperAdmin. Advisory does not reproduce.',
+        );
+        log('======================================================================');
+        expect(sessionRoles).not.toContain(SUPER_ADMIN_ROLE_CODE);
+        expect(dbRoles).not.toContain(SUPER_ADMIN_ROLE_CODE);
+    });
+});


### PR DESCRIPTION
Adds an e2e suite that pins the authorization behaviour behind `assignRoleToAdministrator`.

## Why

GHSA-rcgx-8gc8-92v7 reported that `AdministratorService.assignRole()` has no authorization check, so an administrator holding `UpdateAdministrator` could grant itself the SuperAdmin role. The report was source-verified only and was closed on 2026-08-18 as not exploitable: `assignRole()` resolves the role through `RoleService.findOne()`, which returns `undefined` unless the caller already holds every permission of that role on every channel it is assigned to, so the grant fails with an entity-not-found error.

That guard exists only as a side effect of `findOne()`. Nothing in the suite asserted it, so a refactor of `RoleService.findOne()` or of `assignRole()` could reopen the escalation without a failing test. This suite makes the guarantee explicit.

## What the suite checks

An attacker holding every administrator permission short of SuperAdmin, plus a second attacker scoped to a non-default channel. Persisted roles are read back as SuperAdmin after each attempt, so the assertions do not depend on the session cache.

- Control: the attacker can assign a role whose permissions it already holds.
- Vector 1: `assignRoleToAdministrator` with the SuperAdmin role on itself is refused.
- Vector 2: `updateAdministrator` with the SuperAdmin role id is refused (sibling path, already guarded explicitly).
- Vector 3: `createRole` with the SuperAdmin permission is refused, so there is no role to assign.
- Vector 4: pushing SuperAdmin onto another administrator is refused.
- Vector 5: a channel-scoped administrator cannot reach the global SuperAdmin role.
- Summary: no attempt left either attacker with the SuperAdmin role.

No production code changes.

## Verification

```
DB=sqljs PACKAGE=core vitest --config ../../e2e-common/vitest.config.mts --run administrator-role-escalation
Test Files  1 passed (1)
Tests  7 passed (7)
```

Run against master at `34af53ea2`, after the 37j3 changes to `RoleService`.

Relates to Linear OSS-676.

https://claude.ai/code/session_01FxkXep7b3S9eF4jozyBwEE

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790935742&installation_model_id=20193&pr_number=5254&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5254&signature=52a5e153e37a5dbba2d0e8b481010f4cd1a26319d0e1a55bbc3f4cafe2008d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->