### PR TITLE
fix(core): make the transaction deadlock retry work

### DIFF
--- a/packages/core/src/connection/transaction-wrapper.spec.ts
+++ b/packages/core/src/connection/transaction-wrapper.spec.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { RequestContext } from '../api/common/request-context';
+
+import { TransactionWrapper } from './transaction-wrapper';
+
+/**
+ * A minimal stand-in for a TypeORM QueryRunner which records the transaction lifecycle, so a test
+ * can assert that a retry actually rolled back and started a fresh transaction.
+ */
+function mockQueryRunner() {
+    const calls: string[] = [];
+    return {
+        calls,
+        isReleased: false,
+        isTransactionActive: false,
+        manager: {},
+        startTransaction: vi.fn(async function (this: any) {
+            calls.push('start');
+            runner.isTransactionActive = true;
+        }),
+        commitTransaction: vi.fn(async () => {
+            calls.push('commit');
+            runner.isTransactionActive = false;
+        }),
+        rollbackTransaction: vi.fn(async () => {
+            calls.push('rollback');
+            runner.isTransactionActive = false;
+        }),
+        release: vi.fn(async () => {
+            calls.push('release');
+            runner.isReleased = true;
+        }),
+    } as any;
+}
+
+let runner: any;
+
+function mockConnection() {
+    runner = mockQueryRunner();
+    return { createQueryRunner: () => runner } as any;
+}
+
+function deadlock() {
+    const err: any = new Error('deadlock detected');
+    err.code = '40P01';
+    return err;
+}
+
+describe('TransactionWrapper', () => {
+    const ctx = RequestContext.empty();
+
+    it('commits when the work succeeds', async () => {
+        const connection = mockConnection();
+        const result = await new TransactionWrapper().executeInTransaction(
+            ctx,
+            async () => 'done',
+            'auto',
+            undefined,
+            connection,
+        );
+
+        expect(result).toBe('done');
+        expect(runner.calls).toEqual(['start', 'commit', 'release']);
+    });
+
+    it('rolls back and starts a new transaction before retrying a deadlock', async () => {
+        const connection = mockConnection();
+        let attempts = 0;
+        const result = await new TransactionWrapper().executeInTransaction(
+            ctx,
+            async () => {
+                attempts++;
+                if (attempts === 1) {
+                    throw deadlock();
+                }
+                return 'done';
+            },
+            'auto',
+            undefined,
+            connection,
+        );
+
+        expect(result).toBe('done');
+        expect(attempts).toBe(2);
+        // The retry must not run on the transaction the database has already aborted.
+        expect(runner.calls).toEqual(['start', 'rollback', 'start', 'commit', 'release']);
+    });
+
+    it('throws the original error once the retry budget is spent', async () => {
+        const connection = mockConnection();
+        let attempts = 0;
+        await expect(
+            new TransactionWrapper().executeInTransaction(
+                ctx,
+                async () => {
+                    attempts++;
+                    throw deadlock();
+                },
+                'auto',
+                undefined,
+                connection,
+            ),
+        ).rejects.toThrow('deadlock detected');
+
+        // The initial attempt plus five retries.
+        expect(attempts).toBe(6);
+    });
+
+    it('does not retry an error which is not retriable', async () => {
+        const connection = mockConnection();
+        let attempts = 0;
+        await expect(
+            new TransactionWrapper().executeInTransaction(
+                ctx,
+                async () => {
+                    attempts++;
+                    throw new Error('bad input');
+                },
+                'auto',
+                undefined,
+                connection,
+            ),
+        ).rejects.toThrow('bad input');
+
+        expect(attempts).toBe(1);
+        expect(runner.calls).toEqual(['start', 'rollback', 'release']);
+    });
+});

--- a/packages/core/src/connection/transaction-wrapper.ts
+++ b/packages/core/src/connection/transaction-wrapper.ts
@@ -1,5 +1,4 @@
 import { from, lastValueFrom, Observable } from 'rxjs';
-import { retryWhen, take, tap } from 'rxjs/operators';
 import { DataSource, EntityManager, QueryRunner } from 'typeorm';
 import { TransactionAlreadyStartedError } from 'typeorm/error/TransactionAlreadyStartedError';
 
