### PR TITLE
fix(asset-server-plugin): derive served Content-Type from the file bytes

### DIFF
--- a/packages/asset-server-plugin/e2e/asset-server-plugin.e2e-spec.ts
+++ b/packages/asset-server-plugin/e2e/asset-server-plugin.e2e-spec.ts
@@ -262,6 +262,21 @@ describe('AssetServerPlugin', () => {
             expect(res.headers.get('x-content-type-options')).toBe('nosniff');
             expect(res.headers.get('content-security-policy')).toBe(BASE_CSP);
         });
+
+        // A rasterised SVG used to be served as `image/svg+xml`, which sandboxed and
+        // force-downloaded it. Checked twice: once generated, once from cache.
+        it('serves a transformed SVG as the rasterised type, not as SVG', async () => {
+            const svgAsset = await uploadAsset('test.svg');
+
+            for (const pass of ['generated', 'from cache']) {
+                const res = await fetch(`${svgAsset.source}?w=100`);
+
+                expect(res.headers.get('content-type'), pass).toContain('image/png');
+                expect(res.headers.get('content-disposition'), pass).toBeNull();
+                expect(res.headers.get('x-content-type-options'), pass).toBe('nosniff');
+                expect(res.headers.get('content-security-policy'), pass).toBe(BASE_CSP);
+            }
+        });
     });
 
     describe('unexpected input', () => {

--- a/packages/asset-server-plugin/src/asset-server.ts
+++ b/packages/asset-server-plugin/src/asset-server.ts
@@ -98,10 +98,7 @@ export class AssetServer {
             const key = this.getFileNameFromParameters(req.path, params);
             try {
                 const file = await this.assetStorageStrategy.readFileToBuffer(key);
-                let mimeType = this.getMimeType(key);
-                if (!mimeType) {
-                    mimeType = (await getFileType(file))?.mime || 'application/octet-stream';
-                }
+                const mimeType = await this.resolveMimeType(file, key);
                 res.contentType(mimeType);
                 this.setAssetSecurityHeaders(res, mimeType);
                 res.setHeader('Cache-Control', this.cacheHeader);
@@ -141,10 +138,7 @@ export class AssetServer {
                             await this.assetStorageStrategy.writeFileFromBuffer(cachedFileName, imageBuffer);
                             Logger.debug(`Saved cached asset: ${cachedFileName}`, loggerCtx);
                         }
-                        let mimeType = this.getMimeType(cachedFileName);
-                        if (!mimeType) {
-                            mimeType = (await getFileType(imageBuffer))?.mime || 'image/jpeg';
-                        }
+                        const mimeType = await this.resolveMimeType(imageBuffer, cachedFileName);
                         res.set('Content-Type', mimeType);
                         this.setAssetSecurityHeaders(res, mimeType);
                         res.send(imageBuffer);
@@ -297,10 +291,19 @@ export class AssetServer {
     }
 
     /**
-     * Attempt to get the mime type from the file name.
+     * The mime type to declare for a file about to be served. The bytes win over the file name,
+     * because a transform is cached under the source asset's extension: an SVG rasterised by
+     * sharp is a PNG stored as `.svg`. Text-based formats have no signature, so they fall back
+     * to the name.
      */
-    private getMimeType(fileName: string): string | undefined {
-        return mime.lookup(fileName) || undefined;
+    private async resolveMimeType(buffer: Buffer, fileName: string): Promise<string> {
+        const fromFileName = mime.lookup(fileName) || undefined;
+        const detected = (await getFileType(buffer))?.mime;
+        // `file-type` reports any XML document as `application/xml`; the name is more specific.
+        if (detected === 'application/xml' && fromFileName?.endsWith('+xml')) {
+            return fromFileName;
+        }
+        return detected || fromFileName || 'application/octet-stream';
     }
 
     /**


### PR DESCRIPTION
## Problem

`getFileNameFromParameters` keeps the source asset's extension when a transform request has no `format` param, and the served `Content-Type` was derived from that file name. So `/<asset>.svg?w=100` was served as `image/svg+xml` even though sharp had rasterised the body to a PNG.

That mime value also decides the security headers added in #5102: the mislabelled response got the markup CSP (`sandbox`) and `Content-Disposition: attachment`, so a browser downloaded the transformed image instead of rendering it. With `X-Content-Type-Options: nosniff` it could not recover by sniffing either.

The mislabelling is pre-existing; #5102 is what made it visible.

## Change

`getMimeType(fileName)` is replaced by `resolveMimeType(buffer, fileName)`, used by both serve paths (`sendAsset` and `generateTransformedImage`). The file's own signature takes precedence, with the file name as the fallback for text-based formats which have no signature to detect.

One guard: `file-type` reports every XML document as `application/xml`, so for a `+xml` file name the more specific name-derived type is kept. Without it, real SVG sources would have been served as `application/xml`.

This also corrects any other asset whose bytes disagree with its name, and it fixes the cache-hit path as well as the first request, since the cached file is still stored under the source extension.

## Test

`serves a transformed SVG as the rasterised type, not as SVG` in `asset-server-plugin.e2e-spec.ts` fetches `test.svg?w=100` twice, so it covers the generated response and the later cache hit, and asserts `image/png` with the non-markup headers. It fails on master and passes here.

Full `asset-server-plugin` e2e suite: 41/41 passing.

## Known limitation

The cache file on disk still carries the source extension, so `S3AssetStorageStrategy.writeFileFromBuffer` records the same stale `ContentType` on the S3 object. Assets served through the asset server are unaffected because the type is now resolved at serve time; a URL pointing directly at the S3 object would not be. Left out of this fix.

Relates to #5102

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790941235&installation_model_id=20193&pr_number=5255&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5255&signature=b04ad4110812a2cbc23287090d87aeb7456bdd27fc7dfb6cfcbae3de25932238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->