### PR TITLE
ci: add explicit permissions to workflow jobs

### DIFF
--- a/.github/workflows/back_merge.yml
+++ b/.github/workflows/back_merge.yml
@@ -28,6 +28,8 @@ jobs:
     resolve-branches:
         name: Resolve merge target
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         outputs:
             source: ${{ github.ref_name }}
             target: ${{ steps.target.outputs.branch }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,6 +71,8 @@ jobs:
     codegen:
         needs: detect-changes
         if: needs.detect-changes.outputs.packages == 'true'
+        permissions:
+            contents: read
         uses: ./.github/workflows/codegen.yml
     build:
         name: build

--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -39,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+    permissions:
+      contents: read
     steps:
       - name: Determine publish matrix
         id: set-matrix


### PR DESCRIPTION
Three workflow jobs did not declare a `permissions:` block, so they fell back to the repository default token permissions. CodeQL flags these as `actions/missing-workflow-permissions` (alerts 386, 389 and 393).

Each of the three jobs only reads, so all three get `contents: read`:

| Workflow | Job | What it does |
| --- | --- | --- |
| `back_merge.yml` | `resolve-branches` | Writes a branch name to `$GITHUB_OUTPUT` |
| `build_and_test.yml` | `codegen` | Calls the `codegen.yml` reusable workflow |
| `publish_to_npm.yml` | `setup` | Builds the publish matrix string |

The `codegen` job is worth a note. It calls a reusable workflow, and `codegen.yml` already declares `contents: read` on its own job. That is not sufficient on its own: the calling job's permissions set the ceiling that the called workflow inherits, and a called workflow can only narrow what it is given. Declaring it at the call site is what actually constrains the token.

These were the only three jobs across the three files without an explicit block. Verified by parsing each workflow and printing the resolved permissions for every job.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790947375&installation_model_id=20193&pr_number=5256&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5256&signature=a090561913d58b8b8d65e66442e4afa1609873aefb1b72ac5ab1fd7888e06540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->