### PR TITLE
ci: skip SonarQube scan on dispatched feature branch runs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -165,10 +165,19 @@ jobs:
         # from Actions secrets, so SONAR_TOKEN resolves empty and the scan
         # fails. Skipping is safe: all-passed counts a skipped job as a pass,
         # and the scan still runs on the push to master after the merge.
+        #
+        # A manual `workflow_dispatch` run carries no pull request context, and
+        # the scan action supplies no branch name for that event either, so
+        # SonarCloud files the results against the project's main branch.
+        # Dispatching CI on a feature branch therefore uploads that branch's
+        # findings as if they were master's, which marks real master alerts as
+        # fixed and reopens stale ones. Only scan on dispatch when the ref is one
+        # of the long-lived branches.
         if: >-
             needs.detect-changes.outputs.packages == 'true'
             && github.actor != 'dependabot[bot]'
             && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+            && (github.event_name != 'workflow_dispatch' || contains(fromJSON('["master","minor","major"]'), github.ref_name))
         runs-on: ubuntu-latest
         permissions:
             contents: read


### PR DESCRIPTION
## The problem

A SonarCloud analysis of commit `0d58ade9` was filed against `refs/heads/master` on 2 September. That commit is not on `master` — it belongs to the branch behind open PR 5163. SonarCloud uploaded that branch's 22 findings as if they were master's.

GitHub treats each upload for a ref as the complete current state of that ref. So the stale branch tree, which predates a refactor of the docs workflows, caused code scanning to mark four alerts on `master` as fixed when nobody had fixed them, and to reopen the same findings under new numbers at the old line numbers:

- Marked fixed: alerts 428, 430, 431, 435
- Reopened as: alerts 459 through 465

## The cause

The `sonarqube` job passes no branch or pull request parameters. `sonar-project.properties` only sets `projectKey` and `organization`. The job relies entirely on the scan action's auto-detection.

That auto-detection covers two of the three triggers on this workflow. Comparing the result URL each scan printed:

| Trigger | Scan result URL | Filed as |
| --- | --- | --- |
| `pull_request` | `...?id=vendurehq_vendure&pullRequest=5160` | `refs/pull/5160/head` |
| `push` to master or minor | | `refs/heads/master`, `refs/heads/minor` |
| `workflow_dispatch` | `...?id=vendurehq_vendure` | `refs/heads/master` |

The dispatched run's URL carries no `pullRequest` and no `branch` qualifier. A manual dispatch has no `github.event.pull_request` for the action to read, and unlike a push event it supplies no branch name either, so SonarCloud falls back to the project's main branch.

The run in question was a manual dispatch of Build & Test on PR 5163's branch. Across the last 20 SonarCloud analyses this is the only misfiled one, so the integration is fine for the triggers it covers.

## The change

Extend the existing `if:` on the `sonarqube` job so a manual dispatch only scans when the ref is one of the long-lived branches, reusing the same list as the workflow's own `push:` trigger.

Behaviour across every trigger, unchanged except for the last row:

| Result | Event | Ref |
| --- | --- | --- |
| runs | `pull_request` | same-repo branch |
| skips | `pull_request` | fork |
| runs | `push` | master, minor, major |
| runs | `workflow_dispatch` | master, minor, major |
| skips | `workflow_dispatch` | feature branch |

`all-passed` counts a skipped job as a pass, which is the same pattern the existing Dependabot exclusion on this job relies on, so dispatched runs on feature branches still go green.

## Alternative considered

Passing `-Dsonar.branch.name=${{ github.ref_name }}` for non-PR events would give real branch analysis instead of skipping. That is the fuller fix, but it creates a SonarCloud branch entry per feature branch, so it is worth checking the plan's branch limits first. Skipping is the smaller change and fully stops the pollution.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790950268&installation_model_id=20193&pr_number=5257&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5257&signature=a59e66222a593a7d00695b08dea0c3492356ae8b047df974193b6a0537f179dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->