@@ -45,20 +44,15 @@ export class TransactionWrapper {
         (ctx as any)[TRANSACTION_MANAGER_KEY] = queryRunner.manager;
 
         try {
-            const maxRetries = 5;
-            const result = await lastValueFrom(
-                from(work(ctx)).pipe(
-                    retryWhen(errors =>
-                        errors.pipe(
-                            tap(err => {
-                                if (!this.isRetriableError(err)) {
-                                    throw err;
-                                }
-                            }),
-                            take(maxRetries),
-                        ),
-                    ),
-                ),
+            const result = await this.runWithRetries(
+                () => work(ctx),
+                queryRunner,
+                isolationLevel,
+                // A retry has to roll the transaction back and start a fresh one. That is only
+                // ours to do when we opened the transaction in the first place. When the runner
+                // was inherited from an outer transaction, or the caller manages the transaction
+                // itself, the retry belongs to whoever owns it.
+                mode === 'auto' && !inheritedQueryRunner,
             );
             if (queryRunner.isTransactionActive) {
                 await queryRunner.commitTransaction();
@@ -80,6 +74,43 @@ export class TransactionWrapper {
                 queryRunner.isReleased === false
             ) {
                 await queryRunner.release();
+            }
+        }
+    }
+
+    /**
+     * Runs the unit of work, retrying it from the top if the database rejects it with an error
+     * which is expected to succeed on a second attempt, such as a deadlock.
+     *
+     * The transaction must be rolled back and restarted between attempts. Once the database has
+     * aborted a transaction, every subsequent statement on it fails, so retrying the work on the
+     * same transaction cannot succeed.
+     *
+     * Note that a retry re-runs the whole unit of work, so any side effect it performs happens
+     * again. DB writes are discarded by the rollback, and events published inside a transaction
+     * are only flushed on commit, but anything else the work touches is replayed.
+     */
+    private async runWithRetries<T>(
+        work: () => Observable<T> | Promise<T>,
+        queryRunner: QueryRunner,
+        isolationLevel: TransactionIsolationLevel | undefined,
+        canRestartTransaction: boolean,
+    ): Promise<T> {
+        const maxRetries = 5;
+        let attempts = 0;
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            try {
+                return await lastValueFrom(from(work()));
+            } catch (err: any) {
+                attempts++;
+                if (!canRestartTransaction || !this.isRetriableError(err) || attempts > maxRetries) {
+                    throw err;
+                }
+                if (queryRunner.isTransactionActive) {
+                    await queryRunner.rollbackTransaction();
+                }
+                await this.startTransaction(queryRunner, isolationLevel);
             }
         }
     }
@@ -128,8 +159,14 @@ export class TransactionWrapper {
      * situation, which can usually be retried with success.
      */
     private isRetriableError(err: any): boolean {
+        // MySQL and MariaDB report both deadlocks and serialization failures as ER_LOCK_DEADLOCK.
         const mysqlDeadlock = err.code === 'ER_LOCK_DEADLOCK';
-        const postgresDeadlock = err.code === 'deadlock_detected';
-        return mysqlDeadlock || postgresDeadlock;
+        // node-postgres puts the SQLSTATE in `err.code`, so a deadlock arrives as '40P01' rather
+        // than as its condition name. The name is kept too in case a driver reports it that way.
+        const postgresDeadlock = err.code === 'deadlock_detected' || err.code === '40P01';
+        // Raised in place of a deadlock when the database cannot order this transaction against a
+        // concurrent one, which happens at SERIALIZABLE and on Postgres at REPEATABLE READ.
+        const serializationFailure = err.code === '40001';
+        return mysqlDeadlock || postgresDeadlock || serializationFailure;
     }
 }


### PR DESCRIPTION
## Problem

The deadlock retry in `TransactionWrapper` could never succeed, and could not report its failure either.

**It retried on a dead transaction.** On error it re-subscribed to `work(ctx)` on the same `QueryRunner` without rolling back. By that point the database has already aborted the transaction, so every statement in the retry fails with "current transaction is aborted".

**It swallowed the real error.** `retryWhen` with `take(5)` completes the error stream rather than rethrowing, so once the budget was spent `lastValueFrom` rejected with an empty-sequence error instead of the deadlock that caused it.

**The Postgres branch was dead code.** node-postgres puts the SQLSTATE in `err.code`, so a deadlock arrives as `40P01`, never as the condition name `deadlock_detected` that `isRetriableError` tested for. Only the MySQL path ever matched.

## Fix

Roll the transaction back and start a fresh one between attempts, rethrow the original error when the budget is spent, and recognise the Postgres deadlock SQLSTATE alongside serialization failures (`40001`).

Retries only happen when we opened the transaction ourselves. Restarting a transaction inherited from an outer `@Transaction('manual')` caller, or one the caller manages, belongs to whoever owns it.

The retry docblock now also states that a retry replays the whole unit of work. DB writes are discarded by the rollback and events are only flushed on commit, but anything else the work touches happens again.

## Tests

`packages/core/src/connection/transaction-wrapper.spec.ts`, four unit tests against a QueryRunner stand-in that records the transaction lifecycle. Two of them fail on `master`:

```
✓ commits when the work succeeds
× rolls back and starts a new transaction before retrying a deadlock
× throws the original error once the retry budget is spent
✓ does not retry an error which is not retriable
```

## Verification

- Core unit tests: 1234 passed.
- `tsc --noEmit` error count unchanged from `master` (all pre-existing, in spec files).
- No behaviour change for the non-deadlock path, which is every request that does not hit a lock conflict.

Relates to #4152, and to the design note posted there.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790952299&installation_model_id=20193&pr_number=5258&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5258&signature=856952dad8e7f13471bd8e1472364232520b7eb58a7889e6a85305dcc63f24d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->