### PR TITLE
feat(cli): add nested command trees and shared options to the plugin API

### DIFF
--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -755,6 +755,8 @@ given a `defaultValue` is left out.
 - Two flags that read back under the same name count as the same option, so
   `--api-token` and `--apiToken` collide: both are stored as `apiToken`.
 - No option may use `-h`, `--help`, `-V` or `--version`, which the CLI owns.
+- `subOptions` are registered on the same command as their parent, so every rule
+  above applies to them too.
 - A *command* may declare an option with the same flag as a shared option — the
   built-in `vendure plugins --json` and a shared `--json` for example. The two
   then refer to the same value: whatever is supplied on the command line is

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -651,6 +651,8 @@ given a `defaultValue` is left out.
 - A plugin cannot declare a shared option that another plugin already declares,
   and it cannot declare one that shadows a shared option of its own group. Both
   are reported as errors rather than one quietly overriding the other.
+- Two flags that read back under the same name count as the same option, so
+  `--api-token` and `--apiToken` collide: both are stored as `apiToken`.
 - A plugin cannot use `-h`, `--help`, `-V` or `--version`, which the CLI owns.
 - A command may declare an option with the same flag as a shared option — the
   built-in `vendure plugins --json` and a shared `--json` for example. The two
@@ -665,7 +667,8 @@ and the reason is written to stderr. This applies to:
 
 - a top-level command that a built-in or another plugin already provides, unless
   the definition sets `replaces: true`;
-- a shared option that another plugin already registered, or a flag the CLI owns.
+- a shared option that another plugin already registered, reads back under the
+  same name as one, or is a flag the CLI owns.
 
 The rest of the CLI keeps working, so `vendure plugins remove <package>` is
 always available to disable the plugin.

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -497,7 +497,7 @@ The CLI automatically detects your monorepo structure. No additional configurati
 
 ## Extending the CLI
 
-Packages can add new top-level commands or replace built-in ones (for example overriding
+Packages can add new commands or replace built-in ones (for example overriding
 `vendure dev`) by exporting a CLI plugin.
 
 In the plugin package:
@@ -519,6 +519,8 @@ export default defineCliPlugin({
         {
             name: 'dev',
             description: 'Replace or wrap the built-in dev command',
+            // Required, because `dev` is already a built-in command
+            replaces: true,
             action: async (target, options) => {
                 // optional setup...
                 return builtinCommands.dev.action(target, options);
@@ -541,6 +543,132 @@ Declare the entry point in that package's `package.json`:
 
 The optional `cliCommands` list lets the CLI give actionable errors for unknown
 commands without loading the plugin.
+
+### Nested commands
+
+A command entry that has `subcommands` instead of an `action` is a group. A
+group only exists to hold the commands below it, and running it without a
+subcommand prints its help. Groups can be nested to any depth.
+
+```ts
+import { CliCommandContext, defineCliPlugin } from '@vendure/cli';
+
+interface CloudOptions {
+    token?: string;
+    project?: string;
+}
+
+export default defineCliPlugin({
+    id: '@example/cloud-cli-plugin',
+    rootOptions: [
+        { long: '--token <token>', description: 'API token', required: true },
+        { long: '--project <slug>', description: 'Target project', required: true },
+    ],
+    commands: [
+        {
+            name: 'config',
+            description: 'Manage configuration',
+            options: [{ long: '--profile <name>', description: 'Configuration profile', required: true }],
+            subcommands: [
+                {
+                    name: 'server',
+                    description: 'Server configuration',
+                    subcommands: [
+                        {
+                            name: 'set',
+                            description: 'Set a server configuration value',
+                            arguments: [
+                                { name: 'key', description: 'Configuration key', required: true },
+                                { name: 'value', description: 'Configuration value', required: true },
+                            ],
+                            action: async (
+                                key: string,
+                                value: string,
+                                options: Record<string, any>,
+                                command: unknown,
+                                context: CliCommandContext<CloudOptions>,
+                            ) => {
+                                console.log(context.commandPath); // ['config', 'server', 'set']
+                                console.log(context.inheritedOptions.token);
+                                return 0;
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+});
+```
+
+That plugin adds `vendure config server set <key> <value>`. Help is generated
+by the CLI at every level, so `vendure --help` lists `config`,
+`vendure config --help` lists `server`, and `vendure config server set --help`
+lists the arguments and the options that are valid there. Unknown subcommands,
+unknown options and missing arguments fail through the CLI's normal error path
+with exit code 1.
+
+### Shared options
+
+Options that apply to more than one command are declared once, at the scope
+they belong to:
+
+- `rootOptions` on the plugin are added to `vendure` itself, so every command
+  can be given them.
+- `options` on a command group apply to every command inside that group.
+
+A shared option can be given anywhere on the command line once the command that
+declares it has been reached. These are all equivalent:
+
+```bash
+npx vendure --token abc config server set apiPort 3001
+npx vendure config server set apiPort 3001 --token abc
+npx vendure config --profile ci server set apiPort 3001
+```
+
+A group option is only accepted within its group, so
+`vendure project list --profile ci` fails with an unknown option error.
+
+Values reach the action through the `CliCommandContext` that the CLI appends
+after Commander's own arguments, which means a command never has to read or
+reparse `process.argv`:
+
+```ts
+action: async (options, command, context: CliCommandContext<CloudOptions>) => {
+    context.inheritedOptions.token; // value of the shared --token
+    context.commandPath; // e.g. ['project', 'list']
+};
+```
+
+`inheritedOptions` is keyed by the long flag without `--`, camel-cased, so
+`--api-token` is read as `apiToken`. An option that was neither supplied nor
+given a `defaultValue` is left out.
+
+#### Shared-option precedence
+
+- A shared option is owned by the command that declares it. When it is repeated
+  on one command line, the last value given wins.
+- A plugin cannot declare a shared option that another plugin already declares,
+  and it cannot declare one that shadows a shared option of its own group. Both
+  are reported as errors rather than one quietly overriding the other.
+- A plugin cannot use `-h`, `--help`, `-V` or `--version`, which the CLI owns.
+- A command may declare an option with the same flag as a shared option — the
+  built-in `vendure plugins --json` and a shared `--json` for example. The two
+  then refer to the same value: whatever is supplied on the command line is
+  visible both in the command's own options and in `inheritedOptions`. They must
+  agree on whether a value follows the flag, otherwise the plugin is rejected.
+
+### Collisions
+
+A plugin that would take over a name it does not own is not registered at all,
+and the reason is written to stderr. This applies to:
+
+- a top-level command that a built-in or another plugin already provides, unless
+  the definition sets `replaces: true`;
+- a shared option that another plugin already registered, or a flag the CLI owns.
+
+The rest of the CLI keeps working, so `vendure plugins remove <package>` is
+always available to disable the plugin.
 
 ### Explicit activation
 
@@ -568,11 +696,13 @@ npx vendure plugins remove @example/vendure-cli-plugin
 
 A package named in `plugins` must also be a direct project dependency.
 Disabling a plugin is simply removing it from the list (`vendure plugins remove`).
-Commands are registered in allowlist order (last listed wins when names collide).
+Commands are registered in allowlist order, so when two plugins both declare
+`replaces: true` for the same command, the last listed one wins.
 Plugins can still call the original via `builtinCommands.<name>.action(...)`.
 
-A listed plugin that cannot be resolved or loaded is skipped with an error on
-stderr — the rest of the CLI (including `vendure plugins remove`) stays usable.
+A listed plugin that cannot be resolved, loaded or registered is skipped with an
+error on stderr — the rest of the CLI (including `vendure plugins remove`) stays
+usable.
 
 ## Getting Help
 

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -619,7 +619,7 @@ credential to `vendure dev`, and a Cloud package may need to add to it as well.
 their options are merged onto one command and their decorators are composed.
 
 ```ts
-import { CliCommandContext, defineCliPlugin } from '@vendure/cli';
+import { defineCliPlugin, readCommandContext, readCommandOptions } from '@vendure/cli';
 
 export default defineCliPlugin({
     id: '@example/platform-cli-plugin',
@@ -635,6 +635,11 @@ export default defineCliPlugin({
                     // `command` is the command as composed so far, so you can
                     // see what the built-in and any earlier plugin added.
                     console.log(command.options?.map(option => option.long));
+
+                    const options = readCommandOptions(args);
+                    const context = readCommandContext(args);
+                    console.log(options.rotateCredential, context.commandPath);
+
                     // Forward every argument, so anything you wrap still gets
                     // the options, Command and context the host parsed.
                     return next(...args);
@@ -643,6 +648,11 @@ export default defineCliPlugin({
     ],
 });
 ```
+
+A decorator that takes `...args` in order to forward them should read the tail
+with `readCommandContext()` and `readCommandOptions()` rather than indexing into
+the array, which is easy to get wrong and would break if the host ever appended
+anything else.
 
 `decorate` is called once, when the plugin is registered, and is given:
 
@@ -756,7 +766,8 @@ given a `defaultValue` is left out.
   `--api-token` and `--apiToken` collide: both are stored as `apiToken`.
 - No option may use `-h`, `--help`, `-V` or `--version`, which the CLI owns.
 - `subOptions` are registered on the same command as their parent, so every rule
-  above applies to them too.
+  above applies to them too. They nest one level only; anything deeper is
+  rejected, because the CLI would validate a flag it never registers.
 - A *command* may declare an option with the same flag as a shared option — the
   built-in `vendure plugins --json` and a shared `--json` for example. The two
   then refer to the same value: whatever is supplied on the command line is

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -497,13 +497,13 @@ The CLI automatically detects your monorepo structure. No additional configurati
 
 ## Extending the CLI
 
-Packages can add new commands or replace built-in ones (for example overriding
-`vendure dev`) by exporting a CLI plugin.
+Packages can add new commands, add to existing ones, or replace them outright by
+exporting a CLI plugin.
 
 In the plugin package:
 
 ```ts
-import { builtinCommands, defineCliPlugin } from '@vendure/cli';
+import { defineCliPlugin } from '@vendure/cli';
 
 export default defineCliPlugin({
     id: '@example/vendure-cli-plugin',
@@ -516,15 +516,18 @@ export default defineCliPlugin({
                 return 0;
             },
         },
+    ],
+    extendCommands: [
         {
-            name: 'dev',
-            description: 'Replace or wrap the built-in dev command',
-            // Required, because `dev` is already a built-in command
-            replaces: true,
-            action: async (target, options) => {
-                // optional setup...
-                return builtinCommands.dev.action(target, options);
-            },
+            // Add to the built-in `dev` command rather than replacing it
+            command: 'dev',
+            options: [{ long: '--rotate-credential', description: 'Replace the stored credential' }],
+            decorate:
+                ({ next }) =>
+                async (...args) => {
+                    // setup before the command runs...
+                    return next(...args);
+                },
         },
     ],
 });
@@ -608,6 +611,92 @@ lists the arguments and the options that are valid there. Unknown subcommands,
 unknown options and missing arguments fail through the CLI's normal error path
 with exit code 1.
 
+### Extending an existing command
+
+More than one plugin may need the same command. Vendure Platform adds a
+credential to `vendure dev`, and a Cloud package may need to add to it as well.
+`extendCommands` lets each of them contribute without discarding the others:
+their options are merged onto one command and their decorators are composed.
+
+```ts
+import { CliCommandContext, defineCliPlugin } from '@vendure/cli';
+
+export default defineCliPlugin({
+    id: '@example/platform-cli-plugin',
+    commands: [],
+    extendCommands: [
+        {
+            command: 'dev',
+            description: 'Run Vendure in development mode with linked credentials',
+            options: [{ long: '--rotate-credential', description: 'Replace the stored credential' }],
+            decorate:
+                ({ command, next }) =>
+                async (target, options, cliCommand, context: CliCommandContext) => {
+                    // `command` is the command as composed so far, so you can see
+                    // what the built-in and any earlier plugin already added.
+                    const credential = await resolveCredential({ rotate: options.rotateCredential });
+                    return withCredential(credential, () => next(target, options, cliCommand, context));
+                },
+        },
+    ],
+});
+```
+
+`decorate` is called once, when the plugin is registered, and is given:
+
+- `next`, the action of the command as composed so far. Call it to run
+  everything beneath your wrapper, ending in the original implementation.
+- `command`, that same command's definition, so you can read the options,
+  arguments and description already contributed.
+
+Never import the original action to call it, for example
+`builtinCommands.dev.action`. That binds to the built-in and skips whatever
+other plugins have added, so only one of the wrappers would survive. `next` is
+what makes several plugins able to wrap the same command.
+
+An extension may target a nested command with a path, either
+`['config', 'server', 'set']` or `'config server set'`. Extending a command
+group is allowed for options and the description, but a group has no action to
+decorate.
+
+#### Composition order
+
+Extensions are applied in `vendure.cli.plugins` order, so the **last listed
+plugin is the outermost wrapper and its decorator runs first**. With:
+
+```json
+{
+    "vendure": {
+        "cli": {
+            "plugins": ["@example/platform-cli-plugin", "@example/cloud-cli-plugin"]
+        }
+    }
+}
+```
+
+running `vendure dev` calls the Cloud wrapper, which calls the Platform wrapper,
+which calls the built-in. Each wrapper runs once per invocation. The Cloud
+plugin, being applied last, also sees the option the Platform plugin added in
+its `command` argument; reverse the list and the roles swap.
+
+#### Adding to a command
+
+An extension may also add to what the command declares:
+
+- `options` are appended, keeping every option already on the command.
+- `arguments` are appended and must be optional. A required one would change the
+  arity of a command that other plugins and users already call.
+- `description` replaces the one shown in help. If two plugins set it, the last
+  listed wins and the CLI writes a notice naming both.
+
+#### Extending or replacing
+
+`replaces: true` is still the way to take a command over completely, and it
+discards whatever was there. The two mechanisms interact in one direction only:
+a plugin cannot replace a command that another plugin has already extended,
+because that would throw away their contribution. Listing the replacing plugin
+first works, and later plugins then extend the replacement.
+
 ### Shared options
 
 Options that apply to more than one command are declared once, at the scope
@@ -662,16 +751,25 @@ given a `defaultValue` is left out.
 
 ### Collisions
 
-A plugin that would take over a name it does not own is not registered at all,
-and the reason is written to stderr. This applies to:
+A plugin that would take over or discard something it does not own is not
+registered at all, and the reason is written to stderr. This applies to:
 
 - a top-level command that a built-in or another plugin already provides, unless
   the definition sets `replaces: true`;
+- a replacement of a command that another plugin has extended;
+- an extension of a command that is not registered, or a `decorate` on a command
+  group;
+- an option added by an extension that the command already declares, whoever
+  contributed it;
+- an argument added by an extension that is required, or whose name is taken;
 - a shared option that another plugin already registered, reads back under the
-  same name as one, or is a flag the CLI owns.
+  same name as one, or is a flag the CLI owns;
+- any use of the `plugins` command, which the CLI reserves because it is how a
+  plugin is disabled.
 
-The rest of the CLI keeps working, so `vendure plugins remove <package>` is
-always available to disable the plugin.
+Every conflict a plugin causes is reported together, so one run tells you
+everything to fix. The rest of the CLI keeps working, so
+`vendure plugins remove <package>` is always available to disable the plugin.
 
 ### Explicit activation
 
@@ -700,12 +798,13 @@ npx vendure plugins remove @example/vendure-cli-plugin
 A package named in `plugins` must also be a direct project dependency.
 Disabling a plugin is simply removing it from the list (`vendure plugins remove`).
 Commands are registered in allowlist order, so when two plugins both declare
-`replaces: true` for the same command, the last listed one wins.
-Plugins can still call the original via `builtinCommands.<name>.action(...)`.
+`replaces: true` for the same command, the last listed one wins. Extensions are
+applied in the same order, and all of them are kept.
 
 A listed plugin that cannot be resolved, loaded or registered is skipped with an
 error on stderr — the rest of the CLI (including `vendure plugins remove`) stays
-usable.
+usable. That covers a decorator which throws while it is being applied: the
+plugin contributes nothing and every other plugin is unaffected.
 
 ## Getting Help
 

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -550,15 +550,20 @@ commands without loading the plugin.
 ### Nested commands
 
 A command entry that has `subcommands` instead of an `action` is a group. A
-group only exists to hold the commands below it, and running it without a
-subcommand prints its help. Groups can be nested to any depth.
+group only exists to hold the commands below it. Running it without a
+subcommand prints its help to stderr and exits 1. Groups can be nested to any
+depth.
 
 ```ts
-import { CliCommandContext, defineCliPlugin } from '@vendure/cli';
+import type { Command } from 'commander';
+
+import { defineCliPlugin } from '@vendure/cli';
+import type { CliCommandContext } from '@vendure/cli';
 
 interface CloudOptions {
     token?: string;
     project?: string;
+    profile?: string;
 }
 
 export default defineCliPlugin({
@@ -588,7 +593,7 @@ export default defineCliPlugin({
                                 key: string,
                                 value: string,
                                 options: Record<string, any>,
-                                command: unknown,
+                                command: Command,
                                 context: CliCommandContext<CloudOptions>,
                             ) => {
                                 console.log(context.commandPath); // ['config', 'server', 'set']
@@ -651,8 +656,7 @@ export default defineCliPlugin({
 
 A decorator that takes `...args` in order to forward them should read the tail
 with `readCommandContext()` and `readCommandOptions()` rather than indexing into
-the array, which is easy to get wrong and would break if the host ever appended
-anything else.
+the array. Both throw a named error if handed anything else.
 
 `decorate` is called once, when the plugin is registered, and is given:
 
@@ -726,16 +730,23 @@ they belong to:
 - `options` on a command group apply to every command inside that group.
 
 A shared option can be given anywhere on the command line once the command that
-declares it has been reached. These are all equivalent:
+declares it has been reached. These two are equivalent — same flag, same value,
+different position:
 
 ```bash
 npx vendure --token abc config server set apiPort 3001
 npx vendure config server set apiPort 3001 --token abc
-npx vendure config --profile ci server set apiPort 3001
 ```
 
-A group option is only accepted within its group, so
-`vendure project list --profile ci` fails with an unknown option error.
+A group's own options work the same way from the group onwards:
+
+```bash
+npx vendure config --profile ci server set apiPort 3001
+npx vendure config server set apiPort 3001 --profile ci
+```
+
+but only within that group, so `vendure project list --profile ci` fails with an
+unknown option error.
 
 Values reach the action through the `CliCommandContext` that the CLI appends
 after Commander's own arguments, which means a command never has to read or
@@ -751,6 +762,14 @@ action: async (options, command, context: CliCommandContext<CloudOptions>) => {
 `inheritedOptions` is keyed by the long flag without `--`, camel-cased, so
 `--api-token` is read as `apiToken`. An option that was neither supplied nor
 given a `defaultValue` is left out.
+
+:::note
+`required: true` on an **option** means a value must follow the flag, not that
+the flag has to be given. `--token <token>` with `required: true` may still be
+omitted entirely, and its value will be absent from `inheritedOptions`. Check
+for it in your action. On an **argument**, `required: true` does mean the
+argument is mandatory.
+:::
 
 #### Shared-option precedence
 
@@ -789,8 +808,9 @@ registered at all, and the reason is written to stderr. This applies to:
 - a shared option that another plugin already registered, reads back under the
   same name as one, or is a flag the CLI owns;
 - an option on any command that uses a flag the CLI owns;
-- any use of the `plugins` or `help` commands, which the CLI reserves because
-  they are how a plugin is found and disabled.
+- any use of the `plugins` command, which the CLI reserves because it is how a
+  plugin is disabled, or the `help` command, which is how a user finds their way
+  out of a broken one.
 
 Conflicts are collected and reported together where the CLI can carry on
 checking. The rest of the CLI keeps working either way, so
@@ -819,6 +839,26 @@ npx vendure plugins --json
 npx vendure plugins add @example/vendure-cli-plugin
 npx vendure plugins remove @example/vendure-cli-plugin
 ```
+
+The CLI finds the project root by walking up from the current directory to the
+nearest `package.json` that configures `vendure.cli` or depends on
+`@vendure/cli`, then scans the `dependencies`, `devDependencies` and
+`optionalDependencies` of every `package.json` between the two. In a monorepo
+that means a plugin installed in a workspace package is found even when
+`@vendure/cli` is hoisted to the workspace root.
+
+A package that declares a plugin but is not listed is reported by a one-line
+hint on stderr rather than being loaded:
+
+```text
+2 packages provide CLI commands. Run "vendure plugins" to review them.
+```
+
+`vendure plugins` lists each discovered package as `enabled`, `not-enabled` or
+`failed`. `failed` means the package is listed in `plugins` but could not be
+resolved or loaded — for example it is not a direct dependency, does not declare
+`vendure.cliPlugin`, or its entry file is missing because a workspace package has
+not been built. The reason is shown alongside it.
 
 A package named in `plugins` must also be a direct project dependency.
 Disabling a plugin is simply removing it from the list (`vendure plugins remove`).

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -631,11 +631,13 @@ export default defineCliPlugin({
             options: [{ long: '--rotate-credential', description: 'Replace the stored credential' }],
             decorate:
                 ({ command, next }) =>
-                async (target, options, cliCommand, context: CliCommandContext) => {
-                    // `command` is the command as composed so far, so you can see
-                    // what the built-in and any earlier plugin already added.
-                    const credential = await resolveCredential({ rotate: options.rotateCredential });
-                    return withCredential(credential, () => next(target, options, cliCommand, context));
+                async (...args) => {
+                    // `command` is the command as composed so far, so you can
+                    // see what the built-in and any earlier plugin added.
+                    console.log(command.options?.map(option => option.long));
+                    // Forward every argument, so anything you wrap still gets
+                    // the options, Command and context the host parsed.
+                    return next(...args);
                 },
         },
     ],
@@ -684,18 +686,25 @@ its `command` argument; reverse the list and the roles swap.
 An extension may also add to what the command declares:
 
 - `options` are appended, keeping every option already on the command.
-- `arguments` are appended and must be optional. A required one would change the
-  arity of a command that other plugins and users already call.
 - `description` replaces the one shown in help. If two plugins set it, the last
   listed wins and the CLI writes a notice naming both.
+
+An extension cannot add positional arguments. Commander passes one argument slot
+per declared positional, so an appended argument would shift the options, the
+`Command` and the context that an action written before the extension expects.
 
 #### Extending or replacing
 
 `replaces: true` is still the way to take a command over completely, and it
-discards whatever was there. The two mechanisms interact in one direction only:
-a plugin cannot replace a command that another plugin has already extended,
-because that would throw away their contribution. Listing the replacing plugin
-first works, and later plugins then extend the replacement.
+discards whatever was there. A plugin cannot replace a command that another
+plugin has already extended, because that would throw away their contribution.
+Listing the replacing plugin first works, and later plugins then extend the
+replacement.
+
+An extension cannot add subcommands to a group. Two plugins contributing
+different subcommands to one group is not supported: the second registration of
+the group name is a collision, and `replaces: true` is refused once the group has
+been extended. A group and all its subcommands must come from one plugin.
 
 ### Shared options
 
@@ -737,13 +746,16 @@ given a `defaultValue` is left out.
 
 - A shared option is owned by the command that declares it. When it is repeated
   on one command line, the last value given wins.
-- A plugin cannot declare a shared option that another plugin already declares,
-  and it cannot declare one that shadows a shared option of its own group. Both
-  are reported as errors rather than one quietly overriding the other.
+- A shared option is declared at exactly one level. A plugin cannot declare one
+  another plugin already declares, and a group cannot share a flag that the root
+  or an outer group already shares. Both are errors rather than one quietly
+  overriding the other, so no two levels can disagree about a value.
+- A value supplied on the command line always beats a `defaultValue`, whichever
+  level declared it.
 - Two flags that read back under the same name count as the same option, so
   `--api-token` and `--apiToken` collide: both are stored as `apiToken`.
-- A plugin cannot use `-h`, `--help`, `-V` or `--version`, which the CLI owns.
-- A command may declare an option with the same flag as a shared option — the
+- No option may use `-h`, `--help`, `-V` or `--version`, which the CLI owns.
+- A *command* may declare an option with the same flag as a shared option — the
   built-in `vendure plugins --json` and a shared `--json` for example. The two
   then refer to the same value: whatever is supplied on the command line is
   visible both in the command's own options and in `inheritedOptions`. They must
@@ -761,14 +773,14 @@ registered at all, and the reason is written to stderr. This applies to:
   group;
 - an option added by an extension that the command already declares, whoever
   contributed it;
-- an argument added by an extension that is required, or whose name is taken;
 - a shared option that another plugin already registered, reads back under the
   same name as one, or is a flag the CLI owns;
-- any use of the `plugins` command, which the CLI reserves because it is how a
-  plugin is disabled.
+- an option on any command that uses a flag the CLI owns;
+- any use of the `plugins` or `help` commands, which the CLI reserves because
+  they are how a plugin is found and disabled.
 
-Every conflict a plugin causes is reported together, so one run tells you
-everything to fix. The rest of the CLI keeps working, so
+Conflicts are collected and reported together where the CLI can carry on
+checking. The rest of the CLI keeps working either way, so
 `vendure plugins remove <package>` is always available to disable the plugin.
 
 ### Explicit activation

--- a/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
@@ -1,0 +1,321 @@
+/*
+ * E2E tests for CLI plugins that register nested command trees and shared options.
+ *
+ * These spawn the built CLI (`dist/cli.js`) against a temporary project, so they
+ * exercise plugin discovery, activation, registration and Commander parsing the
+ * same way a real installation does.
+ *
+ * To run these tests:
+ * npm run vitest -- --config e2e/vitest.e2e.config.mts
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+    CliTestProject,
+    createTestProject,
+    installCliPluginFixture,
+    readEnabledCliPlugins,
+} from './cli-test-utils';
+
+interface CloudResult {
+    command: string[];
+    positionals: string[];
+    options: Record<string, any>;
+    inherited: Record<string, any>;
+}
+
+/**
+ * Reads back the line the fixture plugin prints, which is everything the CLI
+ * host passed to the command action.
+ */
+function parseCloudResult(stdout: string): CloudResult {
+    const line = stdout
+        .split('\n')
+        .map(l => l.trim())
+        .find(l => l.startsWith('CLOUD_RESULT '));
+    if (!line) {
+        throw new Error(`No CLOUD_RESULT line in CLI output:\n${stdout}`);
+    }
+    return JSON.parse(line.slice('CLOUD_RESULT '.length));
+}
+
+describe('CLI plugin nested commands', () => {
+    let project: CliTestProject;
+
+    beforeAll(() => {
+        project = createTestProject('cli-plugin-nested');
+        installCliPluginFixture(project, 'cloud-cli-plugin');
+    });
+
+    afterAll(() => {
+        project.cleanup();
+    });
+
+    it('runs a two-level plugin command', async () => {
+        const result = await project.runCliCommand(['project', 'list']);
+
+        expect(result.exitCode).toBe(0);
+        expect(parseCloudResult(result.stdout).command).toEqual(['project', 'list']);
+    });
+
+    it('runs a three-level plugin command with positional arguments', async () => {
+        const result = await project.runCliCommand(['config', 'server', 'set', 'apiPort', '3001']);
+
+        const parsed = parseCloudResult(result.stdout);
+        expect(parsed.command).toEqual(['config', 'server', 'set']);
+        expect(parsed.positionals).toEqual(['apiPort', '3001']);
+    });
+
+    it('runs a three-level plugin command without arguments', async () => {
+        const result = await project.runCliCommand(['backup', 'db', 'list']);
+
+        expect(parseCloudResult(result.stdout).command).toEqual(['backup', 'db', 'list']);
+    });
+
+    it('runs a two-level plugin command with an argument', async () => {
+        const result = await project.runCliCommand(['restore', 'db', 'backup-42']);
+
+        const parsed = parseCloudResult(result.stdout);
+        expect(parsed.command).toEqual(['restore', 'db']);
+        expect(parsed.positionals).toEqual(['backup-42']);
+    });
+
+    it('passes shared options given before the command path', async () => {
+        const result = await project.runCliCommand([
+            '--token',
+            'tok-1',
+            '--project',
+            'my-project',
+            '--environment',
+            'staging',
+            '--json',
+            'project',
+            'list',
+        ]);
+
+        expect(parseCloudResult(result.stdout).inherited).toEqual({
+            token: 'tok-1',
+            project: 'my-project',
+            environment: 'staging',
+            json: true,
+        });
+    });
+
+    it('passes shared options given after the command path', async () => {
+        const result = await project.runCliCommand([
+            'config',
+            'server',
+            'set',
+            'apiPort',
+            '3001',
+            '--token',
+            'tok-2',
+            '--project',
+            'my-project',
+            '--environment',
+            'prod',
+            '--json',
+        ]);
+
+        expect(parseCloudResult(result.stdout).inherited).toEqual({
+            token: 'tok-2',
+            project: 'my-project',
+            environment: 'prod',
+            json: true,
+        });
+    });
+
+    it('passes a group option alongside the shared options', async () => {
+        const result = await project.runCliCommand([
+            'config',
+            '--profile',
+            'ci',
+            'server',
+            'set',
+            'apiPort',
+            '3001',
+            '--token',
+            'tok-3',
+        ]);
+
+        expect(parseCloudResult(result.stdout).inherited).toEqual({ profile: 'ci', token: 'tok-3' });
+    });
+
+    it('leaves a built-in option of the same name working', async () => {
+        // The plugin registers a shared `--json` and the built-in `plugins`
+        // command declares its own, so both must still see the value.
+        const result = await project.runCliCommand(['plugins', '--json']);
+
+        expect(result.exitCode).toBe(0);
+        expect(() => JSON.parse(result.stdout)).not.toThrow();
+    });
+
+    it('rejects a group option outside its group', async () => {
+        const result = await project.runCliCommand(['project', 'list', '--profile', 'ci'], {
+            expectError: true,
+        });
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("unknown option '--profile'");
+    });
+});
+
+describe('CLI plugin help output', () => {
+    let project: CliTestProject;
+
+    beforeAll(() => {
+        project = createTestProject('cli-plugin-help');
+        installCliPluginFixture(project, 'cloud-cli-plugin');
+    });
+
+    afterAll(() => {
+        project.cleanup();
+    });
+
+    it('shows plugin commands and shared options in root help', async () => {
+        const result = await project.runCliCommand(['--help']);
+
+        for (const name of ['project', 'config', 'backup', 'restore']) {
+            expect(result.stdout).toContain(name);
+        }
+        for (const option of ['--token', '--project', '--environment', '--json']) {
+            expect(result.stdout).toContain(option);
+        }
+    });
+
+    it('shows subcommands and inherited options in parent help', async () => {
+        const result = await project.runCliCommand(['config', '--help']);
+
+        expect(result.stdout).toContain('vendure config');
+        expect(result.stdout).toContain('server');
+        expect(result.stdout).toContain('--profile');
+        expect(result.stdout).toContain('Global Options:');
+        expect(result.stdout).toContain('--token');
+    });
+
+    it('shows the options valid at every level in leaf help', async () => {
+        const result = await project.runCliCommand(['config', 'server', 'set', '--help']);
+
+        expect(result.stdout).toContain('vendure config server set [options] <key> <value>');
+        expect(result.stdout).toContain('Global Options:');
+        expect(result.stdout).toContain('--profile');
+        expect(result.stdout).toContain('--environment');
+    });
+
+    it('prints help and fails when a group is run without a subcommand', async () => {
+        const result = await project.runCliCommand(['backup'], { expectError: true });
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain('vendure backup');
+        expect(result.stderr).toContain('db');
+    });
+
+    it('fails on an unknown subcommand', async () => {
+        const result = await project.runCliCommand(['project', 'destroy'], { expectError: true });
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("unknown command 'destroy'");
+    });
+
+    it('fails on an unknown option', async () => {
+        const result = await project.runCliCommand(['project', 'list', '--nope'], { expectError: true });
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("unknown option '--nope'");
+    });
+
+    it('fails on a missing required argument', async () => {
+        const result = await project.runCliCommand(['config', 'server', 'set', 'apiPort'], {
+            expectError: true,
+        });
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("missing required argument 'value'");
+    });
+});
+
+describe('CLI plugin collisions', () => {
+    it('skips a plugin that would take over a built-in command', async () => {
+        const project = createTestProject('cli-plugin-command-collision');
+        try {
+            installCliPluginFixture(project, 'command-collision-cli-plugin');
+
+            const result = await project.runCliCommand(['add', '--help']);
+
+            expect(result.stderr).toContain('Failed to register CLI plugin');
+            expect(result.stderr).toContain('Command "add" is already provided by the CLI');
+            expect(result.stderr).toContain('vendure plugins remove');
+            expect(result.stdout).not.toContain('Silently takes over');
+            expect(result.stdout).toContain('Add a feature to your Vendure project');
+        } finally {
+            project.cleanup();
+        }
+    });
+
+    it('replaces a built-in command when the plugin declares it', async () => {
+        const project = createTestProject('cli-plugin-replaces');
+        try {
+            installCliPluginFixture(project, 'replacing-cli-plugin');
+
+            const result = await project.runCliCommand(['doctor']);
+
+            expect(result.stdout).toContain('REPLACED_DOCTOR');
+            expect(result.stderr).toContain('Replaced command "doctor"');
+        } finally {
+            project.cleanup();
+        }
+    });
+
+    it('skips a plugin whose shared option is already registered', async () => {
+        const project = createTestProject('cli-plugin-option-collision');
+        try {
+            installCliPluginFixture(project, 'cloud-cli-plugin');
+            installCliPluginFixture(project, 'option-collision-cli-plugin');
+
+            const result = await project.runCliCommand(['project', 'list', '--token', 'tok']);
+
+            expect(result.stderr).toContain('Failed to register CLI plugin');
+            expect(result.stderr).toContain('is already registered by @vendure-e2e/cloud-cli-plugin');
+            expect(parseCloudResult(result.stdout).inherited.token).toBe('tok');
+
+            const rival = await project.runCliCommand(['rival'], { expectError: true });
+            expect(rival.exitCode).toBe(1);
+            expect(rival.stderr).toContain('Unknown command "rival"');
+        } finally {
+            project.cleanup();
+        }
+    });
+});
+
+describe('CLI plugin recovery', () => {
+    it('keeps "vendure plugins remove" reachable when a plugin is broken', async () => {
+        const project = createTestProject('cli-plugin-broken');
+        try {
+            const packageName = installCliPluginFixture(project, 'broken-cli-plugin');
+
+            const listed = await project.runCliCommand(['plugins']);
+            expect(listed.stderr).toContain('Failed to load CLI plugin');
+            expect(listed.stdout).toContain(packageName);
+
+            const removed = await project.runCliCommand(['plugins', 'remove', packageName]);
+            expect(removed.exitCode).toBe(0);
+            expect(readEnabledCliPlugins(project)).not.toContain(packageName);
+        } finally {
+            project.cleanup();
+        }
+    });
+
+    it('keeps "vendure plugins remove" reachable when a plugin collides', async () => {
+        const project = createTestProject('cli-plugin-collision-recovery');
+        try {
+            const packageName = installCliPluginFixture(project, 'command-collision-cli-plugin');
+
+            const removed = await project.runCliCommand(['plugins', 'remove', packageName]);
+
+            expect(removed.exitCode).toBe(0);
+            expect(readEnabledCliPlugins(project)).not.toContain(packageName);
+        } finally {
+            project.cleanup();
+        }
+    });
+});

--- a/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
@@ -42,7 +42,7 @@ describe('CLI plugin nested commands', () => {
     });
 
     afterAll(() => {
-        project.cleanup();
+        project?.cleanup();
     });
 
     it('runs a two-level plugin command', async () => {
@@ -50,49 +50,6 @@ describe('CLI plugin nested commands', () => {
 
         expect(result.exitCode).toBe(0);
         expect(parseCloudResult(result.stdout).command).toEqual(['project', 'list']);
-    });
-
-    it('runs a three-level plugin command with positional arguments', async () => {
-        const result = await project.runCliCommand(['config', 'server', 'set', 'apiPort', '3001']);
-
-        const parsed = parseCloudResult(result.stdout);
-        expect(parsed.command).toEqual(['config', 'server', 'set']);
-        expect(parsed.positionals).toEqual(['apiPort', '3001']);
-    });
-
-    it('runs a three-level plugin command without arguments', async () => {
-        const result = await project.runCliCommand(['backup', 'db', 'list']);
-
-        expect(parseCloudResult(result.stdout).command).toEqual(['backup', 'db', 'list']);
-    });
-
-    it('runs a two-level plugin command with an argument', async () => {
-        const result = await project.runCliCommand(['restore', 'db', 'backup-42']);
-
-        const parsed = parseCloudResult(result.stdout);
-        expect(parsed.command).toEqual(['restore', 'db']);
-        expect(parsed.positionals).toEqual(['backup-42']);
-    });
-
-    it('passes shared options given before the command path', async () => {
-        const result = await project.runCliCommand([
-            '--token',
-            'tok-1',
-            '--project',
-            'my-project',
-            '--environment',
-            'staging',
-            '--json',
-            'project',
-            'list',
-        ]);
-
-        expect(parseCloudResult(result.stdout).inherited).toEqual({
-            token: 'tok-1',
-            project: 'my-project',
-            environment: 'staging',
-            json: true,
-        });
     });
 
     it('passes shared options given after the command path', async () => {
@@ -119,6 +76,12 @@ describe('CLI plugin nested commands', () => {
         });
     });
 
+    it('passes a leaf command its own options', async () => {
+        const result = await project.runCliCommand(['project', 'list', '--limit', '5']);
+
+        expect(parseCloudResult(result.stdout).options).toEqual({ limit: '5' });
+    });
+
     it('passes a group option alongside the shared options', async () => {
         const result = await project.runCliCommand([
             'config',
@@ -137,21 +100,19 @@ describe('CLI plugin nested commands', () => {
 
     it('leaves a built-in option of the same name working', async () => {
         // The plugin registers a shared `--json` and the built-in `plugins`
-        // command declares its own, so both must still see the value.
+        // command declares its own. That both readings agree is pinned by the
+        // unit test in command-registry.spec.ts; here we only prove the
+        // built-in still produces its JSON output.
         const result = await project.runCliCommand(['plugins', '--json']);
 
         expect(result.exitCode).toBe(0);
         const listed = JSON.parse(result.stdout);
-        expect(JSON.stringify(listed)).toContain('@vendure-e2e/cloud-cli-plugin');
-    });
-
-    it('rejects a group option outside its group', async () => {
-        const result = await project.runCliCommand(['project', 'list', '--profile', 'ci'], {
-            expectError: true,
-        });
-
-        expect(result.exitCode).toBe(1);
-        expect(result.stderr).toContain("unknown option '--profile'");
+        const entry = listed.plugins.find(
+            (plugin: any) => plugin.packageName === '@vendure-e2e/cloud-cli-plugin',
+        );
+        // A plugin that failed to load is still listed, so the status is the
+        // part that proves --json reached a working built-in.
+        expect(entry?.status).toBe('enabled');
     });
 });
 
@@ -164,7 +125,7 @@ describe('CLI plugin help output', () => {
     });
 
     afterAll(() => {
-        project.cleanup();
+        project?.cleanup();
     });
 
     it('shows plugin commands and shared options in root help', async () => {
@@ -181,16 +142,6 @@ describe('CLI plugin help output', () => {
         }
     });
 
-    it('shows subcommands and inherited options in parent help', async () => {
-        const result = await project.runCliCommand(['config', '--help']);
-
-        expect(result.stdout).toContain('Usage: vendure config');
-        expect(result.stdout).toMatch(/^\s+server\s+Server configuration$/m);
-        expect(result.stdout).toMatch(/^\s+--profile /m);
-        expect(result.stdout).toContain('Global Options:');
-        expect(result.stdout).toMatch(/^\s+--token /m);
-    });
-
     it('shows the options valid at every level in leaf help', async () => {
         const result = await project.runCliCommand(['config', 'server', 'set', '--help']);
 
@@ -198,37 +149,6 @@ describe('CLI plugin help output', () => {
         expect(result.stdout).toContain('Global Options:');
         expect(result.stdout).toContain('--profile');
         expect(result.stdout).toContain('--environment');
-    });
-
-    it('prints help and fails when a group is run without a subcommand', async () => {
-        const result = await project.runCliCommand(['backup'], { expectError: true });
-
-        expect(result.exitCode).toBe(1);
-        expect(result.stderr).toContain('Usage: vendure backup');
-        expect(result.stderr).toMatch(/^\s+db\s+Database backups$/m);
-    });
-
-    it('fails on an unknown subcommand', async () => {
-        const result = await project.runCliCommand(['project', 'destroy'], { expectError: true });
-
-        expect(result.exitCode).toBe(1);
-        expect(result.stderr).toContain("unknown command 'destroy'");
-    });
-
-    it('fails on an unknown option', async () => {
-        const result = await project.runCliCommand(['project', 'list', '--nope'], { expectError: true });
-
-        expect(result.exitCode).toBe(1);
-        expect(result.stderr).toContain("unknown option '--nope'");
-    });
-
-    it('fails on a missing required argument', async () => {
-        const result = await project.runCliCommand(['config', 'server', 'set', 'apiPort'], {
-            expectError: true,
-        });
-
-        expect(result.exitCode).toBe(1);
-        expect(result.stderr).toContain("missing required argument 'value'");
     });
 });
 
@@ -267,13 +187,13 @@ describe('CLI plugin collisions', () => {
     it('skips a plugin whose shared option is already registered', async () => {
         const project = createTestProject('cli-plugin-option-collision');
         try {
-            installCliPluginFixture(project, 'cloud-cli-plugin');
+            const cloud = installCliPluginFixture(project, 'cloud-cli-plugin');
             installCliPluginFixture(project, 'option-collision-cli-plugin');
 
             const result = await project.runCliCommand(['project', 'list', '--token', 'tok']);
 
             expect(result.stderr).toContain('Failed to register CLI plugin');
-            expect(result.stderr).toContain('is already registered by @vendure-e2e/cloud-cli-plugin');
+            expect(result.stderr).toContain(`is already registered by ${cloud}`);
             expect(parseCloudResult(result.stdout).inherited.token).toBe('tok');
 
             const rival = await project.runCliCommand(['rival'], { expectError: true });

--- a/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
@@ -15,6 +15,7 @@ import {
     createTestProject,
     installCliPluginFixture,
     readEnabledCliPlugins,
+    readMarker,
 } from './cli-test-utils';
 
 interface CloudResult {
@@ -29,14 +30,7 @@ interface CloudResult {
  * host passed to the command action.
  */
 function parseCloudResult(stdout: string): CloudResult {
-    const line = stdout
-        .split('\n')
-        .map(l => l.trim())
-        .find(l => l.startsWith('CLOUD_RESULT '));
-    if (!line) {
-        throw new Error(`No CLOUD_RESULT line in CLI output:\n${stdout}`);
-    }
-    return JSON.parse(line.slice('CLOUD_RESULT '.length));
+    return readMarker(stdout, 'CLOUD_RESULT');
 }
 
 describe('CLI plugin nested commands', () => {
@@ -147,7 +141,8 @@ describe('CLI plugin nested commands', () => {
         const result = await project.runCliCommand(['plugins', '--json']);
 
         expect(result.exitCode).toBe(0);
-        expect(() => JSON.parse(result.stdout)).not.toThrow();
+        const listed = JSON.parse(result.stdout);
+        expect(JSON.stringify(listed)).toContain('@vendure-e2e/cloud-cli-plugin');
     });
 
     it('rejects a group option outside its group', async () => {
@@ -175,22 +170,25 @@ describe('CLI plugin help output', () => {
     it('shows plugin commands and shared options in root help', async () => {
         const result = await project.runCliCommand(['--help']);
 
-        for (const name of ['project', 'config', 'backup', 'restore']) {
-            expect(result.stdout).toContain(name);
-        }
+        // Anchored on the command list: these words also appear in built-in
+        // descriptions and option names, so `toContain` would pass regardless.
+        expect(result.stdout).toMatch(/^\s+project\s+Manage Cloud projects$/m);
+        expect(result.stdout).toMatch(/^\s+config \[options\]\s+Manage Cloud configuration$/m);
+        expect(result.stdout).toMatch(/^\s+backup\s+Manage backups$/m);
+        expect(result.stdout).toMatch(/^\s+restore\s+Restore from a backup$/m);
         for (const option of ['--token', '--project', '--environment', '--json']) {
-            expect(result.stdout).toContain(option);
+            expect(result.stdout).toMatch(new RegExp(`^\\s+${option}`, 'm'));
         }
     });
 
     it('shows subcommands and inherited options in parent help', async () => {
         const result = await project.runCliCommand(['config', '--help']);
 
-        expect(result.stdout).toContain('vendure config');
-        expect(result.stdout).toContain('server');
-        expect(result.stdout).toContain('--profile');
+        expect(result.stdout).toContain('Usage: vendure config');
+        expect(result.stdout).toMatch(/^\s+server\s+Server configuration$/m);
+        expect(result.stdout).toMatch(/^\s+--profile /m);
         expect(result.stdout).toContain('Global Options:');
-        expect(result.stdout).toContain('--token');
+        expect(result.stdout).toMatch(/^\s+--token /m);
     });
 
     it('shows the options valid at every level in leaf help', async () => {
@@ -206,8 +204,8 @@ describe('CLI plugin help output', () => {
         const result = await project.runCliCommand(['backup'], { expectError: true });
 
         expect(result.exitCode).toBe(1);
-        expect(result.stderr).toContain('vendure backup');
-        expect(result.stderr).toContain('db');
+        expect(result.stderr).toContain('Usage: vendure backup');
+        expect(result.stderr).toMatch(/^\s+db\s+Database backups$/m);
     });
 
     it('fails on an unknown subcommand', async () => {
@@ -281,6 +279,30 @@ describe('CLI plugin collisions', () => {
             const rival = await project.runCliCommand(['rival'], { expectError: true });
             expect(rival.exitCode).toBe(1);
             expect(rival.stderr).toContain('Unknown command "rival"');
+        } finally {
+            project.cleanup();
+        }
+    });
+});
+
+describe('CLI plugin discovery without activation', () => {
+    it('does not load a plugin that is installed but not enabled', async () => {
+        const project = createTestProject('cli-plugin-inactive');
+        try {
+            const packageName = installCliPluginFixture(project, 'cloud-cli-plugin', { enable: false });
+
+            // The hint is suppressed for --help and for `plugins` itself,
+            // so drive it with an ordinary command that exits quickly.
+            const hinted = await project.runCliCommand(['dev', 'bogus'], { expectError: true });
+            expect(hinted.stderr).toContain('Run "vendure plugins" to review them.');
+
+            // The command it declares is not registered, but the CLI knows
+            // which package would provide it, from vendure.cliCommands.
+            const unknown = await project.runCliCommand(['project', 'list'], { expectError: true });
+            expect(unknown.exitCode).toBe(1);
+            expect(unknown.stderr).toContain('Unknown command "project"');
+            expect(unknown.stderr).toContain(`It is provided by ${packageName}`);
+            expect(unknown.stderr).toContain(`vendure plugins add ${packageName}`);
         } finally {
             project.cleanup();
         }

--- a/packages/cli/e2e/cli-plugin-extensions.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-extensions.e2e-spec.ts
@@ -34,10 +34,6 @@ function traceOf(stdout: string): string[] {
         .map(line => line.split(' ')[0]);
 }
 
-function markerPayload(stdout: string, marker: string): any {
-    return readMarker(stdout, marker);
-}
-
 describe('Several plugins extending one command', () => {
     let project: CliTestProject;
 
@@ -72,18 +68,18 @@ describe('Several plugins extending one command', () => {
             { expectError: true },
         );
 
-        expect(markerPayload(result.stdout, 'PLATFORM_BEFORE')).toEqual({
+        expect(readMarker(result.stdout, 'PLATFORM_BEFORE')).toEqual({
             command: ['dev'],
             rotate: true,
         });
-        expect(markerPayload(result.stdout, 'CLOUD_BEFORE').cloudEnv).toBe('staging');
+        expect(readMarker(result.stdout, 'CLOUD_BEFORE').cloudEnv).toBe('staging');
     });
 
     it('hands the outer plugin the command the inner one already extended', async () => {
         const result = await project.runCliCommand(['dev', 'bogus'], { expectError: true });
 
         // The Cloud fixture is listed last, so it sees the option Platform added.
-        expect(markerPayload(result.stdout, 'CLOUD_BEFORE').sawOptions).toContain('--rotate-credential');
+        expect(readMarker(result.stdout, 'CLOUD_BEFORE').sawOptions).toContain('--rotate-credential');
     });
 
     it('shows every plugin option in dev help', async () => {
@@ -125,9 +121,7 @@ describe('Extension order follows the activation order', () => {
                 'CLOUD_AFTER',
                 'PLATFORM_AFTER',
             ]);
-            expect(markerPayload(result.stdout, 'CLOUD_BEFORE').sawOptions).not.toContain(
-                '--rotate-credential',
-            );
+            expect(readMarker(result.stdout, 'CLOUD_BEFORE').sawOptions).not.toContain('--rotate-credential');
         } finally {
             project.cleanup();
         }

--- a/packages/cli/e2e/cli-plugin-extensions.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-extensions.e2e-spec.ts
@@ -20,6 +20,7 @@ import {
     createTestProject,
     installCliPluginFixture,
     readEnabledCliPlugins,
+    readMarker,
 } from './cli-test-utils';
 
 /**
@@ -34,14 +35,7 @@ function traceOf(stdout: string): string[] {
 }
 
 function markerPayload(stdout: string, marker: string): any {
-    const line = stdout
-        .split('\n')
-        .map(l => l.trim())
-        .find(l => l.startsWith(`${marker} `));
-    if (!line) {
-        throw new Error(`No ${marker} line in CLI output:\n${stdout}`);
-    }
-    return JSON.parse(line.slice(marker.length + 1));
+    return readMarker(stdout, marker);
 }
 
 describe('Several plugins extending one command', () => {
@@ -157,6 +151,7 @@ describe('Extension collisions and recovery', () => {
 
             const unknown = await project.runCliCommand(['broken-extra'], { expectError: true });
             expect(unknown.exitCode).toBe(1);
+            expect(unknown.stderr).toContain('Unknown command "broken-extra"');
 
             const removed = await project.runCliCommand(['plugins', 'remove', broken]);
             expect(removed.exitCode).toBe(0);

--- a/packages/cli/e2e/cli-plugin-extensions.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-extensions.e2e-spec.ts
@@ -1,0 +1,200 @@
+/*
+ * E2E tests for several CLI plugins extending the same command.
+ *
+ * These spawn the built CLI (`dist/cli.js`) against a temporary project, with
+ * one fixture standing in for `@vendure-platform/cli` and another for
+ * `@vendure/cloud`, both wrapping the built-in `dev`.
+ *
+ * `dev bogus` is used to drive the whole chain: the built-in rejects an unknown
+ * target before it starts any process, so the test observes both wrappers and
+ * the built-in running without a server being spawned. The built-in reports the
+ * bad target through the CLI logger and returns exit code 1.
+ *
+ * To run these tests:
+ * npm run vitest -- --config e2e/vitest.e2e.config.mts
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+    CliTestProject,
+    createTestProject,
+    installCliPluginFixture,
+    readEnabledCliPlugins,
+} from './cli-test-utils';
+
+/**
+ * The markers each layer prints, in the order they appear in the output.
+ */
+function traceOf(stdout: string): string[] {
+    return stdout
+        .split('\n')
+        .map(line => line.trim())
+        .filter(line => /^(PLATFORM|CLOUD)_(BEFORE|AFTER)/.test(line))
+        .map(line => line.split(' ')[0]);
+}
+
+function markerPayload(stdout: string, marker: string): any {
+    const line = stdout
+        .split('\n')
+        .map(l => l.trim())
+        .find(l => l.startsWith(`${marker} `));
+    if (!line) {
+        throw new Error(`No ${marker} line in CLI output:\n${stdout}`);
+    }
+    return JSON.parse(line.slice(marker.length + 1));
+}
+
+describe('Several plugins extending one command', () => {
+    let project: CliTestProject;
+
+    beforeAll(() => {
+        project = createTestProject('cli-plugin-extensions');
+        installCliPluginFixture(project, 'platform-cli-plugin');
+        installCliPluginFixture(project, 'cloud-dev-cli-plugin');
+    });
+
+    afterAll(() => {
+        project.cleanup();
+    });
+
+    it('runs both wrappers and the built-in in one invocation', async () => {
+        const result = await project.runCliCommand(['dev', 'bogus'], { expectError: true });
+
+        expect(traceOf(result.stdout)).toEqual([
+            'CLOUD_BEFORE',
+            'PLATFORM_BEFORE',
+            'PLATFORM_AFTER',
+            'CLOUD_AFTER',
+        ]);
+        // The built-in ran: it is what rejects the unknown target, and it
+        // reports through the CLI's own logger rather than throwing.
+        expect(result.stdout).toContain('Unknown dev target "bogus"');
+        expect(result.exitCode).toBe(1);
+    });
+
+    it('gives each wrapper the options and context the host parsed', async () => {
+        const result = await project.runCliCommand(
+            ['dev', 'bogus', '--rotate-credential', '--cloud-env', 'staging'],
+            { expectError: true },
+        );
+
+        expect(markerPayload(result.stdout, 'PLATFORM_BEFORE')).toEqual({
+            command: ['dev'],
+            rotate: true,
+        });
+        expect(markerPayload(result.stdout, 'CLOUD_BEFORE').cloudEnv).toBe('staging');
+    });
+
+    it('hands the outer plugin the command the inner one already extended', async () => {
+        const result = await project.runCliCommand(['dev', 'bogus'], { expectError: true });
+
+        // The Cloud fixture is listed last, so it sees the option Platform added.
+        expect(markerPayload(result.stdout, 'CLOUD_BEFORE').sawOptions).toContain('--rotate-credential');
+    });
+
+    it('shows every plugin option in dev help', async () => {
+        const result = await project.runCliCommand(['dev', '--help']);
+
+        expect(result.stdout).toContain('--rotate-credential');
+        expect(result.stdout).toContain('--cloud-env');
+        // The built-in options survive.
+        expect(result.stdout).toContain('--no-reload');
+        expect(result.stdout).toContain('--server-entry');
+    });
+
+    it('shows the extended description in root help', async () => {
+        const result = await project.runCliCommand(['--help']);
+
+        expect(result.stdout).toContain('Run Vendure in development mode with linked Platform credentials');
+    });
+
+    it('still rejects an unknown option on the extended command', async () => {
+        const result = await project.runCliCommand(['dev', '--nope'], { expectError: true });
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("unknown option '--nope'");
+    });
+});
+
+describe('Extension order follows the activation order', () => {
+    it('makes the last listed plugin the outermost wrapper', async () => {
+        const project = createTestProject('cli-plugin-extensions-reversed');
+        try {
+            installCliPluginFixture(project, 'cloud-dev-cli-plugin');
+            installCliPluginFixture(project, 'platform-cli-plugin');
+
+            const result = await project.runCliCommand(['dev', 'bogus'], { expectError: true });
+
+            expect(traceOf(result.stdout)).toEqual([
+                'PLATFORM_BEFORE',
+                'CLOUD_BEFORE',
+                'CLOUD_AFTER',
+                'PLATFORM_AFTER',
+            ]);
+            expect(markerPayload(result.stdout, 'CLOUD_BEFORE').sawOptions).not.toContain(
+                '--rotate-credential',
+            );
+        } finally {
+            project.cleanup();
+        }
+    });
+});
+
+describe('Extension collisions and recovery', () => {
+    it('skips a plugin whose decorator fails to apply, keeping the others', async () => {
+        const project = createTestProject('cli-plugin-broken-decorator');
+        try {
+            installCliPluginFixture(project, 'platform-cli-plugin');
+            const broken = installCliPluginFixture(project, 'broken-decorator-cli-plugin');
+
+            const result = await project.runCliCommand(['dev', 'bogus'], { expectError: true });
+
+            expect(result.stderr).toContain('Failed to register CLI plugin');
+            expect(result.stderr).toContain('This decorator is broken on purpose');
+            expect(result.stderr).toContain(`vendure plugins remove ${broken}`);
+            // The working plugin is untouched, and nothing from the broken one landed.
+            expect(traceOf(result.stdout)).toEqual(['PLATFORM_BEFORE', 'PLATFORM_AFTER']);
+
+            const unknown = await project.runCliCommand(['broken-extra'], { expectError: true });
+            expect(unknown.exitCode).toBe(1);
+
+            const removed = await project.runCliCommand(['plugins', 'remove', broken]);
+            expect(removed.exitCode).toBe(0);
+            expect(readEnabledCliPlugins(project)).not.toContain(broken);
+        } finally {
+            project.cleanup();
+        }
+    });
+
+    it('refuses to replace a command another plugin has extended', async () => {
+        const project = createTestProject('cli-plugin-replace-extended');
+        try {
+            installCliPluginFixture(project, 'platform-cli-plugin');
+            installCliPluginFixture(project, 'dev-replacement-cli-plugin');
+
+            const result = await project.runCliCommand(['dev', 'bogus'], { expectError: true });
+
+            expect(result.stderr).toContain('has been extended by @vendure-e2e/platform-cli-plugin');
+            expect(result.stdout).not.toContain('REPLACEMENT_DEV');
+            expect(traceOf(result.stdout)).toEqual(['PLATFORM_BEFORE', 'PLATFORM_AFTER']);
+        } finally {
+            project.cleanup();
+        }
+    });
+
+    it('extends a replacement when the replacing plugin is listed first', async () => {
+        const project = createTestProject('cli-plugin-replace-then-extend');
+        try {
+            installCliPluginFixture(project, 'dev-replacement-cli-plugin');
+            installCliPluginFixture(project, 'platform-cli-plugin');
+
+            const result = await project.runCliCommand(['dev']);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain('REPLACEMENT_DEV');
+            expect(traceOf(result.stdout)).toEqual(['PLATFORM_BEFORE', 'PLATFORM_AFTER']);
+        } finally {
+            project.cleanup();
+        }
+    });
+});

--- a/packages/cli/e2e/cli-plugin-extensions.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-extensions.e2e-spec.ts
@@ -44,7 +44,7 @@ describe('Several plugins extending one command', () => {
     });
 
     afterAll(() => {
-        project.cleanup();
+        project?.cleanup();
     });
 
     it('runs both wrappers and the built-in in one invocation', async () => {
@@ -158,12 +158,12 @@ describe('Extension collisions and recovery', () => {
     it('refuses to replace a command another plugin has extended', async () => {
         const project = createTestProject('cli-plugin-replace-extended');
         try {
-            installCliPluginFixture(project, 'platform-cli-plugin');
+            const platform = installCliPluginFixture(project, 'platform-cli-plugin');
             installCliPluginFixture(project, 'dev-replacement-cli-plugin');
 
             const result = await project.runCliCommand(['dev', 'bogus'], { expectError: true });
 
-            expect(result.stderr).toContain('has been extended by @vendure-e2e/platform-cli-plugin');
+            expect(result.stderr).toContain(`has been extended by ${platform}`);
             expect(result.stdout).not.toContain('REPLACEMENT_DEV');
             expect(traceOf(result.stdout)).toEqual(['PLATFORM_BEFORE', 'PLATFORM_AFTER']);
         } finally {

--- a/packages/cli/e2e/cli-test-utils.ts
+++ b/packages/cli/e2e/cli-test-utils.ts
@@ -158,7 +158,7 @@ const CLI_PLUGIN_FIXTURES_DIR = join(__dirname, 'fixtures', 'cli-plugins');
 export function installCliPluginFixture(
     project: CliTestProject,
     fixtureName: string,
-    options: { enable?: boolean } = {},
+    { enable = true }: { enable?: boolean } = {},
 ): string {
     const fixtureDir = join(CLI_PLUGIN_FIXTURES_DIR, fixtureName);
     const packageName = JSON.parse(readFileSync(join(fixtureDir, 'package.json'), 'utf-8')).name as string;
@@ -169,7 +169,7 @@ export function installCliPluginFixture(
 
     updatePackageJson(project, packageJson => {
         packageJson.dependencies = { ...packageJson.dependencies, [packageName]: '1.0.0' };
-        if (options.enable !== false) {
+        if (enable) {
             const vendure = packageJson.vendure ?? {};
             const cli = vendure.cli ?? {};
             packageJson.vendure = {
@@ -185,6 +185,10 @@ export function installCliPluginFixture(
 /**
  * Makes `require('@vendure/cli')` resolve from the test project, so a plugin
  * fixture uses the same public API a real plugin package would.
+ *
+ * Also adds `@vendure/cli` to the project's devDependencies, which is how
+ * `resolveCliProjectRoot` recognises the temp directory as the project root.
+ * Without it plugin discovery walks past the project and finds nothing.
  *
  * The link points at the real package directory. `cleanup()` removes it with
  * `rmSync`, which unlinks the symlink rather than following it, so the
@@ -211,7 +215,7 @@ function updatePackageJson(project: CliTestProject, mutate: (packageJson: any) =
 /**
  * Reads back a `PREFIX {json}` line that a plugin fixture printed.
  */
-export function readMarker(stdout: string, prefix: string): any {
+export function readMarker<T = any>(stdout: string, prefix: string): T {
     const line = stdout
         .split('\n')
         .map(l => l.trim())
@@ -219,7 +223,7 @@ export function readMarker(stdout: string, prefix: string): any {
     if (!line) {
         throw new Error(`No ${prefix} line in CLI output:\n${stdout}`);
     }
-    return JSON.parse(line.slice(prefix.length + 1));
+    return JSON.parse(line.slice(prefix.length + 1)) as T;
 }
 
 export function readEnabledCliPlugins(project: CliTestProject): string[] {

--- a/packages/cli/e2e/cli-test-utils.ts
+++ b/packages/cli/e2e/cli-test-utils.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -143,6 +143,70 @@ export const config: VendureConfig = {
             });
         },
     };
+}
+
+const CLI_PACKAGE_DIR = join(__dirname, '..');
+const CLI_PLUGIN_FIXTURES_DIR = join(__dirname, 'fixtures', 'cli-plugins');
+
+/**
+ * Copies a CLI plugin fixture into the test project's node_modules, declares it
+ * as a direct dependency and, unless `enable` is false, lists it in
+ * `vendure.cli.plugins` so the CLI actually loads it.
+ *
+ * Returns the package name of the installed plugin.
+ */
+export function installCliPluginFixture(
+    project: CliTestProject,
+    fixtureName: string,
+    options: { enable?: boolean } = {},
+): string {
+    const fixtureDir = join(CLI_PLUGIN_FIXTURES_DIR, fixtureName);
+    const packageName = JSON.parse(readFileSync(join(fixtureDir, 'package.json'), 'utf-8')).name as string;
+    const targetDir = join(project.projectDir, 'node_modules', ...packageName.split('/'));
+
+    mkdirSync(targetDir, { recursive: true });
+    cpSync(fixtureDir, targetDir, { recursive: true });
+    linkCliPackage(project);
+
+    updatePackageJson(project, packageJson => {
+        packageJson.dependencies = { ...packageJson.dependencies, [packageName]: '1.0.0' };
+        if (options.enable !== false) {
+            const vendure = packageJson.vendure ?? {};
+            const cli = vendure.cli ?? {};
+            packageJson.vendure = {
+                ...vendure,
+                cli: { ...cli, plugins: [...(cli.plugins ?? []), packageName] },
+            };
+        }
+    });
+
+    return packageName;
+}
+
+/**
+ * Makes `require('@vendure/cli')` resolve from the test project, so a plugin
+ * fixture uses the same public API a real plugin package would.
+ */
+function linkCliPackage(project: CliTestProject): void {
+    const scopeDir = join(project.projectDir, 'node_modules', '@vendure');
+    const linkPath = join(scopeDir, 'cli');
+    if (!existsSync(linkPath)) {
+        mkdirSync(scopeDir, { recursive: true });
+        symlinkSync(CLI_PACKAGE_DIR, linkPath, process.platform === 'win32' ? 'junction' : 'dir');
+    }
+    updatePackageJson(project, packageJson => {
+        packageJson.devDependencies = { ...packageJson.devDependencies, '@vendure/cli': '*' };
+    });
+}
+
+function updatePackageJson(project: CliTestProject, mutate: (packageJson: any) => void): void {
+    const packageJson = JSON.parse(project.readFile('package.json'));
+    mutate(packageJson);
+    project.writeFile('package.json', JSON.stringify(packageJson, null, 2));
+}
+
+export function readEnabledCliPlugins(project: CliTestProject): string[] {
+    return JSON.parse(project.readFile('package.json')).vendure?.cli?.plugins ?? [];
 }
 
 /**

--- a/packages/cli/e2e/cli-test-utils.ts
+++ b/packages/cli/e2e/cli-test-utils.ts
@@ -164,7 +164,6 @@ export function installCliPluginFixture(
     const packageName = JSON.parse(readFileSync(join(fixtureDir, 'package.json'), 'utf-8')).name as string;
     const targetDir = join(project.projectDir, 'node_modules', ...packageName.split('/'));
 
-    mkdirSync(targetDir, { recursive: true });
     cpSync(fixtureDir, targetDir, { recursive: true });
     linkCliPackage(project);
 
@@ -186,6 +185,10 @@ export function installCliPluginFixture(
 /**
  * Makes `require('@vendure/cli')` resolve from the test project, so a plugin
  * fixture uses the same public API a real plugin package would.
+ *
+ * The link points at the real package directory. `cleanup()` removes it with
+ * `rmSync`, which unlinks the symlink rather than following it, so the
+ * repository is not touched.
  */
 function linkCliPackage(project: CliTestProject): void {
     const scopeDir = join(project.projectDir, 'node_modules', '@vendure');
@@ -203,6 +206,20 @@ function updatePackageJson(project: CliTestProject, mutate: (packageJson: any) =
     const packageJson = JSON.parse(project.readFile('package.json'));
     mutate(packageJson);
     project.writeFile('package.json', JSON.stringify(packageJson, null, 2));
+}
+
+/**
+ * Reads back a `PREFIX {json}` line that a plugin fixture printed.
+ */
+export function readMarker(stdout: string, prefix: string): any {
+    const line = stdout
+        .split('\n')
+        .map(l => l.trim())
+        .find(l => l.startsWith(`${prefix} `));
+    if (!line) {
+        throw new Error(`No ${prefix} line in CLI output:\n${stdout}`);
+    }
+    return JSON.parse(line.slice(prefix.length + 1));
 }
 
 export function readEnabledCliPlugins(project: CliTestProject): string[] {

--- a/packages/cli/e2e/fixtures/cli-plugins/broken-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/broken-cli-plugin/cli-plugin.js
@@ -1,3 +1,2 @@
-/* eslint-disable */
 // Fails at require time, so the CLI has to keep working without it.
 throw new Error('This CLI plugin is broken on purpose');

--- a/packages/cli/e2e/fixtures/cli-plugins/broken-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/broken-cli-plugin/cli-plugin.js
@@ -1,0 +1,3 @@
+/* eslint-disable */
+// Fails at require time, so the CLI has to keep working without it.
+throw new Error('This CLI plugin is broken on purpose');

--- a/packages/cli/e2e/fixtures/cli-plugins/broken-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/broken-cli-plugin/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "@vendure-e2e/broken-cli-plugin",
+    "version": "1.0.0",
+    "private": true,
+    "main": "cli-plugin.js",
+    "vendure": {
+        "cliPlugin": "./cli-plugin.js"
+    }
+}

--- a/packages/cli/e2e/fixtures/cli-plugins/broken-decorator-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/broken-decorator-cli-plugin/cli-plugin.js
@@ -1,0 +1,16 @@
+/* eslint-disable */
+// The decorator throws while the plugin is being registered.
+const { defineCliPlugin } = require('@vendure/cli');
+
+module.exports = defineCliPlugin({
+    id: '@vendure-e2e/broken-decorator-cli-plugin',
+    commands: [{ name: 'broken-extra', description: 'Never registered', action: async () => 0 }],
+    extendCommands: [
+        {
+            command: 'dev',
+            decorate: () => {
+                throw new Error('This decorator is broken on purpose');
+            },
+        },
+    ],
+});

--- a/packages/cli/e2e/fixtures/cli-plugins/broken-decorator-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/broken-decorator-cli-plugin/cli-plugin.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 // The decorator throws while the plugin is being registered.
 const { defineCliPlugin } = require('@vendure/cli');
 

--- a/packages/cli/e2e/fixtures/cli-plugins/broken-decorator-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/broken-decorator-cli-plugin/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "@vendure-e2e/broken-decorator-cli-plugin",
+    "version": "1.0.0",
+    "private": true,
+    "main": "cli-plugin.js",
+    "vendure": {
+        "cliPlugin": "./cli-plugin.js"
+    }
+}

--- a/packages/cli/e2e/fixtures/cli-plugins/cloud-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/cloud-cli-plugin/cli-plugin.js
@@ -33,6 +33,9 @@ module.exports = defineCliPlugin({
                 {
                     name: 'list',
                     description: 'List the projects you can access',
+                    options: [
+                        { long: '--limit <n>', description: 'Maximum number of projects', required: true },
+                    ],
                     action: async (options, command, context) => report(context, options),
                 },
             ],

--- a/packages/cli/e2e/fixtures/cli-plugins/cloud-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/cloud-cli-plugin/cli-plugin.js
@@ -1,0 +1,95 @@
+/* eslint-disable */
+/**
+ * A CLI plugin shaped like the Vendure Cloud command surface: nested command
+ * trees plus options shared by every command. Each action prints what the host
+ * handed it, so the e2e tests can assert on it.
+ */
+const { defineCliPlugin } = require('@vendure/cli');
+
+function report(context, options, positionals) {
+    process.stdout.write(
+        `CLOUD_RESULT ${JSON.stringify({
+            command: context.commandPath,
+            positionals: positionals || [],
+            options,
+            inherited: context.inheritedOptions,
+        })}\n`,
+    );
+    return 0;
+}
+
+module.exports = defineCliPlugin({
+    id: '@vendure-e2e/cloud-cli-plugin',
+    rootOptions: [
+        { long: '--token <token>', description: 'Cloud API token', required: true },
+        { long: '--project <slug>', description: 'Cloud project slug', required: true },
+        { long: '--environment <name>', description: 'Cloud environment name', required: true },
+        { long: '--json', description: 'Print machine-readable output' },
+    ],
+    commands: [
+        {
+            name: 'project',
+            description: 'Manage Cloud projects',
+            subcommands: [
+                {
+                    name: 'list',
+                    description: 'List the projects you can access',
+                    action: async (options, command, context) => report(context, options),
+                },
+            ],
+        },
+        {
+            name: 'config',
+            description: 'Manage Cloud configuration',
+            options: [{ long: '--profile <name>', description: 'Configuration profile', required: true }],
+            subcommands: [
+                {
+                    name: 'server',
+                    description: 'Server configuration',
+                    subcommands: [
+                        {
+                            name: 'set',
+                            description: 'Set a server configuration value',
+                            arguments: [
+                                { name: 'key', description: 'Configuration key', required: true },
+                                { name: 'value', description: 'Configuration value', required: true },
+                            ],
+                            action: async (key, value, options, command, context) =>
+                                report(context, options, [key, value]),
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'backup',
+            description: 'Manage backups',
+            subcommands: [
+                {
+                    name: 'db',
+                    description: 'Database backups',
+                    subcommands: [
+                        {
+                            name: 'list',
+                            description: 'List database backups',
+                            action: async (options, command, context) => report(context, options),
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'restore',
+            description: 'Restore from a backup',
+            subcommands: [
+                {
+                    name: 'db',
+                    description: 'Restore the database from a backup',
+                    arguments: [{ name: 'backupId', description: 'Backup to restore', required: true }],
+                    action: async (backupId, options, command, context) =>
+                        report(context, options, [backupId]),
+                },
+            ],
+        },
+    ],
+});

--- a/packages/cli/e2e/fixtures/cli-plugins/cloud-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/cloud-cli-plugin/cli-plugin.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * A CLI plugin shaped like the Vendure Cloud command surface: nested command
  * trees plus options shared by every command. Each action prints what the host

--- a/packages/cli/e2e/fixtures/cli-plugins/cloud-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/cloud-cli-plugin/package.json
@@ -5,6 +5,11 @@
     "main": "cli-plugin.js",
     "vendure": {
         "cliPlugin": "./cli-plugin.js",
-        "cliCommands": ["project", "config", "backup", "restore"]
+        "cliCommands": [
+            "project",
+            "config",
+            "backup",
+            "restore"
+        ]
     }
 }

--- a/packages/cli/e2e/fixtures/cli-plugins/cloud-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/cloud-cli-plugin/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "@vendure-e2e/cloud-cli-plugin",
+    "version": "1.0.0",
+    "private": true,
+    "main": "cli-plugin.js",
+    "vendure": {
+        "cliPlugin": "./cli-plugin.js",
+        "cliCommands": ["project", "config", "backup", "restore"]
+    }
+}

--- a/packages/cli/e2e/fixtures/cli-plugins/cloud-dev-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/cloud-dev-cli-plugin/cli-plugin.js
@@ -1,7 +1,7 @@
 /**
  * A second plugin extending the same command, standing in for @vendure/cloud.
  */
-const { defineCliPlugin } = require('@vendure/cli');
+const { defineCliPlugin, readCommandOptions } = require('@vendure/cli');
 
 module.exports = defineCliPlugin({
     id: '@vendure-e2e/cloud-dev-cli-plugin',
@@ -19,9 +19,7 @@ module.exports = defineCliPlugin({
             decorate:
                 ({ command, next }) =>
                 async (...args) => {
-                    // The host appends its context after Commander's options
-                    // and Command, so the last three slots are always these.
-                    const [options] = args.slice(-3);
+                    const options = readCommandOptions(args);
                     process.stdout.write(
                         `CLOUD_BEFORE ${JSON.stringify({
                             sawOptions: (command.options || []).map(option => option.long),

--- a/packages/cli/e2e/fixtures/cli-plugins/cloud-dev-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/cloud-dev-cli-plugin/cli-plugin.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * A second plugin extending the same command, standing in for @vendure/cloud.
  */
@@ -20,10 +19,13 @@ module.exports = defineCliPlugin({
             decorate:
                 ({ command, next }) =>
                 async (...args) => {
+                    // The host appends its context after Commander's options
+                    // and Command, so the last three slots are always these.
+                    const [options] = args.slice(-3);
                     process.stdout.write(
                         `CLOUD_BEFORE ${JSON.stringify({
                             sawOptions: (command.options || []).map(option => option.long),
-                            cloudEnv: args[args.length - 3].cloudEnv,
+                            cloudEnv: options.cloudEnv,
                         })}\n`,
                     );
                     try {

--- a/packages/cli/e2e/fixtures/cli-plugins/cloud-dev-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/cloud-dev-cli-plugin/cli-plugin.js
@@ -1,0 +1,37 @@
+/* eslint-disable */
+/**
+ * A second plugin extending the same command, standing in for @vendure/cloud.
+ */
+const { defineCliPlugin } = require('@vendure/cli');
+
+module.exports = defineCliPlugin({
+    id: '@vendure-e2e/cloud-dev-cli-plugin',
+    commands: [],
+    extendCommands: [
+        {
+            command: 'dev',
+            options: [
+                {
+                    long: '--cloud-env <name>',
+                    description: 'Cloud environment to source configuration from',
+                    required: true,
+                },
+            ],
+            decorate:
+                ({ command, next }) =>
+                async (...args) => {
+                    process.stdout.write(
+                        `CLOUD_BEFORE ${JSON.stringify({
+                            sawOptions: (command.options || []).map(option => option.long),
+                            cloudEnv: args[args.length - 3].cloudEnv,
+                        })}\n`,
+                    );
+                    try {
+                        return await next(...args);
+                    } finally {
+                        process.stdout.write('CLOUD_AFTER\n');
+                    }
+                },
+        },
+    ],
+});

--- a/packages/cli/e2e/fixtures/cli-plugins/cloud-dev-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/cloud-dev-cli-plugin/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "@vendure-e2e/cloud-dev-cli-plugin",
+    "version": "1.0.0",
+    "private": true,
+    "main": "cli-plugin.js",
+    "vendure": {
+        "cliPlugin": "./cli-plugin.js"
+    }
+}

--- a/packages/cli/e2e/fixtures/cli-plugins/command-collision-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/command-collision-cli-plugin/cli-plugin.js
@@ -1,0 +1,17 @@
+/* eslint-disable */
+// Takes over the built-in `add` command without declaring `replaces: true`.
+const { defineCliPlugin } = require('@vendure/cli');
+
+module.exports = defineCliPlugin({
+    id: '@vendure-e2e/command-collision-cli-plugin',
+    commands: [
+        {
+            name: 'add',
+            description: 'Silently takes over the built-in add command',
+            action: async () => {
+                process.stdout.write('COLLIDING_ADD\n');
+                return 0;
+            },
+        },
+    ],
+});

--- a/packages/cli/e2e/fixtures/cli-plugins/command-collision-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/command-collision-cli-plugin/cli-plugin.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 // Takes over the built-in `add` command without declaring `replaces: true`.
 const { defineCliPlugin } = require('@vendure/cli');
 

--- a/packages/cli/e2e/fixtures/cli-plugins/command-collision-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/command-collision-cli-plugin/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "@vendure-e2e/command-collision-cli-plugin",
+    "version": "1.0.0",
+    "private": true,
+    "main": "cli-plugin.js",
+    "vendure": {
+        "cliPlugin": "./cli-plugin.js",
+        "cliCommands": ["add"]
+    }
+}

--- a/packages/cli/e2e/fixtures/cli-plugins/command-collision-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/command-collision-cli-plugin/package.json
@@ -5,6 +5,8 @@
     "main": "cli-plugin.js",
     "vendure": {
         "cliPlugin": "./cli-plugin.js",
-        "cliCommands": ["add"]
+        "cliCommands": [
+            "add"
+        ]
     }
 }

--- a/packages/cli/e2e/fixtures/cli-plugins/dev-replacement-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/dev-replacement-cli-plugin/cli-plugin.js
@@ -1,0 +1,19 @@
+/* eslint-disable */
+// Replaces `dev` outright, which must be refused once another plugin has
+// extended it.
+const { defineCliPlugin } = require('@vendure/cli');
+
+module.exports = defineCliPlugin({
+    id: '@vendure-e2e/dev-replacement-cli-plugin',
+    commands: [
+        {
+            name: 'dev',
+            description: 'Replaces the built-in dev command outright',
+            replaces: true,
+            action: async () => {
+                process.stdout.write('REPLACEMENT_DEV\n');
+                return 0;
+            },
+        },
+    ],
+});

--- a/packages/cli/e2e/fixtures/cli-plugins/dev-replacement-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/dev-replacement-cli-plugin/cli-plugin.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 // Replaces `dev` outright, which must be refused once another plugin has
 // extended it.
 const { defineCliPlugin } = require('@vendure/cli');

--- a/packages/cli/e2e/fixtures/cli-plugins/dev-replacement-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/dev-replacement-cli-plugin/package.json
@@ -5,6 +5,8 @@
     "main": "cli-plugin.js",
     "vendure": {
         "cliPlugin": "./cli-plugin.js",
-        "cliCommands": ["dev"]
+        "cliCommands": [
+            "dev"
+        ]
     }
 }

--- a/packages/cli/e2e/fixtures/cli-plugins/dev-replacement-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/dev-replacement-cli-plugin/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "@vendure-e2e/dev-replacement-cli-plugin",
+    "version": "1.0.0",
+    "private": true,
+    "main": "cli-plugin.js",
+    "vendure": {
+        "cliPlugin": "./cli-plugin.js",
+        "cliCommands": ["dev"]
+    }
+}

--- a/packages/cli/e2e/fixtures/cli-plugins/option-collision-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/option-collision-cli-plugin/cli-plugin.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 // Registers a shared option that another plugin already owns.
 const { defineCliPlugin } = require('@vendure/cli');
 

--- a/packages/cli/e2e/fixtures/cli-plugins/option-collision-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/option-collision-cli-plugin/cli-plugin.js
@@ -1,0 +1,15 @@
+/* eslint-disable */
+// Registers a shared option that another plugin already owns.
+const { defineCliPlugin } = require('@vendure/cli');
+
+module.exports = defineCliPlugin({
+    id: '@vendure-e2e/option-collision-cli-plugin',
+    rootOptions: [{ long: '--token <token>', description: 'A rival API token', required: true }],
+    commands: [
+        {
+            name: 'rival',
+            description: 'A command from a plugin with a colliding shared option',
+            action: async () => 0,
+        },
+    ],
+});

--- a/packages/cli/e2e/fixtures/cli-plugins/option-collision-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/option-collision-cli-plugin/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "@vendure-e2e/option-collision-cli-plugin",
+    "version": "1.0.0",
+    "private": true,
+    "main": "cli-plugin.js",
+    "vendure": {
+        "cliPlugin": "./cli-plugin.js",
+        "cliCommands": ["rival"]
+    }
+}

--- a/packages/cli/e2e/fixtures/cli-plugins/option-collision-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/option-collision-cli-plugin/package.json
@@ -5,6 +5,8 @@
     "main": "cli-plugin.js",
     "vendure": {
         "cliPlugin": "./cli-plugin.js",
-        "cliCommands": ["rival"]
+        "cliCommands": [
+            "rival"
+        ]
     }
 }

--- a/packages/cli/e2e/fixtures/cli-plugins/platform-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/platform-cli-plugin/cli-plugin.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Mirrors what @vendure-platform/cli does to `dev`: add an option and wrap the
  * action. The wrapper calls the action it is handed, so another plugin can wrap
@@ -22,11 +21,13 @@ module.exports = defineCliPlugin({
             decorate:
                 ({ next }) =>
                 async (...args) => {
-                    const context = args[args.length - 1];
+                    // The host appends its context after Commander's options
+                    // and Command, so the last three slots are always these.
+                    const [options, , context] = args.slice(-3);
                     process.stdout.write(
                         `PLATFORM_BEFORE ${JSON.stringify({
                             command: context.commandPath,
-                            rotate: args[args.length - 3].rotateCredential === true,
+                            rotate: options.rotateCredential === true,
                         })}\n`,
                     );
                     try {

--- a/packages/cli/e2e/fixtures/cli-plugins/platform-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/platform-cli-plugin/cli-plugin.js
@@ -1,0 +1,40 @@
+/* eslint-disable */
+/**
+ * Mirrors what @vendure-platform/cli does to `dev`: add an option and wrap the
+ * action. The wrapper calls the action it is handed, so another plugin can wrap
+ * it in turn.
+ */
+const { defineCliPlugin } = require('@vendure/cli');
+
+module.exports = defineCliPlugin({
+    id: '@vendure-e2e/platform-cli-plugin',
+    commands: [],
+    extendCommands: [
+        {
+            command: 'dev',
+            description: 'Run Vendure in development mode with linked Platform credentials',
+            options: [
+                {
+                    long: '--rotate-credential',
+                    description: 'Replace the active development credential',
+                },
+            ],
+            decorate:
+                ({ next }) =>
+                async (...args) => {
+                    const context = args[args.length - 1];
+                    process.stdout.write(
+                        `PLATFORM_BEFORE ${JSON.stringify({
+                            command: context.commandPath,
+                            rotate: args[args.length - 3].rotateCredential === true,
+                        })}\n`,
+                    );
+                    try {
+                        return await next(...args);
+                    } finally {
+                        process.stdout.write('PLATFORM_AFTER\n');
+                    }
+                },
+        },
+    ],
+});

--- a/packages/cli/e2e/fixtures/cli-plugins/platform-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/platform-cli-plugin/cli-plugin.js
@@ -3,7 +3,7 @@
  * action. The wrapper calls the action it is handed, so another plugin can wrap
  * it in turn.
  */
-const { defineCliPlugin } = require('@vendure/cli');
+const { defineCliPlugin, readCommandContext, readCommandOptions } = require('@vendure/cli');
 
 module.exports = defineCliPlugin({
     id: '@vendure-e2e/platform-cli-plugin',
@@ -21,9 +21,8 @@ module.exports = defineCliPlugin({
             decorate:
                 ({ next }) =>
                 async (...args) => {
-                    // The host appends its context after Commander's options
-                    // and Command, so the last three slots are always these.
-                    const [options, , context] = args.slice(-3);
+                    const context = readCommandContext(args);
+                    const options = readCommandOptions(args);
                     process.stdout.write(
                         `PLATFORM_BEFORE ${JSON.stringify({
                             command: context.commandPath,

--- a/packages/cli/e2e/fixtures/cli-plugins/platform-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/platform-cli-plugin/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "@vendure-e2e/platform-cli-plugin",
+    "version": "1.0.0",
+    "private": true,
+    "main": "cli-plugin.js",
+    "vendure": {
+        "cliPlugin": "./cli-plugin.js"
+    }
+}

--- a/packages/cli/e2e/fixtures/cli-plugins/replacing-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/replacing-cli-plugin/cli-plugin.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 // Deliberately replaces a built-in command.
 const { defineCliPlugin } = require('@vendure/cli');
 

--- a/packages/cli/e2e/fixtures/cli-plugins/replacing-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/replacing-cli-plugin/cli-plugin.js
@@ -1,0 +1,18 @@
+/* eslint-disable */
+// Deliberately replaces a built-in command.
+const { defineCliPlugin } = require('@vendure/cli');
+
+module.exports = defineCliPlugin({
+    id: '@vendure-e2e/replacing-cli-plugin',
+    commands: [
+        {
+            name: 'doctor',
+            description: 'Replaces the built-in doctor command',
+            replaces: true,
+            action: async () => {
+                process.stdout.write('REPLACED_DOCTOR\n');
+                return 0;
+            },
+        },
+    ],
+});

--- a/packages/cli/e2e/fixtures/cli-plugins/replacing-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/replacing-cli-plugin/package.json
@@ -5,6 +5,8 @@
     "main": "cli-plugin.js",
     "vendure": {
         "cliPlugin": "./cli-plugin.js",
-        "cliCommands": ["doctor"]
+        "cliCommands": [
+            "doctor"
+        ]
     }
 }

--- a/packages/cli/e2e/fixtures/cli-plugins/replacing-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/replacing-cli-plugin/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "@vendure-e2e/replacing-cli-plugin",
+    "version": "1.0.0",
+    "private": true,
+    "main": "cli-plugin.js",
+    "vendure": {
+        "cliPlugin": "./cli-plugin.js",
+        "cliCommands": ["doctor"]
+    }
+}

--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -72,7 +72,7 @@ to forward them should read the tail with the exported `readCommandContext()`
 and `readCommandOptions()` rather than indexing:
 
 ```typescript
-interface CliCommandContext<TInheritedOptions = Record<string, any>> {
+interface CliCommandContext<TInheritedOptions extends Record<string, any> = Record<string, any>> {
     inheritedOptions: TInheritedOptions; // Values of the shared options in scope
     commandPath: string[]; // e.g. ['config', 'server', 'set']
 }
@@ -85,7 +85,8 @@ interface CliCommandOption {
     short?: string; // Short flag (e.g., '-p')
     long: string; // Long flag (e.g., '--plugin <name>')
     description: string; // Option description
-    required?: boolean; // Whether the option is required
+    required?: boolean; // Whether a value must follow the flag, not whether the flag is required
+    defaultValue?: any; // Value used when the flag is absent
     subOptions?: CliCommandOption[]; // Sub-options for complex commands
 }
 ```
@@ -432,7 +433,7 @@ External packages add commands, add to existing ones, or replace them by
 exporting a CLI plugin with `defineCliPlugin`.
 
 **The plugin API reference lives in the developer guide**, under
-[Extending the CLI](/guides/developer-guide/cli/#extending-the-cli): the
+[Extending the CLI](https://docs.vendure.io/guides/developer-guide/cli/#extending-the-cli): the
 `extendCommands` composition model, shared options and their precedence, the
 collision rules, and discovery and activation. That page is the source of truth
 for plugin authors; this file covers what a contributor to the CLI itself needs.
@@ -457,12 +458,12 @@ for plugin authors; this file covers what a contributor to the CLI itself needs.
   declaring it has been reached, so shared options are declared once on their
   owning command and never copied onto descendants. `registerCommands()` enables
   Commander's `showGlobalOptions` so subcommand help still lists them.
-- **The declaring command wins the parse.** When a command declares the same flag
-  as a shared option, Commander gives the value to the shared option, and
-  `fillSharedValues()` copies it onto the command so both readings agree. That
-  relies on Commander's `opts()` returning its own `_optionValues` rather than a
-  copy; the unit test named `shares one value between a shared option and a
-command option of the same name` pins the assumption.
+- **The ancestor that declared the shared option wins the parse.** When a
+  command declares the same flag as a shared option, Commander gives the value
+  to the ancestor, so `fillSharedValues()` writes it into the options object
+  Commander passed to the action, and onto the `Command`, so both readings
+  agree. Registration rejects the two declarations if they disagree about
+  whether a value follows the flag. Covered in `command-registry.spec.ts`.
 - **Extensions cannot add positional arguments.** Commander passes one argument
   slot per declared positional, so an appended argument would shift the options,
   `Command` and context that an existing action expects.

--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -487,7 +487,8 @@ written to stderr, when it declares:
 - a top-level command name that a built-in or an earlier plugin already
   provides, without `replaces: true`;
 - a shared option an earlier plugin already registered, or one of the CLI's own
-  flags (`-h`, `--help`, `-V`, `--version`);
+  flags (`-h`, `--help`, `-V`, `--version`). Options are compared by the name
+  they read back under, so `--api-token` and `--apiToken` collide;
 - a shared option that disagrees with an existing command option of the same
   flag about whether a value follows it.
 

--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -52,7 +52,6 @@ interface CliCommandExtension {
     command: string | string[]; // 'dev', or ['config', 'server', 'set']
     description?: string; // Replaces the description in help
     options?: CliCommandOption[]; // Appended to the command's options
-    arguments?: CliCommandArgument[]; // Appended; must be optional
     decorate?: CliCommandDecorator; // Wraps the command's action
 }
 
@@ -68,7 +67,9 @@ interface CliCommandDecoratorInput {
 
 Commander passes positional arguments first, then the parsed options object and
 the `Command` instance. The CLI host appends a `CliCommandContext`, so an action
-never has to read or reparse `process.argv`:
+never has to read or reparse `process.argv`. An action taking `...args` in order
+to forward them should read the tail with the exported `readCommandContext()`
+and `readCommandOptions()` rather than indexing:
 
 ```typescript
 interface CliCommandContext<TInheritedOptions = Record<string, any>> {

--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -427,198 +427,49 @@ Keep the lazy `import()` inside the action so heavy command modules are not load
 
 ## Extending the CLI with Plugins
 
-External packages can add new commands or replace built-in ones (for example a
-Cloud package overriding `vendure dev`).
+External packages add commands, add to existing ones, or replace them by
+exporting a CLI plugin with `defineCliPlugin`.
 
-### 1. Author a plugin package
+**The plugin API reference lives in the developer guide**, under
+[Extending the CLI](/guides/developer-guide/cli/#extending-the-cli): the
+`extendCommands` composition model, shared options and their precedence, the
+collision rules, and discovery and activation. That page is the source of truth
+for plugin authors; this file covers what a contributor to the CLI itself needs.
 
-```typescript
-import { CliCommandContext, defineCliPlugin } from '@vendure/cli';
+### How registration works
 
-export default defineCliPlugin({
-    id: '@example/vendure-cli-plugin',
-    // Options added to `vendure` itself, and so shared by every command
-    rootOptions: [{ long: '--token <token>', description: 'API token', required: true }],
-    commands: [
-        {
-            name: 'hello',
-            description: 'A new command',
-            action: async () => {
-                console.log('hello');
-                return 0;
-            },
-        },
-        {
-            // A group: `vendure project list`
-            name: 'project',
-            description: 'Manage projects',
-            options: [{ long: '--profile <name>', description: 'Profile', required: true }],
-            subcommands: [
-                {
-                    name: 'list',
-                    description: 'List projects',
-                    action: async (options, command, context: CliCommandContext) => {
-                        console.log(context.inheritedOptions.token, context.inheritedOptions.profile);
-                        return 0;
-                    },
-                },
-            ],
-        },
-    ],
-    extendCommands: [
-        {
-            // Add to the built-in `dev` rather than replacing it
-            command: 'dev',
-            options: [{ long: '--rotate-credential', description: 'Replace the stored credential' }],
-            decorate:
-                ({ next }) =>
-                async (...args) => {
-                    // optional setup...
-                    return next(...args);
-                },
-        },
-    ],
-});
-```
+1. `cli.ts` builds a `CommandRegistry` and calls `registerAll(builtinCommandDefs)`.
+2. `resolveCliPlugins()` loads the packages listed in `vendure.cli.plugins`,
+   returning failures rather than throwing.
+3. Each loaded plugin goes through `registry.applyPlugin()`, which is the only
+   path that enforces the collision rules. It applies the plugin's root options,
+   commands and extensions to a **draft** copy of the registry state and commits
+   the draft only if nothing conflicts, so a plugin's contributions are either
+   all registered or none are.
+4. A plugin that conflicts is reported on stderr and skipped. Built-ins stay
+   registered, which is what keeps `vendure plugins remove` reachable.
+5. `registerCommands()` walks the resulting tree onto Commander.
 
-Declare the entry in the plugin package's `package.json`:
+### Things worth knowing before changing this code
 
-```json
-{
-    "name": "@example/vendure-cli-plugin",
-    "vendure": {
-        "cliPlugin": "./dist/cli-plugin.js",
-        "cliCommands": ["hello", "project", "dev"]
-    }
-}
-```
-
-`cliCommands` is optional metadata used for actionable unknown-command hints
-without loading plugin code. Only top-level names belong in it.
-
-### 2. Extending an existing command
-
-`extendCommands` composes several plugins against the command currently
-registered at a path. Extensions are applied in `vendure.cli.plugins` order, so
-the last listed plugin is the outermost wrapper and its decorator runs first.
-Each wrapper runs once per invocation.
-
-`decorate` is called once, at registration, and receives `next` (the action of
-the command as composed so far) and `command` (that command's definition).
-Always call `next`; never import the original action, for example
-`builtinCommands.dev.action`, because that binds to the built-in and skips every
-other plugin's contribution.
-
-Options are appended keeping earlier ones, arguments are appended and must be
-optional, and a description replaces the one in help with a notice when two
-plugins set it. An extension may target a nested command with a path, and may
-add options and a description to a command group, which has no action to
-decorate.
-
-`replaces: true` remains the way to take a command over completely. A plugin
-cannot replace a command another plugin has already extended, because that would
-discard their contribution; listing the replacing plugin first works, and later
-plugins then extend the replacement.
-
-### 3. Shared options
-
-Shared options are declared once, at the scope they apply to: `rootOptions` on
-the plugin for every command, and `options` on a group for the commands inside
-it. Commander accepts them anywhere on the command line once the declaring
-command has been reached, so `vendure --token X project list` and
-`vendure project list --token X` are equivalent, and a repeated option takes its
-last value. Their values are passed to actions in `context.inheritedOptions`,
-keyed by the long flag without `--`, camel-cased.
-
-Help output at every level lists the options valid there: the host enables
-Commander's `showGlobalOptions`, so a subcommand's help shows its own options
-followed by the shared ones under `Global Options`.
-
-### 4. Collisions
-
-A plugin is registered whole or not at all: everything is applied to a draft
-first, and a single conflict discards the draft. Every conflict is reported
-together, with the reason written to stderr. A plugin is rejected when it
-declares:
-
-- a top-level command name that a built-in or an earlier plugin already
-  provides, without `replaces: true`;
-- a replacement of a command another plugin has extended;
-- an extension of a path where nothing is registered, or a `decorate` or
-  argument on a command group;
-- an option added by an extension that the command already declares, or an
-  argument that is required or whose name is taken;
-- a shared option an earlier plugin already registered, or one of the CLI's own
-  flags (`-h`, `--help`, `-V`, `--version`). Options are compared by the name
-  they read back under, so `--api-token` and `--apiToken` collide;
-- a shared option that disagrees with an existing command option of the same
-  flag about whether a value follows it;
-- any command named `plugins`, whether replaced or extended, which the CLI
-  reserves because it is how a plugin is disabled.
-
-A `decorate` that throws while it is being applied is reported the same way, so
-a broken decorator cannot leave the registry half-built.
-
-`defineCliPlugin` additionally rejects, at definition time, duplicate sibling
-command names, duplicate flags on one command, an empty group, a group that also
-declares an action, a nested command that shadows one of the plugin's own shared
-options, two extensions of the same command, an extension that adds nothing, and
-an extension that adds a required argument.
-
-A command may otherwise declare the same flag as a shared option — the built-in
-`vendure plugins --json` alongside a shared `--json`, for example. Commander
-gives the value to the shared option, and the host copies it onto the command so
-both readings agree.
-
-### 5. Discovery and explicit activation
-
-On startup the CLI:
-
-1. Resolves the project root (nearest `package.json` with `vendure.cli` or a
-   dependency on `@vendure/cli`).
-2. Scans **direct** `dependencies` / `devDependencies` / `optionalDependencies`
-   for packages that declare `vendure.cliPlugin`.
-3. **Loads only packages listed in `vendure.cli.plugins`** (explicit activation).
-4. Merges plugin commands into the registry in allowlist order (last enabled
-   plugin wins among those declaring `replaces: true`). A non-dim stderr notice
-   is printed when a command is replaced.
-
-Packages that declare a plugin but are not enabled are **not** executed. The CLI
-prints a one-line hint instead:
-
-```text
-2 packages provide CLI commands. Run "vendure plugins" to review them.
-```
-
-Manage activation with:
-
-```bash
-vendure plugins
-vendure plugins --json
-vendure plugins add @example/vendure-cli-plugin
-vendure plugins remove @example/vendure-cli-plugin
-```
-
-Project control in the **project** `package.json`:
-
-```json
-{
-    "vendure": {
-        "cli": {
-            "plugins": ["@example/vendure-cli-plugin"]
-        }
-    }
-}
-```
-
-- `plugins` is the allowlist (missing or empty = load nothing). Disabling a
-  plugin is simply removing it from the list.
-- In a monorepo, direct dependencies of every `package.json` from the current
-  directory up to the project root are scanned, so a plugin installed in a
-  workspace package is found even when `@vendure/cli` is hoisted.
-- Enabled packages that cannot be resolved, loaded or registered are **skipped
-  with an error on stderr** — the CLI (including `vendure plugins remove`) stays
-  usable. `vendure plugins` reports them as `failed` with the reason.
+- **Commander accepts an option anywhere on the command line** once the command
+  declaring it has been reached, so shared options are declared once on their
+  owning command and never copied onto descendants. `registerCommands()` enables
+  Commander's `showGlobalOptions` so subcommand help still lists them.
+- **The declaring command wins the parse.** When a command declares the same flag
+  as a shared option, Commander gives the value to the shared option, and
+  `fillSharedValues()` copies it onto the command so both readings agree. That
+  relies on Commander's `opts()` returning its own `_optionValues` rather than a
+  copy; the unit test named `shares one value between a shared option and a
+command option of the same name` pins the assumption.
+- **Extensions cannot add positional arguments.** Commander passes one argument
+  slot per declared positional, so an appended argument would shift the options,
+  `Command` and context that an existing action expects.
+- **Extension order is `vendure.cli.plugins` order**, so the last listed plugin
+  is the outermost wrapper and its decorator runs first.
+- **Nodes are never mutated.** `extendNode()` returns new objects, so
+  `builtinCommands.<name>` keeps pointing at the original definition and each
+  decorator wraps only what was registered before it.
 
 ## File Structure
 

--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -17,11 +17,11 @@ contribute or replace commands via the CLI plugin API (`defineCliPlugin`).
 
 ```typescript
 interface CliCommandDefinition {
-    name: string;                    // The command name (e.g., 'add', 'migrate')
-    description: string;             // Command description shown in help
+    name: string; // The command name (e.g., 'add', 'migrate')
+    description: string; // Command description shown in help
     arguments?: CliCommandArgument[]; // Optional positional arguments
-    options?: CliCommandOption[];    // Optional array of command options
-    replaces?: boolean;              // Deliberately replace a command of the same name
+    options?: CliCommandOption[]; // Optional array of command options
+    replaces?: boolean; // Deliberately replace a command of the same name
     action: (...args: any[]) => Promise<void | number>; // Command implementation
 }
 ```
@@ -34,12 +34,34 @@ prints its help.
 interface CliCommandGroupDefinition {
     name: string;
     description: string;
-    options?: CliCommandOption[];    // Shared by every command in the group
-    subcommands: CliCommandNode[];   // A command or a further group
+    options?: CliCommandOption[]; // Shared by every command in the group
+    subcommands: CliCommandNode[]; // A command or a further group
     replaces?: boolean;
 }
 
 type CliCommandNode = CliCommandDefinition | CliCommandGroupDefinition;
+```
+
+## Command Extension Interface
+
+A plugin adds to a command that is already registered, instead of replacing it,
+so that several plugins can contribute to the same command.
+
+```typescript
+interface CliCommandExtension {
+    command: string | string[]; // 'dev', or ['config', 'server', 'set']
+    description?: string; // Replaces the description in help
+    options?: CliCommandOption[]; // Appended to the command's options
+    arguments?: CliCommandArgument[]; // Appended; must be optional
+    decorate?: CliCommandDecorator; // Wraps the command's action
+}
+
+type CliCommandDecorator = (input: CliCommandDecoratorInput) => CliCommandAction;
+
+interface CliCommandDecoratorInput {
+    command: Readonly<CliCommandDefinition>; // The command as composed so far
+    next: CliCommandAction; // Its action: call it to run everything below
+}
 ```
 
 ## Command Context
@@ -51,7 +73,7 @@ never has to read or reparse `process.argv`:
 ```typescript
 interface CliCommandContext<TInheritedOptions = Record<string, any>> {
     inheritedOptions: TInheritedOptions; // Values of the shared options in scope
-    commandPath: string[];               // e.g. ['config', 'server', 'set']
+    commandPath: string[]; // e.g. ['config', 'server', 'set']
 }
 ```
 
@@ -59,10 +81,10 @@ interface CliCommandContext<TInheritedOptions = Record<string, any>> {
 
 ```typescript
 interface CliCommandOption {
-    short?: string;                  // Short flag (e.g., '-p')
-    long: string;                    // Long flag (e.g., '--plugin <name>')
-    description: string;             // Option description
-    required?: boolean;              // Whether the option is required
+    short?: string; // Short flag (e.g., '-p')
+    long: string; // Long flag (e.g., '--plugin <name>')
+    description: string; // Option description
+    required?: boolean; // Whether the option is required
     subOptions?: CliCommandOption[]; // Sub-options for complex commands
 }
 ```
@@ -185,11 +207,13 @@ npx vendure start all --server-entry ./build/server.js --worker-entry ./build/wo
 The `add` command supports both modes for adding features to your Vendure project.
 
 **Interactive Mode:**
+
 ```bash
 npx vendure add
 ```
 
 **Non-Interactive Mode:**
+
 ```bash
 # Create a new plugin
 npx vendure add -p MyPlugin
@@ -224,11 +248,13 @@ npx vendure add -u MyPlugin
 The `migrate` command supports both modes for database migration management.
 
 **Interactive Mode:**
+
 ```bash
 npx vendure migrate
 ```
 
 **Non-Interactive Mode:**
+
 ```bash
 # Generate a new migration
 npx vendure migrate -g my-migration-name
@@ -353,6 +379,7 @@ Entity and service commands now support non-interactive mode with the `--selecte
 - Service commands support `--type` parameter to specify service type (basic or entity)
 
 **Example Error Handling:**
+
 ```bash
 $ npx vendure add -e MyEntity --selected-plugin NonExistentPlugin
 Error: Plugin "NonExistentPlugin" not found. Available plugins: MyActualPlugin, AnotherPlugin
@@ -406,7 +433,7 @@ Cloud package overriding `vendure dev`).
 ### 1. Author a plugin package
 
 ```typescript
-import { builtinCommands, CliCommandContext, defineCliPlugin } from '@vendure/cli';
+import { CliCommandContext, defineCliPlugin } from '@vendure/cli';
 
 export default defineCliPlugin({
     id: '@example/vendure-cli-plugin',
@@ -437,14 +464,18 @@ export default defineCliPlugin({
                 },
             ],
         },
+    ],
+    extendCommands: [
         {
-            name: 'dev',
-            description: 'Replaces the built-in dev command',
-            replaces: true,
-            action: async (target, options) => {
-                // optional setup...
-                return builtinCommands.dev.action(target, options);
-            },
+            // Add to the built-in `dev` rather than replacing it
+            command: 'dev',
+            options: [{ long: '--rotate-credential', description: 'Replace the stored credential' }],
+            decorate:
+                ({ next }) =>
+                async (...args) => {
+                    // optional setup...
+                    return next(...args);
+                },
         },
     ],
 });
@@ -454,18 +485,42 @@ Declare the entry in the plugin package's `package.json`:
 
 ```json
 {
-  "name": "@example/vendure-cli-plugin",
-  "vendure": {
-    "cliPlugin": "./dist/cli-plugin.js",
-    "cliCommands": ["hello", "project", "dev"]
-  }
+    "name": "@example/vendure-cli-plugin",
+    "vendure": {
+        "cliPlugin": "./dist/cli-plugin.js",
+        "cliCommands": ["hello", "project", "dev"]
+    }
 }
 ```
 
 `cliCommands` is optional metadata used for actionable unknown-command hints
 without loading plugin code. Only top-level names belong in it.
 
-### 2. Shared options
+### 2. Extending an existing command
+
+`extendCommands` composes several plugins against the command currently
+registered at a path. Extensions are applied in `vendure.cli.plugins` order, so
+the last listed plugin is the outermost wrapper and its decorator runs first.
+Each wrapper runs once per invocation.
+
+`decorate` is called once, at registration, and receives `next` (the action of
+the command as composed so far) and `command` (that command's definition).
+Always call `next`; never import the original action, for example
+`builtinCommands.dev.action`, because that binds to the built-in and skips every
+other plugin's contribution.
+
+Options are appended keeping earlier ones, arguments are appended and must be
+optional, and a description replaces the one in help with a notice when two
+plugins set it. An extension may target a nested command with a path, and may
+add options and a description to a command group, which has no action to
+decorate.
+
+`replaces: true` remains the way to take a command over completely. A plugin
+cannot replace a command another plugin has already extended, because that would
+discard their contribution; listing the replacing plugin first works, and later
+plugins then extend the replacement.
+
+### 3. Shared options
 
 Shared options are declared once, at the scope they apply to: `rootOptions` on
 the plugin for every command, and `options` on a group for the commands inside
@@ -479,29 +534,43 @@ Help output at every level lists the options valid there: the host enables
 Commander's `showGlobalOptions`, so a subcommand's help shows its own options
 followed by the shared ones under `Global Options`.
 
-### 3. Collisions
+### 4. Collisions
 
-A plugin is registered whole or not at all. It is rejected, with the reason
-written to stderr, when it declares:
+A plugin is registered whole or not at all: everything is applied to a draft
+first, and a single conflict discards the draft. Every conflict is reported
+together, with the reason written to stderr. A plugin is rejected when it
+declares:
 
 - a top-level command name that a built-in or an earlier plugin already
   provides, without `replaces: true`;
+- a replacement of a command another plugin has extended;
+- an extension of a path where nothing is registered, or a `decorate` or
+  argument on a command group;
+- an option added by an extension that the command already declares, or an
+  argument that is required or whose name is taken;
 - a shared option an earlier plugin already registered, or one of the CLI's own
   flags (`-h`, `--help`, `-V`, `--version`). Options are compared by the name
   they read back under, so `--api-token` and `--apiToken` collide;
 - a shared option that disagrees with an existing command option of the same
-  flag about whether a value follows it.
+  flag about whether a value follows it;
+- any command named `plugins`, whether replaced or extended, which the CLI
+  reserves because it is how a plugin is disabled.
+
+A `decorate` that throws while it is being applied is reported the same way, so
+a broken decorator cannot leave the registry half-built.
 
 `defineCliPlugin` additionally rejects, at definition time, duplicate sibling
-command names, duplicate flags on one command, an empty group, and a nested
-command that shadows one of the plugin's own shared options.
+command names, duplicate flags on one command, an empty group, a group that also
+declares an action, a nested command that shadows one of the plugin's own shared
+options, two extensions of the same command, an extension that adds nothing, and
+an extension that adds a required argument.
 
 A command may otherwise declare the same flag as a shared option — the built-in
 `vendure plugins --json` alongside a shared `--json`, for example. Commander
 gives the value to the shared option, and the host copies it onto the command so
 both readings agree.
 
-### 4. Discovery and explicit activation
+### 5. Discovery and explicit activation
 
 On startup the CLI:
 
@@ -534,11 +603,11 @@ Project control in the **project** `package.json`:
 
 ```json
 {
-  "vendure": {
-    "cli": {
-      "plugins": ["@example/vendure-cli-plugin"]
+    "vendure": {
+        "cli": {
+            "plugins": ["@example/vendure-cli-plugin"]
+        }
     }
-  }
 }
 ```
 
@@ -557,7 +626,7 @@ Project control in the **project** `package.json`:
 - `packages/cli/src/shared/cli-command-options.ts` - Option flag parsing shared by registration and collision checks
 - `packages/cli/src/shared/cli-plugin.ts` - `defineCliPlugin` / `CliPlugin`
 - `packages/cli/src/shared/cli-plugin-project-config.ts` - Read/write `vendure.cli` allowlist
-- `packages/cli/src/shared/command-registry-store.ts` - Command registry (add/replace)
+- `packages/cli/src/shared/command-registry-store.ts` - Command registry (add, replace, extend)
 - `packages/cli/src/shared/resolve-cli-plugins.ts` - Plugin discovery & loading
 - `packages/cli/src/shared/command-registry.ts` - Commander registration utility
 - `packages/cli/src/commands/builtins.ts` - Ordered list of built-in command definitions

--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -19,8 +19,39 @@ contribute or replace commands via the CLI plugin API (`defineCliPlugin`).
 interface CliCommandDefinition {
     name: string;                    // The command name (e.g., 'add', 'migrate')
     description: string;             // Command description shown in help
+    arguments?: CliCommandArgument[]; // Optional positional arguments
     options?: CliCommandOption[];    // Optional array of command options
-    action: (options?: Record<string, any>) => Promise<void>; // Command implementation
+    replaces?: boolean;              // Deliberately replace a command of the same name
+    action: (...args: any[]) => Promise<void | number>; // Command implementation
+}
+```
+
+A command that groups further commands declares `subcommands` instead of an
+action. Groups can be nested to any depth, and running one without a subcommand
+prints its help.
+
+```typescript
+interface CliCommandGroupDefinition {
+    name: string;
+    description: string;
+    options?: CliCommandOption[];    // Shared by every command in the group
+    subcommands: CliCommandNode[];   // A command or a further group
+    replaces?: boolean;
+}
+
+type CliCommandNode = CliCommandDefinition | CliCommandGroupDefinition;
+```
+
+## Command Context
+
+Commander passes positional arguments first, then the parsed options object and
+the `Command` instance. The CLI host appends a `CliCommandContext`, so an action
+never has to read or reparse `process.argv`:
+
+```typescript
+interface CliCommandContext<TInheritedOptions = Record<string, any>> {
+    inheritedOptions: TInheritedOptions; // Values of the shared options in scope
+    commandPath: string[];               // e.g. ['config', 'server', 'set']
 }
 ```
 
@@ -375,10 +406,12 @@ Cloud package overriding `vendure dev`).
 ### 1. Author a plugin package
 
 ```typescript
-import { builtinCommands, defineCliPlugin } from '@vendure/cli';
+import { builtinCommands, CliCommandContext, defineCliPlugin } from '@vendure/cli';
 
 export default defineCliPlugin({
     id: '@example/vendure-cli-plugin',
+    // Options added to `vendure` itself, and so shared by every command
+    rootOptions: [{ long: '--token <token>', description: 'API token', required: true }],
     commands: [
         {
             name: 'hello',
@@ -389,8 +422,25 @@ export default defineCliPlugin({
             },
         },
         {
+            // A group: `vendure project list`
+            name: 'project',
+            description: 'Manage projects',
+            options: [{ long: '--profile <name>', description: 'Profile', required: true }],
+            subcommands: [
+                {
+                    name: 'list',
+                    description: 'List projects',
+                    action: async (options, command, context: CliCommandContext) => {
+                        console.log(context.inheritedOptions.token, context.inheritedOptions.profile);
+                        return 0;
+                    },
+                },
+            ],
+        },
+        {
             name: 'dev',
             description: 'Replaces the built-in dev command',
+            replaces: true,
             action: async (target, options) => {
                 // optional setup...
                 return builtinCommands.dev.action(target, options);
@@ -407,15 +457,50 @@ Declare the entry in the plugin package's `package.json`:
   "name": "@example/vendure-cli-plugin",
   "vendure": {
     "cliPlugin": "./dist/cli-plugin.js",
-    "cliCommands": ["hello", "dev"]
+    "cliCommands": ["hello", "project", "dev"]
   }
 }
 ```
 
 `cliCommands` is optional metadata used for actionable unknown-command hints
-without loading plugin code.
+without loading plugin code. Only top-level names belong in it.
 
-### 2. Discovery and explicit activation
+### 2. Shared options
+
+Shared options are declared once, at the scope they apply to: `rootOptions` on
+the plugin for every command, and `options` on a group for the commands inside
+it. Commander accepts them anywhere on the command line once the declaring
+command has been reached, so `vendure --token X project list` and
+`vendure project list --token X` are equivalent, and a repeated option takes its
+last value. Their values are passed to actions in `context.inheritedOptions`,
+keyed by the long flag without `--`, camel-cased.
+
+Help output at every level lists the options valid there: the host enables
+Commander's `showGlobalOptions`, so a subcommand's help shows its own options
+followed by the shared ones under `Global Options`.
+
+### 3. Collisions
+
+A plugin is registered whole or not at all. It is rejected, with the reason
+written to stderr, when it declares:
+
+- a top-level command name that a built-in or an earlier plugin already
+  provides, without `replaces: true`;
+- a shared option an earlier plugin already registered, or one of the CLI's own
+  flags (`-h`, `--help`, `-V`, `--version`);
+- a shared option that disagrees with an existing command option of the same
+  flag about whether a value follows it.
+
+`defineCliPlugin` additionally rejects, at definition time, duplicate sibling
+command names, duplicate flags on one command, an empty group, and a nested
+command that shadows one of the plugin's own shared options.
+
+A command may otherwise declare the same flag as a shared option — the built-in
+`vendure plugins --json` alongside a shared `--json`, for example. Commander
+gives the value to the shared option, and the host copies it onto the command so
+both readings agree.
+
+### 4. Discovery and explicit activation
 
 On startup the CLI:
 
@@ -424,9 +509,9 @@ On startup the CLI:
 2. Scans **direct** `dependencies` / `devDependencies` / `optionalDependencies`
    for packages that declare `vendure.cliPlugin`.
 3. **Loads only packages listed in `vendure.cli.plugins`** (explicit activation).
-4. Merges plugin commands into the registry in allowlist order (same name =
-   replace; last enabled plugin wins). A non-dim stderr notice is printed when
-   a command is replaced.
+4. Merges plugin commands into the registry in allowlist order (last enabled
+   plugin wins among those declaring `replaces: true`). A non-dim stderr notice
+   is printed when a command is replaced.
 
 Packages that declare a plugin but are not enabled are **not** executed. The CLI
 prints a one-line hint instead:
@@ -461,13 +546,14 @@ Project control in the **project** `package.json`:
 - In a monorepo, direct dependencies of every `package.json` from the current
   directory up to the project root are scanned, so a plugin installed in a
   workspace package is found even when `@vendure/cli` is hoisted.
-- Enabled packages that cannot be resolved or loaded are **skipped with an
-  error on stderr** — the CLI (including `vendure plugins remove`) stays
+- Enabled packages that cannot be resolved, loaded or registered are **skipped
+  with an error on stderr** — the CLI (including `vendure plugins remove`) stays
   usable. `vendure plugins` reports them as `failed` with the reason.
 
 ## File Structure
 
 - `packages/cli/src/shared/cli-command-definition.ts` - Interface definitions
+- `packages/cli/src/shared/cli-command-options.ts` - Option flag parsing shared by registration and collision checks
 - `packages/cli/src/shared/cli-plugin.ts` - `defineCliPlugin` / `CliPlugin`
 - `packages/cli/src/shared/cli-plugin-project-config.ts` - Read/write `vendure.cli` allowlist
 - `packages/cli/src/shared/command-registry-store.ts` - Command registry (add/replace)

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -91,8 +91,8 @@ function writePluginSkipped(packageName: string, headline: string, reason: strin
  * Local to this file: they overlap the registry's reserved lists today, but
  * answer a different question and should not move when those change.
  */
-const HINT_SUPPRESSING_ARGS = ['--help', '-h', '--version', '-V'];
-const HINT_SUPPRESSING_COMMANDS = ['plugins', 'help'];
+const HINT_SUPPRESSING_ARGS = new Set(['--help', '-h', '--version', '-V']);
+const HINT_SUPPRESSING_COMMANDS = new Set(['plugins', 'help']);
 
 /**
  * One-line hint when packages declare CLI plugins but are not enabled yet.
@@ -105,8 +105,8 @@ function maybeWriteInactivePluginsHint(argv: string[]): void {
     }
     const primary = args.find(arg => !arg.startsWith('-'));
     if (
-        (primary && HINT_SUPPRESSING_COMMANDS.includes(primary)) ||
-        args.some(arg => HINT_SUPPRESSING_ARGS.includes(arg))
+        (primary && HINT_SUPPRESSING_COMMANDS.has(primary)) ||
+        args.some(arg => HINT_SUPPRESSING_ARGS.has(arg))
     ) {
         return;
     }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,7 +5,7 @@ import pc from 'picocolors';
 
 import { builtinCommandDefs } from './commands/builtins';
 import { registerCommands } from './shared/command-registry';
-import { CommandRegistry } from './shared/command-registry-store';
+import { CommandRegistry, RESERVED_FLAGS } from './shared/command-registry-store';
 import {
     findInactivePluginProvidingCommand,
     listInactiveCliPluginPackages,
@@ -50,8 +50,6 @@ Y88  88P 88888888 888  888 888  888 888  888 888    88888888
         try {
             registry.applyPlugin(plugin);
         } catch (e) {
-            // A plugin whose commands or shared options collide with something
-            // already registered is skipped whole, rather than applied by halves.
             const reason = e instanceof Error ? e.message : String(e);
             writePluginSkipped(packageName, 'Failed to register CLI plugin', reason);
         }
@@ -91,14 +89,7 @@ function maybeWriteInactivePluginsHint(argv: string[]): void {
         return;
     }
     const primary = args.find(arg => !arg.startsWith('-'));
-    if (
-        primary === 'plugins' ||
-        primary === 'help' ||
-        args.includes('--help') ||
-        args.includes('-h') ||
-        args.includes('--version') ||
-        args.includes('-V')
-    ) {
+    if (primary === 'plugins' || primary === 'help' || args.some(arg => RESERVED_FLAGS.includes(arg))) {
         return;
     }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,7 +5,7 @@ import pc from 'picocolors';
 
 import { builtinCommandDefs } from './commands/builtins';
 import { registerCommands } from './shared/command-registry';
-import { CommandRegistry, RESERVED_FLAGS } from './shared/command-registry-store';
+import { CommandRegistry, RESERVED_COMMANDS } from './shared/command-registry-store';
 import {
     findInactivePluginProvidingCommand,
     listInactiveCliPluginPackages,
@@ -36,6 +36,11 @@ Y88  88P 88888888 888  888 888  888 888  888 888    88888888
   Y88P    "Y8888  888  888  "Y88888  "Y88888 888     "Y8888                             
 `),
         );
+
+    // Shared options are declared once on the command that owns them, so
+    // subcommand help needs Commander's "Global Options" section to be complete.
+    // Set before any subcommand is created, which copies the help configuration.
+    program.configureHelp({ showGlobalOptions: true });
 
     const registry = new CommandRegistry();
     registry.registerAll(builtinCommandDefs);
@@ -80,6 +85,14 @@ function writePluginSkipped(packageName: string, headline: string, reason: strin
 }
 
 /**
+ * Arguments that mean the user is orienting themselves rather than running a
+ * command, so the inactive-plugins hint would be noise. Deliberately its own
+ * list: it happens to match the reserved flags today, but they answer
+ * different questions.
+ */
+const HINT_SUPPRESSING_ARGS = ['--help', '-h', '--version', '-V'];
+
+/**
  * One-line hint when packages declare CLI plugins but are not enabled yet.
  * Skipped for `vendure plugins` itself and for `--help` / `--version`.
  */
@@ -89,7 +102,10 @@ function maybeWriteInactivePluginsHint(argv: string[]): void {
         return;
     }
     const primary = args.find(arg => !arg.startsWith('-'));
-    if (primary === 'plugins' || primary === 'help' || args.some(arg => RESERVED_FLAGS.includes(arg))) {
+    if (
+        (primary && RESERVED_COMMANDS.includes(primary)) ||
+        args.some(arg => HINT_SUPPRESSING_ARGS.includes(arg))
+    ) {
         return;
     }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,7 +5,7 @@ import pc from 'picocolors';
 
 import { builtinCommandDefs } from './commands/builtins';
 import { registerCommands } from './shared/command-registry';
-import { CommandRegistry, RESERVED_COMMANDS } from './shared/command-registry-store';
+import { CommandRegistry } from './shared/command-registry-store';
 import {
     findInactivePluginProvidingCommand,
     listInactiveCliPluginPackages,
@@ -38,8 +38,9 @@ Y88  88P 88888888 888  888 888  888 888  888 888    88888888
         );
 
     // Shared options are declared once on the command that owns them, so
-    // subcommand help needs Commander's "Global Options" section to be complete.
-    // Set before any subcommand is created, which copies the help configuration.
+    // subcommand help needs Commander's "Global Options" section to be
+    // complete. Commander copies the help configuration into each subcommand as
+    // it is created, so this must be set first.
     program.configureHelp({ showGlobalOptions: true });
 
     const registry = new CommandRegistry();
@@ -85,12 +86,13 @@ function writePluginSkipped(packageName: string, headline: string, reason: strin
 }
 
 /**
- * Arguments that mean the user is orienting themselves rather than running a
- * command, so the inactive-plugins hint would be noise. Deliberately its own
- * list: it happens to match the reserved flags today, but they answer
- * different questions.
+ * Arguments and command names that mean the user is orienting themselves
+ * rather than running a command, so the inactive-plugins hint would be noise.
+ * Local to this file: they overlap the registry's reserved lists today, but
+ * answer a different question and should not move when those change.
  */
 const HINT_SUPPRESSING_ARGS = ['--help', '-h', '--version', '-V'];
+const HINT_SUPPRESSING_COMMANDS = ['plugins', 'help'];
 
 /**
  * One-line hint when packages declare CLI plugins but are not enabled yet.
@@ -103,7 +105,7 @@ function maybeWriteInactivePluginsHint(argv: string[]): void {
     }
     const primary = args.find(arg => !arg.startsWith('-'));
     if (
-        (primary && RESERVED_COMMANDS.includes(primary)) ||
+        (primary && HINT_SUPPRESSING_COMMANDS.includes(primary)) ||
         args.some(arg => HINT_SUPPRESSING_ARGS.includes(arg))
     ) {
         return;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,8 +4,8 @@ import { Command } from 'commander';
 import pc from 'picocolors';
 
 import { builtinCommandDefs } from './commands/builtins';
-import { CommandRegistry } from './shared/command-registry-store';
 import { registerCommands } from './shared/command-registry';
+import { CommandRegistry } from './shared/command-registry-store';
 import {
     findInactivePluginProvidingCommand,
     listInactiveCliPluginPackages,
@@ -19,8 +19,11 @@ async function main(): Promise<void> {
     const version = require('../package.json').version;
 
     program
+        // Commander otherwise names the program after the binary file
+        // (`cli.js`), which would make every subcommand's help say `cli ...`.
+        .name('vendure')
         .version(version)
-        .usage(`vendure <command>`)
+        .usage(`<command>`)
         .description(
             pc.blue(`
                                 888                          
@@ -41,16 +44,20 @@ Y88  88P 88888888 888  888 888  888 888  888 888    88888888
     // `plugins` command needed to disable it) stay available.
     const { loaded, failures } = resolveCliPlugins();
     for (const failure of failures) {
-        process.stderr.write(pc.red(`Failed to load CLI plugin "${failure.packageName}": ${failure.reason}\n`));
-        process.stderr.write(
-            `Skipping it. Fix the issue or disable it with: vendure plugins remove ${failure.packageName}\n`,
-        );
+        writePluginSkipped(failure.packageName, 'Failed to load CLI plugin', failure.reason);
     }
-    for (const { plugin } of loaded) {
-        registry.applyPlugin(plugin);
+    for (const { packageName, plugin } of loaded) {
+        try {
+            registry.applyPlugin(plugin);
+        } catch (e) {
+            // A plugin whose commands or shared options collide with something
+            // already registered is skipped whole, rather than applied by halves.
+            const reason = e instanceof Error ? e.message : String(e);
+            writePluginSkipped(packageName, 'Failed to register CLI plugin', reason);
+        }
     }
 
-    registerCommands(program, registry.toArray());
+    registerCommands(program, registry.toArray(), registry.getRootOptions());
 
     program.on('command:*', operands => {
         const unknown = operands[0] ?? '';
@@ -61,6 +68,17 @@ Y88  88P 88888888 888  888 888  888 888  888 888    88888888
     maybeWriteInactivePluginsHint(process.argv);
 
     await program.parseAsync(process.argv);
+}
+
+/**
+ * Reports a plugin the CLI could not use, and how to disable it. Built-ins stay
+ * registered either way, so `vendure plugins remove` remains reachable.
+ */
+function writePluginSkipped(packageName: string, headline: string, reason: string): void {
+    process.stderr.write(pc.red(`${headline} "${packageName}": ${reason}\n`));
+    process.stderr.write(
+        `Skipping it. Fix the issue or disable it with: vendure plugins remove ${packageName}\n`,
+    );
 }
 
 /**
@@ -90,9 +108,7 @@ function maybeWriteInactivePluginsHint(argv: string[]): void {
     }
 
     const noun = inactive.length === 1 ? 'package provides' : 'packages provide';
-    process.stderr.write(
-        `${inactive.length} ${noun} CLI commands. Run "vendure plugins" to review them.\n`,
-    );
+    process.stderr.write(`${inactive.length} ${noun} CLI commands. Run "vendure plugins" to review them.\n`);
 }
 
 function writeUnknownCommandHelp(commandName: string): void {
@@ -109,9 +125,7 @@ function writeUnknownCommandHelp(commandName: string): void {
 
     const inactive = listInactiveCliPluginPackages();
     if (inactive.length === 1) {
-        process.stderr.write(
-            `It may be provided by ${inactive[0]}, which is installed but not enabled.\n`,
-        );
+        process.stderr.write(`It may be provided by ${inactive[0]}, which is installed but not enabled.\n`);
         process.stderr.write(`Enable it with: vendure plugins add ${inactive[0]}\n`);
         return;
     }
@@ -122,7 +136,7 @@ function writeUnknownCommandHelp(commandName: string): void {
     }
 }
 
-void main().catch((e: any) => {
-    process.stderr.write(`${e?.message ?? String(e)}\n`);
+void main().catch((e: unknown) => {
+    process.stderr.write(`${e instanceof Error ? e.message : String(e)}\n`);
     process.exit(1);
 });

--- a/packages/cli/src/commands/builtins.ts
+++ b/packages/cli/src/commands/builtins.ts
@@ -29,8 +29,11 @@ export const builtinCommandDefs: CliCommandDefinition[] = [
 ];
 
 /**
- * Built-in command definitions keyed by name. Plugins that wrap a command
- * (e.g. Cloud overriding `dev`) can call `builtinCommands.dev.action(...)`.
+ * Built-in command definitions keyed by name, for reading a command's metadata.
+ *
+ * Do not call `builtinCommands.<name>.action(...)` to wrap a command: that
+ * binds to the built-in and skips whatever other plugins have added. Use
+ * `extendCommands` and call the `next` action the host hands the decorator.
  */
 export const builtinCommands: Readonly<Record<string, CliCommandDefinition>> = Object.freeze(
     Object.fromEntries(builtinCommandDefs.map(command => [command.name, command])),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,6 +39,7 @@
  * ```
  */
 export { builtinCommands } from './commands/builtins';
+export { readCommandContext, readCommandOptions } from './shared/cli-command-definition';
 export type {
     CliCommandAction,
     CliCommandArgument,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,9 +38,13 @@
  */
 export { builtinCommands } from './commands/builtins';
 export type {
+    CliCommandAction,
     CliCommandArgument,
     CliCommandContext,
+    CliCommandDecorator,
+    CliCommandDecoratorInput,
     CliCommandDefinition,
+    CliCommandExtension,
     CliCommandGroupDefinition,
     CliCommandNode,
     CliCommandOption,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,7 +3,7 @@
  *
  * @example
  * ```ts
- * import { builtinCommands, defineCliPlugin, CliCommandContext } from '@vendure/cli';
+ * import { defineCliPlugin, CliCommandContext } from '@vendure/cli';
  *
  * export default defineCliPlugin({
  *   id: '@example/vendure-cli-plugin',
@@ -23,13 +23,15 @@
  *         },
  *       ],
  *     },
+ *   ],
+ *   extendCommands: [
  *     {
- *       name: 'dev',
- *       description: 'Custom development command',
- *       replaces: true,
- *       action: async (target, options) => {
+ *       // Adds to the built-in dev command, so other plugins can wrap it too
+ *       command: 'dev',
+ *       options: [{ long: '--rotate-credential', description: 'Replace the credential' }],
+ *       decorate: ({ next }) => async (...args) => {
  *         // optional setup...
- *         return builtinCommands.dev.action(target, options);
+ *         return next(...args);
  *       },
  *     },
  *   ],

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,14 +3,30 @@
  *
  * @example
  * ```ts
- * import { builtinCommands, defineCliPlugin } from '@vendure/cli';
+ * import { builtinCommands, defineCliPlugin, CliCommandContext } from '@vendure/cli';
  *
  * export default defineCliPlugin({
  *   id: '@example/vendure-cli-plugin',
+ *   rootOptions: [{ long: '--token <token>', description: 'API token' }],
  *   commands: [
+ *     {
+ *       name: 'project',
+ *       description: 'Manage projects',
+ *       subcommands: [
+ *         {
+ *           name: 'list',
+ *           description: 'List projects',
+ *           action: async (options, command, context: CliCommandContext<{ token?: string }>) => {
+ *             // context.inheritedOptions.token holds the shared --token value
+ *             return 0;
+ *           },
+ *         },
+ *       ],
+ *     },
  *     {
  *       name: 'dev',
  *       description: 'Custom development command',
+ *       replaces: true,
  *       action: async (target, options) => {
  *         // optional setup...
  *         return builtinCommands.dev.action(target, options);
@@ -23,7 +39,10 @@
 export { builtinCommands } from './commands/builtins';
 export type {
     CliCommandArgument,
+    CliCommandContext,
     CliCommandDefinition,
+    CliCommandGroupDefinition,
+    CliCommandNode,
     CliCommandOption,
     ProjectCliPluginConfig,
 } from './shared/cli-command-definition';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,7 +3,8 @@
  *
  * @example
  * ```ts
- * import { defineCliPlugin, CliCommandContext } from '@vendure/cli';
+ * import { defineCliPlugin } from '@vendure/cli';
+ * import type { CliCommandContext } from '@vendure/cli';
  *
  * export default defineCliPlugin({
  *   id: '@example/vendure-cli-plugin',

--- a/packages/cli/src/shared/__tests__/fixtures/example-cli-plugin.ts
+++ b/packages/cli/src/shared/__tests__/fixtures/example-cli-plugin.ts
@@ -10,10 +10,20 @@
  *   }
  * }
  */
-import { builtinCommands, defineCliPlugin } from '../../../index';
+import { builtinCommands, CliCommandContext, defineCliPlugin } from '../../../index';
+
+interface ExampleSharedOptions {
+    token?: string;
+    json?: boolean;
+}
 
 export default defineCliPlugin({
     id: '@vendure/cli-example-plugin',
+    // Shared by every command, and readable through `context.inheritedOptions`.
+    rootOptions: [
+        { long: '--token <token>', description: 'API token', required: true },
+        { long: '--json', description: 'Print machine-readable output' },
+    ],
     commands: [
         {
             name: 'example',
@@ -24,8 +34,31 @@ export default defineCliPlugin({
             },
         },
         {
+            name: 'project',
+            description: 'Example nested command group',
+            options: [{ long: '--profile <name>', description: 'Configuration profile', required: true }],
+            subcommands: [
+                {
+                    name: 'list',
+                    description: 'List projects',
+                    action: async (
+                        options: Record<string, any>,
+                        command: unknown,
+                        context: CliCommandContext<ExampleSharedOptions>,
+                    ) => {
+                        process.stdout.write(
+                            `Listing projects with token ${context.inheritedOptions.token ?? ''}\n`,
+                        );
+                        return 0;
+                    },
+                },
+            ],
+        },
+        {
             name: 'dev',
             description: 'Example wrap of the built-in dev command',
+            // Required to take over a command that already exists.
+            replaces: true,
             action: async (target, options) => {
                 process.stdout.write('Running wrapped vendure dev via plugin\n');
                 return builtinCommands.dev.action(target, options);
@@ -40,7 +73,7 @@ export default defineCliPlugin({
  * {
  *   "vendure": {
  *     "cliPlugin": "./dist/cli-plugin.js",
- *     "cliCommands": ["example", "dev"]
+ *     "cliCommands": ["example", "project", "dev"]
  *   }
  * }
  *

--- a/packages/cli/src/shared/__tests__/fixtures/example-cli-plugin.ts
+++ b/packages/cli/src/shared/__tests__/fixtures/example-cli-plugin.ts
@@ -46,9 +46,14 @@ export default defineCliPlugin({
                         command: unknown,
                         context: CliCommandContext<ExampleSharedOptions>,
                     ) => {
-                        process.stdout.write(
-                            `Listing projects with token ${context.inheritedOptions.token ?? ''}\n`,
-                        );
+                        // `required: true` on an option means a value must follow
+                        // the flag, not that the flag has to be given, so check.
+                        const token = context.inheritedOptions.token;
+                        if (!token) {
+                            process.stderr.write('Missing --token\n');
+                            return 1;
+                        }
+                        process.stdout.write(`Listing projects with token ${token}\n`);
                         return 0;
                     },
                 },
@@ -74,16 +79,8 @@ export default defineCliPlugin({
 });
 
 /**
- * Companion package.json fields for this plugin:
- *
- * {
- *   "vendure": {
- *     "cliPlugin": "./dist/cli-plugin.js",
- *     "cliCommands": ["example", "project"]
- *   }
- * }
- *
- * Consumers must also list the package in their project package.json:
+ * Consumers must also list the package in their own package.json for it to be
+ * loaded:
  *
  * {
  *   "vendure": {

--- a/packages/cli/src/shared/__tests__/fixtures/example-cli-plugin.ts
+++ b/packages/cli/src/shared/__tests__/fixtures/example-cli-plugin.ts
@@ -10,7 +10,7 @@
  *   }
  * }
  */
-import { builtinCommands, CliCommandContext, defineCliPlugin } from '../../../index';
+import { CliCommandContext, defineCliPlugin } from '../../../index';
 
 interface ExampleSharedOptions {
     token?: string;
@@ -54,15 +54,21 @@ export default defineCliPlugin({
                 },
             ],
         },
+    ],
+    extendCommands: [
         {
-            name: 'dev',
-            description: 'Example wrap of the built-in dev command',
-            // Required to take over a command that already exists.
-            replaces: true,
-            action: async (target, options) => {
-                process.stdout.write('Running wrapped vendure dev via plugin\n');
-                return builtinCommands.dev.action(target, options);
-            },
+            // Adds to the built-in dev command instead of replacing it, so
+            // other plugins can wrap it too.
+            command: 'dev',
+            options: [{ long: '--example-flag', description: 'An option added to dev' }],
+            decorate:
+                ({ next }) =>
+                async (...args) => {
+                    process.stdout.write('Running wrapped vendure dev via plugin\n');
+                    // Call the action handed to us, never builtinCommands.dev.action,
+                    // so any other plugin wrapping dev still runs.
+                    return next(...args);
+                },
         },
     ],
 });
@@ -73,7 +79,7 @@ export default defineCliPlugin({
  * {
  *   "vendure": {
  *     "cliPlugin": "./dist/cli-plugin.js",
- *     "cliCommands": ["example", "project", "dev"]
+ *     "cliCommands": ["example", "project"]
  *   }
  * }
  *

--- a/packages/cli/src/shared/__tests__/run-cli.ts
+++ b/packages/cli/src/shared/__tests__/run-cli.ts
@@ -16,7 +16,9 @@ class ExitSignal extends Error {
 
 export interface CliRun {
     exitCode?: number;
+    /** Commander's own output plus anything the action wrote to stdout. */
     stdout: string;
+    /** Commander's own errors plus anything the host or action wrote to stderr. */
     stderr: string;
 }
 
@@ -51,6 +53,10 @@ export async function runCli(
         stderr += String(str);
         return true;
     });
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(str => {
+        stdout += String(str);
+        return true;
+    });
 
     let exitCode: number | undefined;
     try {
@@ -66,6 +72,7 @@ export async function runCli(
     } finally {
         exitSpy.mockRestore();
         stderrSpy.mockRestore();
+        stdoutSpy.mockRestore();
     }
 
     return { exitCode, stdout, stderr };

--- a/packages/cli/src/shared/__tests__/run-cli.ts
+++ b/packages/cli/src/shared/__tests__/run-cli.ts
@@ -1,0 +1,72 @@
+import { Command, CommanderError } from 'commander';
+import { vi } from 'vitest';
+
+import { CliCommandNode, CliCommandOption } from '../cli-command-definition';
+import { registerCommands } from '../command-registry';
+
+/**
+ * Thrown in place of `process.exit` so a test can observe the exit code the
+ * CLI host asked for.
+ */
+class ExitSignal extends Error {
+    constructor(readonly code: number) {
+        super(`exit ${code}`);
+    }
+}
+
+export interface CliRun {
+    exitCode?: number;
+    stdout: string;
+    stderr: string;
+}
+
+/**
+ * Registers a command tree on a fresh Commander program and parses `argv`,
+ * capturing everything the host would have written or exited with.
+ */
+export async function runCli(
+    commands: CliCommandNode[],
+    sharedOptions: CliCommandOption[],
+    argv: string[],
+): Promise<CliRun> {
+    let stdout = '';
+    let stderr = '';
+
+    const program = new Command();
+    program.name('vendure').exitOverride();
+    program.configureOutput({
+        writeOut: str => {
+            stdout += str;
+        },
+        writeErr: str => {
+            stderr += str;
+        },
+    });
+    registerCommands(program, commands, sharedOptions);
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new ExitSignal(code ?? 0);
+    }) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(str => {
+        stderr += String(str);
+        return true;
+    });
+
+    let exitCode: number | undefined;
+    try {
+        await program.parseAsync(['node', 'vendure', ...argv]);
+    } catch (e) {
+        if (e instanceof ExitSignal) {
+            exitCode = e.code;
+        } else if (e instanceof CommanderError) {
+            exitCode = e.exitCode;
+        } else {
+            throw e;
+        }
+    } finally {
+        exitSpy.mockRestore();
+        stderrSpy.mockRestore();
+    }
+
+    return { exitCode, stdout, stderr };
+}

--- a/packages/cli/src/shared/__tests__/run-cli.ts
+++ b/packages/cli/src/shared/__tests__/run-cli.ts
@@ -36,6 +36,8 @@ export async function runCli(
 
     const program = new Command();
     program.name('vendure').exitOverride();
+    // Mirrors the host: set before any subcommand is created.
+    program.configureHelp({ showGlobalOptions: true });
     program.configureOutput({
         writeOut: str => {
             stdout += str;

--- a/packages/cli/src/shared/cli-command-definition.spec.ts
+++ b/packages/cli/src/shared/cli-command-definition.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { CliCommandContext, readCommandContext, readCommandOptions } from './cli-command-definition';
+
+/**
+ * The argument list a command action receives: positionals, then Commander's
+ * parsed options, then the Command, then the context the host appends.
+ */
+function actionArgs(positionals: unknown[], options: Record<string, any>): unknown[] {
+    const context: CliCommandContext = { inheritedOptions: { token: 'tok' }, commandPath: ['a', 'b'] };
+    return [...positionals, options, { name: () => 'b' }, context];
+}
+
+describe('readCommandContext()', () => {
+    it('reads the context from an action argument list', () => {
+        const context = readCommandContext(actionArgs(['x'], { limit: '5' }));
+
+        expect(context.commandPath).toEqual(['a', 'b']);
+        expect(context.inheritedOptions.token).toBe('tok');
+    });
+
+    it('reads the context whatever the number of positionals', () => {
+        expect(readCommandContext(actionArgs([], {})).commandPath).toEqual(['a', 'b']);
+        expect(readCommandContext(actionArgs(['x', 'y', 'z'], {})).commandPath).toEqual(['a', 'b']);
+    });
+
+    it('throws when handed something that is not an action argument list', () => {
+        expect(() => readCommandContext([])).toThrow(/No CliCommandContext found/);
+        expect(() => readCommandContext(['just', 'strings'])).toThrow(/No CliCommandContext found/);
+    });
+});
+
+describe('readCommandOptions()', () => {
+    it('reads the parsed options from an action argument list', () => {
+        expect(readCommandOptions(actionArgs(['x'], { limit: '5' }))).toEqual({ limit: '5' });
+    });
+
+    it('reads the options whatever the number of positionals', () => {
+        expect(readCommandOptions(actionArgs([], { a: 1 }))).toEqual({ a: 1 });
+        expect(readCommandOptions(actionArgs(['x', 'y'], { a: 1 }))).toEqual({ a: 1 });
+    });
+
+    it('throws rather than returning an empty object, like its sibling', () => {
+        expect(() => readCommandOptions([])).toThrow(/No parsed options found/);
+        expect(() => readCommandOptions(['a', 'b', 'c'])).toThrow(/No parsed options found/);
+    });
+});

--- a/packages/cli/src/shared/cli-command-definition.ts
+++ b/packages/cli/src/shared/cli-command-definition.ts
@@ -17,23 +17,91 @@ export interface CliCommandArgument {
     required?: boolean;
 }
 
+/**
+ * Values of the shared options that are in scope for a command, i.e. the root
+ * options registered by a CLI plugin plus the options of every command group
+ * the command is nested in.
+ *
+ * The CLI host builds this from the parsed command line and passes it to the
+ * action as the final argument, so a command never has to read or reparse
+ * `process.argv`.
+ *
+ * Keys are Commander attribute names: the long flag without `--`, camel-cased.
+ * `--api-token <token>` is therefore `apiToken`.
+ */
+export interface CliCommandContext<TInheritedOptions extends Record<string, any> = Record<string, any>> {
+    /**
+     * Values of the shared options in scope, resolved with nearest-wins
+     * precedence: a value given on the command itself overrides the same option
+     * given on a parent group, which overrides the same option given at the root.
+     * Options that were neither supplied nor given a default value are omitted.
+     */
+    inheritedOptions: TInheritedOptions;
+    /**
+     * The names of the commands leading to this action, e.g.
+     * `['config', 'server', 'set']` for `vendure config server set`.
+     */
+    commandPath: string[];
+}
+
 export interface CliCommandDefinition {
     name: string;
     description: string;
     arguments?: CliCommandArgument[];
     options?: CliCommandOption[];
     /**
+     * Set to `true` to deliberately replace a top-level command of the same
+     * name — a built-in, or one registered by an earlier plugin. Without it a
+     * name collision is reported as an error and the plugin is skipped, so a
+     * command can never be replaced by accident.
+     */
+    replaces?: boolean;
+    /**
      * Commander calling convention: positional arguments are passed first
      * (in the order they are declared in `arguments`), followed by the
      * parsed options object, followed by the Command instance itself.
+     * The CLI host appends a {@link CliCommandContext} as the final argument.
      * E.g. for `vendure codemod <transform> [path]`:
-     *   action(transform, path, options, command)
+     *   action(transform, path, options, command, context)
      *
      * May return a numeric process exit code. The CLI host calls
      * `process.exit` after the action settles so plugins can wrap built-ins
      * without a premature exit.
      */
     action: (...args: any[]) => Promise<void | number>;
+}
+
+/**
+ * A command that exists only to group subcommands, e.g. the `config` in
+ * `vendure config server set`. A group has no action of its own: running it
+ * without a subcommand prints its help.
+ */
+export interface CliCommandGroupDefinition {
+    name: string;
+    description: string;
+    /**
+     * Options shared by every command in this group. They are accepted both on
+     * the group itself (`vendure config --profile x server set a b`) and on any
+     * command below it (`vendure config server set a b --profile x`), and their
+     * values reach actions via {@link CliCommandContext.inheritedOptions}.
+     */
+    options?: CliCommandOption[];
+    subcommands: CliCommandNode[];
+    /**
+     * See {@link CliCommandDefinition.replaces}. Replacing a group replaces its
+     * whole subtree.
+     */
+    replaces?: boolean;
+}
+
+/**
+ * A node in a CLI command tree: either a command that runs an action, or a
+ * group of further commands.
+ */
+export type CliCommandNode = CliCommandDefinition | CliCommandGroupDefinition;
+
+export function isCliCommandGroup(node: CliCommandNode): node is CliCommandGroupDefinition {
+    return Array.isArray((node as CliCommandGroupDefinition).subcommands);
 }
 
 /**

--- a/packages/cli/src/shared/cli-command-definition.ts
+++ b/packages/cli/src/shared/cli-command-definition.ts
@@ -166,6 +166,33 @@ export interface CliCommandDecoratorInput {
 export type CliCommandDecorator = (input: CliCommandDecoratorInput) => CliCommandAction;
 
 /**
+ * Reads the {@link CliCommandContext} the host appends to a command action's
+ * arguments. Use it instead of indexing into the argument list, which a plugin
+ * has to do when it takes `...args` in order to forward them to `next`.
+ *
+ * @since 3.8.0
+ */
+export function readCommandContext<TInheritedOptions extends Record<string, any> = Record<string, any>>(
+    args: readonly unknown[],
+): CliCommandContext<TInheritedOptions> {
+    const context = args[args.length - 1] as CliCommandContext<TInheritedOptions> | undefined;
+    if (!context || !Array.isArray(context.commandPath)) {
+        throw new Error('No CliCommandContext found. Pass the full argument list a command action received.');
+    }
+    return context;
+}
+
+/**
+ * Reads the parsed options Commander passed to a command action. See
+ * {@link readCommandContext}.
+ *
+ * @since 3.8.0
+ */
+export function readCommandOptions(args: readonly unknown[]): Record<string, any> {
+    return (args[args.length - 3] as Record<string, any> | undefined) ?? {};
+}
+
+/**
  * Adds to a command that is already registered instead of replacing it, so
  * that several plugins can contribute to the same command.
  *
@@ -211,8 +238,10 @@ export interface CliCommandExtension {
  */
 export interface ProjectCliPluginConfig {
     /**
-     * Allowlist of packages to load as CLI plugins, in registration order
-     * (last listed wins when two plugins register the same command name).
+     * Allowlist of packages to load as CLI plugins, in registration order.
+     * A name that is already taken is rejected unless the command sets
+     * `replaces: true`; among plugins that do, the last listed wins. Command
+     * extensions are applied in the same order, and all of them are kept.
      * Each must be a direct dependency and declare `vendure.cliPlugin`.
      * When missing or empty, no plugins are loaded — disabling a plugin is
      * simply not listing it.

--- a/packages/cli/src/shared/cli-command-definition.ts
+++ b/packages/cli/src/shared/cli-command-definition.ts
@@ -68,8 +68,13 @@ export interface CliCommandDefinition {
      * `process.exit` after the action settles so plugins can wrap built-ins
      * without a premature exit.
      */
-    action: (...args: any[]) => Promise<void | number>;
+    action: CliCommandAction;
 }
+
+/**
+ * A command implementation, as the CLI host invokes it.
+ */
+export type CliCommandAction = (...args: any[]) => Promise<void | number>;
 
 /**
  * A command that exists only to group subcommands, e.g. the `config` in
@@ -102,6 +107,65 @@ export type CliCommandNode = CliCommandDefinition | CliCommandGroupDefinition;
 
 export function isCliCommandGroup(node: CliCommandNode): node is CliCommandGroupDefinition {
     return Array.isArray((node as CliCommandGroupDefinition).subcommands);
+}
+
+/**
+ * What the host hands a {@link CliCommandDecorator}.
+ */
+export interface CliCommandDecoratorInput {
+    /**
+     * The command as it stands before this decorator: the original definition
+     * plus every extension already applied to it. Read its `options`,
+     * `arguments` and `description` to see what other plugins have contributed.
+     */
+    command: Readonly<CliCommandDefinition>;
+    /**
+     * The action of that command. Call it to run everything beneath this
+     * decorator, ending in the original implementation. Never import the
+     * original action directly: `next` is what makes several plugins able to
+     * wrap the same command.
+     */
+    next: CliCommandAction;
+}
+
+/**
+ * Builds a replacement action that wraps the one it is given. The host calls it
+ * once, when the plugin is registered.
+ */
+export type CliCommandDecorator = (input: CliCommandDecoratorInput) => CliCommandAction;
+
+/**
+ * Adds to a command that is already registered instead of replacing it, so
+ * that several plugins can contribute to the same command.
+ *
+ * Extensions are applied in `vendure.cli.plugins` order, so the last listed
+ * plugin wraps the others and its decorator runs first.
+ */
+export interface CliCommandExtension {
+    /**
+     * The command to extend: `'dev'`, or `['config', 'server', 'set']` for a
+     * nested one.
+     */
+    command: string | string[];
+    /**
+     * Replaces the description shown in help. When more than one plugin sets
+     * it, the last listed plugin wins and the host writes a notice naming both.
+     */
+    description?: string;
+    /**
+     * Options added to the command, keeping the options already declared on it.
+     */
+    options?: CliCommandOption[];
+    /**
+     * Positional arguments appended after the existing ones. They must be
+     * optional: a required argument would change the arity of a command that
+     * other plugins and users already call.
+     */
+    arguments?: CliCommandArgument[];
+    /**
+     * Wraps the command's action.
+     */
+    decorate?: CliCommandDecorator;
 }
 
 /**

--- a/packages/cli/src/shared/cli-command-definition.ts
+++ b/packages/cli/src/shared/cli-command-definition.ts
@@ -31,9 +31,11 @@ export interface CliCommandArgument {
  */
 export interface CliCommandContext<TInheritedOptions extends Record<string, any> = Record<string, any>> {
     /**
-     * Values of the shared options in scope, resolved with nearest-wins
-     * precedence: a value given on the command itself overrides the same option
-     * given on a parent group, which overrides the same option given at the root.
+     * Values of the shared options in scope. A shared option is declared at
+     * exactly one level — a flag declared on a group that an ancestor already
+     * shares is rejected at registration — so values do not compete. Where a
+     * command declares the same flag as a shared option, both read the same
+     * value. A value supplied on the command line always beats a default.
      * Options that were neither supplied nor given a default value are omitted.
      */
     inheritedOptions: TInheritedOptions;
@@ -140,6 +142,11 @@ export type CliCommandDecorator = (input: CliCommandDecoratorInput) => CliComman
  *
  * Extensions are applied in `vendure.cli.plugins` order, so the last listed
  * plugin wraps the others and its decorator runs first.
+ *
+ * An extension contributes options, a description and action decoration. It
+ * cannot add positional arguments: Commander passes one argument slot per
+ * declared positional, so an appended argument would shift the options,
+ * command and context an existing action receives.
  */
 export interface CliCommandExtension {
     /**
@@ -156,12 +163,6 @@ export interface CliCommandExtension {
      * Options added to the command, keeping the options already declared on it.
      */
     options?: CliCommandOption[];
-    /**
-     * Positional arguments appended after the existing ones. They must be
-     * optional: a required argument would change the arity of a command that
-     * other plugins and users already call.
-     */
-    arguments?: CliCommandArgument[];
     /**
      * Wraps the command's action.
      */

--- a/packages/cli/src/shared/cli-command-definition.ts
+++ b/packages/cli/src/shared/cli-command-definition.ts
@@ -166,6 +166,14 @@ export interface CliCommandDecoratorInput {
 export type CliCommandDecorator = (input: CliCommandDecoratorInput) => CliCommandAction;
 
 /**
+ * Where each value sits, counting back from the end of a command action's
+ * arguments. The host appends the context after the arguments Commander
+ * supplies, so code inside the host that reads the tail before that point uses
+ * offsets one smaller than these.
+ */
+const ACTION_TAIL_OFFSETS = { context: 1, command: 2, options: 3 } as const;
+
+/**
  * Reads the {@link CliCommandContext} the host appends to a command action's
  * arguments. Use it instead of indexing into the argument list, which a plugin
  * has to do when it takes `...args` in order to forward them to `next`.
@@ -175,7 +183,9 @@ export type CliCommandDecorator = (input: CliCommandDecoratorInput) => CliComman
 export function readCommandContext<TInheritedOptions extends Record<string, any> = Record<string, any>>(
     args: readonly unknown[],
 ): CliCommandContext<TInheritedOptions> {
-    const context = args[args.length - 1] as CliCommandContext<TInheritedOptions> | undefined;
+    const context = args[args.length - ACTION_TAIL_OFFSETS.context] as
+        | CliCommandContext<TInheritedOptions>
+        | undefined;
     if (!context || !Array.isArray(context.commandPath)) {
         throw new Error('No CliCommandContext found. Pass the full argument list a command action received.');
     }
@@ -188,8 +198,14 @@ export function readCommandContext<TInheritedOptions extends Record<string, any>
  *
  * @since 3.8.0
  */
-export function readCommandOptions(args: readonly unknown[]): Record<string, any> {
-    return (args[args.length - 3] as Record<string, any> | undefined) ?? {};
+export function readCommandOptions<TOptions extends Record<string, any> = Record<string, any>>(
+    args: readonly unknown[],
+): TOptions {
+    const options = args[args.length - ACTION_TAIL_OFFSETS.options];
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+        throw new Error('No parsed options found. Pass the full argument list a command action received.');
+    }
+    return options as TOptions;
 }
 
 /**

--- a/packages/cli/src/shared/cli-command-definition.ts
+++ b/packages/cli/src/shared/cli-command-definition.ts
@@ -1,3 +1,8 @@
+/**
+ * An option on a CLI command.
+ *
+ * @since 3.8.0
+ */
 export interface CliCommandOption {
     long: string;
     short?: string;
@@ -11,6 +16,11 @@ export interface CliCommandOption {
     interactiveFn?: () => Promise<any>; // Function to execute in interactive mode
 }
 
+/**
+ * A positional argument on a CLI command.
+ *
+ * @since 3.8.0
+ */
 export interface CliCommandArgument {
     name: string;
     description: string;
@@ -28,6 +38,8 @@ export interface CliCommandArgument {
  *
  * Keys are Commander attribute names: the long flag without `--`, camel-cased.
  * `--api-token <token>` is therefore `apiToken`.
+ *
+ * @since 3.8.0
  */
 export interface CliCommandContext<TInheritedOptions extends Record<string, any> = Record<string, any>> {
     /**
@@ -46,6 +58,11 @@ export interface CliCommandContext<TInheritedOptions extends Record<string, any>
     commandPath: string[];
 }
 
+/**
+ * A CLI command that runs an action.
+ *
+ * @since 3.8.0
+ */
 export interface CliCommandDefinition {
     name: string;
     description: string;
@@ -56,6 +73,8 @@ export interface CliCommandDefinition {
      * name — a built-in, or one registered by an earlier plugin. Without it a
      * name collision is reported as an error and the plugin is skipped, so a
      * command can never be replaced by accident.
+     *
+     * @since 3.8.0
      */
     replaces?: boolean;
     /**
@@ -75,6 +94,8 @@ export interface CliCommandDefinition {
 
 /**
  * A command implementation, as the CLI host invokes it.
+ *
+ * @since 3.8.0
  */
 export type CliCommandAction = (...args: any[]) => Promise<void | number>;
 
@@ -82,6 +103,8 @@ export type CliCommandAction = (...args: any[]) => Promise<void | number>;
  * A command that exists only to group subcommands, e.g. the `config` in
  * `vendure config server set`. A group has no action of its own: running it
  * without a subcommand prints its help.
+ *
+ * @since 3.8.0
  */
 export interface CliCommandGroupDefinition {
     name: string;
@@ -104,6 +127,8 @@ export interface CliCommandGroupDefinition {
 /**
  * A node in a CLI command tree: either a command that runs an action, or a
  * group of further commands.
+ *
+ * @since 3.8.0
  */
 export type CliCommandNode = CliCommandDefinition | CliCommandGroupDefinition;
 
@@ -113,6 +138,8 @@ export function isCliCommandGroup(node: CliCommandNode): node is CliCommandGroup
 
 /**
  * What the host hands a {@link CliCommandDecorator}.
+ *
+ * @since 3.8.0
  */
 export interface CliCommandDecoratorInput {
     /**
@@ -133,6 +160,8 @@ export interface CliCommandDecoratorInput {
 /**
  * Builds a replacement action that wraps the one it is given. The host calls it
  * once, when the plugin is registered.
+ *
+ * @since 3.8.0
  */
 export type CliCommandDecorator = (input: CliCommandDecoratorInput) => CliCommandAction;
 
@@ -147,6 +176,8 @@ export type CliCommandDecorator = (input: CliCommandDecoratorInput) => CliComman
  * cannot add positional arguments: Commander passes one argument slot per
  * declared positional, so an appended argument would shift the options,
  * command and context an existing action receives.
+ *
+ * @since 3.8.0
  */
 export interface CliCommandExtension {
     /**
@@ -175,6 +206,8 @@ export interface CliCommandExtension {
  * Plugin packages are discovered from direct dependencies that declare
  * `vendure.cliPlugin`, but are only **loaded** when listed in `plugins`
  * (explicit activation). Use `vendure plugins` to manage this list.
+ *
+ * @since 3.8.0
  */
 export interface ProjectCliPluginConfig {
     /**

--- a/packages/cli/src/shared/cli-command-options.ts
+++ b/packages/cli/src/shared/cli-command-options.ts
@@ -46,12 +46,16 @@ export function parseOptionFlags(option: CliCommandOption): ParsedCliOption {
 }
 
 /**
- * An option together with every sub-option it declares. Sub-options are
+ * An option together with the sub-options it declares. Sub-options are
  * registered on the same Commander command as their parent, so every check
  * that applies to an option applies to them too.
+ *
+ * Sub-options nest one level only, matching what the host registers.
+ * `defineCliPlugin` rejects anything deeper, so validation and registration
+ * cannot disagree about which flags exist.
  */
 export function withSubOptions(options: CliCommandOption[]): CliCommandOption[] {
-    return options.flatMap(option => [option, ...withSubOptions(option.subOptions ?? [])]);
+    return options.flatMap(option => [option, ...(option.subOptions ?? [])]);
 }
 
 /**

--- a/packages/cli/src/shared/cli-command-options.ts
+++ b/packages/cli/src/shared/cli-command-options.ts
@@ -1,0 +1,51 @@
+import { Option } from 'commander';
+
+import { CliCommandOption } from './cli-command-definition';
+
+/**
+ * Builds the Commander flags string for an option, e.g. `-p, --plugin [name]`.
+ *
+ * Options that are not marked `required` have their value placeholder relaxed
+ * from `<value>` to `[value]`, so `--plugin <name>` can also be passed as a
+ * bare `--plugin`.
+ */
+export function buildOptionFlags(option: CliCommandOption): string {
+    const parts: string[] = [];
+    if (option.short) {
+        parts.push(option.short);
+    }
+    parts.push(option.long);
+
+    const flags = parts.join(', ');
+    return option.required ? flags : flags.replace(/<([^>]+)>/g, '[$1]');
+}
+
+export interface ParsedCliOption {
+    /** The long flag including dashes, e.g. `--plugin`. */
+    long?: string;
+    /** The short flag including the dash, e.g. `-p`. */
+    short?: string;
+    /** The key the parsed value is stored under, e.g. `plugin`. */
+    attributeName: string;
+}
+
+/**
+ * Resolves a definition's flags the same way Commander does, so that collision
+ * detection and registration always agree on what a flag is called.
+ */
+export function parseOptionFlags(option: CliCommandOption): ParsedCliOption {
+    const parsed = new Option(buildOptionFlags(option), option.description);
+    return {
+        long: parsed.long ?? undefined,
+        short: parsed.short ?? undefined,
+        attributeName: parsed.attributeName(),
+    };
+}
+
+/**
+ * How an option is named in error messages.
+ */
+export function describeOption(option: CliCommandOption): string {
+    const { long, short } = parseOptionFlags(option);
+    return [short, long].filter(Boolean).join(', ');
+}

--- a/packages/cli/src/shared/cli-command-options.ts
+++ b/packages/cli/src/shared/cli-command-options.ts
@@ -17,7 +17,9 @@ export function buildOptionFlags(option: CliCommandOption): string {
     parts.push(option.long);
 
     const flags = parts.join(', ');
-    return option.required ? flags : flags.replace(/<([^>]+)>/g, '[$1]');
+    // `[^<>]` rather than `[^>]`: a placeholder never contains `<`, and
+    // excluding it stops a run of unmatched `<` backtracking over the same text.
+    return option.required ? flags : flags.replace(/<([^<>]+)>/g, '[$1]');
 }
 
 export interface ParsedCliOption {

--- a/packages/cli/src/shared/cli-command-options.ts
+++ b/packages/cli/src/shared/cli-command-options.ts
@@ -27,6 +27,8 @@ export interface ParsedCliOption {
     short?: string;
     /** The key the parsed value is stored under, e.g. `plugin`. */
     attributeName: string;
+    /** Whether a value follows the flag, required or optional. */
+    takesValue: boolean;
 }
 
 /**
@@ -39,6 +41,7 @@ export function parseOptionFlags(option: CliCommandOption): ParsedCliOption {
         long: parsed.long ?? undefined,
         short: parsed.short ?? undefined,
         attributeName: parsed.attributeName(),
+        takesValue: parsed.required || parsed.optional,
     };
 }
 

--- a/packages/cli/src/shared/cli-command-options.ts
+++ b/packages/cli/src/shared/cli-command-options.ts
@@ -46,6 +46,15 @@ export function parseOptionFlags(option: CliCommandOption): ParsedCliOption {
 }
 
 /**
+ * An option together with every sub-option it declares. Sub-options are
+ * registered on the same Commander command as their parent, so every check
+ * that applies to an option applies to them too.
+ */
+export function withSubOptions(options: CliCommandOption[]): CliCommandOption[] {
+    return options.flatMap(option => [option, ...withSubOptions(option.subOptions ?? [])]);
+}
+
+/**
  * How an option is named in error messages.
  */
 export function describeOption(option: CliCommandOption): string {

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -5,7 +5,7 @@ import {
     CliCommandOption,
     isCliCommandGroup,
 } from './cli-command-definition';
-import { describeOption, parseOptionFlags } from './cli-command-options';
+import { describeOption, parseOptionFlags, withSubOptions } from './cli-command-options';
 
 /**
  * A CLI plugin that can add new commands or replace existing ones.
@@ -19,6 +19,8 @@ import { describeOption, parseOptionFlags } from './cli-command-options';
  *   }
  * }
  * ```
+ *
+ * @since 3.8.0
  */
 export interface CliPlugin {
     /**
@@ -37,6 +39,8 @@ export interface CliPlugin {
      * by every command. They can be given anywhere on the command line
      * (`vendure --token X project list` and `vendure project list --token X`
      * are equivalent) and reach actions via `CliCommandContext.inheritedOptions`.
+     *
+     * @since 3.8.0
      */
     rootOptions?: CliCommandOption[];
     /**
@@ -44,6 +48,8 @@ export interface CliPlugin {
      * contributed by another plugin. Unlike replacing a command, several
      * plugins can extend the same one: their options are merged and their
      * decorators are composed in `vendure.cli.plugins` order.
+     *
+     * @since 3.8.0
      */
     extendCommands?: CliCommandExtension[];
 }
@@ -121,6 +127,8 @@ function assertExtensions(
 
 /**
  * Validates and returns a CLI plugin definition for export from a plugin package.
+ *
+ * @since 3.8.0
  */
 export function defineCliPlugin(plugin: CliPlugin): CliPlugin {
     assertCliPlugin(plugin);
@@ -173,7 +181,7 @@ function assertNodes(
 
 function assertUniqueOptions(pluginId: string, options: CliCommandOption[], context: string): void {
     const seenFlags = new Set<string>();
-    for (const option of options) {
+    for (const option of withSubOptions(options)) {
         if (!option || typeof option.long !== 'string' || option.long.trim().length === 0) {
             throw new Error(`CLI plugin "${pluginId}" has an option without a long flag in ${context}`);
         }
@@ -202,7 +210,7 @@ function assertDoesNotShadow(
     inheritedOptions: CliCommandOption[],
 ): void {
     const inheritedFlags = new Map<string, CliCommandOption>();
-    for (const option of inheritedOptions) {
+    for (const option of withSubOptions(inheritedOptions)) {
         const { long, short } = parseOptionFlags(option);
         for (const flag of [long, short]) {
             if (flag) {
@@ -210,7 +218,7 @@ function assertDoesNotShadow(
             }
         }
     }
-    for (const option of ownOptions) {
+    for (const option of withSubOptions(ownOptions)) {
         const { long, short } = parseOptionFlags(option);
         for (const flag of [long, short]) {
             if (!flag) {

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -63,18 +63,18 @@ export function assertCliPlugin(value: unknown): asserts value is CliPlugin {
         throw new Error('CLI plugin id must be a non-empty string');
     }
     if (!Array.isArray(plugin.commands)) {
-        throw new Error(`CLI plugin "${plugin.id}" must provide a commands array`);
+        throw new TypeError(`CLI plugin "${plugin.id}" must provide a commands array`);
     }
     const rootOptions = plugin.rootOptions ?? [];
     if (!Array.isArray(rootOptions)) {
-        throw new Error(`CLI plugin "${plugin.id}" rootOptions must be an array`);
+        throw new TypeError(`CLI plugin "${plugin.id}" rootOptions must be an array`);
     }
     assertUniqueOptions(plugin.id, rootOptions, 'shared root options');
     assertNodes(plugin.id, plugin.commands, [], rootOptions);
 
     const extensions = plugin.extendCommands ?? [];
     if (!Array.isArray(extensions)) {
-        throw new Error(`CLI plugin "${plugin.id}" extendCommands must be an array`);
+        throw new TypeError(`CLI plugin "${plugin.id}" extendCommands must be an array`);
     }
     assertExtensions(plugin.id, extensions, rootOptions);
 }
@@ -143,57 +143,61 @@ function assertNodes(
 ): void {
     const seenNames = new Set<string>();
     for (const node of nodes) {
-        if (!node || typeof node.name !== 'string' || node.name.trim().length === 0) {
-            throw new Error(`CLI plugin "${pluginId}" has a command with an invalid name`);
-        }
-        const commandPath = [...path, node.name];
-        const label = commandPath.join(' ');
-        if (seenNames.has(node.name)) {
-            throw new Error(`CLI plugin "${pluginId}" declares the command "${label}" more than once`);
-        }
-        seenNames.add(node.name);
-
-        if (typeof node.description !== 'string' || node.description.trim().length === 0) {
-            throw new Error(`CLI plugin "${pluginId}" command "${label}" must provide a description`);
-        }
-
-        const ownOptions = node.options ?? [];
-        assertUniqueOptions(pluginId, ownOptions, `options of command "${label}"`);
-        if (!isCliCommandGroup(node)) {
-            assertMatchesInheritedShape(pluginId, label, ownOptions, inheritedOptions);
-        }
-        if (isCliCommandGroup(node)) {
-            assertDoesNotShadow(pluginId, label, ownOptions, inheritedOptions);
-            if (typeof (node as Partial<CliCommandDefinition>).action === 'function') {
-                throw new Error(
-                    `CLI plugin "${pluginId}" command "${label}" declares both subcommands and an action. ` +
-                        `A command group has no action of its own: move it into a subcommand.`,
-                );
-            }
-            if (node.subcommands.length === 0) {
-                throw new Error(
-                    `CLI plugin "${pluginId}" command group "${label}" must provide at least one subcommand`,
-                );
-            }
-            assertNodes(pluginId, node.subcommands, commandPath, [...inheritedOptions, ...ownOptions]);
-        } else if (typeof node.action !== 'function') {
-            throw new Error(`CLI plugin "${pluginId}" command "${label}" must provide an action function`);
-        }
+        assertNode(pluginId, node, path, inheritedOptions, seenNames);
     }
 }
 
-function assertUniqueOptions(pluginId: string, options: CliCommandOption[], context: string): void {
-    for (const option of options) {
-        for (const subOption of option.subOptions ?? []) {
-            if (subOption.subOptions?.length) {
-                throw new Error(
-                    `CLI plugin "${pluginId}" nests sub-options more than one level deep under ` +
-                        `"${describeOption(option)}" in ${context}. The CLI registers one level, so a ` +
-                        `deeper option would be validated but never parsed.`,
-                );
-            }
-        }
+function assertNode(
+    pluginId: string,
+    node: CliCommandNode,
+    path: string[],
+    inheritedOptions: CliCommandOption[],
+    seenNames: Set<string>,
+): void {
+    if (!node || typeof node.name !== 'string' || node.name.trim().length === 0) {
+        throw new Error(`CLI plugin "${pluginId}" has a command with an invalid name`);
     }
+    const commandPath = [...path, node.name];
+    const label = commandPath.join(' ');
+    if (seenNames.has(node.name)) {
+        throw new Error(`CLI plugin "${pluginId}" declares the command "${label}" more than once`);
+    }
+    seenNames.add(node.name);
+
+    if (typeof node.description !== 'string' || node.description.trim().length === 0) {
+        throw new Error(`CLI plugin "${pluginId}" command "${label}" must provide a description`);
+    }
+
+    const ownOptions = node.options ?? [];
+    assertUniqueOptions(pluginId, ownOptions, `options of command "${label}"`);
+
+    if (!isCliCommandGroup(node)) {
+        assertMatchesInheritedShape(pluginId, label, ownOptions, inheritedOptions);
+        if (typeof node.action !== 'function') {
+            throw new TypeError(
+                `CLI plugin "${pluginId}" command "${label}" must provide an action function`,
+            );
+        }
+        return;
+    }
+
+    assertDoesNotShadow(pluginId, label, ownOptions, inheritedOptions);
+    if (typeof (node as Partial<CliCommandDefinition>).action === 'function') {
+        throw new Error(
+            `CLI plugin "${pluginId}" command "${label}" declares both subcommands and an action. ` +
+                `A command group has no action of its own: move it into a subcommand.`,
+        );
+    }
+    if (node.subcommands.length === 0) {
+        throw new Error(
+            `CLI plugin "${pluginId}" command group "${label}" must provide at least one subcommand`,
+        );
+    }
+    assertNodes(pluginId, node.subcommands, commandPath, [...inheritedOptions, ...ownOptions]);
+}
+
+function assertUniqueOptions(pluginId: string, options: CliCommandOption[], context: string): void {
+    assertSubOptionDepth(pluginId, options, context);
 
     const seenFlags = new Set<string>();
     for (const option of withSubOptions(options)) {
@@ -209,6 +213,24 @@ function assertUniqueOptions(pluginId: string, options: CliCommandOption[], cont
                 throw new Error(`CLI plugin "${pluginId}" declares "${flag}" twice in ${context}`);
             }
             seenFlags.add(flag);
+        }
+    }
+}
+
+/**
+ * Sub-options nest one level, matching what the host registers. Anything
+ * deeper would be validated here and then never parsed.
+ */
+function assertSubOptionDepth(pluginId: string, options: CliCommandOption[], context: string): void {
+    for (const option of options) {
+        for (const subOption of option.subOptions ?? []) {
+            if (subOption.subOptions?.length) {
+                throw new Error(
+                    `CLI plugin "${pluginId}" nests sub-options more than one level deep under ` +
+                        `"${describeOption(option)}" in ${context}. The CLI registers one level, so a ` +
+                        `deeper option would be validated but never parsed.`,
+                );
+            }
         }
     }
 }

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -29,8 +29,8 @@ export interface CliPlugin {
     id: string;
     /**
      * Commands to register. Each entry is either a command with an action, or a
-     * group of subcommands. A top-level name that matches a built-in (or a
-     * previously registered) command replaces it, which must be declared with
+     * group of subcommands. A top-level name that a built-in or an earlier
+     * plugin already provides is rejected unless the command sets
      * `replaces: true`.
      */
     commands: CliCommandNode[];
@@ -180,6 +180,18 @@ function assertNodes(
 }
 
 function assertUniqueOptions(pluginId: string, options: CliCommandOption[], context: string): void {
+    for (const option of options) {
+        for (const subOption of option.subOptions ?? []) {
+            if (subOption.subOptions?.length) {
+                throw new Error(
+                    `CLI plugin "${pluginId}" nests sub-options more than one level deep under ` +
+                        `"${describeOption(option)}" in ${context}. The CLI registers one level, so a ` +
+                        `deeper option would be validated but never parsed.`,
+                );
+            }
+        }
+    }
+
     const seenFlags = new Set<string>();
     for (const option of withSubOptions(options)) {
         if (!option || typeof option.long !== 'string' || option.long.trim().length === 0) {

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -108,36 +108,14 @@ function assertExtensions(
         if (extension.decorate !== undefined && typeof extension.decorate !== 'function') {
             throw new Error(`CLI plugin "${pluginId}" extension of "${label}" has a non-function decorate`);
         }
-        if (
-            extension.decorate === undefined &&
-            !extension.description &&
-            !extension.options?.length &&
-            !extension.arguments?.length
-        ) {
+        if (extension.decorate === undefined && !extension.description && !extension.options?.length) {
             throw new Error(
                 `CLI plugin "${pluginId}" extension of "${label}" adds nothing. Give it a decorate, ` +
-                    `description, options or arguments.`,
+                    `description or options.`,
             );
         }
 
-        const options = extension.options ?? [];
-        assertUniqueOptions(pluginId, options, `options added to "${label}"`);
-        assertDoesNotShadow(pluginId, label, options, rootOptions);
-
-        for (const argument of extension.arguments ?? []) {
-            if (!argument || typeof argument.name !== 'string' || argument.name.trim().length === 0) {
-                throw new Error(
-                    `CLI plugin "${pluginId}" extension of "${label}" has an argument without a name`,
-                );
-            }
-            if (argument.required === true) {
-                throw new Error(
-                    `CLI plugin "${pluginId}" extension of "${label}" adds a required argument ` +
-                        `"${argument.name}". An extension may only add optional arguments, because a ` +
-                        `required one would change the arity of a command that is already in use.`,
-                );
-            }
-        }
+        assertUniqueOptions(pluginId, extension.options ?? [], `options added to "${label}"`);
     }
 }
 
@@ -173,9 +151,8 @@ function assertNodes(
 
         const ownOptions = node.options ?? [];
         assertUniqueOptions(pluginId, ownOptions, `options of command "${label}"`);
-        assertDoesNotShadow(pluginId, label, ownOptions, inheritedOptions);
-
         if (isCliCommandGroup(node)) {
+            assertDoesNotShadow(pluginId, label, ownOptions, inheritedOptions);
             if (typeof (node as Partial<CliCommandDefinition>).action === 'function') {
                 throw new Error(
                     `CLI plugin "${pluginId}" command "${label}" declares both subcommands and an action. ` +
@@ -214,9 +191,9 @@ function assertUniqueOptions(pluginId: string, options: CliCommandOption[], cont
 }
 
 /**
- * A shared option is consumed by the command that declares it wherever it
- * appears on the command line, so a nested command redeclaring the same flag
- * would never receive a value. Reject it while the author can still see why.
+ * A group's options are shared with everything below it, so two levels sharing
+ * one flag would leave the value's owner ambiguous. A leaf may repeat a shared
+ * flag: the host copies the value onto it, so both readings agree.
  */
 function assertDoesNotShadow(
     pluginId: string,
@@ -243,7 +220,8 @@ function assertDoesNotShadow(
             if (shadowed) {
                 throw new Error(
                     `CLI plugin "${pluginId}" command "${label}" declares "${flag}", which is already a shared ` +
-                        `option ("${describeOption(shadowed)}"). Remove it and read the value from the command context.`,
+                        `option ("${describeOption(shadowed)}"). Declare it at one level only and read the ` +
+                        `value from the command context.`,
                 );
             }
         }

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -1,5 +1,6 @@
 import {
     CliCommandDefinition,
+    CliCommandExtension,
     CliCommandNode,
     CliCommandOption,
     isCliCommandGroup,
@@ -38,6 +39,13 @@ export interface CliPlugin {
      * are equivalent) and reach actions via `CliCommandContext.inheritedOptions`.
      */
     rootOptions?: CliCommandOption[];
+    /**
+     * Additions to commands that are already registered, whether built-in or
+     * contributed by another plugin. Unlike replacing a command, several
+     * plugins can extend the same one: their options are merged and their
+     * decorators are composed in `vendure.cli.plugins` order.
+     */
+    extendCommands?: CliCommandExtension[];
 }
 
 export function assertCliPlugin(value: unknown): asserts value is CliPlugin {
@@ -57,6 +65,80 @@ export function assertCliPlugin(value: unknown): asserts value is CliPlugin {
     }
     assertUniqueOptions(plugin.id, rootOptions, 'shared root options');
     assertNodes(plugin.id, plugin.commands, [], rootOptions);
+
+    const extensions = plugin.extendCommands ?? [];
+    if (!Array.isArray(extensions)) {
+        throw new Error(`CLI plugin "${plugin.id}" extendCommands must be an array`);
+    }
+    assertExtensions(plugin.id, extensions, rootOptions);
+}
+
+/**
+ * Normalises the `command` of an extension to a path, e.g. `'dev'` and
+ * `['config', 'server', 'set']`.
+ */
+export function normalizeCommandPath(command: string | string[]): string[] {
+    return (Array.isArray(command) ? command : command.split(' '))
+        .map(segment => segment.trim())
+        .filter(segment => segment.length > 0);
+}
+
+function assertExtensions(
+    pluginId: string,
+    extensions: CliCommandExtension[],
+    rootOptions: CliCommandOption[],
+): void {
+    const seenPaths = new Set<string>();
+    for (const extension of extensions) {
+        if (!extension || typeof extension !== 'object') {
+            throw new Error(`CLI plugin "${pluginId}" has a command extension that is not an object`);
+        }
+        const path = normalizeCommandPath(extension.command);
+        if (path.length === 0) {
+            throw new Error(`CLI plugin "${pluginId}" has a command extension without a command path`);
+        }
+        const label = path.join(' ');
+        if (seenPaths.has(label)) {
+            throw new Error(
+                `CLI plugin "${pluginId}" extends "${label}" more than once. Combine them into one extension.`,
+            );
+        }
+        seenPaths.add(label);
+
+        if (extension.decorate !== undefined && typeof extension.decorate !== 'function') {
+            throw new Error(`CLI plugin "${pluginId}" extension of "${label}" has a non-function decorate`);
+        }
+        if (
+            extension.decorate === undefined &&
+            !extension.description &&
+            !extension.options?.length &&
+            !extension.arguments?.length
+        ) {
+            throw new Error(
+                `CLI plugin "${pluginId}" extension of "${label}" adds nothing. Give it a decorate, ` +
+                    `description, options or arguments.`,
+            );
+        }
+
+        const options = extension.options ?? [];
+        assertUniqueOptions(pluginId, options, `options added to "${label}"`);
+        assertDoesNotShadow(pluginId, label, options, rootOptions);
+
+        for (const argument of extension.arguments ?? []) {
+            if (!argument || typeof argument.name !== 'string' || argument.name.trim().length === 0) {
+                throw new Error(
+                    `CLI plugin "${pluginId}" extension of "${label}" has an argument without a name`,
+                );
+            }
+            if (argument.required === true) {
+                throw new Error(
+                    `CLI plugin "${pluginId}" extension of "${label}" adds a required argument ` +
+                        `"${argument.name}". An extension may only add optional arguments, because a ` +
+                        `required one would change the arity of a command that is already in use.`,
+                );
+            }
+        }
+    }
 }
 
 /**

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -1,4 +1,10 @@
-import { CliCommandDefinition } from './cli-command-definition';
+import {
+    CliCommandDefinition,
+    CliCommandNode,
+    CliCommandOption,
+    isCliCommandGroup,
+} from './cli-command-definition';
+import { describeOption, parseOptionFlags } from './cli-command-options';
 
 /**
  * A CLI plugin that can add new commands or replace existing ones.
@@ -19,10 +25,19 @@ export interface CliPlugin {
      */
     id: string;
     /**
-     * Commands to register. A command whose `name` matches a built-in
-     * (or previously registered) command replaces it.
+     * Commands to register. Each entry is either a command with an action, or a
+     * group of subcommands. A top-level name that matches a built-in (or a
+     * previously registered) command replaces it, which must be declared with
+     * `replaces: true`.
      */
-    commands: CliCommandDefinition[];
+    commands: CliCommandNode[];
+    /**
+     * Options registered on the `vendure` command itself, and therefore shared
+     * by every command. They can be given anywhere on the command line
+     * (`vendure --token X project list` and `vendure project list --token X`
+     * are equivalent) and reach actions via `CliCommandContext.inheritedOptions`.
+     */
+    rootOptions?: CliCommandOption[];
 }
 
 export function assertCliPlugin(value: unknown): asserts value is CliPlugin {
@@ -36,19 +51,12 @@ export function assertCliPlugin(value: unknown): asserts value is CliPlugin {
     if (!Array.isArray(plugin.commands)) {
         throw new Error(`CLI plugin "${plugin.id}" must provide a commands array`);
     }
-    for (const command of plugin.commands) {
-        if (!command || typeof command.name !== 'string' || command.name.trim().length === 0) {
-            throw new Error(`CLI plugin "${plugin.id}" has a command with an invalid name`);
-        }
-        if (typeof command.description !== 'string' || command.description.trim().length === 0) {
-            throw new Error(`CLI plugin "${plugin.id}" command "${command.name}" must provide a description`);
-        }
-        if (typeof command.action !== 'function') {
-            throw new Error(
-                `CLI plugin "${plugin.id}" command "${command.name}" must provide an action function`,
-            );
-        }
+    const rootOptions = plugin.rootOptions ?? [];
+    if (!Array.isArray(rootOptions)) {
+        throw new Error(`CLI plugin "${plugin.id}" rootOptions must be an array`);
     }
+    assertUniqueOptions(plugin.id, rootOptions, 'shared root options');
+    assertNodes(plugin.id, plugin.commands, [], rootOptions);
 }
 
 /**
@@ -57,4 +65,105 @@ export function assertCliPlugin(value: unknown): asserts value is CliPlugin {
 export function defineCliPlugin(plugin: CliPlugin): CliPlugin {
     assertCliPlugin(plugin);
     return plugin;
+}
+
+function assertNodes(
+    pluginId: string,
+    nodes: CliCommandNode[],
+    path: string[],
+    inheritedOptions: CliCommandOption[],
+): void {
+    const seenNames = new Set<string>();
+    for (const node of nodes) {
+        if (!node || typeof node.name !== 'string' || node.name.trim().length === 0) {
+            throw new Error(`CLI plugin "${pluginId}" has a command with an invalid name`);
+        }
+        const commandPath = [...path, node.name];
+        const label = commandPath.join(' ');
+        if (seenNames.has(node.name)) {
+            throw new Error(`CLI plugin "${pluginId}" declares the command "${label}" more than once`);
+        }
+        seenNames.add(node.name);
+
+        if (typeof node.description !== 'string' || node.description.trim().length === 0) {
+            throw new Error(`CLI plugin "${pluginId}" command "${label}" must provide a description`);
+        }
+
+        const ownOptions = node.options ?? [];
+        assertUniqueOptions(pluginId, ownOptions, `options of command "${label}"`);
+        assertDoesNotShadow(pluginId, label, ownOptions, inheritedOptions);
+
+        if (isCliCommandGroup(node)) {
+            if (typeof (node as Partial<CliCommandDefinition>).action === 'function') {
+                throw new Error(
+                    `CLI plugin "${pluginId}" command "${label}" declares both subcommands and an action. ` +
+                        `A command group has no action of its own: move it into a subcommand.`,
+                );
+            }
+            if (node.subcommands.length === 0) {
+                throw new Error(
+                    `CLI plugin "${pluginId}" command group "${label}" must provide at least one subcommand`,
+                );
+            }
+            assertNodes(pluginId, node.subcommands, commandPath, [...inheritedOptions, ...ownOptions]);
+        } else if (typeof node.action !== 'function') {
+            throw new Error(`CLI plugin "${pluginId}" command "${label}" must provide an action function`);
+        }
+    }
+}
+
+function assertUniqueOptions(pluginId: string, options: CliCommandOption[], context: string): void {
+    const seenFlags = new Set<string>();
+    for (const option of options) {
+        if (!option || typeof option.long !== 'string' || option.long.trim().length === 0) {
+            throw new Error(`CLI plugin "${pluginId}" has an option without a long flag in ${context}`);
+        }
+        const { long, short } = parseOptionFlags(option);
+        for (const flag of [long, short]) {
+            if (!flag) {
+                continue;
+            }
+            if (seenFlags.has(flag)) {
+                throw new Error(`CLI plugin "${pluginId}" declares "${flag}" twice in ${context}`);
+            }
+            seenFlags.add(flag);
+        }
+    }
+}
+
+/**
+ * A shared option is consumed by the command that declares it wherever it
+ * appears on the command line, so a nested command redeclaring the same flag
+ * would never receive a value. Reject it while the author can still see why.
+ */
+function assertDoesNotShadow(
+    pluginId: string,
+    label: string,
+    ownOptions: CliCommandOption[],
+    inheritedOptions: CliCommandOption[],
+): void {
+    const inheritedFlags = new Map<string, CliCommandOption>();
+    for (const option of inheritedOptions) {
+        const { long, short } = parseOptionFlags(option);
+        for (const flag of [long, short]) {
+            if (flag) {
+                inheritedFlags.set(flag, option);
+            }
+        }
+    }
+    for (const option of ownOptions) {
+        const { long, short } = parseOptionFlags(option);
+        for (const flag of [long, short]) {
+            if (!flag) {
+                continue;
+            }
+            const shadowed = inheritedFlags.get(flag);
+            if (shadowed) {
+                throw new Error(
+                    `CLI plugin "${pluginId}" command "${label}" declares "${flag}", which is already a shared ` +
+                        `option ("${describeOption(shadowed)}"). Remove it and read the value from the command context.`,
+                );
+            }
+        }
+    }
 }

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -159,6 +159,9 @@ function assertNodes(
 
         const ownOptions = node.options ?? [];
         assertUniqueOptions(pluginId, ownOptions, `options of command "${label}"`);
+        if (!isCliCommandGroup(node)) {
+            assertMatchesInheritedShape(pluginId, label, ownOptions, inheritedOptions);
+        }
         if (isCliCommandGroup(node)) {
             assertDoesNotShadow(pluginId, label, ownOptions, inheritedOptions);
             if (typeof (node as Partial<CliCommandDefinition>).action === 'function') {
@@ -206,6 +209,39 @@ function assertUniqueOptions(pluginId: string, options: CliCommandOption[], cont
                 throw new Error(`CLI plugin "${pluginId}" declares "${flag}" twice in ${context}`);
             }
             seenFlags.add(flag);
+        }
+    }
+}
+
+/**
+ * A command may repeat a flag one of its groups shares — the host copies the
+ * value onto it — but only if both agree on whether a value follows the flag.
+ * Otherwise the group consumes the flag and hands the command a value its own
+ * declaration says it will never see.
+ */
+function assertMatchesInheritedShape(
+    pluginId: string,
+    label: string,
+    ownOptions: CliCommandOption[],
+    inheritedOptions: CliCommandOption[],
+): void {
+    const inherited = withSubOptions(inheritedOptions);
+    for (const option of withSubOptions(ownOptions)) {
+        const parsed = parseOptionFlags(option);
+        const clash = inherited.find(existing => {
+            const other = parseOptionFlags(existing);
+            return (
+                other.long === parsed.long ||
+                (other.short != null && other.short === parsed.short) ||
+                other.attributeName === parsed.attributeName
+            );
+        });
+        if (clash && parseOptionFlags(clash).takesValue !== parsed.takesValue) {
+            throw new Error(
+                `CLI plugin "${pluginId}" command "${label}" declares "${describeOption(option)}", which ` +
+                    `is not compatible with the shared option "${describeOption(clash)}": one takes a ` +
+                    `value and the other does not.`,
+            );
         }
     }
 }

--- a/packages/cli/src/shared/command-extensions.spec.ts
+++ b/packages/cli/src/shared/command-extensions.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { runCli } from './__tests__/run-cli';
 import { CliCommandDefinition, CliCommandGroupDefinition, CliCommandOption } from './cli-command-definition';
@@ -10,6 +10,10 @@ import { CliPluginRegistrationError, CommandRegistry } from './command-registry-
  * test can assert that every wrapper ran exactly once and in which order.
  */
 const trace: string[] = [];
+
+beforeEach(() => {
+    trace.length = 0;
+});
 
 const PLATFORM_ID = '@vendure-platform/cli';
 const CLOUD_ID = '@vendure/cloud';
@@ -97,10 +101,6 @@ function devCommand(registry: CommandRegistry): CliCommandDefinition {
 }
 
 describe('Command extensions: composition', () => {
-    afterEach(() => {
-        trace.length = 0;
-    });
-
     it('runs every wrapper exactly once, outermost first', async () => {
         const registry = registryWithCore();
         registry.applyPlugin(platformPlugin());
@@ -263,10 +263,6 @@ describe('Command extensions: composition', () => {
 });
 
 describe('Command extensions: registration through Commander', () => {
-    afterEach(() => {
-        trace.length = 0;
-    });
-
     it('exposes every plugin option and runs the whole chain', async () => {
         const registry = registryWithCore();
         registry.applyPlugin(platformPlugin());
@@ -308,10 +304,6 @@ describe('Command extensions: registration through Commander', () => {
 });
 
 describe('Command extensions: collisions', () => {
-    afterEach(() => {
-        trace.length = 0;
-    });
-
     it('rejects an extension of a command that is not registered', () => {
         const registry = registryWithCore();
         const plugin = defineCliPlugin({
@@ -553,7 +545,8 @@ describe('defineCliPlugin() with command extensions', () => {
         ).toThrow(/already a shared option/);
     });
 
-    it('allows a command to repeat a shared option, which the host keeps in step', () => {
+    it('allows a command to repeat a shared option of the same shape', () => {
+        const registry = registryWithCore();
         const plugin = defineCliPlugin({
             id: '@example/repeat',
             rootOptions: [{ long: '--token <token>', description: 'API token', required: true }],
@@ -567,7 +560,10 @@ describe('defineCliPlugin() with command extensions', () => {
             ],
         });
 
-        expect(plugin.commands).toHaveLength(1);
+        expect(() => registry.applyPlugin(plugin)).not.toThrow();
+        expect((registry.get('thing') as CliCommandDefinition).options?.map(o => o.long)).toEqual([
+            '--token <token>',
+        ]);
     });
 
     it('rejects a non-function decorate', () => {
@@ -595,10 +591,6 @@ describe('defineCliPlugin() with command extensions', () => {
 });
 
 describe('Command extensions: plugin-provided commands', () => {
-    afterEach(() => {
-        trace.length = 0;
-    });
-
     function providerPlugin() {
         return defineCliPlugin({
             id: '@a/provider',
@@ -737,10 +729,6 @@ describe('Command extensions: plugin-provided commands', () => {
 });
 
 describe('Command extensions: nested composition', () => {
-    afterEach(() => {
-        trace.length = 0;
-    });
-
     function nestedProvider() {
         return defineCliPlugin({
             id: '@a/provider',
@@ -950,7 +938,7 @@ describe('Command extensions: reserved names and shared-option scope', () => {
         expect(() => registry.applyPlugin(shadow)).toThrow(/cannot be shared at two levels/);
     });
 
-    it('lets a supplied value beat a group default', async () => {
+    it('passes a supplied root option value to a nested command', async () => {
         let inherited: Record<string, any> | undefined;
         const registry = new CommandRegistry();
         registry.applyPlugin(
@@ -1270,7 +1258,7 @@ describe('Command extensions: sub-option depth', () => {
         const run = await runCli(registry.toArray(), [], ['deep', '--a', '1', '--b', '2']);
 
         expect(run.exitCode).toBe(0);
-        expect(seen).toMatchObject({ a: '1', b: '2' });
+        expect(seen).toEqual({ a: '1', b: '2' });
     });
 });
 
@@ -1300,5 +1288,188 @@ describe('Command extensions: the decorator cannot reach the registered command'
 
         expect(() => registry.applyPlugin(naughty)).toThrow(/Extending "vendure dev" failed/);
         expect(original.options?.length).toBe(optionCount);
+    });
+});
+
+describe('Command extensions: value shape across levels', () => {
+    it('rejects a group extension whose flag disagrees with a leaf below it', () => {
+        const registry = new CommandRegistry();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/tree',
+                commands: [
+                    {
+                        name: 'config',
+                        description: 'Config',
+                        subcommands: [
+                            {
+                                name: 'server',
+                                description: 'Server',
+                                options: [{ long: '--dry-run', description: 'Boolean' }],
+                                action: async () => 0,
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        const rival = defineCliPlugin({
+            id: '@b/ext',
+            commands: [],
+            extendCommands: [
+                {
+                    command: 'config',
+                    options: [{ long: '--dry-run <path>', description: 'Valued', required: true }],
+                },
+            ],
+        });
+
+        expect(() => registry.applyPlugin(rival)).toThrow(/one takes a value and the other does not/);
+    });
+
+    it('rejects a leaf whose flag disagrees with its own group', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@a/one',
+                commands: [
+                    {
+                        name: 'config',
+                        description: 'Config',
+                        options: [{ long: '--dry-run <path>', description: 'Valued', required: true }],
+                        subcommands: [
+                            {
+                                name: 'server',
+                                description: 'Server',
+                                options: [{ long: '--dry-run', description: 'Boolean' }],
+                                action: async () => 0,
+                            },
+                        ],
+                    },
+                ],
+            }),
+        ).toThrow(/one takes a value and the other does not/);
+    });
+
+    it('accepts a leaf repeating a group flag of the same shape', async () => {
+        let seen: Record<string, any> | undefined;
+        const registry = new CommandRegistry();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/one',
+                commands: [
+                    {
+                        name: 'config',
+                        description: 'Config',
+                        options: [{ long: '--dry-run', description: 'Boolean' }],
+                        subcommands: [
+                            {
+                                name: 'server',
+                                description: 'Server',
+                                options: [{ long: '--dry-run', description: 'Boolean' }],
+                                action: async (options: Record<string, any>) => {
+                                    seen = options;
+                                    return 0;
+                                },
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        const run = await runCli(registry.toArray(), registry.getRootOptions(), [
+            'config',
+            '--dry-run',
+            'server',
+        ]);
+
+        expect(run.exitCode).toBe(0);
+        expect(seen?.dryRun).toBe(true);
+    });
+});
+
+describe('Shared root options with sub-options', () => {
+    it('registers a root sub-option exactly once', async () => {
+        const registry = new CommandRegistry();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/sub',
+                rootOptions: [
+                    {
+                        long: '--auth <mode>',
+                        description: 'Auth mode',
+                        required: true,
+                        subOptions: [{ long: '--auth-token <t>', description: 'Token', required: true }],
+                    },
+                ],
+                commands: [{ name: 'x', description: 'X', action: async () => 0 }],
+            }),
+        );
+
+        // The parent still carries its sub-option, so the host expands it once.
+        expect(registry.getRootOptions().map(option => option.long)).toEqual(['--auth <mode>']);
+
+        const help = await runCli(registry.toArray(), registry.getRootOptions(), ['--help']);
+        const authTokenLines = help.stdout.split('\n').filter(line => line.includes('--auth-token'));
+        expect(authTokenLines).toHaveLength(1);
+    });
+
+    it('still detects a collision on a root sub-option', () => {
+        const registry = new CommandRegistry();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/first',
+                rootOptions: [
+                    {
+                        long: '--a <v>',
+                        description: 'A',
+                        required: true,
+                        subOptions: [{ long: '--shared <v>', description: 'Shared', required: true }],
+                    },
+                ],
+                commands: [{ name: 'ca', description: 'CA', action: async () => 0 }],
+            }),
+        );
+
+        const rival = defineCliPlugin({
+            id: '@b/second',
+            rootOptions: [{ long: '--shared <v>', description: 'Mine', required: true }],
+            commands: [{ name: 'cb', description: 'CB', action: async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(rival)).toThrow(/already registered by @a\/first/);
+    });
+});
+
+describe('Reserved short flags', () => {
+    it('rejects a shared option using the short version flag', () => {
+        const registry = registryWithCore();
+        const plugin = defineCliPlugin({
+            id: '@example/greedy',
+            rootOptions: [{ short: '-V', long: '--verbose', description: 'Verbose' }],
+            commands: [{ name: 'thing', description: 'Thing', action: async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/"-V", which is reserved by the CLI/);
+    });
+
+    it('detects a collision on the short flag alone', () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/first',
+                rootOptions: [{ short: '-t', long: '--token <t>', description: 'Token', required: true }],
+                commands: [{ name: 'ca', description: 'CA', action: async () => 0 }],
+            }),
+        );
+
+        const rival = defineCliPlugin({
+            id: '@b/second',
+            rootOptions: [{ short: '-t', long: '--target <t>', description: 'Target', required: true }],
+            commands: [{ name: 'cb', description: 'CB', action: async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(rival)).toThrow(/already registered by @a\/first/);
     });
 });

--- a/packages/cli/src/shared/command-extensions.spec.ts
+++ b/packages/cli/src/shared/command-extensions.spec.ts
@@ -981,3 +981,157 @@ describe('Command extensions: reserved names and shared-option scope', () => {
         expect(inherited).toEqual({ env: 'staging' });
     });
 });
+
+describe('Command extensions: sub-options and description ownership', () => {
+    it('rejects a shared option whose sub-option uses a reserved flag', () => {
+        const registry = registryWithCore();
+        const plugin = defineCliPlugin({
+            id: '@example/sneaky',
+            rootOptions: [
+                {
+                    long: '--mode <m>',
+                    description: 'Mode',
+                    required: true,
+                    subOptions: [{ long: '--help', description: 'Sneaky' }],
+                },
+            ],
+            commands: [{ name: 'thing', description: 'Thing', action: async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/reserved by the CLI/);
+        expect(registry.has('thing')).toBe(false);
+    });
+
+    it('rejects a sub-option that another plugin already shares', () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/first',
+                rootOptions: [
+                    {
+                        long: '--a <v>',
+                        description: 'A',
+                        required: true,
+                        subOptions: [{ long: '--shared <v>', description: 'Shared', required: true }],
+                    },
+                ],
+                commands: [{ name: 'ca', description: 'CA', action: async () => 0 }],
+            }),
+        );
+
+        const rival = defineCliPlugin({
+            id: '@b/second',
+            rootOptions: [
+                {
+                    long: '--b <v>',
+                    description: 'B',
+                    required: true,
+                    subOptions: [{ long: '--shared <v>', description: 'Mine', required: true }],
+                },
+            ],
+            commands: [{ name: 'cb', description: 'CB', action: async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(rival)).toThrow(/already registered by @a\/first/);
+        expect(registry.has('cb')).toBe(false);
+    });
+
+    it('rejects a command sub-option that uses a reserved flag', () => {
+        const registry = registryWithCore();
+        const plugin = defineCliPlugin({
+            id: '@example/sneaky',
+            commands: [
+                {
+                    name: 'thing',
+                    description: 'Thing',
+                    options: [
+                        {
+                            long: '--mode <m>',
+                            description: 'Mode',
+                            required: true,
+                            subOptions: [{ long: '-h', description: 'Sneaky' }],
+                        },
+                    ],
+                    action: async () => 0,
+                },
+            ],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/reserved by the CLI/);
+    });
+
+    it('records description ownership per command, not per tree', () => {
+        const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+        const registry = new CommandRegistry();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/provider',
+                commands: [
+                    {
+                        name: 'config',
+                        description: 'Config',
+                        subcommands: [
+                            { name: 'server', description: 'Server', action: async () => 0 },
+                            { name: 'database', description: 'Database', action: async () => 0 },
+                        ],
+                    },
+                ],
+            }),
+        );
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@b/first',
+                commands: [],
+                extendCommands: [{ command: 'config server', description: 'Server by B' }],
+            }),
+        );
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@c/second',
+                commands: [],
+                extendCommands: [{ command: 'config database', description: 'Database by C' }],
+            }),
+        );
+
+        // Two different commands were described, so nothing was replaced.
+        const written = writeSpy.mock.calls.map(call => String(call[0])).join('');
+        expect(written).not.toContain('Description of');
+        writeSpy.mockRestore();
+    });
+
+    it('still reports a replacement when the same command is described twice', () => {
+        const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+        const registry = new CommandRegistry();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/provider',
+                commands: [
+                    {
+                        name: 'config',
+                        description: 'Config',
+                        subcommands: [{ name: 'server', description: 'Server', action: async () => 0 }],
+                    },
+                ],
+            }),
+        );
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@b/first',
+                commands: [],
+                extendCommands: [{ command: 'config server', description: 'Server by B' }],
+            }),
+        );
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@c/second',
+                commands: [],
+                extendCommands: [{ command: 'config server', description: 'Server by C' }],
+            }),
+        );
+
+        const written = writeSpy.mock.calls.map(call => String(call[0])).join('');
+        expect(written).toContain('Description of "vendure config server" set by @c/second');
+        expect(written).toContain('@b/first');
+        writeSpy.mockRestore();
+    });
+});

--- a/packages/cli/src/shared/command-extensions.spec.ts
+++ b/packages/cli/src/shared/command-extensions.spec.ts
@@ -256,25 +256,9 @@ describe('Command extensions: composition', () => {
         );
 
         const group = registry.get('config') as CliCommandGroupDefinition;
-        expect((group.subcommands[0] as CliCommandDefinition).options).toHaveLength(1);
-    });
-
-    it('adds an optional argument', () => {
-        const registry = registryWithCore();
-        registry.applyPlugin(
-            defineCliPlugin({
-                id: '@example/args',
-                commands: [],
-                extendCommands: [
-                    {
-                        command: 'dev',
-                        arguments: [{ name: 'profile', description: 'Profile', required: false }],
-                    },
-                ],
-            }),
-        );
-
-        expect(devCommand(registry).arguments?.map(argument => argument.name)).toEqual(['target', 'profile']);
+        expect((group.subcommands[0] as CliCommandDefinition).options?.map(o => o.long)).toEqual([
+            '--dry-run',
+        ]);
     });
 });
 
@@ -324,6 +308,10 @@ describe('Command extensions: registration through Commander', () => {
 });
 
 describe('Command extensions: collisions', () => {
+    afterEach(() => {
+        trace.length = 0;
+    });
+
     it('rejects an extension of a command that is not registered', () => {
         const registry = registryWithCore();
         const plugin = defineCliPlugin({
@@ -371,7 +359,9 @@ describe('Command extensions: collisions', () => {
             }),
         );
 
-        expect((registry.get('config') as CliCommandGroupDefinition).options).toHaveLength(1);
+        expect((registry.get('config') as CliCommandGroupDefinition).options?.map(o => o.long)).toEqual([
+            '--profile <name>',
+        ]);
     });
 
     it('rejects an option that the target already declares', () => {
@@ -387,7 +377,7 @@ describe('Command extensions: collisions', () => {
         });
 
         expect(() => registry.applyPlugin(rival)).toThrow(
-            /already declared on "vendure dev" \(contributed by the CLI, @vendure-platform\/cli\)/,
+            /Option "--rotate-credential" is already declared on "vendure dev"/,
         );
         expect(registry.getExtendedBy('dev')).toEqual([PLATFORM_ID]);
     });
@@ -462,18 +452,6 @@ describe('Command extensions: collisions', () => {
         await devCommand(registry).action();
 
         expect(trace).toEqual(['platform:before', 'replacement', 'platform:after']);
-        trace.length = 0;
-    });
-
-    it('rejects an argument name the target already declares', () => {
-        const registry = registryWithCore();
-        const plugin = defineCliPlugin({
-            id: '@example/args',
-            commands: [],
-            extendCommands: [{ command: 'dev', arguments: [{ name: 'target', description: 'Mine' }] }],
-        });
-
-        expect(() => registry.applyPlugin(plugin)).toThrow(/Argument "target" is already declared/);
     });
 
     it('reports a decorator that throws while being applied, and applies nothing', () => {
@@ -521,7 +499,6 @@ describe('Command extensions: collisions', () => {
 
         await devCommand(registry).action('server');
         expect(trace).toEqual(['platform:before', 'core:server', 'platform:after']);
-        trace.length = 0;
     });
 });
 
@@ -559,35 +536,38 @@ describe('defineCliPlugin() with command extensions', () => {
         ).toThrow(/extends "dev" more than once/);
     });
 
-    it('rejects an extension that adds a required argument', () => {
-        expect(() =>
-            defineCliPlugin({
-                id: '@example/args',
-                commands: [],
-                extendCommands: [
-                    {
-                        command: 'dev',
-                        arguments: [{ name: 'profile', description: 'Profile', required: true }],
-                    },
-                ],
-            }),
-        ).toThrow(/adds a required argument/);
-    });
-
-    it('rejects an added option that shadows one of the plugin shared options', () => {
+    it('rejects a group that redeclares one of the plugin shared options', () => {
         expect(() =>
             defineCliPlugin({
                 id: '@example/shadow',
                 rootOptions: [{ long: '--token <token>', description: 'API token', required: true }],
-                commands: [],
-                extendCommands: [
+                commands: [
                     {
-                        command: 'dev',
+                        name: 'group',
+                        description: 'Group',
                         options: [{ long: '--token <token>', description: 'Override', required: true }],
+                        subcommands: [{ name: 'run', description: 'Run', action: async () => 0 }],
                     },
                 ],
             }),
         ).toThrow(/already a shared option/);
+    });
+
+    it('allows a command to repeat a shared option, which the host keeps in step', () => {
+        const plugin = defineCliPlugin({
+            id: '@example/repeat',
+            rootOptions: [{ long: '--token <token>', description: 'API token', required: true }],
+            commands: [
+                {
+                    name: 'thing',
+                    description: 'Thing',
+                    options: [{ long: '--token <token>', description: 'Same value', required: true }],
+                    action: async () => 0,
+                },
+            ],
+        });
+
+        expect(plugin.commands).toHaveLength(1);
     });
 
     it('rejects a non-function decorate', () => {
@@ -600,15 +580,404 @@ describe('defineCliPlugin() with command extensions', () => {
         ).toThrow(/non-function decorate/);
     });
 
-    it('accepts an extension that only adds options', () => {
-        const plugin = defineCliPlugin({
-            id: '@example/options',
-            commands: [],
-            extendCommands: [{ command: 'dev', options: [{ long: '--x', description: 'X' }] }],
-        });
+    it('applies an extension that only adds options', () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@example/options',
+                commands: [],
+                extendCommands: [{ command: 'dev', options: [{ long: '--x', description: 'X' }] }],
+            }),
+        );
 
-        expect(plugin.extendCommands).toHaveLength(1);
+        expect(devCommand(registry).options?.map(option => option.long)).toEqual(['--no-reload', '--x']);
     });
 });
 
-const _typeCheck: CliCommandNode[] = [coreDev()];
+describe('Command extensions: plugin-provided commands', () => {
+    afterEach(() => {
+        trace.length = 0;
+    });
+
+    function providerPlugin() {
+        return defineCliPlugin({
+            id: '@a/provider',
+            commands: [
+                {
+                    name: 'cloud',
+                    description: 'Cloud utilities',
+                    options: [{ long: '--region <r>', description: 'Region', required: true }],
+                    action: async () => {
+                        trace.push('provider');
+                        return 0;
+                    },
+                },
+            ],
+        });
+    }
+
+    it('extends a command an earlier plugin added', async () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(providerPlugin());
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@b/extender',
+                commands: [],
+                extendCommands: [
+                    {
+                        command: 'cloud',
+                        options: [{ long: '--verbose', description: 'Verbose' }],
+                        decorate:
+                            ({ next }) =>
+                            async (...args: any[]) => {
+                                trace.push('extender');
+                                return next(...args);
+                            },
+                    },
+                ],
+            }),
+        );
+
+        const cloud = registry.get('cloud') as CliCommandDefinition;
+        expect(cloud.options?.map(option => option.long)).toEqual(['--region <r>', '--verbose']);
+        await cloud.action();
+        expect(trace).toEqual(['extender', 'provider']);
+        expect(registry.getExtendedBy('cloud')).toEqual(['@b/extender']);
+    });
+
+    it('extends a nested command an earlier plugin added', async () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/provider',
+                commands: [
+                    {
+                        name: 'project',
+                        description: 'Projects',
+                        subcommands: [
+                            {
+                                name: 'list',
+                                description: 'List projects',
+                                action: async () => {
+                                    trace.push('provider');
+                                    return 0;
+                                },
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@b/extender',
+                commands: [],
+                extendCommands: [
+                    {
+                        command: 'project list',
+                        decorate:
+                            ({ next }) =>
+                            async (...args: any[]) => {
+                                trace.push('extender');
+                                return next(...args);
+                            },
+                    },
+                ],
+            }),
+        );
+
+        const group = registry.get('project') as CliCommandGroupDefinition;
+        await (group.subcommands[0] as CliCommandDefinition).action();
+        expect(trace).toEqual(['extender', 'provider']);
+    });
+
+    it('extends a command the same plugin adds', async () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/self',
+                commands: [
+                    {
+                        name: 'solo',
+                        description: 'Solo',
+                        action: async () => {
+                            trace.push('own');
+                            return 0;
+                        },
+                    },
+                ],
+                extendCommands: [
+                    {
+                        command: 'solo',
+                        decorate:
+                            ({ next }) =>
+                            async (...args: any[]) => {
+                                trace.push('own-wrapper');
+                                return next(...args);
+                            },
+                    },
+                ],
+            }),
+        );
+
+        await (registry.get('solo') as CliCommandDefinition).action();
+        expect(trace).toEqual(['own-wrapper', 'own']);
+    });
+
+    it('rejects extending a command only a later plugin would provide', () => {
+        const registry = registryWithCore();
+        const extender = defineCliPlugin({
+            id: '@b/extender',
+            commands: [],
+            extendCommands: [{ command: 'cloud', options: [{ long: '--verbose', description: 'V' }] }],
+        });
+
+        expect(() => registry.applyPlugin(extender)).toThrow(/No command is registered at "vendure cloud"/);
+    });
+});
+
+describe('Command extensions: nested composition', () => {
+    afterEach(() => {
+        trace.length = 0;
+    });
+
+    function nestedProvider() {
+        return defineCliPlugin({
+            id: '@a/provider',
+            commands: [
+                {
+                    name: 'console',
+                    description: 'Console commands',
+                    subcommands: [
+                        {
+                            name: 'link',
+                            description: 'Link the project',
+                            action: async () => {
+                                trace.push('core-link');
+                                return 0;
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+    }
+
+    function nestedExtender(id: string, flag: string) {
+        return defineCliPlugin({
+            id,
+            commands: [],
+            extendCommands: [
+                {
+                    command: ['console', 'link'],
+                    options: [{ long: flag, description: `Added by ${id}` }],
+                    decorate:
+                        ({ next }) =>
+                        async (...args: any[]) => {
+                            trace.push(`${id}:before`);
+                            try {
+                                return await next(...args);
+                            } finally {
+                                trace.push(`${id}:after`);
+                            }
+                        },
+                },
+            ],
+        });
+    }
+
+    it('composes two plugins at a nested path, last listed outermost', async () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(nestedProvider());
+        registry.applyPlugin(nestedExtender('@b/first', '--first'));
+        registry.applyPlugin(nestedExtender('@c/second', '--second'));
+
+        const group = registry.get('console') as CliCommandGroupDefinition;
+        await (group.subcommands[0] as CliCommandDefinition).action();
+
+        expect(trace).toEqual([
+            '@c/second:before',
+            '@b/first:before',
+            'core-link',
+            '@b/first:after',
+            '@c/second:after',
+        ]);
+    });
+
+    it('merges both plugins options into the nested command help', async () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(nestedProvider());
+        registry.applyPlugin(nestedExtender('@b/first', '--first'));
+        registry.applyPlugin(nestedExtender('@c/second', '--second'));
+
+        const help = await runCli(registry.toArray(), registry.getRootOptions(), [
+            'console',
+            'link',
+            '--help',
+        ]);
+
+        expect(help.stdout).toContain('--first');
+        expect(help.stdout).toContain('--second');
+    });
+
+    it('rejects a second plugin adding an option the nested command already has', () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(nestedProvider());
+        registry.applyPlugin(nestedExtender('@b/first', '--first'));
+
+        expect(() => registry.applyPlugin(nestedExtender('@c/second', '--first'))).toThrow(
+            /Option "--first" is already declared on "vendure console link"/,
+        );
+    });
+});
+
+describe('Command extensions: reserved names and shared-option scope', () => {
+    it('rejects a plugin command that declares a reserved flag', () => {
+        const registry = registryWithCore();
+        const plugin = defineCliPlugin({
+            id: '@example/greedy',
+            commands: [
+                {
+                    name: 'thing',
+                    description: 'Thing',
+                    options: [{ long: '--help', description: 'Mine' }],
+                    action: async () => 0,
+                },
+            ],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/reserved by the CLI/);
+        expect(registry.has('thing')).toBe(false);
+    });
+
+    it('rejects a plugin command named help', () => {
+        const registry = registryWithCore();
+        const plugin = defineCliPlugin({
+            id: '@example/hijack',
+            commands: [{ name: 'help', description: 'Mine', action: async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/reserved by the CLI/);
+        expect(registry.has('help')).toBe(false);
+    });
+
+    it('rejects a group option that another plugin already shares at the root', () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/root',
+                rootOptions: [{ long: '--token <t>', description: 'Token', required: true }],
+                commands: [{ name: 'a', description: 'A', action: async () => 0 }],
+            }),
+        );
+
+        const rival = defineCliPlugin({
+            id: '@b/group',
+            commands: [
+                {
+                    name: 'g',
+                    description: 'G',
+                    options: [{ long: '--token <t>', description: 'Mine', required: true }],
+                    subcommands: [{ name: 'run', description: 'Run', action: async () => 0 }],
+                },
+            ],
+        });
+
+        expect(() => registry.applyPlugin(rival)).toThrow(/cannot be shared at two levels/);
+        expect(registry.has('g')).toBe(false);
+    });
+
+    it('rejects an extension whose option disagrees with an ancestor group option', () => {
+        const registry = new CommandRegistry();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/provider',
+                commands: [
+                    {
+                        name: 'settings',
+                        description: 'Settings',
+                        options: [{ long: '--profile <n>', description: 'Profile', required: true }],
+                        subcommands: [{ name: 'set', description: 'Set', action: async () => 0 }],
+                    },
+                ],
+            }),
+        );
+
+        const shadow = defineCliPlugin({
+            id: '@b/shadow',
+            commands: [],
+            extendCommands: [
+                { command: 'settings set', options: [{ long: '--profile', description: 'Mine' }] },
+            ],
+        });
+
+        expect(() => registry.applyPlugin(shadow)).toThrow(/one takes a value and the other does not/);
+    });
+
+    it('rejects an extension adding an option a group already shares', () => {
+        const registry = new CommandRegistry();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/provider',
+                commands: [
+                    {
+                        name: 'settings',
+                        description: 'Settings',
+                        options: [{ long: '--profile <n>', description: 'Profile', required: true }],
+                        subcommands: [
+                            {
+                                name: 'nested',
+                                description: 'Nested',
+                                subcommands: [{ name: 'set', description: 'Set', action: async () => 0 }],
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        const shadow = defineCliPlugin({
+            id: '@b/shadow',
+            commands: [],
+            extendCommands: [
+                {
+                    command: 'settings nested',
+                    options: [{ long: '--profile <n>', description: 'Mine', required: true }],
+                },
+            ],
+        });
+
+        expect(() => registry.applyPlugin(shadow)).toThrow(/cannot be shared at two levels/);
+    });
+
+    it('lets a supplied value beat a group default', async () => {
+        let inherited: Record<string, any> | undefined;
+        const registry = new CommandRegistry();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/root',
+                rootOptions: [{ long: '--env <e>', description: 'Environment', required: true }],
+                commands: [
+                    {
+                        name: 'g',
+                        description: 'G',
+                        subcommands: [
+                            {
+                                name: 'run',
+                                description: 'Run',
+                                action: async (...args: any[]) => {
+                                    inherited = args[args.length - 1].inheritedOptions;
+                                    return 0;
+                                },
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        await runCli(registry.toArray(), registry.getRootOptions(), ['--env', 'staging', 'g', 'run']);
+
+        expect(inherited).toEqual({ env: 'staging' });
+    });
+});

--- a/packages/cli/src/shared/command-extensions.spec.ts
+++ b/packages/cli/src/shared/command-extensions.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { runCli } from './__tests__/run-cli';
-import { CliCommandDefinition, CliCommandGroupDefinition } from './cli-command-definition';
+import { CliCommandDefinition, CliCommandGroupDefinition, CliCommandOption } from './cli-command-definition';
 import { defineCliPlugin } from './cli-plugin';
 import { CliPluginRegistrationError, CommandRegistry } from './command-registry-store';
 
@@ -1133,5 +1133,172 @@ describe('Command extensions: sub-options and description ownership', () => {
         expect(written).toContain('Description of "vendure config server" set by @c/second');
         expect(written).toContain('@b/first');
         writeSpy.mockRestore();
+    });
+});
+
+describe('Command extensions: shared-option scope is order-independent', () => {
+    function groupPlugin() {
+        return defineCliPlugin({
+            id: '@a/group',
+            commands: [
+                {
+                    name: 'settings',
+                    description: 'Settings',
+                    options: [{ long: '--profile <n>', description: 'Profile', required: true }],
+                    subcommands: [{ name: 'set', description: 'Set', action: async () => 0 }],
+                },
+            ],
+        });
+    }
+
+    function rootPlugin() {
+        return defineCliPlugin({
+            id: '@b/root',
+            rootOptions: [{ long: '--profile <n>', description: 'Profile', required: true }],
+            commands: [{ name: 'other', description: 'Other', action: async () => 0 }],
+        });
+    }
+
+    it('rejects a root option that a group already shares', () => {
+        const registry = new CommandRegistry();
+        registry.applyPlugin(groupPlugin());
+
+        expect(() => registry.applyPlugin(rootPlugin())).toThrow(/cannot be shared at two levels/);
+        expect(registry.has('other')).toBe(false);
+    });
+
+    it('rejects a group option that the root already shares', () => {
+        const registry = new CommandRegistry();
+        registry.applyPlugin(rootPlugin());
+
+        expect(() => registry.applyPlugin(groupPlugin())).toThrow(/cannot be shared at two levels/);
+        expect(registry.has('settings')).toBe(false);
+    });
+
+    it('rejects an extension adding a flag a descendant group already shares', () => {
+        const registry = new CommandRegistry();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/tree',
+                commands: [
+                    {
+                        name: 'settings',
+                        description: 'Settings',
+                        subcommands: [
+                            {
+                                name: 'nested',
+                                description: 'Nested',
+                                options: [{ long: '--profile <n>', description: 'Profile', required: true }],
+                                subcommands: [{ name: 'set', description: 'Set', action: async () => 0 }],
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        const shadow = defineCliPlugin({
+            id: '@b/ext',
+            commands: [],
+            extendCommands: [
+                {
+                    command: 'settings',
+                    options: [{ long: '--profile <n>', description: 'Mine', required: true }],
+                },
+            ],
+        });
+
+        expect(() => registry.applyPlugin(shadow)).toThrow(
+            /already shared by "vendure settings nested" below it/,
+        );
+    });
+});
+
+describe('Command extensions: sub-option depth', () => {
+    it('rejects sub-options nested more than one level', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/deep',
+                commands: [
+                    {
+                        name: 'deep',
+                        description: 'Deep',
+                        options: [
+                            {
+                                long: '--a <v>',
+                                description: 'A',
+                                required: true,
+                                subOptions: [
+                                    {
+                                        long: '--b <v>',
+                                        description: 'B',
+                                        required: true,
+                                        subOptions: [{ long: '--c <v>', description: 'C', required: true }],
+                                    },
+                                ],
+                            },
+                        ],
+                        action: async () => 0,
+                    },
+                ],
+            }),
+        ).toThrow(/nests sub-options more than one level deep/);
+    });
+
+    it('registers a one-level sub-option so Commander can parse it', async () => {
+        let seen: Record<string, any> | undefined;
+        const registry = new CommandRegistry();
+        registry.registerAll([
+            {
+                name: 'deep',
+                description: 'Deep',
+                options: [
+                    {
+                        long: '--a <v>',
+                        description: 'A',
+                        required: true,
+                        subOptions: [{ long: '--b <v>', description: 'B', required: true }],
+                    },
+                ],
+                action: async (options: Record<string, any>) => {
+                    seen = options;
+                    return 0;
+                },
+            },
+        ]);
+
+        const run = await runCli(registry.toArray(), [], ['deep', '--a', '1', '--b', '2']);
+
+        expect(run.exitCode).toBe(0);
+        expect(seen).toMatchObject({ a: '1', b: '2' });
+    });
+});
+
+describe('Command extensions: the decorator cannot reach the registered command', () => {
+    it('rejects a decorator that mutates the command it is given', () => {
+        const original = coreDev();
+        const optionCount = original.options?.length ?? 0;
+        const registry = new CommandRegistry();
+        registry.registerAll([original]);
+
+        const naughty = defineCliPlugin({
+            id: '@example/naughty',
+            commands: [],
+            extendCommands: [
+                {
+                    command: 'dev',
+                    decorate: ({ command, next }) => {
+                        (command.options as CliCommandOption[]).push({
+                            long: '--injected',
+                            description: 'Injected',
+                        });
+                        return next;
+                    },
+                },
+            ],
+        });
+
+        expect(() => registry.applyPlugin(naughty)).toThrow(/Extending "vendure dev" failed/);
+        expect(original.options?.length).toBe(optionCount);
     });
 });

--- a/packages/cli/src/shared/command-extensions.spec.ts
+++ b/packages/cli/src/shared/command-extensions.spec.ts
@@ -1,0 +1,614 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { runCli } from './__tests__/run-cli';
+import { CliCommandDefinition, CliCommandGroupDefinition } from './cli-command-definition';
+import { defineCliPlugin } from './cli-plugin';
+import { CliPluginRegistrationError, CommandRegistry } from './command-registry-store';
+
+/**
+ * Records the order in which the built-in and each plugin wrapper runs, so a
+ * test can assert that every wrapper ran exactly once and in which order.
+ */
+const trace: string[] = [];
+
+const PLATFORM_ID = '@vendure-platform/cli';
+const CLOUD_ID = '@vendure/cloud';
+
+/**
+ * Stands in for the built-in `dev` command.
+ */
+function coreDev(): CliCommandDefinition {
+    return {
+        name: 'dev',
+        description: 'Run Vendure in development mode',
+        arguments: [{ name: 'target', description: 'Target to run', required: false }],
+        options: [{ long: '--no-reload', description: 'Disable automatic restarts' }],
+        action: async (target: string | undefined) => {
+            trace.push(`core:${target ?? 'all'}`);
+            return 0;
+        },
+    };
+}
+
+function registryWithCore(): CommandRegistry {
+    const registry = new CommandRegistry();
+    registry.registerAll([
+        coreDev(),
+        { name: 'plugins', description: 'Manage CLI plugins', action: async () => 0 },
+        {
+            name: 'config',
+            description: 'Manage configuration',
+            subcommands: [{ name: 'server', description: 'Server configuration', action: async () => 0 }],
+        },
+    ]);
+    return registry;
+}
+
+/**
+ * Mirrors what `@vendure-platform/cli` does today: add an option to `dev` and
+ * wrap its action, calling the action it was handed rather than importing the
+ * built-in one.
+ */
+function platformPlugin() {
+    return defineCliPlugin({
+        id: PLATFORM_ID,
+        commands: [],
+        extendCommands: [
+            {
+                command: 'dev',
+                description: 'Run Vendure in development mode with linked Platform credentials',
+                options: [{ long: '--rotate-credential', description: 'Replace the active credential' }],
+                decorate:
+                    ({ next }) =>
+                    async (...args: any[]) => {
+                        trace.push('platform:before');
+                        const code = await next(...args);
+                        trace.push('platform:after');
+                        return code;
+                    },
+            },
+        ],
+    });
+}
+
+function cloudPlugin() {
+    return defineCliPlugin({
+        id: CLOUD_ID,
+        commands: [],
+        extendCommands: [
+            {
+                command: 'dev',
+                options: [{ long: '--cloud-env <name>', description: 'Cloud environment', required: true }],
+                decorate:
+                    ({ next }) =>
+                    async (...args: any[]) => {
+                        trace.push('cloud:before');
+                        const code = await next(...args);
+                        trace.push('cloud:after');
+                        return code;
+                    },
+            },
+        ],
+    });
+}
+
+function devCommand(registry: CommandRegistry): CliCommandDefinition {
+    return registry.get('dev') as CliCommandDefinition;
+}
+
+describe('Command extensions: composition', () => {
+    afterEach(() => {
+        trace.length = 0;
+    });
+
+    it('runs every wrapper exactly once, outermost first', async () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(platformPlugin());
+        registry.applyPlugin(cloudPlugin());
+
+        await devCommand(registry).action('server');
+
+        expect(trace).toEqual([
+            'cloud:before',
+            'platform:before',
+            'core:server',
+            'platform:after',
+            'cloud:after',
+        ]);
+    });
+
+    it('follows vendure.cli.plugins order, so the last listed plugin is outermost', async () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(cloudPlugin());
+        registry.applyPlugin(platformPlugin());
+
+        await devCommand(registry).action('server');
+
+        expect(trace).toEqual([
+            'platform:before',
+            'cloud:before',
+            'core:server',
+            'cloud:after',
+            'platform:after',
+        ]);
+    });
+
+    it('records which plugins extended the command, in application order', () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(platformPlugin());
+        registry.applyPlugin(cloudPlugin());
+
+        expect(registry.getExtendedBy('dev')).toEqual([PLATFORM_ID, CLOUD_ID]);
+    });
+
+    it('keeps the options contributed by every plugin', () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(platformPlugin());
+        registry.applyPlugin(cloudPlugin());
+
+        expect(devCommand(registry).options?.map(option => option.long)).toEqual([
+            '--no-reload',
+            '--rotate-credential',
+            '--cloud-env <name>',
+        ]);
+    });
+
+    it('hands each decorator the command composed so far', () => {
+        const registry = registryWithCore();
+        const seen: Array<string[] | undefined> = [];
+        const observer = (id: string) =>
+            defineCliPlugin({
+                id,
+                commands: [],
+                extendCommands: [
+                    {
+                        command: 'dev',
+                        options: [{ long: `--${id.replace(/\W/g, '')}`, description: 'Marker' }],
+                        decorate: ({ command, next }) => {
+                            seen.push(command.options?.map(option => option.long));
+                            return next;
+                        },
+                    },
+                ],
+            });
+
+        registry.applyPlugin(observer('first'));
+        registry.applyPlugin(observer('second'));
+
+        expect(seen).toEqual([['--no-reload'], ['--no-reload', '--first']]);
+    });
+
+    it('does not mutate the command it extends', async () => {
+        const original = coreDev();
+        const originalAction = original.action;
+        const registry = new CommandRegistry();
+        registry.registerAll([original]);
+        registry.applyPlugin(platformPlugin());
+
+        expect(original.options?.map(option => option.long)).toEqual(['--no-reload']);
+        expect(original.action).toBe(originalAction);
+        expect(original.description).toBe('Run Vendure in development mode');
+
+        await original.action('worker');
+        expect(trace).toEqual(['core:worker']);
+    });
+
+    it('takes the description from the last plugin that sets one, with a notice', () => {
+        const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+        const registry = registryWithCore();
+        registry.applyPlugin(platformPlugin());
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: CLOUD_ID,
+                commands: [],
+                extendCommands: [{ command: 'dev', description: 'Run against Vendure Cloud' }],
+            }),
+        );
+
+        expect(devCommand(registry).description).toBe('Run against Vendure Cloud');
+        const written = writeSpy.mock.calls.map(call => String(call[0])).join('');
+        expect(written).toContain(`Description of "vendure dev" set by ${CLOUD_ID}`);
+        expect(written).toContain(PLATFORM_ID);
+        writeSpy.mockRestore();
+    });
+
+    it('extends a nested command', async () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@example/nested',
+                commands: [],
+                extendCommands: [
+                    {
+                        command: ['config', 'server'],
+                        options: [{ long: '--dry-run', description: 'Do not write' }],
+                        decorate:
+                            ({ next }) =>
+                            async (...args: any[]) => {
+                                trace.push('nested:before');
+                                return next(...args);
+                            },
+                    },
+                ],
+            }),
+        );
+
+        const group = registry.get('config') as CliCommandGroupDefinition;
+        const leaf = group.subcommands[0] as CliCommandDefinition;
+        expect(leaf.options?.map(option => option.long)).toEqual(['--dry-run']);
+        await leaf.action();
+        expect(trace).toEqual(['nested:before']);
+    });
+
+    it('accepts a space-separated command path', () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@example/nested',
+                commands: [],
+                extendCommands: [
+                    {
+                        command: 'config server',
+                        options: [{ long: '--dry-run', description: 'Do not write' }],
+                    },
+                ],
+            }),
+        );
+
+        const group = registry.get('config') as CliCommandGroupDefinition;
+        expect((group.subcommands[0] as CliCommandDefinition).options).toHaveLength(1);
+    });
+
+    it('adds an optional argument', () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@example/args',
+                commands: [],
+                extendCommands: [
+                    {
+                        command: 'dev',
+                        arguments: [{ name: 'profile', description: 'Profile', required: false }],
+                    },
+                ],
+            }),
+        );
+
+        expect(devCommand(registry).arguments?.map(argument => argument.name)).toEqual(['target', 'profile']);
+    });
+});
+
+describe('Command extensions: registration through Commander', () => {
+    afterEach(() => {
+        trace.length = 0;
+    });
+
+    it('exposes every plugin option and runs the whole chain', async () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(platformPlugin());
+        registry.applyPlugin(cloudPlugin());
+
+        const help = await runCli(registry.toArray(), registry.getRootOptions(), ['dev', '--help']);
+        expect(help.stdout).toContain('--rotate-credential');
+        expect(help.stdout).toContain('--cloud-env');
+        expect(help.stdout).toContain('--no-reload');
+        expect(help.stdout).toContain('Run Vendure in development mode with linked Platform credentials');
+
+        const run = await runCli(registry.toArray(), registry.getRootOptions(), [
+            'dev',
+            'server',
+            '--rotate-credential',
+            '--cloud-env',
+            'staging',
+        ]);
+        expect(run.exitCode).toBe(0);
+        expect(trace).toEqual([
+            'cloud:before',
+            'platform:before',
+            'core:server',
+            'platform:after',
+            'cloud:after',
+        ]);
+    });
+
+    it('keeps the exit code of the innermost command', async () => {
+        const registry = new CommandRegistry();
+        registry.registerAll([{ name: 'dev', description: 'Dev', action: async () => 7 }]);
+        registry.applyPlugin(platformPlugin());
+
+        const run = await runCli(registry.toArray(), [], ['dev']);
+
+        expect(run.exitCode).toBe(7);
+        expect(trace).toEqual(['platform:before', 'platform:after']);
+    });
+});
+
+describe('Command extensions: collisions', () => {
+    it('rejects an extension of a command that is not registered', () => {
+        const registry = registryWithCore();
+        const plugin = defineCliPlugin({
+            id: '@example/missing',
+            commands: [],
+            extendCommands: [{ command: 'nope', options: [{ long: '--x', description: 'X' }] }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/No command is registered at "vendure nope"/);
+    });
+
+    it('rejects an extension of a nested path that is not registered', () => {
+        const registry = registryWithCore();
+        const plugin = defineCliPlugin({
+            id: '@example/missing',
+            commands: [],
+            extendCommands: [{ command: ['config', 'client'], options: [{ long: '--x', description: 'X' }] }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(
+            /No command is registered at "vendure config client"/,
+        );
+    });
+
+    it('rejects decorating a command group', () => {
+        const registry = registryWithCore();
+        const plugin = defineCliPlugin({
+            id: '@example/group',
+            commands: [],
+            extendCommands: [{ command: 'config', decorate: ({ next }) => next }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/is a command group and has no action/);
+    });
+
+    it('allows extending a command group with a shared option', () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@example/group',
+                commands: [],
+                extendCommands: [
+                    { command: 'config', options: [{ long: '--profile <name>', description: 'Profile' }] },
+                ],
+            }),
+        );
+
+        expect((registry.get('config') as CliCommandGroupDefinition).options).toHaveLength(1);
+    });
+
+    it('rejects an option that the target already declares', () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(platformPlugin());
+
+        const rival = defineCliPlugin({
+            id: '@example/rival',
+            commands: [],
+            extendCommands: [
+                { command: 'dev', options: [{ long: '--rotate-credential', description: 'Mine' }] },
+            ],
+        });
+
+        expect(() => registry.applyPlugin(rival)).toThrow(
+            /already declared on "vendure dev" \(contributed by the CLI, @vendure-platform\/cli\)/,
+        );
+        expect(registry.getExtendedBy('dev')).toEqual([PLATFORM_ID]);
+    });
+
+    it('rejects an added option that uses a flag reserved by the CLI', () => {
+        const registry = registryWithCore();
+        const plugin = defineCliPlugin({
+            id: '@example/greedy',
+            commands: [],
+            extendCommands: [{ command: 'dev', options: [{ long: '--help', description: 'Custom' }] }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/reserved by the CLI/);
+    });
+
+    it('rejects extending the reserved plugins command', () => {
+        const registry = registryWithCore();
+        const plugin = defineCliPlugin({
+            id: '@example/hijack',
+            commands: [],
+            extendCommands: [{ command: 'plugins', decorate: () => async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/reserved by the CLI/);
+        expect(registry.has('plugins')).toBe(true);
+    });
+
+    it('rejects replacing the reserved plugins command', () => {
+        const registry = registryWithCore();
+        const plugin = defineCliPlugin({
+            id: '@example/hijack',
+            commands: [{ name: 'plugins', description: 'Mine', replaces: true, action: async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/reserved by the CLI/);
+        expect(registry.get('plugins')?.description).toBe('Manage CLI plugins');
+    });
+
+    it('rejects replacing a command that another plugin has extended', () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(platformPlugin());
+
+        const replacer = defineCliPlugin({
+            id: '@example/replacer',
+            commands: [{ name: 'dev', description: 'My dev', replaces: true, action: async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(replacer)).toThrow(/has been extended by @vendure-platform\/cli/);
+        expect(devCommand(registry).description).toContain('Platform credentials');
+    });
+
+    it('extends a replacement when the replacing plugin is listed first', async () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@example/replacer',
+                commands: [
+                    {
+                        name: 'dev',
+                        description: 'My dev',
+                        replaces: true,
+                        action: async () => {
+                            trace.push('replacement');
+                            return 0;
+                        },
+                    },
+                ],
+            }),
+        );
+        registry.applyPlugin(platformPlugin());
+
+        await devCommand(registry).action();
+
+        expect(trace).toEqual(['platform:before', 'replacement', 'platform:after']);
+        trace.length = 0;
+    });
+
+    it('rejects an argument name the target already declares', () => {
+        const registry = registryWithCore();
+        const plugin = defineCliPlugin({
+            id: '@example/args',
+            commands: [],
+            extendCommands: [{ command: 'dev', arguments: [{ name: 'target', description: 'Mine' }] }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/Argument "target" is already declared/);
+    });
+
+    it('reports a decorator that throws while being applied, and applies nothing', () => {
+        const registry = registryWithCore();
+        const plugin = defineCliPlugin({
+            id: '@example/broken',
+            commands: [{ name: 'extra', description: 'Extra', action: async () => 0 }],
+            extendCommands: [
+                {
+                    command: 'dev',
+                    decorate: () => {
+                        throw new Error('decorator blew up');
+                    },
+                },
+            ],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/decorator blew up/);
+        expect(registry.has('extra')).toBe(false);
+        expect(registry.getExtendedBy('dev')).toEqual([]);
+        expect(registry.has('plugins')).toBe(true);
+    });
+
+    it('reports a decorator that does not return a function', () => {
+        const registry = registryWithCore();
+        const plugin = defineCliPlugin({
+            id: '@example/broken',
+            commands: [],
+            extendCommands: [{ command: 'dev', decorate: () => undefined as any }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/must return an action function/);
+    });
+
+    it('keeps earlier plugins intact when a later one is rejected', async () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(platformPlugin());
+        const broken = defineCliPlugin({
+            id: '@example/broken',
+            commands: [],
+            extendCommands: [{ command: 'dev', options: [{ long: '--help', description: 'Custom' }] }],
+        });
+
+        expect(() => registry.applyPlugin(broken)).toThrow(CliPluginRegistrationError);
+
+        await devCommand(registry).action('server');
+        expect(trace).toEqual(['platform:before', 'core:server', 'platform:after']);
+        trace.length = 0;
+    });
+});
+
+describe('defineCliPlugin() with command extensions', () => {
+    it('rejects an extension that adds nothing', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/empty',
+                commands: [],
+                extendCommands: [{ command: 'dev' }],
+            }),
+        ).toThrow(/adds nothing/);
+    });
+
+    it('rejects an extension without a command path', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/empty',
+                commands: [],
+                extendCommands: [{ command: '  ', decorate: ({ next }) => next }],
+            }),
+        ).toThrow(/without a command path/);
+    });
+
+    it('rejects two extensions of the same command', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/twice',
+                commands: [],
+                extendCommands: [
+                    { command: 'dev', options: [{ long: '--a', description: 'A' }] },
+                    { command: 'dev', options: [{ long: '--b', description: 'B' }] },
+                ],
+            }),
+        ).toThrow(/extends "dev" more than once/);
+    });
+
+    it('rejects an extension that adds a required argument', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/args',
+                commands: [],
+                extendCommands: [
+                    {
+                        command: 'dev',
+                        arguments: [{ name: 'profile', description: 'Profile', required: true }],
+                    },
+                ],
+            }),
+        ).toThrow(/adds a required argument/);
+    });
+
+    it('rejects an added option that shadows one of the plugin shared options', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/shadow',
+                rootOptions: [{ long: '--token <token>', description: 'API token', required: true }],
+                commands: [],
+                extendCommands: [
+                    {
+                        command: 'dev',
+                        options: [{ long: '--token <token>', description: 'Override', required: true }],
+                    },
+                ],
+            }),
+        ).toThrow(/already a shared option/);
+    });
+
+    it('rejects a non-function decorate', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/broken',
+                commands: [],
+                extendCommands: [{ command: 'dev', decorate: 'nope' as any }],
+            }),
+        ).toThrow(/non-function decorate/);
+    });
+
+    it('accepts an extension that only adds options', () => {
+        const plugin = defineCliPlugin({
+            id: '@example/options',
+            commands: [],
+            extendCommands: [{ command: 'dev', options: [{ long: '--x', description: 'X' }] }],
+        });
+
+        expect(plugin.extendCommands).toHaveLength(1);
+    });
+});
+
+const _typeCheck: CliCommandNode[] = [coreDev()];

--- a/packages/cli/src/shared/command-registry-store.spec.ts
+++ b/packages/cli/src/shared/command-registry-store.spec.ts
@@ -265,6 +265,28 @@ describe('CommandRegistry nested commands and shared options', () => {
         expect(registry.has('other')).toBe(false);
     });
 
+    it('rejects a shared option that resolves to the same name as another', () => {
+        // `--api-token` and `--apiToken` are written differently, but Commander
+        // stores both under `apiToken`.
+        const registry = registryWithBuiltins();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@example/first',
+                rootOptions: [{ long: '--api-token <token>', description: 'API token', required: true }],
+                commands: [{ name: 'first', description: 'First', action: async () => 0 }],
+            }),
+        );
+
+        const second = defineCliPlugin({
+            id: '@example/second',
+            rootOptions: [{ long: '--apiToken <token>', description: 'API token', required: true }],
+            commands: [{ name: 'second', description: 'Second', action: async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(second)).toThrow(/already registered by @example\/first/);
+        expect(registry.getRootOptions()).toHaveLength(1);
+    });
+
     it('rejects a shared option that takes a flag reserved by the CLI', () => {
         const registry = registryWithBuiltins();
         const plugin = defineCliPlugin({

--- a/packages/cli/src/shared/command-registry-store.spec.ts
+++ b/packages/cli/src/shared/command-registry-store.spec.ts
@@ -223,7 +223,9 @@ describe('CommandRegistry nested commands and shared options', () => {
         // The built-in `plugins --json` and a shared `--json` both take no
         // value, so they can refer to the same value.
         const registry = registryWithBuiltins();
-        expect(() => registry.applyPlugin(cloudPlugin())).not.toThrow();
+        registry.applyPlugin(cloudPlugin());
+
+        expect(registry.getRootOptions().map(option => option.long)).toEqual(['--token <token>', '--json']);
     });
 
     it('rejects a plugin that replaces a built-in without opting in', () => {
@@ -358,7 +360,11 @@ describe('CommandRegistry nested commands and shared options', () => {
             expect.unreachable('applyPlugin should have thrown');
         } catch (e) {
             expect(e).toBeInstanceOf(CliPluginRegistrationError);
-            expect((e as CliPluginRegistrationError).conflicts).toHaveLength(2);
+            expect((e as CliPluginRegistrationError).conflicts).toEqual([
+                'Shared option "--version" uses "--version", which is reserved by the CLI.',
+                'Command "dev" is already provided by the CLI. Set "replaces: true" on it to override ' +
+                    'that deliberately, or use "extendCommands" to add to it without discarding it.',
+            ]);
         }
     });
 });
@@ -457,7 +463,7 @@ describe('defineCliPlugin() with nested commands', () => {
         ).toThrow(/declares the command "project list" more than once/);
     });
 
-    it('rejects a nested command that shadows a shared option', () => {
+    it('rejects a nested group that shares a flag an ancestor already shares', () => {
         expect(() =>
             defineCliPlugin({
                 id: '@example/shadow',
@@ -466,16 +472,8 @@ describe('defineCliPlugin() with nested commands', () => {
                     {
                         name: 'project',
                         description: 'Manage projects',
-                        subcommands: [
-                            {
-                                name: 'list',
-                                description: 'List projects',
-                                options: [
-                                    { long: '--token <token>', description: 'Override', required: true },
-                                ],
-                                action: async () => 0,
-                            },
-                        ],
+                        options: [{ long: '--token <token>', description: 'Override', required: true }],
+                        subcommands: [{ name: 'list', description: 'List projects', action: async () => 0 }],
                     },
                 ],
             }),

--- a/packages/cli/src/shared/command-registry-store.spec.ts
+++ b/packages/cli/src/shared/command-registry-store.spec.ts
@@ -4,9 +4,17 @@ import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { builtinCommands } from '../commands/builtins';
+import { CliCommandDefinition, CliCommandGroupDefinition, isCliCommandGroup } from './cli-command-definition';
 import { defineCliPlugin } from './cli-plugin';
-import { CommandRegistry } from './command-registry-store';
-import { PackageJsonLike, discoverCliPlugins, findInactivePluginProvidingCommand, listDirectDependencyNames, listInactiveCliPluginPackages, resolveCliPlugins } from './resolve-cli-plugins';
+import { CliPluginRegistrationError, CommandRegistry } from './command-registry-store';
+import {
+    PackageJsonLike,
+    discoverCliPlugins,
+    findInactivePluginProvidingCommand,
+    listDirectDependencyNames,
+    listInactiveCliPluginPackages,
+    resolveCliPlugins,
+} from './resolve-cli-plugins';
 
 describe('defineCliPlugin()', () => {
     it('returns a valid plugin definition', () => {
@@ -80,6 +88,7 @@ describe('CommandRegistry', () => {
                     {
                         name: 'dev',
                         description: 'Cloud dev',
+                        replaces: true,
                         action: async () => 0,
                     },
                 ],
@@ -132,7 +141,7 @@ describe('CommandRegistry', () => {
             description: 'Built-in',
             action: builtinAction,
         });
-        const builtin = registry.get('dev')!;
+        const builtin = registry.get('dev') as CliCommandDefinition;
         registry.applyPlugin(
             defineCliPlugin({
                 id: '@example/wrap',
@@ -140,6 +149,7 @@ describe('CommandRegistry', () => {
                     {
                         name: 'dev',
                         description: 'Wrapped',
+                        replaces: true,
                         action: async (...args) => {
                             order.push('before');
                             const code = await builtin.action(...args);
@@ -150,7 +160,7 @@ describe('CommandRegistry', () => {
                 ],
             }),
         );
-        const exitCode = await registry.get('dev')!.action();
+        const exitCode = await (registry.get('dev') as CliCommandDefinition).action();
         expect(exitCode).toBe(0);
         expect(order).toEqual(['before', 'builtin', 'after']);
     });
@@ -165,6 +175,302 @@ describe('CommandRegistry', () => {
         expect(exitCode).toBe(1);
         expect(exitSpy).not.toHaveBeenCalled();
         exitSpy.mockRestore();
+    });
+});
+
+describe('CommandRegistry nested commands and shared options', () => {
+    function registryWithBuiltins(): CommandRegistry {
+        const registry = new CommandRegistry();
+        registry.registerAll([
+            { name: 'dev', description: 'Built-in dev', action: async () => 0 },
+            {
+                name: 'plugins',
+                description: 'Manage CLI plugins',
+                options: [{ long: '--json', description: 'Output JSON' }],
+                action: async () => 0,
+            },
+        ]);
+        return registry;
+    }
+
+    const cloudPlugin = () =>
+        defineCliPlugin({
+            id: '@vendure/cloud',
+            rootOptions: [
+                { long: '--token <token>', description: 'API token', required: true },
+                { long: '--json', description: 'Output JSON' },
+            ],
+            commands: [
+                {
+                    name: 'project',
+                    description: 'Manage projects',
+                    subcommands: [{ name: 'list', description: 'List projects', action: async () => 0 }],
+                },
+            ],
+        });
+
+    it('registers a nested command tree and its shared options', () => {
+        const registry = registryWithBuiltins();
+        registry.applyPlugin(cloudPlugin());
+
+        const project = registry.get('project');
+        expect(project && isCliCommandGroup(project)).toBe(true);
+        expect((project as CliCommandGroupDefinition).subcommands.map(c => c.name)).toEqual(['list']);
+        expect(registry.getRootOptions().map(o => o.long)).toEqual(['--token <token>', '--json']);
+    });
+
+    it('accepts a shared option that an existing command also declares', () => {
+        // The built-in `plugins --json` and a shared `--json` both take no
+        // value, so they can refer to the same value.
+        const registry = registryWithBuiltins();
+        expect(() => registry.applyPlugin(cloudPlugin())).not.toThrow();
+    });
+
+    it('rejects a plugin that replaces a built-in without opting in', () => {
+        const registry = registryWithBuiltins();
+        const plugin = defineCliPlugin({
+            id: '@example/sneaky',
+            commands: [{ name: 'dev', description: 'Sneaky dev', action: async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(CliPluginRegistrationError);
+        expect(registry.get('dev')?.description).toBe('Built-in dev');
+    });
+
+    it('rejects a plugin that replaces another plugin command without opting in', () => {
+        const registry = registryWithBuiltins();
+        registry.applyPlugin(cloudPlugin());
+
+        const other = defineCliPlugin({
+            id: '@example/other',
+            commands: [{ name: 'project', description: 'Other projects', action: async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(other)).toThrow(/already provided by @vendure\/cloud/);
+        const stillRegistered = registry.get('project');
+        expect(stillRegistered && isCliCommandGroup(stillRegistered)).toBe(true);
+    });
+
+    it('rejects a shared option already registered by another plugin', () => {
+        const registry = registryWithBuiltins();
+        registry.applyPlugin(cloudPlugin());
+
+        const other = defineCliPlugin({
+            id: '@example/other',
+            rootOptions: [{ long: '--token <token>', description: 'Another token', required: true }],
+            commands: [{ name: 'other', description: 'Other', action: async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(other)).toThrow(/already registered by @vendure\/cloud/);
+        expect(registry.has('other')).toBe(false);
+    });
+
+    it('rejects a shared option that takes a flag reserved by the CLI', () => {
+        const registry = registryWithBuiltins();
+        const plugin = defineCliPlugin({
+            id: '@example/greedy',
+            rootOptions: [{ long: '--help', description: 'Custom help' }],
+            commands: [{ name: 'greedy', description: 'Greedy', action: async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/reserved by the CLI/);
+    });
+
+    it('rejects a shared option whose value shape disagrees with an existing command option', () => {
+        const registry = registryWithBuiltins();
+        const plugin = defineCliPlugin({
+            id: '@example/clash',
+            rootOptions: [{ long: '--json <file>', description: 'Write JSON to a file', required: true }],
+            commands: [{ name: 'clash', description: 'Clash', action: async () => 0 }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/one takes a value and the other does not/);
+    });
+
+    it('rejects a command option whose value shape disagrees with a shared option', () => {
+        const registry = registryWithBuiltins();
+        registry.applyPlugin(cloudPlugin());
+
+        const plugin = defineCliPlugin({
+            id: '@example/clash',
+            commands: [
+                {
+                    name: 'clash',
+                    description: 'Clash',
+                    options: [{ long: '--token', description: 'Use the stored token' }],
+                    action: async () => 0,
+                },
+            ],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/one takes a value and the other does not/);
+    });
+
+    it('keeps the built-in commands available when a plugin is rejected', () => {
+        const registry = registryWithBuiltins();
+        const plugin = defineCliPlugin({
+            id: '@example/broken',
+            rootOptions: [{ long: '--help', description: 'Custom help' }],
+            commands: [
+                { name: 'dev', description: 'Broken dev', replaces: true, action: async () => 0 },
+                { name: 'broken', description: 'Broken', action: async () => 0 },
+            ],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(CliPluginRegistrationError);
+        expect(registry.has('plugins')).toBe(true);
+        expect(registry.get('dev')?.description).toBe('Built-in dev');
+        expect(registry.has('broken')).toBe(false);
+    });
+
+    it('reports every conflict at once', () => {
+        const registry = registryWithBuiltins();
+        const plugin = defineCliPlugin({
+            id: '@example/messy',
+            rootOptions: [{ long: '--version', description: 'Custom version' }],
+            commands: [{ name: 'dev', description: 'Messy dev', action: async () => 0 }],
+        });
+
+        try {
+            registry.applyPlugin(plugin);
+            expect.unreachable('applyPlugin should have thrown');
+        } catch (e) {
+            expect(e).toBeInstanceOf(CliPluginRegistrationError);
+            expect((e as CliPluginRegistrationError).conflicts).toHaveLength(2);
+        }
+    });
+});
+
+describe('defineCliPlugin() with nested commands', () => {
+    it('accepts a nested tree with shared options', () => {
+        const plugin = defineCliPlugin({
+            id: '@vendure/cloud',
+            rootOptions: [{ long: '--token <token>', description: 'API token', required: true }],
+            commands: [
+                {
+                    name: 'config',
+                    description: 'Manage configuration',
+                    options: [{ long: '--profile <name>', description: 'Profile', required: true }],
+                    subcommands: [
+                        {
+                            name: 'server',
+                            description: 'Server configuration',
+                            subcommands: [
+                                {
+                                    name: 'set',
+                                    description: 'Set a value',
+                                    arguments: [
+                                        { name: 'key', description: 'Key', required: true },
+                                        { name: 'value', description: 'Value', required: true },
+                                    ],
+                                    action: async () => 0,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+
+        expect(plugin.commands).toHaveLength(1);
+    });
+
+    it('rejects a command group without subcommands', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/empty',
+                commands: [{ name: 'project', description: 'Manage projects', subcommands: [] }],
+            }),
+        ).toThrow(/at least one subcommand/);
+    });
+
+    it('rejects a command group that also declares an action', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/both',
+                commands: [
+                    {
+                        name: 'project',
+                        description: 'Manage projects',
+                        subcommands: [{ name: 'list', description: 'List projects', action: async () => 0 }],
+                        action: async () => 0,
+                    } as any,
+                ],
+            }),
+        ).toThrow(/declares both subcommands and an action/);
+    });
+
+    it('rejects a nested command without an action', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/broken',
+                commands: [
+                    {
+                        name: 'project',
+                        description: 'Manage projects',
+                        subcommands: [
+                            { name: 'list', description: 'List projects', action: undefined as any },
+                        ],
+                    },
+                ],
+            }),
+        ).toThrow(/command "project list" must provide an action function/);
+    });
+
+    it('rejects duplicate sibling command names', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/dupes',
+                commands: [
+                    {
+                        name: 'project',
+                        description: 'Manage projects',
+                        subcommands: [
+                            { name: 'list', description: 'List projects', action: async () => 0 },
+                            { name: 'list', description: 'List projects again', action: async () => 0 },
+                        ],
+                    },
+                ],
+            }),
+        ).toThrow(/declares the command "project list" more than once/);
+    });
+
+    it('rejects a nested command that shadows a shared option', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/shadow',
+                rootOptions: [{ long: '--token <token>', description: 'API token', required: true }],
+                commands: [
+                    {
+                        name: 'project',
+                        description: 'Manage projects',
+                        subcommands: [
+                            {
+                                name: 'list',
+                                description: 'List projects',
+                                options: [
+                                    { long: '--token <token>', description: 'Override', required: true },
+                                ],
+                                action: async () => 0,
+                            },
+                        ],
+                    },
+                ],
+            }),
+        ).toThrow(/already a shared option/);
+    });
+
+    it('rejects a shared option declared twice', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/dupes',
+                rootOptions: [
+                    { long: '--token <token>', description: 'API token', required: true },
+                    { long: '--token <token>', description: 'API token again', required: true },
+                ],
+                commands: [{ name: 'noop', description: 'Noop', action: async () => 0 }],
+            }),
+        ).toThrow(/declares "--token" twice/);
     });
 });
 
@@ -581,10 +887,12 @@ describe('resolveCliPlugins()', () => {
             resolvePackage: fixture.resolvePackage,
         });
         expect(match?.packageName).toBe('@vendure/cloud');
-        expect(listInactiveCliPluginPackages({
-            cwd: fixture.root,
-            projectPackageJson,
-            resolvePackage: fixture.resolvePackage,
-        })).toEqual(['@vendure/cloud']);
+        expect(
+            listInactiveCliPluginPackages({
+                cwd: fixture.root,
+                projectPackageJson,
+                resolvePackage: fixture.resolvePackage,
+            }),
+        ).toEqual(['@vendure/cloud']);
     });
 });

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -375,9 +375,22 @@ function draftExtension(
 }
 
 /**
- * Checks each option an extension adds against the flags the CLI owns, the
- * target's own options, and the options shared by the groups above and below
- * it.
+ * The options an added option has to agree with: the target's own, those
+ * shared by the groups above it, and — when the target is a group — those
+ * declared anywhere below it.
+ */
+interface ExtensionOptionScope {
+    ancestors: CliCommandOption[];
+    descendantGroups: Array<{ path: string[]; option: CliCommandOption }>;
+    descendantLeaves: Array<{ path: string[]; option: CliCommandOption }>;
+    own: CliCommandOption[];
+    targetIsGroup: boolean;
+    label: string;
+}
+
+/**
+ * Checks each option an extension adds against the flags the CLI owns and
+ * every option already in scope at the target.
  */
 function extensionOptionConflicts(
     draft: RegistryState,
@@ -385,75 +398,82 @@ function extensionOptionConflicts(
     target: CliCommandNode,
     path: string[],
 ): string[] {
-    const label = path.join(' ');
     const targetIsGroup = isCliCommandGroup(target);
-    const scope = {
+    const scope: ExtensionOptionScope = {
         // Extending a group shares the option with everything below it, so the
         // subtree matters as much as the ancestors.
         ancestors: ancestorSharedOptions(draft, path),
         descendantGroups: targetIsGroup ? descendantGroupOptions(target, path) : [],
         descendantLeaves: targetIsGroup ? descendantLeafOptions(target, path) : [],
         own: withSubOptions(target.options ?? []),
+        targetIsGroup,
+        label: path.join(' '),
     };
 
+    return withSubOptions(extension.options ?? []).flatMap(option =>
+        addedOptionConflicts(draft, option, scope),
+    );
+}
+
+function addedOptionConflicts(
+    draft: RegistryState,
+    option: CliCommandOption,
+    scope: ExtensionOptionScope,
+): string[] {
+    const parsed = parseOptionFlags(option);
+    const name = describeOption(option);
+    const { label } = scope;
+    const group = `the command group "vendure ${label}"`;
     const conflicts: string[] = [];
-    for (const option of withSubOptions(extension.options ?? [])) {
-        const parsed = parseOptionFlags(option);
-        const name = describeOption(option);
-        const group = `the command group "vendure ${label}"`;
 
-        for (const flag of [parsed.long, parsed.short]) {
-            if (flag && RESERVED_FLAGS.includes(flag)) {
-                conflicts.push(
-                    `Option "${name}" added to "vendure ${label}" uses "${flag}", which is reserved by ` +
-                        `the CLI.`,
-                );
-            }
+    for (const flag of [parsed.long, parsed.short]) {
+        if (flag && RESERVED_FLAGS.includes(flag)) {
+            conflicts.push(
+                `Option "${name}" added to "vendure ${label}" uses "${flag}", which is reserved by the CLI.`,
+            );
         }
-        if (scope.own.some(existing => isSameOption(existing, parsed))) {
-            conflicts.push(`Option "${name}" is already declared on "vendure ${label}".`);
-        }
+    }
+    if (scope.own.some(existing => isSameOption(existing, parsed))) {
+        conflicts.push(`Option "${name}" is already declared on "vendure ${label}".`);
+    }
 
-        const descendantGroup = scope.descendantGroups.find(existing =>
-            isSameOption(existing.option, parsed),
+    const descendantGroup = scope.descendantGroups.find(existing => isSameOption(existing.option, parsed));
+    if (descendantGroup) {
+        conflicts.push(
+            `Option "${name}" added to ${group} is already shared by ` +
+                `"vendure ${descendantGroup.path.join(' ')}" below it. ${GROUP_SHARING_EXPLANATION}`,
         );
-        if (descendantGroup) {
-            conflicts.push(
-                `Option "${name}" added to ${group} is already shared by ` +
-                    `"vendure ${descendantGroup.path.join(' ')}" below it. ${GROUP_SHARING_EXPLANATION}`,
-            );
-            continue;
-        }
+        return conflicts;
+    }
 
-        const leafBelow = scope.descendantLeaves.find(
-            existing => isSameOption(existing.option, parsed) && !takesSameValue(existing.option, option),
+    const leafBelow = scope.descendantLeaves.find(
+        existing => isSameOption(existing.option, parsed) && !takesSameValue(existing.option, option),
+    );
+    if (leafBelow) {
+        conflicts.push(
+            `Option "${name}" added to ${group} is not compatible with ` +
+                `"${describeOption(leafBelow.option)}" on "vendure ${leafBelow.path.join(' ')}" below it: ` +
+                `one takes a value and the other does not.`,
         );
-        if (leafBelow) {
-            conflicts.push(
-                `Option "${name}" added to ${group} is not compatible with ` +
-                    `"${describeOption(leafBelow.option)}" on "vendure ${leafBelow.path.join(' ')}" ` +
-                    `below it: one takes a value and the other does not.`,
-            );
-            continue;
-        }
+        return conflicts;
+    }
 
-        const sharedOption =
-            findRootOption(draft, parsed)?.option ??
-            scope.ancestors.find(existing => isSameOption(existing, parsed));
-        if (!sharedOption) {
-            continue;
-        }
-        if (targetIsGroup) {
-            conflicts.push(
-                `Option "${name}" added to ${group} is already a shared option ` +
-                    `("${describeOption(sharedOption)}"). ${GROUP_SHARING_EXPLANATION}`,
-            );
-        } else if (!takesSameValue(sharedOption, option)) {
-            conflicts.push(
-                `Option "${name}" added to "vendure ${label}" is not compatible with the shared option ` +
-                    `"${describeOption(sharedOption)}": one takes a value and the other does not.`,
-            );
-        }
+    const sharedOption =
+        findRootOption(draft, parsed)?.option ??
+        scope.ancestors.find(existing => isSameOption(existing, parsed));
+    if (!sharedOption) {
+        return conflicts;
+    }
+    if (scope.targetIsGroup) {
+        conflicts.push(
+            `Option "${name}" added to ${group} is already a shared option ` +
+                `("${describeOption(sharedOption)}"). ${GROUP_SHARING_EXPLANATION}`,
+        );
+    } else if (!takesSameValue(sharedOption, option)) {
+        conflicts.push(
+            `Option "${name}" added to "vendure ${label}" is not compatible with the shared option ` +
+                `"${describeOption(sharedOption)}": one takes a value and the other does not.`,
+        );
     }
     return conflicts;
 }

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -13,6 +13,12 @@ import { describeOption, ParsedCliOption, parseOptionFlags, withSubOptions } fro
 import { CliPlugin, normalizeCommandPath } from './cli-plugin';
 
 /**
+ * Why a flag cannot be shared by a group and by something above or below it.
+ */
+const GROUP_SHARING_EXPLANATION =
+    'A group shares its options with everything below it, so the same flag cannot be shared at two levels.';
+
+/**
  * Flags the CLI host owns. A plugin that took one of these would break
  * `vendure --help`, which is how a user recovers from a bad plugin.
  */
@@ -24,14 +30,15 @@ export const RESERVED_FLAGS = ['--help', '-h', '--version', '-V'];
  * extend either. Commander adds `help` implicitly, so the registry would not
  * otherwise see a collision.
  */
-export const RESERVED_COMMANDS = ['plugins', 'help'];
+const RESERVED_COMMAND_REASONS: Record<string, string> = {
+    plugins: 'it is how a plugin is disabled',
+    help: 'it is how a user finds their way out of a broken plugin',
+};
+
+export const RESERVED_COMMANDS = Object.keys(RESERVED_COMMAND_REASONS);
 
 function reservedCommandConflict(name: string): string {
-    const reason =
-        name === 'plugins'
-            ? 'it is how a plugin is disabled'
-            : 'it is how a user finds their way out of a broken plugin';
-    return `Command "${name}" is reserved by the CLI, because ${reason}.`;
+    return `Command "${name}" is reserved by the CLI, because ${RESERVED_COMMAND_REASONS[name]}.`;
 }
 
 interface RegisteredCommand {
@@ -51,6 +58,12 @@ interface RegisteredCommand {
 interface RegisteredOption {
     option: CliCommandOption;
     source?: string;
+    /**
+     * True for an entry that came from a parent's `subOptions`. Kept in the map
+     * so collision lookups see it, but left out of {@link CommandRegistry.getRootOptions}
+     * because the parent already carries it and the host expands it once.
+     */
+    isSubOption: boolean;
 }
 
 interface RegistryState {
@@ -111,8 +124,11 @@ export class CommandRegistry {
         const conflicts: string[] = [];
         const notices: string[] = [];
 
-        for (const option of withSubOptions(plugin.rootOptions ?? [])) {
-            this.draftRootOption(draft, option, plugin.id, conflicts);
+        for (const option of plugin.rootOptions ?? []) {
+            this.draftRootOption(draft, option, plugin.id, conflicts, false);
+            for (const subOption of option.subOptions ?? []) {
+                this.draftRootOption(draft, subOption, plugin.id, conflicts, true);
+            }
         }
         for (const node of plugin.commands) {
             draftCommand(draft, node, plugin.id, conflicts, notices);
@@ -147,16 +163,20 @@ export class CommandRegistry {
      * Options registered on the `vendure` command itself by plugins.
      */
     getRootOptions(): CliCommandOption[] {
-        return Array.from(this.state.rootOptions.values(), entry => entry.option);
+        // Sub-options are excluded: their parent still carries them, and the
+        // host expands each parent once when it registers the option.
+        return Array.from(this.state.rootOptions.values())
+            .filter(entry => !entry.isSubOption)
+            .map(entry => entry.option);
     }
 
     /**
      * Plugins that have extended anything in the tree under the top-level
      * command `name`, in the order they were applied.
      *
-     * Deliberately tree-scoped rather than per command path: it backs the
-     * refusal to replace a command another plugin has extended, and replacing
-     * a group does discard an extension of one of its subcommands.
+     * Tree-scoped rather than per command path, matching the state
+     * `draftCommand` reads when it refuses to replace an extended command.
+     * Exposed for tests and diagnostics; the CLI itself does not call it.
      */
     getExtendedBy(name: string): string[] {
         return [...(this.state.commands.get(name)?.extendedBy ?? [])];
@@ -167,6 +187,7 @@ export class CommandRegistry {
         option: CliCommandOption,
         source: string,
         conflicts: string[],
+        isSubOption: boolean,
     ): void {
         const before = conflicts.length;
         const parsed = parseOptionFlags(option);
@@ -193,8 +214,7 @@ export class CommandRegistry {
                 // would depend on which of the two plugins is listed first.
                 conflicts.push(
                     `Shared option "${describeOption(option)}" is already shared by the command group ` +
-                        `"vendure ${declared.path.join(' ')}". A group shares its options with everything ` +
-                        `below it, so the same flag cannot be shared at two levels.`,
+                        `"vendure ${declared.path.join(' ')}". ${GROUP_SHARING_EXPLANATION}`,
                 );
             } else if (!takesSameValue(declared.option, option)) {
                 conflicts.push(
@@ -205,7 +225,7 @@ export class CommandRegistry {
             }
         }
         if (conflicts.length === before) {
-            draft.rootOptions.set(parsed.attributeName, { option, source });
+            draft.rootOptions.set(parsed.attributeName, { option, source, isSubOption });
         }
     }
 }
@@ -261,8 +281,7 @@ function draftCommand(
             conflicts.push(
                 `Option "${describeOption(declared.option)}" on the command group ` +
                     `"vendure ${declared.path.join(' ')}" is already a shared option registered by ` +
-                    `${shared.source ?? 'the CLI'}. A group shares its options with everything below it, ` +
-                    `so the same flag cannot be shared at two levels.`,
+                    `${shared.source ?? 'the CLI'}. ${GROUP_SHARING_EXPLANATION}`,
             );
         } else if (!takesSameValue(shared.option, declared.option)) {
             conflicts.push(
@@ -319,6 +338,7 @@ function draftExtension(
     // Extending a group shares the option with everything below it, so the
     // subtree matters as much as the ancestors.
     const descendantShared = targetIsGroup ? descendantGroupOptions(target, path) : [];
+    const descendantLeaf = targetIsGroup ? descendantLeafOptions(target, path) : [];
     const targetOptions = withSubOptions(target.options ?? []);
     for (const option of withSubOptions(extension.options ?? [])) {
         const parsed = parseOptionFlags(option);
@@ -338,9 +358,19 @@ function draftExtension(
         if (descendant) {
             conflicts.push(
                 `Option "${describeOption(option)}" added to the command group "vendure ${label}" is ` +
-                    `already shared by "vendure ${descendant.path.join(' ')}" below it. A group shares ` +
-                    `its options with everything below it, so the same flag cannot be shared at two ` +
-                    `levels.`,
+                    `already shared by "vendure ${descendant.path.join(' ')}" below it. ${GROUP_SHARING_EXPLANATION}`,
+            );
+            continue;
+        }
+        const leafBelow = descendantLeaf.find(
+            existing => isSameOption(existing.option, parsed) && !takesSameValue(existing.option, option),
+        );
+        if (leafBelow) {
+            conflicts.push(
+                `Option "${describeOption(option)}" added to the command group "vendure ${label}" is not ` +
+                    `compatible with "${describeOption(leafBelow.option)}" on ` +
+                    `"vendure ${leafBelow.path.join(' ')}" below it: one takes a value and the other ` +
+                    `does not.`,
             );
             continue;
         }
@@ -353,8 +383,7 @@ function draftExtension(
         if (targetIsGroup) {
             conflicts.push(
                 `Option "${describeOption(option)}" added to the command group "vendure ${label}" is ` +
-                    `already a shared option ("${describeOption(sharedOption)}"). A group shares its ` +
-                    `options with everything below it, so the same flag cannot be shared at two levels.`,
+                    `already a shared option ("${describeOption(sharedOption)}"). ${GROUP_SHARING_EXPLANATION}`,
             );
         } else if (!takesSameValue(sharedOption, option)) {
             conflicts.push(
@@ -515,6 +544,32 @@ function descendantGroupOptions(
                 found.push({ path: subPath, option });
             }
             found.push(...descendantGroupOptions(subcommand, subPath));
+        }
+    }
+    return found;
+}
+
+/**
+ * Options declared by the commands below `node`. A group option is shared with
+ * all of them, so the shapes have to agree even though repeating the flag is
+ * allowed.
+ */
+function descendantLeafOptions(
+    node: CliCommandNode,
+    path: string[],
+): Array<{ path: string[]; option: CliCommandOption }> {
+    if (!isCliCommandGroup(node)) {
+        return [];
+    }
+    const found: Array<{ path: string[]; option: CliCommandOption }> = [];
+    for (const subcommand of node.subcommands) {
+        const subPath = [...path, subcommand.name];
+        if (isCliCommandGroup(subcommand)) {
+            found.push(...descendantLeafOptions(subcommand, subPath));
+        } else {
+            for (const option of withSubOptions(subcommand.options ?? [])) {
+                found.push({ path: subPath, option });
+            }
         }
     }
     return found;

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -1,7 +1,7 @@
 import pc from 'picocolors';
 
 import { CliCommandNode, CliCommandOption, isCliCommandGroup } from './cli-command-definition';
-import { buildOptionFlags, describeOption, parseOptionFlags } from './cli-command-options';
+import { buildOptionFlags, describeOption, ParsedCliOption, parseOptionFlags } from './cli-command-options';
 import { CliPlugin } from './cli-plugin';
 
 /**
@@ -109,15 +109,15 @@ export class CommandRegistry {
         const declaredOptions = this.listDeclaredCommandOptions();
 
         for (const option of plugin.rootOptions ?? []) {
-            const { long, short } = parseOptionFlags(option);
-            for (const flag of [long, short]) {
+            const parsed = parseOptionFlags(option);
+            for (const flag of [parsed.long, parsed.short]) {
                 if (flag && RESERVED_FLAGS.includes(flag)) {
                     conflicts.push(
                         `Shared option "${describeOption(option)}" uses "${flag}", which is reserved by the CLI.`,
                     );
                 }
             }
-            const existing = this.findRootOptionByFlag(long, short);
+            const existing = this.findRootOption(parsed);
             if (existing) {
                 conflicts.push(
                     `Shared option "${describeOption(option)}" is already registered by ` +
@@ -125,7 +125,7 @@ export class CommandRegistry {
                 );
             }
             for (const declared of declaredOptions) {
-                if (matchesFlag(declared.option, long, short) && !takesSameValue(declared.option, option)) {
+                if (isSameOption(declared.option, parsed) && !takesSameValue(declared.option, option)) {
                     conflicts.push(
                         `Shared option "${describeOption(option)}" is not compatible with ` +
                             `"${describeOption(declared.option)}" on "vendure ${declared.path.join(' ')}": ` +
@@ -146,8 +146,7 @@ export class CommandRegistry {
         }
 
         for (const declared of listCommandOptions(plugin.commands)) {
-            const { long, short } = parseOptionFlags(declared.option);
-            const shared = this.findRootOptionByFlag(long, short);
+            const shared = this.findRootOption(parseOptionFlags(declared.option));
             if (shared && !takesSameValue(shared.option, declared.option)) {
                 conflicts.push(
                     `Option "${describeOption(declared.option)}" on "vendure ${declared.path.join(' ')}" is not ` +
@@ -160,8 +159,8 @@ export class CommandRegistry {
         return conflicts;
     }
 
-    private findRootOptionByFlag(long?: string, short?: string): RegisteredOption | undefined {
-        return Array.from(this.rootOptions.values()).find(entry => matchesFlag(entry.option, long, short));
+    private findRootOption(parsed: ParsedCliOption): RegisteredOption | undefined {
+        return Array.from(this.rootOptions.values()).find(entry => isSameOption(entry.option, parsed));
     }
 
     private listDeclaredCommandOptions(): Array<{ path: string[]; option: CliCommandOption }> {
@@ -186,9 +185,18 @@ function listCommandOptions(
     return declared;
 }
 
-function matchesFlag(option: CliCommandOption, long?: string, short?: string): boolean {
+/**
+ * Two options are the same option when they share a flag, or when they resolve
+ * to the same attribute name — `--api-token` and `--apiToken` are written
+ * differently but Commander stores both under `apiToken`.
+ */
+function isSameOption(option: CliCommandOption, other: ParsedCliOption): boolean {
     const parsed = parseOptionFlags(option);
-    return (long != null && parsed.long === long) || (short != null && parsed.short === short);
+    return (
+        (other.long != null && parsed.long === other.long) ||
+        (other.short != null && parsed.short === other.short) ||
+        parsed.attributeName === other.attributeName
+    );
 }
 
 /**

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -8,7 +8,7 @@ import {
     CliCommandOption,
     isCliCommandGroup,
 } from './cli-command-definition';
-import { describeOption, ParsedCliOption, parseOptionFlags } from './cli-command-options';
+import { describeOption, ParsedCliOption, parseOptionFlags, withSubOptions } from './cli-command-options';
 import { CliPlugin, normalizeCommandPath } from './cli-plugin';
 
 /**
@@ -31,8 +31,12 @@ interface RegisteredCommand {
     source?: string;
     /** Plugins that have extended this command, in the order they were applied. */
     extendedBy: string[];
-    /** Plugin whose extension last set the description. */
-    describedBy?: string;
+    /**
+     * Plugin whose extension last set the description, keyed by the command
+     * path it set. A tree holds several commands, so ownership cannot be
+     * recorded against the tree as a whole.
+     */
+    describedBy: Record<string, string>;
 }
 
 interface RegisteredOption {
@@ -78,7 +82,7 @@ export class CommandRegistry {
     }
 
     register(command: CliCommandNode): void {
-        this.state.commands.set(command.name, { node: command, extendedBy: [] });
+        this.state.commands.set(command.name, { node: command, extendedBy: [], describedBy: {} });
     }
 
     /**
@@ -98,7 +102,7 @@ export class CommandRegistry {
         const conflicts: string[] = [];
         const notices: string[] = [];
 
-        for (const option of plugin.rootOptions ?? []) {
+        for (const option of withSubOptions(plugin.rootOptions ?? [])) {
             this.draftRootOption(draft, option, plugin.id, conflicts);
         }
         for (const node of plugin.commands) {
@@ -253,7 +257,7 @@ function draftCommand(
     if (existing) {
         notices.push(`Replaced command "${node.name}" via ${source}\n`);
     }
-    draft.commands.set(node.name, { node, source, extendedBy: [] });
+    draft.commands.set(node.name, { node, source, extendedBy: [], describedBy: {} });
 }
 
 function draftExtension(
@@ -292,7 +296,8 @@ function draftExtension(
         );
     }
     const inheritedShared = ancestorSharedOptions(draft, path);
-    for (const option of extension.options ?? []) {
+    const targetOptions = withSubOptions(target.options ?? []);
+    for (const option of withSubOptions(extension.options ?? [])) {
         const parsed = parseOptionFlags(option);
         for (const flag of [parsed.long, parsed.short]) {
             if (flag && RESERVED_FLAGS.includes(flag)) {
@@ -302,7 +307,7 @@ function draftExtension(
                 );
             }
         }
-        const clash = (target.options ?? []).find(existing => isSameOption(existing, parsed));
+        const clash = targetOptions.find(existing => isSameOption(existing, parsed));
         if (clash) {
             conflicts.push(`Option "${describeOption(option)}" is already declared on "vendure ${label}".`);
         }
@@ -339,10 +344,11 @@ function draftExtension(
         return;
     }
 
-    if (extension.description && entry.describedBy && entry.describedBy !== source) {
+    const previousDescriber = entry.describedBy[label];
+    if (extension.description && previousDescriber && previousDescriber !== source) {
         notices.push(
             `Description of "vendure ${label}" set by ${source} replaces the one set by ` +
-                `${entry.describedBy}\n`,
+                `${previousDescriber}\n`,
         );
     }
 
@@ -350,7 +356,7 @@ function draftExtension(
         ...entry,
         node: replaceNodeAtPath(entry.node, path.slice(1), extended),
         extendedBy: [...entry.extendedBy, source],
-        describedBy: extension.description ? source : entry.describedBy,
+        describedBy: extension.description ? { ...entry.describedBy, [label]: source } : entry.describedBy,
     });
 }
 
@@ -434,7 +440,7 @@ function listCommandOptions(nodes: CliCommandNode[], path: string[] = []): Decla
     for (const node of nodes) {
         const commandPath = [...path, node.name];
         const isGroupOption = isCliCommandGroup(node);
-        for (const option of node.options ?? []) {
+        for (const option of withSubOptions(node.options ?? [])) {
             declared.push({ path: commandPath, option, isGroupOption });
         }
         if (isCliCommandGroup(node)) {
@@ -455,7 +461,7 @@ function ancestorSharedOptions(draft: RegistryState, path: string[]): CliCommand
         if (!isCliCommandGroup(node)) {
             break;
         }
-        options.push(...(node.options ?? []));
+        options.push(...withSubOptions(node.options ?? []));
         node = node.subcommands.find(subcommand => subcommand.name === path[i + 1]);
     }
     return options;

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -1,6 +1,7 @@
 import pc from 'picocolors';
 
 import {
+    CliCommandArgument,
     CliCommandDefinition,
     CliCommandExtension,
     CliCommandGroupDefinition,
@@ -23,7 +24,15 @@ export const RESERVED_FLAGS = ['--help', '-h', '--version', '-V'];
  * extend either. Commander adds `help` implicitly, so the registry would not
  * otherwise see a collision.
  */
-const RESERVED_COMMANDS = ['plugins', 'help'];
+export const RESERVED_COMMANDS = ['plugins', 'help'];
+
+function reservedCommandConflict(name: string): string {
+    const reason =
+        name === 'plugins'
+            ? 'it is how a plugin is disabled'
+            : 'it is how a user finds their way out of a broken plugin';
+    return `Command "${name}" is reserved by the CLI, because ${reason}.`;
+}
 
 interface RegisteredCommand {
     node: CliCommandNode;
@@ -142,8 +151,12 @@ export class CommandRegistry {
     }
 
     /**
-     * Plugins that have extended the command at `path`, in the order they were
-     * applied. The last one is the outermost wrapper.
+     * Plugins that have extended anything in the tree under the top-level
+     * command `name`, in the order they were applied.
+     *
+     * Deliberately tree-scoped rather than per command path: it backs the
+     * refusal to replace a command another plugin has extended, and replacing
+     * a group does discard an extension of one of its subcommands.
      */
     getExtendedBy(name: string): string[] {
         return [...(this.state.commands.get(name)?.extendedBy ?? [])];
@@ -172,7 +185,18 @@ export class CommandRegistry {
             );
         }
         for (const declared of listCommandOptions(Array.from(draft.commands.values(), entry => entry.node))) {
-            if (isSameOption(declared.option, parsed) && !takesSameValue(declared.option, option)) {
+            if (!isSameOption(declared.option, parsed)) {
+                continue;
+            }
+            if (declared.isGroupOption) {
+                // The mirror of the check in draftCommand. Without it the rule
+                // would depend on which of the two plugins is listed first.
+                conflicts.push(
+                    `Shared option "${describeOption(option)}" is already shared by the command group ` +
+                        `"vendure ${declared.path.join(' ')}". A group shares its options with everything ` +
+                        `below it, so the same flag cannot be shared at two levels.`,
+                );
+            } else if (!takesSameValue(declared.option, option)) {
                 conflicts.push(
                     `Shared option "${describeOption(option)}" is not compatible with ` +
                         `"${describeOption(declared.option)}" on "vendure ${declared.path.join(' ')}": ` +
@@ -195,9 +219,7 @@ function draftCommand(
 ): void {
     const before = conflicts.length;
     if (RESERVED_COMMANDS.includes(node.name)) {
-        conflicts.push(
-            `Command "${node.name}" is reserved by the CLI, because it is how a plugin is disabled.`,
-        );
+        conflicts.push(reservedCommandConflict(node.name));
         return;
     }
 
@@ -272,9 +294,7 @@ function draftExtension(
     const label = path.join(' ');
 
     if (RESERVED_COMMANDS.includes(path[0])) {
-        conflicts.push(
-            `Command "${path[0]}" is reserved by the CLI, because it is how a plugin is disabled.`,
-        );
+        conflicts.push(reservedCommandConflict(path[0]));
         return;
     }
 
@@ -296,6 +316,9 @@ function draftExtension(
         );
     }
     const inheritedShared = ancestorSharedOptions(draft, path);
+    // Extending a group shares the option with everything below it, so the
+    // subtree matters as much as the ancestors.
+    const descendantShared = targetIsGroup ? descendantGroupOptions(target, path) : [];
     const targetOptions = withSubOptions(target.options ?? []);
     for (const option of withSubOptions(extension.options ?? [])) {
         const parsed = parseOptionFlags(option);
@@ -310,6 +333,16 @@ function draftExtension(
         const clash = targetOptions.find(existing => isSameOption(existing, parsed));
         if (clash) {
             conflicts.push(`Option "${describeOption(option)}" is already declared on "vendure ${label}".`);
+        }
+        const descendant = descendantShared.find(existing => isSameOption(existing.option, parsed));
+        if (descendant) {
+            conflicts.push(
+                `Option "${describeOption(option)}" added to the command group "vendure ${label}" is ` +
+                    `already shared by "vendure ${descendant.path.join(' ')}" below it. A group shares ` +
+                    `its options with everything below it, so the same flag cannot be shared at two ` +
+                    `levels.`,
+            );
+            continue;
         }
         const inherited = inheritedShared.find(existing => isSameOption(existing, parsed));
         const shared = findRootOption(draft, parsed);
@@ -382,11 +415,23 @@ function extendNode(target: CliCommandNode, extension: CliCommandExtension): Cli
     if (!extension.decorate) {
         return command;
     }
-    const action = extension.decorate({ command: target, next: target.action });
+    // The decorator gets a frozen copy: `Readonly` is shallow, and on a first
+    // extension `target.options` is the array the built-in module exports.
+    const action = extension.decorate({ command: freezeCommand(target), next: target.action });
     if (typeof action !== 'function') {
         throw new Error('decorate must return an action function');
     }
     return { ...command, action };
+}
+
+function freezeCommand(command: CliCommandDefinition): Readonly<CliCommandDefinition> {
+    // The arrays are copied as well as frozen: freezing makes a mutating
+    // decorator fail loudly, and copying means it could not have reached the
+    // registered definition even if it did not.
+    const frozenOptions = command.options && (Object.freeze([...command.options]) as CliCommandOption[]);
+    const frozenArguments =
+        command.arguments && (Object.freeze([...command.arguments]) as CliCommandArgument[]);
+    return Object.freeze({ ...command, options: frozenOptions, arguments: frozenArguments });
 }
 
 function findNodeAtPath(node: CliCommandNode, path: string[]): CliCommandNode | undefined {
@@ -448,6 +493,31 @@ function listCommandOptions(nodes: CliCommandNode[], path: string[] = []): Decla
         }
     }
     return declared;
+}
+
+/**
+ * Options that groups below `node` share with their own subtrees. An option
+ * added to `node` would be shared with them, so the same flag cannot appear in
+ * both places.
+ */
+function descendantGroupOptions(
+    node: CliCommandNode,
+    path: string[],
+): Array<{ path: string[]; option: CliCommandOption }> {
+    if (!isCliCommandGroup(node)) {
+        return [];
+    }
+    const found: Array<{ path: string[]; option: CliCommandOption }> = [];
+    for (const subcommand of node.subcommands) {
+        const subPath = [...path, subcommand.name];
+        if (isCliCommandGroup(subcommand)) {
+            for (const option of withSubOptions(subcommand.options ?? [])) {
+                found.push({ path: subPath, option });
+            }
+            found.push(...descendantGroupOptions(subcommand, subPath));
+        }
+    }
+    return found;
 }
 
 /**

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -1,8 +1,15 @@
 import pc from 'picocolors';
 
-import { CliCommandNode, CliCommandOption, isCliCommandGroup } from './cli-command-definition';
+import {
+    CliCommandDefinition,
+    CliCommandExtension,
+    CliCommandGroupDefinition,
+    CliCommandNode,
+    CliCommandOption,
+    isCliCommandGroup,
+} from './cli-command-definition';
 import { buildOptionFlags, describeOption, ParsedCliOption, parseOptionFlags } from './cli-command-options';
-import { CliPlugin } from './cli-plugin';
+import { CliPlugin, normalizeCommandPath } from './cli-plugin';
 
 /**
  * Flags the CLI host owns. A plugin that took one of these would break
@@ -10,10 +17,20 @@ import { CliPlugin } from './cli-plugin';
  */
 const RESERVED_FLAGS = ['--help', '-h', '--version', '-V'];
 
+/**
+ * Commands the CLI host owns. `plugins` is how a user disables a plugin that
+ * misbehaves, so no plugin may replace or extend it.
+ */
+const RESERVED_COMMANDS = ['plugins'];
+
 interface RegisteredCommand {
     node: CliCommandNode;
     /** Plugin id, or undefined for a built-in. */
     source?: string;
+    /** Plugins that have extended this command, in the order they were applied. */
+    extendedBy: string[];
+    /** Plugin whose extension last set the description. */
+    describedBy?: string;
 }
 
 interface RegisteredOption {
@@ -21,10 +38,15 @@ interface RegisteredOption {
     source?: string;
 }
 
+interface RegistryState {
+    commands: Map<string, RegisteredCommand>;
+    rootOptions: Map<string, RegisteredOption>;
+}
+
 /**
- * Thrown when a plugin's commands or shared options would collide with what is
- * already registered. The CLI host reports it and skips that plugin, so one
- * plugin cannot make the rest of the CLI unusable.
+ * Thrown when a plugin's commands, extensions or shared options would collide
+ * with what is already registered. The CLI host reports it and skips that
+ * plugin, so one plugin cannot make the rest of the CLI unusable.
  */
 export class CliPluginRegistrationError extends Error {
     constructor(
@@ -44,8 +66,7 @@ export class CliPluginRegistrationError extends Error {
  * activation order.
  */
 export class CommandRegistry {
-    private readonly commands = new Map<string, RegisteredCommand>();
-    private readonly rootOptions = new Map<string, RegisteredOption>();
+    private state: RegistryState = { commands: new Map(), rootOptions: new Map() };
 
     /**
      * Registers built-in or plugin commands. When a command name already
@@ -58,114 +79,340 @@ export class CommandRegistry {
     }
 
     register(command: CliCommandNode, source?: string): void {
-        if (this.commands.has(command.name) && source) {
+        if (this.state.commands.has(command.name) && source) {
             // Not dim: this is the main signal that a built-in (or earlier
             // plugin) command was overridden, and precedence follows
             // vendure.cli.plugins order (last enabled plugin wins).
             process.stderr.write(pc.yellow(`Replaced command "${command.name}" via ${source}\n`));
         }
-        this.commands.set(command.name, { node: command, source });
+        this.state.commands.set(command.name, { node: command, source, extendedBy: [] });
     }
 
     /**
-     * Applies the commands and shared options of a loaded CLI plugin.
+     * Applies the commands, extensions and shared options of a loaded CLI
+     * plugin.
      *
-     * Throws {@link CliPluginRegistrationError} without registering anything
-     * when the plugin would collide with an existing command or shared option,
-     * so a plugin is never applied by halves.
+     * Everything is applied to a draft first. If any part of the plugin
+     * collides with what is already registered, {@link CliPluginRegistrationError}
+     * is thrown and the draft is discarded, so a plugin is never applied by
+     * halves.
      */
     applyPlugin(plugin: CliPlugin): void {
-        const conflicts = this.findConflicts(plugin);
+        const draft: RegistryState = {
+            commands: new Map(this.state.commands),
+            rootOptions: new Map(this.state.rootOptions),
+        };
+        const conflicts: string[] = [];
+        const notices: string[] = [];
+
+        for (const option of plugin.rootOptions ?? []) {
+            this.draftRootOption(draft, option, plugin.id, conflicts);
+        }
+        for (const node of plugin.commands) {
+            draftCommand(draft, node, plugin.id, conflicts, notices);
+        }
+        for (const extension of plugin.extendCommands ?? []) {
+            draftExtension(draft, extension, plugin.id, conflicts, notices);
+        }
+
         if (conflicts.length > 0) {
             throw new CliPluginRegistrationError(plugin.id, conflicts);
         }
-        for (const option of plugin.rootOptions ?? []) {
-            this.rootOptions.set(parseOptionFlags(option).attributeName, { option, source: plugin.id });
+
+        this.state = draft;
+        for (const notice of notices) {
+            process.stderr.write(pc.yellow(notice));
         }
-        this.registerAll(plugin.commands, plugin.id);
     }
 
     get(name: string): CliCommandNode | undefined {
-        return this.commands.get(name)?.node;
+        return this.state.commands.get(name)?.node;
     }
 
     has(name: string): boolean {
-        return this.commands.has(name);
+        return this.state.commands.has(name);
     }
 
     toArray(): CliCommandNode[] {
-        return Array.from(this.commands.values(), entry => entry.node);
+        return Array.from(this.state.commands.values(), entry => entry.node);
     }
 
     /**
      * Options registered on the `vendure` command itself by plugins.
      */
     getRootOptions(): CliCommandOption[] {
-        return Array.from(this.rootOptions.values(), entry => entry.option);
+        return Array.from(this.state.rootOptions.values(), entry => entry.option);
     }
 
-    private findConflicts(plugin: CliPlugin): string[] {
-        const conflicts: string[] = [];
-        const declaredOptions = this.listDeclaredCommandOptions();
+    /**
+     * Plugins that have extended the command at `path`, in the order they were
+     * applied. The last one is the outermost wrapper.
+     */
+    getExtendedBy(name: string): string[] {
+        return [...(this.state.commands.get(name)?.extendedBy ?? [])];
+    }
 
-        for (const option of plugin.rootOptions ?? []) {
-            const parsed = parseOptionFlags(option);
-            for (const flag of [parsed.long, parsed.short]) {
-                if (flag && RESERVED_FLAGS.includes(flag)) {
-                    conflicts.push(
-                        `Shared option "${describeOption(option)}" uses "${flag}", which is reserved by the CLI.`,
-                    );
-                }
-            }
-            const existing = this.findRootOption(parsed);
-            if (existing) {
+    private draftRootOption(
+        draft: RegistryState,
+        option: CliCommandOption,
+        source: string,
+        conflicts: string[],
+    ): void {
+        const before = conflicts.length;
+        const parsed = parseOptionFlags(option);
+        for (const flag of [parsed.long, parsed.short]) {
+            if (flag && RESERVED_FLAGS.includes(flag)) {
                 conflicts.push(
-                    `Shared option "${describeOption(option)}" is already registered by ` +
-                        `${existing.source ?? 'the CLI'}.`,
-                );
-            }
-            for (const declared of declaredOptions) {
-                if (isSameOption(declared.option, parsed) && !takesSameValue(declared.option, option)) {
-                    conflicts.push(
-                        `Shared option "${describeOption(option)}" is not compatible with ` +
-                            `"${describeOption(declared.option)}" on "vendure ${declared.path.join(' ')}": ` +
-                            `one takes a value and the other does not.`,
-                    );
-                }
-            }
-        }
-
-        for (const node of plugin.commands) {
-            const existing = this.commands.get(node.name);
-            if (existing && node.replaces !== true) {
-                conflicts.push(
-                    `Command "${node.name}" is already provided by ${existing.source ?? 'the CLI'}. ` +
-                        `Set "replaces: true" on it to override that deliberately.`,
+                    `Shared option "${describeOption(option)}" uses "${flag}", which is reserved by the CLI.`,
                 );
             }
         }
-
-        for (const declared of listCommandOptions(plugin.commands)) {
-            const shared = this.findRootOption(parseOptionFlags(declared.option));
-            if (shared && !takesSameValue(shared.option, declared.option)) {
+        const existing = findRootOption(draft, parsed);
+        if (existing) {
+            conflicts.push(
+                `Shared option "${describeOption(option)}" is already registered by ` +
+                    `${existing.source ?? 'the CLI'}.`,
+            );
+        }
+        for (const declared of listCommandOptions(Array.from(draft.commands.values(), entry => entry.node))) {
+            if (isSameOption(declared.option, parsed) && !takesSameValue(declared.option, option)) {
                 conflicts.push(
-                    `Option "${describeOption(declared.option)}" on "vendure ${declared.path.join(' ')}" is not ` +
-                        `compatible with the shared option "${describeOption(shared.option)}" registered by ` +
-                        `${shared.source ?? 'the CLI'}: one takes a value and the other does not.`,
+                    `Shared option "${describeOption(option)}" is not compatible with ` +
+                        `"${describeOption(declared.option)}" on "vendure ${declared.path.join(' ')}": ` +
+                        `one takes a value and the other does not.`,
                 );
             }
         }
+        if (conflicts.length === before) {
+            draft.rootOptions.set(parsed.attributeName, { option, source });
+        }
+    }
+}
 
-        return conflicts;
+function draftCommand(
+    draft: RegistryState,
+    node: CliCommandNode,
+    source: string,
+    conflicts: string[],
+    notices: string[],
+): void {
+    const before = conflicts.length;
+    if (RESERVED_COMMANDS.includes(node.name)) {
+        conflicts.push(
+            `Command "${node.name}" is reserved by the CLI, because it is how a plugin is disabled.`,
+        );
+        return;
     }
 
-    private findRootOption(parsed: ParsedCliOption): RegisteredOption | undefined {
-        return Array.from(this.rootOptions.values()).find(entry => isSameOption(entry.option, parsed));
+    const existing = draft.commands.get(node.name);
+    if (existing && node.replaces !== true) {
+        conflicts.push(
+            `Command "${node.name}" is already provided by ${existing.source ?? 'the CLI'}. ` +
+                `Set "replaces: true" on it to override that deliberately, or use "extendCommands" ` +
+                `to add to it without discarding it.`,
+        );
+        return;
     }
 
-    private listDeclaredCommandOptions(): Array<{ path: string[]; option: CliCommandOption }> {
-        return listCommandOptions(this.toArray());
+    const discarded = existing?.extendedBy.filter(id => id !== source) ?? [];
+    if (discarded.length > 0) {
+        conflicts.push(
+            `Command "${node.name}" has been extended by ${discarded.join(', ')}. Replacing it would ` +
+                `discard that. Use "extendCommands" instead, or list this plugin before them in ` +
+                `vendure.cli.plugins.`,
+        );
+        return;
     }
+
+    for (const declared of listCommandOptions([node])) {
+        const shared = findRootOption(draft, parseOptionFlags(declared.option));
+        if (shared && !takesSameValue(shared.option, declared.option)) {
+            conflicts.push(
+                `Option "${describeOption(declared.option)}" on "vendure ${declared.path.join(' ')}" is not ` +
+                    `compatible with the shared option "${describeOption(shared.option)}" registered by ` +
+                    `${shared.source ?? 'the CLI'}: one takes a value and the other does not.`,
+            );
+        }
+    }
+
+    if (conflicts.length > before) {
+        return;
+    }
+    if (existing) {
+        notices.push(`Replaced command "${node.name}" via ${source}\n`);
+    }
+    draft.commands.set(node.name, { node, source, extendedBy: [] });
+}
+
+function draftExtension(
+    draft: RegistryState,
+    extension: CliCommandExtension,
+    source: string,
+    conflicts: string[],
+    notices: string[],
+): void {
+    const before = conflicts.length;
+    const path = normalizeCommandPath(extension.command);
+    const label = path.join(' ');
+
+    if (RESERVED_COMMANDS.includes(path[0])) {
+        conflicts.push(
+            `Command "${path[0]}" is reserved by the CLI, because it is how a plugin is disabled.`,
+        );
+        return;
+    }
+
+    const entry = draft.commands.get(path[0]);
+    const target = entry && findNodeAtPath(entry.node, path.slice(1));
+    if (!entry || !target) {
+        conflicts.push(
+            `No command is registered at "vendure ${label}", so there is nothing to extend. ` +
+                `Check the path, and that the plugin providing it is listed first in vendure.cli.plugins.`,
+        );
+        return;
+    }
+
+    const targetIsGroup = isCliCommandGroup(target);
+    if (targetIsGroup && extension.decorate) {
+        conflicts.push(
+            `"vendure ${label}" is a command group and has no action to decorate. Extend one of its ` +
+                `subcommands instead.`,
+        );
+    }
+    if (targetIsGroup && extension.arguments?.length) {
+        conflicts.push(`"vendure ${label}" is a command group and takes no positional arguments.`);
+    }
+
+    const contributors = [entry.source ?? 'the CLI', ...entry.extendedBy].join(', ');
+    for (const option of extension.options ?? []) {
+        const parsed = parseOptionFlags(option);
+        for (const flag of [parsed.long, parsed.short]) {
+            if (flag && RESERVED_FLAGS.includes(flag)) {
+                conflicts.push(
+                    `Option "${describeOption(option)}" added to "vendure ${label}" uses "${flag}", ` +
+                        `which is reserved by the CLI.`,
+                );
+            }
+        }
+        const clash = (target.options ?? []).find(existing => isSameOption(existing, parsed));
+        if (clash) {
+            conflicts.push(
+                `Option "${describeOption(option)}" is already declared on "vendure ${label}" ` +
+                    `(contributed by ${contributors}).`,
+            );
+        }
+        const shared = findRootOption(draft, parsed);
+        if (shared && !takesSameValue(shared.option, option)) {
+            conflicts.push(
+                `Option "${describeOption(option)}" added to "vendure ${label}" is not compatible with ` +
+                    `the shared option "${describeOption(shared.option)}" registered by ` +
+                    `${shared.source ?? 'the CLI'}: one takes a value and the other does not.`,
+            );
+        }
+    }
+
+    if (!targetIsGroup) {
+        const existingArguments = target.arguments ?? [];
+        for (const argument of extension.arguments ?? []) {
+            if (existingArguments.some(existing => existing.name === argument.name)) {
+                conflicts.push(
+                    `Argument "${argument.name}" is already declared on "vendure ${label}" ` +
+                        `(contributed by ${contributors}).`,
+                );
+            }
+        }
+    }
+
+    if (conflicts.length > before) {
+        return;
+    }
+
+    let extended: CliCommandNode;
+    try {
+        extended = extendNode(target, extension);
+    } catch (e) {
+        conflicts.push(`Extending "vendure ${label}" failed: ${e instanceof Error ? e.message : String(e)}`);
+        return;
+    }
+
+    if (extension.description && entry.describedBy && entry.describedBy !== source) {
+        notices.push(
+            `Description of "vendure ${label}" set by ${source} replaces the one set by ` +
+                `${entry.describedBy}\n`,
+        );
+    }
+
+    draft.commands.set(path[0], {
+        ...entry,
+        node: replaceNodeAtPath(entry.node, path.slice(1), extended),
+        extendedBy: [...entry.extendedBy, source],
+        describedBy: extension.description ? source : entry.describedBy,
+    });
+}
+
+/**
+ * Builds the extended command. The original definition is never mutated, so
+ * `builtinCommands.<name>.action` keeps pointing at the original
+ * implementation and each decorator wraps only what was registered before it.
+ */
+function extendNode(target: CliCommandNode, extension: CliCommandExtension): CliCommandNode {
+    const options = [...(target.options ?? []), ...(extension.options ?? [])];
+    const description = extension.description ?? target.description;
+
+    if (isCliCommandGroup(target)) {
+        return { ...target, description, options: options.length > 0 ? options : undefined };
+    }
+
+    const commandArguments = [...(target.arguments ?? []), ...(extension.arguments ?? [])];
+    const command: CliCommandDefinition = {
+        ...target,
+        description,
+        options: options.length > 0 ? options : undefined,
+        arguments: commandArguments.length > 0 ? commandArguments : undefined,
+    };
+
+    if (!extension.decorate) {
+        return command;
+    }
+    const action = extension.decorate({ command: target, next: target.action });
+    if (typeof action !== 'function') {
+        throw new Error('decorate must return an action function');
+    }
+    return { ...command, action };
+}
+
+function findNodeAtPath(node: CliCommandNode, path: string[]): CliCommandNode | undefined {
+    if (path.length === 0) {
+        return node;
+    }
+    if (!isCliCommandGroup(node)) {
+        return undefined;
+    }
+    const child = node.subcommands.find(subcommand => subcommand.name === path[0]);
+    return child && findNodeAtPath(child, path.slice(1));
+}
+
+function replaceNodeAtPath(
+    node: CliCommandNode,
+    path: string[],
+    replacement: CliCommandNode,
+): CliCommandNode {
+    if (path.length === 0) {
+        return replacement;
+    }
+    const group = node as CliCommandGroupDefinition;
+    return {
+        ...group,
+        subcommands: group.subcommands.map(subcommand =>
+            subcommand.name === path[0]
+                ? replaceNodeAtPath(subcommand, path.slice(1), replacement)
+                : subcommand,
+        ),
+    };
+}
+
+function findRootOption(draft: RegistryState, parsed: ParsedCliOption): RegisteredOption | undefined {
+    return Array.from(draft.rootOptions.values()).find(entry => isSameOption(entry.option, parsed));
 }
 
 function listCommandOptions(

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -1,53 +1,201 @@
 import pc from 'picocolors';
 
-import { CliCommandDefinition } from './cli-command-definition';
+import { CliCommandNode, CliCommandOption, isCliCommandGroup } from './cli-command-definition';
+import { buildOptionFlags, describeOption, parseOptionFlags } from './cli-command-options';
 import { CliPlugin } from './cli-plugin';
 
 /**
- * In-memory registry of CLI commands. Supports adding new commands and
- * replacing existing ones (last registration wins).
+ * Flags the CLI host owns. A plugin that took one of these would break
+ * `vendure --help`, which is how a user recovers from a bad plugin.
+ */
+const RESERVED_FLAGS = ['--help', '-h', '--version', '-V'];
+
+interface RegisteredCommand {
+    node: CliCommandNode;
+    /** Plugin id, or undefined for a built-in. */
+    source?: string;
+}
+
+interface RegisteredOption {
+    option: CliCommandOption;
+    source?: string;
+}
+
+/**
+ * Thrown when a plugin's commands or shared options would collide with what is
+ * already registered. The CLI host reports it and skips that plugin, so one
+ * plugin cannot make the rest of the CLI unusable.
+ */
+export class CliPluginRegistrationError extends Error {
+    constructor(
+        readonly pluginId: string,
+        readonly conflicts: string[],
+    ) {
+        super(
+            `${conflicts.length === 1 ? 'Conflict' : 'Conflicts'}:\n${conflicts.map(c => `  - ${c}`).join('\n')}`,
+        );
+        this.name = 'CliPluginRegistrationError';
+    }
+}
+
+/**
+ * In-memory registry of CLI commands and the options shared by all of them.
+ * Built-in commands are registered first and plugins are applied on top, in
+ * activation order.
  */
 export class CommandRegistry {
-    private readonly commands = new Map<string, CliCommandDefinition>();
+    private readonly commands = new Map<string, RegisteredCommand>();
+    private readonly rootOptions = new Map<string, RegisteredOption>();
 
     /**
      * Registers built-in or plugin commands. When a command name already
      * exists, it is replaced and a short notice is written to stderr.
      */
-    registerAll(commands: CliCommandDefinition[], source?: string): void {
+    registerAll(commands: CliCommandNode[], source?: string): void {
         for (const command of commands) {
             this.register(command, source);
         }
     }
 
-    register(command: CliCommandDefinition, source?: string): void {
+    register(command: CliCommandNode, source?: string): void {
         if (this.commands.has(command.name) && source) {
             // Not dim: this is the main signal that a built-in (or earlier
             // plugin) command was overridden, and precedence follows
             // vendure.cli.plugins order (last enabled plugin wins).
-            process.stderr.write(
-                pc.yellow(`Replaced command "${command.name}" via ${source}\n`),
-            );
+            process.stderr.write(pc.yellow(`Replaced command "${command.name}" via ${source}\n`));
         }
-        this.commands.set(command.name, command);
+        this.commands.set(command.name, { node: command, source });
     }
 
     /**
-     * Applies all commands from a loaded CLI plugin.
+     * Applies the commands and shared options of a loaded CLI plugin.
+     *
+     * Throws {@link CliPluginRegistrationError} without registering anything
+     * when the plugin would collide with an existing command or shared option,
+     * so a plugin is never applied by halves.
      */
     applyPlugin(plugin: CliPlugin): void {
+        const conflicts = this.findConflicts(plugin);
+        if (conflicts.length > 0) {
+            throw new CliPluginRegistrationError(plugin.id, conflicts);
+        }
+        for (const option of plugin.rootOptions ?? []) {
+            this.rootOptions.set(parseOptionFlags(option).attributeName, { option, source: plugin.id });
+        }
         this.registerAll(plugin.commands, plugin.id);
     }
 
-    get(name: string): CliCommandDefinition | undefined {
-        return this.commands.get(name);
+    get(name: string): CliCommandNode | undefined {
+        return this.commands.get(name)?.node;
     }
 
     has(name: string): boolean {
         return this.commands.has(name);
     }
 
-    toArray(): CliCommandDefinition[] {
-        return Array.from(this.commands.values());
+    toArray(): CliCommandNode[] {
+        return Array.from(this.commands.values(), entry => entry.node);
     }
+
+    /**
+     * Options registered on the `vendure` command itself by plugins.
+     */
+    getRootOptions(): CliCommandOption[] {
+        return Array.from(this.rootOptions.values(), entry => entry.option);
+    }
+
+    private findConflicts(plugin: CliPlugin): string[] {
+        const conflicts: string[] = [];
+        const declaredOptions = this.listDeclaredCommandOptions();
+
+        for (const option of plugin.rootOptions ?? []) {
+            const { long, short } = parseOptionFlags(option);
+            for (const flag of [long, short]) {
+                if (flag && RESERVED_FLAGS.includes(flag)) {
+                    conflicts.push(
+                        `Shared option "${describeOption(option)}" uses "${flag}", which is reserved by the CLI.`,
+                    );
+                }
+            }
+            const existing = this.findRootOptionByFlag(long, short);
+            if (existing) {
+                conflicts.push(
+                    `Shared option "${describeOption(option)}" is already registered by ` +
+                        `${existing.source ?? 'the CLI'}.`,
+                );
+            }
+            for (const declared of declaredOptions) {
+                if (matchesFlag(declared.option, long, short) && !takesSameValue(declared.option, option)) {
+                    conflicts.push(
+                        `Shared option "${describeOption(option)}" is not compatible with ` +
+                            `"${describeOption(declared.option)}" on "vendure ${declared.path.join(' ')}": ` +
+                            `one takes a value and the other does not.`,
+                    );
+                }
+            }
+        }
+
+        for (const node of plugin.commands) {
+            const existing = this.commands.get(node.name);
+            if (existing && node.replaces !== true) {
+                conflicts.push(
+                    `Command "${node.name}" is already provided by ${existing.source ?? 'the CLI'}. ` +
+                        `Set "replaces: true" on it to override that deliberately.`,
+                );
+            }
+        }
+
+        for (const declared of listCommandOptions(plugin.commands)) {
+            const { long, short } = parseOptionFlags(declared.option);
+            const shared = this.findRootOptionByFlag(long, short);
+            if (shared && !takesSameValue(shared.option, declared.option)) {
+                conflicts.push(
+                    `Option "${describeOption(declared.option)}" on "vendure ${declared.path.join(' ')}" is not ` +
+                        `compatible with the shared option "${describeOption(shared.option)}" registered by ` +
+                        `${shared.source ?? 'the CLI'}: one takes a value and the other does not.`,
+                );
+            }
+        }
+
+        return conflicts;
+    }
+
+    private findRootOptionByFlag(long?: string, short?: string): RegisteredOption | undefined {
+        return Array.from(this.rootOptions.values()).find(entry => matchesFlag(entry.option, long, short));
+    }
+
+    private listDeclaredCommandOptions(): Array<{ path: string[]; option: CliCommandOption }> {
+        return listCommandOptions(this.toArray());
+    }
+}
+
+function listCommandOptions(
+    nodes: CliCommandNode[],
+    path: string[] = [],
+): Array<{ path: string[]; option: CliCommandOption }> {
+    const declared: Array<{ path: string[]; option: CliCommandOption }> = [];
+    for (const node of nodes) {
+        const commandPath = [...path, node.name];
+        for (const option of node.options ?? []) {
+            declared.push({ path: commandPath, option });
+        }
+        if (isCliCommandGroup(node)) {
+            declared.push(...listCommandOptions(node.subcommands, commandPath));
+        }
+    }
+    return declared;
+}
+
+function matchesFlag(option: CliCommandOption, long?: string, short?: string): boolean {
+    const parsed = parseOptionFlags(option);
+    return (long != null && parsed.long === long) || (short != null && parsed.short === short);
+}
+
+/**
+ * Two options can share a value only when they agree on whether a value
+ * follows the flag. Otherwise the shared option would eat the flag and leave
+ * the other command's value stranded as a stray argument.
+ */
+function takesSameValue(a: CliCommandOption, b: CliCommandOption): boolean {
+    return /[<[]/.test(buildOptionFlags(a)) === /[<[]/.test(buildOptionFlags(b));
 }

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -8,20 +8,22 @@ import {
     CliCommandOption,
     isCliCommandGroup,
 } from './cli-command-definition';
-import { buildOptionFlags, describeOption, ParsedCliOption, parseOptionFlags } from './cli-command-options';
+import { describeOption, ParsedCliOption, parseOptionFlags } from './cli-command-options';
 import { CliPlugin, normalizeCommandPath } from './cli-plugin';
 
 /**
  * Flags the CLI host owns. A plugin that took one of these would break
  * `vendure --help`, which is how a user recovers from a bad plugin.
  */
-const RESERVED_FLAGS = ['--help', '-h', '--version', '-V'];
+export const RESERVED_FLAGS = ['--help', '-h', '--version', '-V'];
 
 /**
  * Commands the CLI host owns. `plugins` is how a user disables a plugin that
- * misbehaves, so no plugin may replace or extend it.
+ * misbehaves and `help` is how they find it, so no plugin may replace or
+ * extend either. Commander adds `help` implicitly, so the registry would not
+ * otherwise see a collision.
  */
-const RESERVED_COMMANDS = ['plugins'];
+const RESERVED_COMMANDS = ['plugins', 'help'];
 
 interface RegisteredCommand {
     node: CliCommandNode;
@@ -49,10 +51,7 @@ interface RegistryState {
  * plugin, so one plugin cannot make the rest of the CLI unusable.
  */
 export class CliPluginRegistrationError extends Error {
-    constructor(
-        readonly pluginId: string,
-        readonly conflicts: string[],
-    ) {
+    constructor(readonly conflicts: string[]) {
         super(
             `${conflicts.length === 1 ? 'Conflict' : 'Conflicts'}:\n${conflicts.map(c => `  - ${c}`).join('\n')}`,
         );
@@ -69,23 +68,17 @@ export class CommandRegistry {
     private state: RegistryState = { commands: new Map(), rootOptions: new Map() };
 
     /**
-     * Registers built-in or plugin commands. When a command name already
-     * exists, it is replaced and a short notice is written to stderr.
+     * Registers the built-in commands. Plugins go through {@link applyPlugin},
+     * which is the only path that enforces the collision rules.
      */
-    registerAll(commands: CliCommandNode[], source?: string): void {
+    registerAll(commands: CliCommandNode[]): void {
         for (const command of commands) {
-            this.register(command, source);
+            this.register(command);
         }
     }
 
-    register(command: CliCommandNode, source?: string): void {
-        if (this.state.commands.has(command.name) && source) {
-            // Not dim: this is the main signal that a built-in (or earlier
-            // plugin) command was overridden, and precedence follows
-            // vendure.cli.plugins order (last enabled plugin wins).
-            process.stderr.write(pc.yellow(`Replaced command "${command.name}" via ${source}\n`));
-        }
-        this.state.commands.set(command.name, { node: command, source, extendedBy: [] });
+    register(command: CliCommandNode): void {
+        this.state.commands.set(command.name, { node: command, extendedBy: [] });
     }
 
     /**
@@ -94,8 +87,8 @@ export class CommandRegistry {
      *
      * Everything is applied to a draft first. If any part of the plugin
      * collides with what is already registered, {@link CliPluginRegistrationError}
-     * is thrown and the draft is discarded, so a plugin is never applied by
-     * halves.
+     * is thrown and the draft is discarded, so a plugin's commands and options
+     * are either all registered or none are.
      */
     applyPlugin(plugin: CliPlugin): void {
         const draft: RegistryState = {
@@ -116,7 +109,7 @@ export class CommandRegistry {
         }
 
         if (conflicts.length > 0) {
-            throw new CliPluginRegistrationError(plugin.id, conflicts);
+            throw new CliPluginRegistrationError(conflicts);
         }
 
         this.state = draft;
@@ -225,8 +218,27 @@ function draftCommand(
     }
 
     for (const declared of listCommandOptions([node])) {
-        const shared = findRootOption(draft, parseOptionFlags(declared.option));
-        if (shared && !takesSameValue(shared.option, declared.option)) {
+        const parsed = parseOptionFlags(declared.option);
+        for (const flag of [parsed.long, parsed.short]) {
+            if (flag && RESERVED_FLAGS.includes(flag)) {
+                conflicts.push(
+                    `Option "${describeOption(declared.option)}" on "vendure ${declared.path.join(' ')}" ` +
+                        `uses "${flag}", which is reserved by the CLI.`,
+                );
+            }
+        }
+        const shared = findRootOption(draft, parsed);
+        if (!shared) {
+            continue;
+        }
+        if (declared.isGroupOption) {
+            conflicts.push(
+                `Option "${describeOption(declared.option)}" on the command group ` +
+                    `"vendure ${declared.path.join(' ')}" is already a shared option registered by ` +
+                    `${shared.source ?? 'the CLI'}. A group shares its options with everything below it, ` +
+                    `so the same flag cannot be shared at two levels.`,
+            );
+        } else if (!takesSameValue(shared.option, declared.option)) {
             conflicts.push(
                 `Option "${describeOption(declared.option)}" on "vendure ${declared.path.join(' ')}" is not ` +
                     `compatible with the shared option "${describeOption(shared.option)}" registered by ` +
@@ -279,11 +291,7 @@ function draftExtension(
                 `subcommands instead.`,
         );
     }
-    if (targetIsGroup && extension.arguments?.length) {
-        conflicts.push(`"vendure ${label}" is a command group and takes no positional arguments.`);
-    }
-
-    const contributors = [entry.source ?? 'the CLI', ...entry.extendedBy].join(', ');
+    const inheritedShared = ancestorSharedOptions(draft, path);
     for (const option of extension.options ?? []) {
         const parsed = parseOptionFlags(option);
         for (const flag of [parsed.long, parsed.short]) {
@@ -296,30 +304,26 @@ function draftExtension(
         }
         const clash = (target.options ?? []).find(existing => isSameOption(existing, parsed));
         if (clash) {
-            conflicts.push(
-                `Option "${describeOption(option)}" is already declared on "vendure ${label}" ` +
-                    `(contributed by ${contributors}).`,
-            );
+            conflicts.push(`Option "${describeOption(option)}" is already declared on "vendure ${label}".`);
         }
+        const inherited = inheritedShared.find(existing => isSameOption(existing, parsed));
         const shared = findRootOption(draft, parsed);
-        if (shared && !takesSameValue(shared.option, option)) {
+        const sharedOption = shared?.option ?? inherited;
+        if (!sharedOption) {
+            continue;
+        }
+        if (targetIsGroup) {
+            conflicts.push(
+                `Option "${describeOption(option)}" added to the command group "vendure ${label}" is ` +
+                    `already a shared option ("${describeOption(sharedOption)}"). A group shares its ` +
+                    `options with everything below it, so the same flag cannot be shared at two levels.`,
+            );
+        } else if (!takesSameValue(sharedOption, option)) {
             conflicts.push(
                 `Option "${describeOption(option)}" added to "vendure ${label}" is not compatible with ` +
-                    `the shared option "${describeOption(shared.option)}" registered by ` +
-                    `${shared.source ?? 'the CLI'}: one takes a value and the other does not.`,
+                    `the shared option "${describeOption(sharedOption)}": one takes a value and the ` +
+                    `other does not.`,
             );
-        }
-    }
-
-    if (!targetIsGroup) {
-        const existingArguments = target.arguments ?? [];
-        for (const argument of extension.arguments ?? []) {
-            if (existingArguments.some(existing => existing.name === argument.name)) {
-                conflicts.push(
-                    `Argument "${argument.name}" is already declared on "vendure ${label}" ` +
-                        `(contributed by ${contributors}).`,
-                );
-            }
         }
     }
 
@@ -363,12 +367,10 @@ function extendNode(target: CliCommandNode, extension: CliCommandExtension): Cli
         return { ...target, description, options: options.length > 0 ? options : undefined };
     }
 
-    const commandArguments = [...(target.arguments ?? []), ...(extension.arguments ?? [])];
     const command: CliCommandDefinition = {
         ...target,
         description,
         options: options.length > 0 ? options : undefined,
-        arguments: commandArguments.length > 0 ? commandArguments : undefined,
     };
 
     if (!extension.decorate) {
@@ -392,6 +394,11 @@ function findNodeAtPath(node: CliCommandNode, path: string[]): CliCommandNode | 
     return child && findNodeAtPath(child, path.slice(1));
 }
 
+/**
+ * Rebuilds the tree with the node at `path` replaced. The caller must have
+ * resolved `path` with {@link findNodeAtPath} first, which is what guarantees
+ * every node above the replacement is a group.
+ */
 function replaceNodeAtPath(
     node: CliCommandNode,
     path: string[],
@@ -415,21 +422,43 @@ function findRootOption(draft: RegistryState, parsed: ParsedCliOption): Register
     return Array.from(draft.rootOptions.values()).find(entry => isSameOption(entry.option, parsed));
 }
 
-function listCommandOptions(
-    nodes: CliCommandNode[],
-    path: string[] = [],
-): Array<{ path: string[]; option: CliCommandOption }> {
-    const declared: Array<{ path: string[]; option: CliCommandOption }> = [];
+interface DeclaredOption {
+    path: string[];
+    option: CliCommandOption;
+    /** Group options are shared with every command below them. */
+    isGroupOption: boolean;
+}
+
+function listCommandOptions(nodes: CliCommandNode[], path: string[] = []): DeclaredOption[] {
+    const declared: DeclaredOption[] = [];
     for (const node of nodes) {
         const commandPath = [...path, node.name];
+        const isGroupOption = isCliCommandGroup(node);
         for (const option of node.options ?? []) {
-            declared.push({ path: commandPath, option });
+            declared.push({ path: commandPath, option, isGroupOption });
         }
         if (isCliCommandGroup(node)) {
             declared.push(...listCommandOptions(node.subcommands, commandPath));
         }
     }
     return declared;
+}
+
+/**
+ * Options shared with the command at `path` by the groups above it. Together
+ * with the root options these are the shared options in scope there.
+ */
+function ancestorSharedOptions(draft: RegistryState, path: string[]): CliCommandOption[] {
+    const options: CliCommandOption[] = [];
+    let node = draft.commands.get(path[0])?.node;
+    for (let i = 0; i < path.length - 1 && node; i++) {
+        if (!isCliCommandGroup(node)) {
+            break;
+        }
+        options.push(...(node.options ?? []));
+        node = node.subcommands.find(subcommand => subcommand.name === path[i + 1]);
+    }
+    return options;
 }
 
 /**
@@ -452,5 +481,5 @@ function isSameOption(option: CliCommandOption, other: ParsedCliOption): boolean
  * the other command's value stranded as a stray argument.
  */
 function takesSameValue(a: CliCommandOption, b: CliCommandOption): boolean {
-    return /[<[]/.test(buildOptionFlags(a)) === /[<[]/.test(buildOptionFlags(b));
+    return parseOptionFlags(a).takesValue === parseOptionFlags(b).takesValue;
 }

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -78,9 +78,9 @@ interface RegistryState {
  */
 export class CliPluginRegistrationError extends Error {
     constructor(readonly conflicts: string[]) {
-        super(
-            `${conflicts.length === 1 ? 'Conflict' : 'Conflicts'}:\n${conflicts.map(c => `  - ${c}`).join('\n')}`,
-        );
+        const heading = conflicts.length === 1 ? 'Conflict' : 'Conflicts';
+        const bullets = conflicts.map(conflict => `  - ${conflict}`).join('\n');
+        super(`${heading}:\n${bullets}`);
         this.name = 'CliPluginRegistrationError';
     }
 }
@@ -263,13 +263,31 @@ function draftCommand(
         return;
     }
 
+    conflicts.push(...commandOptionConflicts(draft, node));
+
+    if (conflicts.length > before) {
+        return;
+    }
+    if (existing) {
+        notices.push(`Replaced command "${node.name}" via ${source}\n`);
+    }
+    draft.commands.set(node.name, { node, source, extendedBy: [], describedBy: {} });
+}
+
+/**
+ * Checks every option a new command tree declares, at any depth, against the
+ * flags the CLI owns and the options already shared at the root.
+ */
+function commandOptionConflicts(draft: RegistryState, node: CliCommandNode): string[] {
+    const conflicts: string[] = [];
     for (const declared of listCommandOptions([node])) {
         const parsed = parseOptionFlags(declared.option);
+        const where = `"vendure ${declared.path.join(' ')}"`;
         for (const flag of [parsed.long, parsed.short]) {
             if (flag && RESERVED_FLAGS.includes(flag)) {
                 conflicts.push(
-                    `Option "${describeOption(declared.option)}" on "vendure ${declared.path.join(' ')}" ` +
-                        `uses "${flag}", which is reserved by the CLI.`,
+                    `Option "${describeOption(declared.option)}" on ${where} uses "${flag}", which is ` +
+                        `reserved by the CLI.`,
                 );
             }
         }
@@ -279,26 +297,19 @@ function draftCommand(
         }
         if (declared.isGroupOption) {
             conflicts.push(
-                `Option "${describeOption(declared.option)}" on the command group ` +
-                    `"vendure ${declared.path.join(' ')}" is already a shared option registered by ` +
-                    `${shared.source ?? 'the CLI'}. ${GROUP_SHARING_EXPLANATION}`,
+                `Option "${describeOption(declared.option)}" on the command group ${where} is already ` +
+                    `a shared option registered by ${shared.source ?? 'the CLI'}. ` +
+                    `${GROUP_SHARING_EXPLANATION}`,
             );
         } else if (!takesSameValue(shared.option, declared.option)) {
             conflicts.push(
-                `Option "${describeOption(declared.option)}" on "vendure ${declared.path.join(' ')}" is not ` +
-                    `compatible with the shared option "${describeOption(shared.option)}" registered by ` +
+                `Option "${describeOption(declared.option)}" on ${where} is not compatible with the ` +
+                    `shared option "${describeOption(shared.option)}" registered by ` +
                     `${shared.source ?? 'the CLI'}: one takes a value and the other does not.`,
             );
         }
     }
-
-    if (conflicts.length > before) {
-        return;
-    }
-    if (existing) {
-        notices.push(`Replaced command "${node.name}" via ${source}\n`);
-    }
-    draft.commands.set(node.name, { node, source, extendedBy: [], describedBy: {} });
+    return conflicts;
 }
 
 function draftExtension(
@@ -327,72 +338,13 @@ function draftExtension(
         return;
     }
 
-    const targetIsGroup = isCliCommandGroup(target);
-    if (targetIsGroup && extension.decorate) {
+    if (isCliCommandGroup(target) && extension.decorate) {
         conflicts.push(
             `"vendure ${label}" is a command group and has no action to decorate. Extend one of its ` +
                 `subcommands instead.`,
         );
     }
-    const inheritedShared = ancestorSharedOptions(draft, path);
-    // Extending a group shares the option with everything below it, so the
-    // subtree matters as much as the ancestors.
-    const descendantShared = targetIsGroup ? descendantGroupOptions(target, path) : [];
-    const descendantLeaf = targetIsGroup ? descendantLeafOptions(target, path) : [];
-    const targetOptions = withSubOptions(target.options ?? []);
-    for (const option of withSubOptions(extension.options ?? [])) {
-        const parsed = parseOptionFlags(option);
-        for (const flag of [parsed.long, parsed.short]) {
-            if (flag && RESERVED_FLAGS.includes(flag)) {
-                conflicts.push(
-                    `Option "${describeOption(option)}" added to "vendure ${label}" uses "${flag}", ` +
-                        `which is reserved by the CLI.`,
-                );
-            }
-        }
-        const clash = targetOptions.find(existing => isSameOption(existing, parsed));
-        if (clash) {
-            conflicts.push(`Option "${describeOption(option)}" is already declared on "vendure ${label}".`);
-        }
-        const descendant = descendantShared.find(existing => isSameOption(existing.option, parsed));
-        if (descendant) {
-            conflicts.push(
-                `Option "${describeOption(option)}" added to the command group "vendure ${label}" is ` +
-                    `already shared by "vendure ${descendant.path.join(' ')}" below it. ${GROUP_SHARING_EXPLANATION}`,
-            );
-            continue;
-        }
-        const leafBelow = descendantLeaf.find(
-            existing => isSameOption(existing.option, parsed) && !takesSameValue(existing.option, option),
-        );
-        if (leafBelow) {
-            conflicts.push(
-                `Option "${describeOption(option)}" added to the command group "vendure ${label}" is not ` +
-                    `compatible with "${describeOption(leafBelow.option)}" on ` +
-                    `"vendure ${leafBelow.path.join(' ')}" below it: one takes a value and the other ` +
-                    `does not.`,
-            );
-            continue;
-        }
-        const inherited = inheritedShared.find(existing => isSameOption(existing, parsed));
-        const shared = findRootOption(draft, parsed);
-        const sharedOption = shared?.option ?? inherited;
-        if (!sharedOption) {
-            continue;
-        }
-        if (targetIsGroup) {
-            conflicts.push(
-                `Option "${describeOption(option)}" added to the command group "vendure ${label}" is ` +
-                    `already a shared option ("${describeOption(sharedOption)}"). ${GROUP_SHARING_EXPLANATION}`,
-            );
-        } else if (!takesSameValue(sharedOption, option)) {
-            conflicts.push(
-                `Option "${describeOption(option)}" added to "vendure ${label}" is not compatible with ` +
-                    `the shared option "${describeOption(sharedOption)}": one takes a value and the ` +
-                    `other does not.`,
-            );
-        }
-    }
+    conflicts.push(...extensionOptionConflicts(draft, extension, target, path));
 
     if (conflicts.length > before) {
         return;
@@ -423,10 +375,89 @@ function draftExtension(
 }
 
 /**
- * Builds the extended command. The original definition is never mutated, so
- * `builtinCommands.<name>.action` keeps pointing at the original
- * implementation and each decorator wraps only what was registered before it.
+ * Checks each option an extension adds against the flags the CLI owns, the
+ * target's own options, and the options shared by the groups above and below
+ * it.
  */
+function extensionOptionConflicts(
+    draft: RegistryState,
+    extension: CliCommandExtension,
+    target: CliCommandNode,
+    path: string[],
+): string[] {
+    const label = path.join(' ');
+    const targetIsGroup = isCliCommandGroup(target);
+    const scope = {
+        // Extending a group shares the option with everything below it, so the
+        // subtree matters as much as the ancestors.
+        ancestors: ancestorSharedOptions(draft, path),
+        descendantGroups: targetIsGroup ? descendantGroupOptions(target, path) : [],
+        descendantLeaves: targetIsGroup ? descendantLeafOptions(target, path) : [],
+        own: withSubOptions(target.options ?? []),
+    };
+
+    const conflicts: string[] = [];
+    for (const option of withSubOptions(extension.options ?? [])) {
+        const parsed = parseOptionFlags(option);
+        const name = describeOption(option);
+        const group = `the command group "vendure ${label}"`;
+
+        for (const flag of [parsed.long, parsed.short]) {
+            if (flag && RESERVED_FLAGS.includes(flag)) {
+                conflicts.push(
+                    `Option "${name}" added to "vendure ${label}" uses "${flag}", which is reserved by ` +
+                        `the CLI.`,
+                );
+            }
+        }
+        if (scope.own.some(existing => isSameOption(existing, parsed))) {
+            conflicts.push(`Option "${name}" is already declared on "vendure ${label}".`);
+        }
+
+        const descendantGroup = scope.descendantGroups.find(existing =>
+            isSameOption(existing.option, parsed),
+        );
+        if (descendantGroup) {
+            conflicts.push(
+                `Option "${name}" added to ${group} is already shared by ` +
+                    `"vendure ${descendantGroup.path.join(' ')}" below it. ${GROUP_SHARING_EXPLANATION}`,
+            );
+            continue;
+        }
+
+        const leafBelow = scope.descendantLeaves.find(
+            existing => isSameOption(existing.option, parsed) && !takesSameValue(existing.option, option),
+        );
+        if (leafBelow) {
+            conflicts.push(
+                `Option "${name}" added to ${group} is not compatible with ` +
+                    `"${describeOption(leafBelow.option)}" on "vendure ${leafBelow.path.join(' ')}" ` +
+                    `below it: one takes a value and the other does not.`,
+            );
+            continue;
+        }
+
+        const sharedOption =
+            findRootOption(draft, parsed)?.option ??
+            scope.ancestors.find(existing => isSameOption(existing, parsed));
+        if (!sharedOption) {
+            continue;
+        }
+        if (targetIsGroup) {
+            conflicts.push(
+                `Option "${name}" added to ${group} is already a shared option ` +
+                    `("${describeOption(sharedOption)}"). ${GROUP_SHARING_EXPLANATION}`,
+            );
+        } else if (!takesSameValue(sharedOption, option)) {
+            conflicts.push(
+                `Option "${name}" added to "vendure ${label}" is not compatible with the shared option ` +
+                    `"${describeOption(sharedOption)}": one takes a value and the other does not.`,
+            );
+        }
+    }
+    return conflicts;
+}
+
 function extendNode(target: CliCommandNode, extension: CliCommandExtension): CliCommandNode {
     const options = [...(target.options ?? []), ...(extension.options ?? [])];
     const description = extension.description ?? target.description;
@@ -448,7 +479,7 @@ function extendNode(target: CliCommandNode, extension: CliCommandExtension): Cli
     // extension `target.options` is the array the built-in module exports.
     const action = extension.decorate({ command: freezeCommand(target), next: target.action });
     if (typeof action !== 'function') {
-        throw new Error('decorate must return an action function');
+        throw new TypeError('decorate must return an action function');
     }
     return { ...command, action };
 }

--- a/packages/cli/src/shared/command-registry.spec.ts
+++ b/packages/cli/src/shared/command-registry.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { runCli } from './__tests__/run-cli';
 import {
@@ -17,6 +17,10 @@ interface RecordedCall {
 }
 
 const calls: RecordedCall[] = [];
+
+beforeEach(() => {
+    calls.length = 0;
+});
 
 /**
  * A leaf that records what the host handed to it. The context is always the
@@ -101,10 +105,6 @@ function cloudCommands(): CliCommandNode[] {
 }
 
 describe('registerCommands() with nested commands', () => {
-    afterEach(() => {
-        calls.length = 0;
-    });
-
     it('executes a two-level command', async () => {
         const result = await runCli(cloudCommands(), rootOptions, ['project', 'list']);
 
@@ -317,10 +317,6 @@ describe('registerCommands() help output', () => {
 });
 
 describe('registerCommands() error handling', () => {
-    afterEach(() => {
-        calls.length = 0;
-    });
-
     it('fails on an unknown subcommand', async () => {
         const result = await runCli(cloudCommands(), rootOptions, ['project', 'destroy']);
 

--- a/packages/cli/src/shared/command-registry.spec.ts
+++ b/packages/cli/src/shared/command-registry.spec.ts
@@ -1,0 +1,430 @@
+import { Command, CommanderError } from 'commander';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    CliCommandContext,
+    CliCommandDefinition,
+    CliCommandNode,
+    CliCommandOption,
+} from './cli-command-definition';
+import { exitCliCommand } from './cli-command-exit';
+import { registerCommands } from './command-registry';
+
+/**
+ * Thrown in place of `process.exit` so a test can observe the exit code the
+ * CLI host asked for.
+ */
+class ExitSignal extends Error {
+    constructor(readonly code: number) {
+        super(`exit ${code}`);
+    }
+}
+
+interface CliRun {
+    exitCode?: number;
+    stdout: string;
+    stderr: string;
+}
+
+/**
+ * Registers a command tree on a fresh Commander program and parses `argv`,
+ * capturing everything the host would have written or exited with.
+ */
+async function runCli(
+    commands: CliCommandNode[],
+    sharedOptions: CliCommandOption[],
+    argv: string[],
+): Promise<CliRun> {
+    let stdout = '';
+    let stderr = '';
+
+    const program = new Command();
+    program.name('vendure').exitOverride();
+    program.configureOutput({
+        writeOut: str => {
+            stdout += str;
+        },
+        writeErr: str => {
+            stderr += str;
+        },
+    });
+    registerCommands(program, commands, sharedOptions);
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new ExitSignal(code ?? 0);
+    }) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(str => {
+        stderr += String(str);
+        return true;
+    });
+
+    let exitCode: number | undefined;
+    try {
+        await program.parseAsync(['node', 'vendure', ...argv]);
+    } catch (e) {
+        if (e instanceof ExitSignal) {
+            exitCode = e.code;
+        } else if (e instanceof CommanderError) {
+            exitCode = e.exitCode;
+        } else {
+            throw e;
+        }
+    } finally {
+        exitSpy.mockRestore();
+        stderrSpy.mockRestore();
+    }
+
+    return { exitCode, stdout, stderr };
+}
+
+interface RecordedCall {
+    commandPath: string[];
+    positionals: any[];
+    options: Record<string, any>;
+    inheritedOptions: Record<string, any>;
+}
+
+const calls: RecordedCall[] = [];
+
+/**
+ * A leaf that records what the host handed to it. The context is always the
+ * final argument, after Commander's positionals, options and Command.
+ */
+function recordingLeaf(
+    name: string,
+    description: string,
+    extra: Partial<CliCommandDefinition> = {},
+): CliCommandDefinition {
+    return {
+        name,
+        description,
+        ...extra,
+        action: async (...args: any[]) => {
+            const context = args[args.length - 1] as CliCommandContext;
+            calls.push({
+                commandPath: context.commandPath,
+                positionals: args.slice(0, args.length - 3),
+                options: args[args.length - 3],
+                inheritedOptions: context.inheritedOptions,
+            });
+            return 0;
+        },
+    };
+}
+
+const rootOptions: CliCommandOption[] = [
+    { long: '--token <token>', description: 'API token', required: true },
+    { long: '--project <slug>', description: 'Target project', required: true },
+    { long: '--environment <name>', description: 'Target environment', required: true },
+    { long: '--json', description: 'Output JSON' },
+];
+
+function cloudCommands(): CliCommandNode[] {
+    return [
+        {
+            name: 'project',
+            description: 'Manage projects',
+            subcommands: [recordingLeaf('list', 'List projects')],
+        },
+        {
+            name: 'config',
+            description: 'Manage configuration',
+            options: [{ long: '--profile <name>', description: 'Configuration profile', required: true }],
+            subcommands: [
+                {
+                    name: 'server',
+                    description: 'Server configuration',
+                    subcommands: [
+                        recordingLeaf('set', 'Set a server config value', {
+                            arguments: [
+                                { name: 'key', description: 'Key', required: true },
+                                { name: 'value', description: 'Value', required: true },
+                            ],
+                        }),
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'backup',
+            description: 'Manage backups',
+            subcommands: [
+                {
+                    name: 'db',
+                    description: 'Database backups',
+                    subcommands: [recordingLeaf('list', 'List database backups')],
+                },
+            ],
+        },
+        {
+            name: 'restore',
+            description: 'Restore from a backup',
+            subcommands: [
+                recordingLeaf('db', 'Restore the database', {
+                    arguments: [{ name: 'backupId', description: 'Backup id', required: true }],
+                }),
+            ],
+        },
+    ];
+}
+
+describe('registerCommands() with nested commands', () => {
+    afterEach(() => {
+        calls.length = 0;
+    });
+
+    it('executes a two-level command', async () => {
+        const result = await runCli(cloudCommands(), rootOptions, ['project', 'list']);
+
+        expect(result.exitCode).toBe(0);
+        expect(calls[0].commandPath).toEqual(['project', 'list']);
+    });
+
+    it('executes a three-level command with positional arguments', async () => {
+        const result = await runCli(cloudCommands(), rootOptions, [
+            'config',
+            'server',
+            'set',
+            'apiPort',
+            '3001',
+        ]);
+
+        expect(result.exitCode).toBe(0);
+        expect(calls[0].commandPath).toEqual(['config', 'server', 'set']);
+        expect(calls[0].positionals).toEqual(['apiPort', '3001']);
+    });
+
+    it('executes the remaining fixture commands', async () => {
+        await runCli(cloudCommands(), rootOptions, ['backup', 'db', 'list']);
+        await runCli(cloudCommands(), rootOptions, ['restore', 'db', 'backup-42']);
+
+        expect(calls.map(call => call.commandPath)).toEqual([
+            ['backup', 'db', 'list'],
+            ['restore', 'db'],
+        ]);
+        expect(calls[1].positionals).toEqual(['backup-42']);
+    });
+
+    it('passes shared root options given before the command path', async () => {
+        await runCli(cloudCommands(), rootOptions, [
+            '--token',
+            'tok',
+            '--project',
+            'my-project',
+            '--environment',
+            'staging',
+            '--json',
+            'project',
+            'list',
+        ]);
+
+        expect(calls[0].inheritedOptions).toEqual({
+            token: 'tok',
+            project: 'my-project',
+            environment: 'staging',
+            json: true,
+        });
+    });
+
+    it('passes shared root options given after the command path', async () => {
+        await runCli(cloudCommands(), rootOptions, [
+            'backup',
+            'db',
+            'list',
+            '--token',
+            'tok',
+            '--project',
+            'my-project',
+            '--environment',
+            'prod',
+            '--json',
+        ]);
+
+        expect(calls[0].inheritedOptions).toEqual({
+            token: 'tok',
+            project: 'my-project',
+            environment: 'prod',
+            json: true,
+        });
+    });
+
+    it('takes the last value when a shared option is repeated', async () => {
+        await runCli(cloudCommands(), rootOptions, [
+            '--token',
+            'first',
+            'project',
+            'list',
+            '--token',
+            'last',
+        ]);
+
+        expect(calls[0].inheritedOptions.token).toBe('last');
+    });
+
+    it('omits shared options that were neither supplied nor defaulted', async () => {
+        await runCli(cloudCommands(), rootOptions, ['project', 'list', '--token', 'tok']);
+
+        expect(calls[0].inheritedOptions).toEqual({ token: 'tok' });
+    });
+
+    it('includes the default value of a shared option that was not supplied', async () => {
+        await runCli(
+            cloudCommands(),
+            [{ long: '--environment <name>', description: 'Environment', defaultValue: 'production' }],
+            ['project', 'list'],
+        );
+
+        expect(calls[0].inheritedOptions).toEqual({ environment: 'production' });
+    });
+
+    it('inherits a group option only within that group', async () => {
+        await runCli(cloudCommands(), rootOptions, [
+            'config',
+            'server',
+            'set',
+            'apiPort',
+            '3001',
+            '--profile',
+            'ci',
+        ]);
+        expect(calls[0].inheritedOptions.profile).toBe('ci');
+
+        const outside = await runCli(cloudCommands(), rootOptions, ['project', 'list', '--profile', 'ci']);
+        expect(outside.exitCode).toBe(1);
+        expect(outside.stderr).toContain("unknown option '--profile'");
+    });
+
+    it('separates a command own options from the shared ones', async () => {
+        const commands: CliCommandNode[] = [
+            {
+                name: 'project',
+                description: 'Manage projects',
+                subcommands: [
+                    recordingLeaf('list', 'List projects', {
+                        options: [{ long: '--limit <n>', description: 'Maximum results', required: true }],
+                    }),
+                ],
+            },
+        ];
+        await runCli(commands, rootOptions, ['project', 'list', '--limit', '5', '--token', 'tok']);
+
+        expect(calls[0].options).toEqual({ limit: '5' });
+        expect(calls[0].inheritedOptions).toEqual({ token: 'tok' });
+    });
+
+    it('gives a command its own value when it declares the same flag as a shared option', async () => {
+        const commands: CliCommandNode[] = [
+            recordingLeaf('plugins', 'Manage CLI plugins', {
+                options: [{ long: '--json', description: 'Output JSON' }],
+            }),
+        ];
+        await runCli(commands, rootOptions, ['plugins', '--json']);
+
+        expect(calls[0].options.json).toBe(true);
+        expect(calls[0].inheritedOptions.json).toBe(true);
+    });
+});
+
+describe('registerCommands() help output', () => {
+    it('lists top-level commands and shared options in root help', async () => {
+        const result = await runCli(cloudCommands(), rootOptions, ['--help']);
+
+        expect(result.stdout).toContain('--token');
+        expect(result.stdout).toContain('--json');
+        for (const name of ['project', 'config', 'backup', 'restore']) {
+            expect(result.stdout).toContain(name);
+        }
+    });
+
+    it('lists subcommands and inherited options in parent help', async () => {
+        const result = await runCli(cloudCommands(), rootOptions, ['config', '--help']);
+
+        expect(result.stdout).toContain('vendure config');
+        expect(result.stdout).toContain('server');
+        expect(result.stdout).toContain('--profile');
+        expect(result.stdout).toContain('Global Options:');
+        expect(result.stdout).toContain('--token');
+    });
+
+    it('lists the options valid at every level in leaf help', async () => {
+        const result = await runCli(cloudCommands(), rootOptions, ['config', 'server', 'set', '--help']);
+
+        expect(result.stdout).toContain('vendure config server set [options] <key> <value>');
+        expect(result.stdout).toContain('Global Options:');
+        expect(result.stdout).toContain('--profile');
+        expect(result.stdout).toContain('--token');
+    });
+
+    it('prints help and fails when a group is run without a subcommand', async () => {
+        const result = await runCli(cloudCommands(), rootOptions, ['config']);
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain('vendure config');
+        expect(result.stderr).toContain('server');
+    });
+});
+
+describe('registerCommands() error handling', () => {
+    afterEach(() => {
+        calls.length = 0;
+    });
+
+    it('fails on an unknown subcommand', async () => {
+        const result = await runCli(cloudCommands(), rootOptions, ['project', 'destroy']);
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("unknown command 'destroy'");
+        expect(calls).toHaveLength(0);
+    });
+
+    it('fails on an unknown option', async () => {
+        const result = await runCli(cloudCommands(), rootOptions, ['project', 'list', '--nope']);
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("unknown option '--nope'");
+        expect(calls).toHaveLength(0);
+    });
+
+    it('fails on a missing required argument', async () => {
+        const result = await runCli(cloudCommands(), rootOptions, ['config', 'server', 'set', 'apiPort']);
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("missing required argument 'value'");
+    });
+
+    it('uses the numeric result of an action as the exit code', async () => {
+        const commands: CliCommandNode[] = [{ name: 'fail', description: 'Fails', action: async () => 3 }];
+        const result = await runCli(commands, [], ['fail']);
+
+        expect(result.exitCode).toBe(3);
+    });
+
+    it('reports a thrown error and exits 1', async () => {
+        const commands: CliCommandNode[] = [
+            {
+                name: 'boom',
+                description: 'Throws',
+                action: async () => {
+                    throw new Error('something broke');
+                },
+            },
+        ];
+        const result = await runCli(commands, [], ['boom']);
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain('something broke');
+    });
+
+    it('honours an exit requested by exitCliCommand', async () => {
+        const commands: CliCommandNode[] = [
+            {
+                name: 'stop',
+                description: 'Stops early',
+                action: async () => exitCliCommand(2),
+            },
+        ];
+        const result = await runCli(commands, [], ['stop']);
+
+        expect(result.exitCode).toBe(2);
+    });
+});

--- a/packages/cli/src/shared/command-registry.spec.ts
+++ b/packages/cli/src/shared/command-registry.spec.ts
@@ -2,10 +2,11 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { runCli } from './__tests__/run-cli';
 import {
-    CliCommandContext,
     CliCommandDefinition,
     CliCommandNode,
     CliCommandOption,
+    readCommandContext,
+    readCommandOptions,
 } from './cli-command-definition';
 import { exitCliCommand } from './cli-command-exit';
 
@@ -36,11 +37,12 @@ function recordingLeaf(
         description,
         ...extra,
         action: async (...args: any[]) => {
-            const context = args[args.length - 1] as CliCommandContext;
+            // Uses the exported helpers, so a break in them fails these tests.
+            const context = readCommandContext(args);
             calls.push({
                 commandPath: context.commandPath,
                 positionals: args.slice(0, args.length - 3),
-                options: args[args.length - 3],
+                options: readCommandOptions(args),
                 inheritedOptions: context.inheritedOptions,
             });
             return 0;
@@ -109,6 +111,7 @@ describe('registerCommands() with nested commands', () => {
         const result = await runCli(cloudCommands(), rootOptions, ['project', 'list']);
 
         expect(result.exitCode).toBe(0);
+        expect(calls).toHaveLength(1);
         expect(calls[0].commandPath).toEqual(['project', 'list']);
     });
 

--- a/packages/cli/src/shared/command-registry.spec.ts
+++ b/packages/cli/src/shared/command-registry.spec.ts
@@ -1,6 +1,6 @@
-import { Command, CommanderError } from 'commander';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
+import { runCli } from './__tests__/run-cli';
 import {
     CliCommandContext,
     CliCommandDefinition,
@@ -8,74 +8,6 @@ import {
     CliCommandOption,
 } from './cli-command-definition';
 import { exitCliCommand } from './cli-command-exit';
-import { registerCommands } from './command-registry';
-
-/**
- * Thrown in place of `process.exit` so a test can observe the exit code the
- * CLI host asked for.
- */
-class ExitSignal extends Error {
-    constructor(readonly code: number) {
-        super(`exit ${code}`);
-    }
-}
-
-interface CliRun {
-    exitCode?: number;
-    stdout: string;
-    stderr: string;
-}
-
-/**
- * Registers a command tree on a fresh Commander program and parses `argv`,
- * capturing everything the host would have written or exited with.
- */
-async function runCli(
-    commands: CliCommandNode[],
-    sharedOptions: CliCommandOption[],
-    argv: string[],
-): Promise<CliRun> {
-    let stdout = '';
-    let stderr = '';
-
-    const program = new Command();
-    program.name('vendure').exitOverride();
-    program.configureOutput({
-        writeOut: str => {
-            stdout += str;
-        },
-        writeErr: str => {
-            stderr += str;
-        },
-    });
-    registerCommands(program, commands, sharedOptions);
-
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-        throw new ExitSignal(code ?? 0);
-    }) as never);
-    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(str => {
-        stderr += String(str);
-        return true;
-    });
-
-    let exitCode: number | undefined;
-    try {
-        await program.parseAsync(['node', 'vendure', ...argv]);
-    } catch (e) {
-        if (e instanceof ExitSignal) {
-            exitCode = e.code;
-        } else if (e instanceof CommanderError) {
-            exitCode = e.exitCode;
-        } else {
-            throw e;
-        }
-    } finally {
-        exitSpy.mockRestore();
-        stderrSpy.mockRestore();
-    }
-
-    return { exitCode, stdout, stderr };
-}
 
 interface RecordedCall {
     commandPath: string[];

--- a/packages/cli/src/shared/command-registry.spec.ts
+++ b/packages/cli/src/shared/command-registry.spec.ts
@@ -126,15 +126,18 @@ describe('registerCommands() with nested commands', () => {
         expect(calls[0].positionals).toEqual(['apiPort', '3001']);
     });
 
-    it('executes the remaining fixture commands', async () => {
+    it('executes a three-level command with no arguments', async () => {
         await runCli(cloudCommands(), rootOptions, ['backup', 'db', 'list']);
+
+        expect(calls[0].commandPath).toEqual(['backup', 'db', 'list']);
+        expect(calls[0].positionals).toEqual([]);
+    });
+
+    it('executes a two-level command with an argument', async () => {
         await runCli(cloudCommands(), rootOptions, ['restore', 'db', 'backup-42']);
 
-        expect(calls.map(call => call.commandPath)).toEqual([
-            ['backup', 'db', 'list'],
-            ['restore', 'db'],
-        ]);
-        expect(calls[1].positionals).toEqual(['backup-42']);
+        expect(calls[0].commandPath).toEqual(['restore', 'db']);
+        expect(calls[0].positionals).toEqual(['backup-42']);
     });
 
     it('passes shared root options given before the command path', async () => {
@@ -255,27 +258,44 @@ describe('registerCommands() with nested commands', () => {
         expect(calls[0].options.json).toBe(true);
         expect(calls[0].inheritedOptions.json).toBe(true);
     });
+
+    it('shares one value between a shared option and a command option of the same name', async () => {
+        // The flag written before the command is consumed by the shared option,
+        // so only the host copying it onto the command keeps both in step.
+        const commands: CliCommandNode[] = [
+            recordingLeaf('plugins', 'Manage CLI plugins', {
+                options: [{ long: '--json', description: 'Output JSON' }],
+            }),
+        ];
+        await runCli(commands, rootOptions, ['--json', 'plugins']);
+
+        expect(calls[0].options.json).toBe(true);
+        expect(calls[0].inheritedOptions.json).toBe(true);
+    });
 });
 
 describe('registerCommands() help output', () => {
     it('lists top-level commands and shared options in root help', async () => {
         const result = await runCli(cloudCommands(), rootOptions, ['--help']);
 
-        expect(result.stdout).toContain('--token');
-        expect(result.stdout).toContain('--json');
-        for (const name of ['project', 'config', 'backup', 'restore']) {
-            expect(result.stdout).toContain(name);
-        }
+        expect(result.stdout).toMatch(/^\s+--token /m);
+        expect(result.stdout).toMatch(/^\s+--json /m);
+        // Anchored on the command list: the bare words appear in descriptions
+        // and option names too, so `toContain` would pass without the commands.
+        expect(result.stdout).toMatch(/^\s+project\s+Manage projects$/m);
+        expect(result.stdout).toMatch(/^\s+config \[options\]\s+Manage configuration$/m);
+        expect(result.stdout).toMatch(/^\s+backup\s+Manage backups$/m);
+        expect(result.stdout).toMatch(/^\s+restore\s+Restore from a backup$/m);
     });
 
     it('lists subcommands and inherited options in parent help', async () => {
         const result = await runCli(cloudCommands(), rootOptions, ['config', '--help']);
 
-        expect(result.stdout).toContain('vendure config');
-        expect(result.stdout).toContain('server');
-        expect(result.stdout).toContain('--profile');
+        expect(result.stdout).toContain('Usage: vendure config');
+        expect(result.stdout).toMatch(/^\s+server\s+Server configuration$/m);
+        expect(result.stdout).toMatch(/^\s+--profile /m);
         expect(result.stdout).toContain('Global Options:');
-        expect(result.stdout).toContain('--token');
+        expect(result.stdout).toMatch(/^\s+--token /m);
     });
 
     it('lists the options valid at every level in leaf help', async () => {
@@ -283,16 +303,16 @@ describe('registerCommands() help output', () => {
 
         expect(result.stdout).toContain('vendure config server set [options] <key> <value>');
         expect(result.stdout).toContain('Global Options:');
-        expect(result.stdout).toContain('--profile');
-        expect(result.stdout).toContain('--token');
+        expect(result.stdout).toMatch(/^\s+--profile /m);
+        expect(result.stdout).toMatch(/^\s+--token /m);
     });
 
     it('prints help and fails when a group is run without a subcommand', async () => {
         const result = await runCli(cloudCommands(), rootOptions, ['config']);
 
         expect(result.exitCode).toBe(1);
-        expect(result.stderr).toContain('vendure config');
-        expect(result.stderr).toContain('server');
+        expect(result.stderr).toContain('Usage: vendure config');
+        expect(result.stderr).toMatch(/^\s+server\s+Server configuration$/m);
     });
 });
 

--- a/packages/cli/src/shared/command-registry.ts
+++ b/packages/cli/src/shared/command-registry.ts
@@ -112,28 +112,27 @@ function addOption(command: Command, option: CliCommandOption): void {
 }
 
 /**
- * Reads the value of each shared option in scope. A value supplied on the
- * command line always beats a default, whichever level declared it, so a group
- * option carrying a `defaultValue` cannot discard what the user typed.
+ * Reads the value of each shared option in scope.
+ *
+ * No two entries can share a name: registration rejects a flag shared by both
+ * a group and the root, or by a group and one of its ancestors, whichever
+ * order the plugins load in. So there is nothing here to resolve — an option
+ * has one owner, and that owner holds its value.
  */
 function readSharedValues(sharedOptions: SharedOption[]): Record<string, any> {
     const values: Record<string, any> = {};
     for (const { owner, attributeName } of sharedOptions) {
-        const source = owner.getOptionValueSource(attributeName);
-        if (source === undefined) {
-            continue;
+        if (owner.getOptionValueSource(attributeName) !== undefined) {
+            values[attributeName] = owner.getOptionValue(attributeName);
         }
-        if (source === 'default' && attributeName in values) {
-            continue;
-        }
-        values[attributeName] = owner.getOptionValue(attributeName);
     }
     return values;
 }
 
 /**
  * Commander calls an action with the positional arguments, then the parsed
- * options, then the Command.
+ * options, then the Command. This runs before the host appends the context, so
+ * the offset is one less than the exported `readCommandOptions` uses.
  */
 function commanderOptions(args: any[]): Record<string, any> {
     return args[args.length - 2] ?? {};

--- a/packages/cli/src/shared/command-registry.ts
+++ b/packages/cli/src/shared/command-registry.ts
@@ -1,8 +1,8 @@
 import { Command } from 'commander';
 
 import {
+    CliCommandAction,
     CliCommandContext,
-    CliCommandDefinition,
     CliCommandNode,
     CliCommandOption,
     isCliCommandGroup,
@@ -77,15 +77,11 @@ function registerNode(
  * passes positional args first, then the options object and the Command
  * instance; the host appends the context.
  */
-async function runAction(
-    action: CliCommandDefinition['action'],
-    args: any[],
-    context: CliCommandContext,
-): Promise<number> {
+async function runAction(action: CliCommandAction, args: any[], context: CliCommandContext): Promise<number> {
     try {
         const result = await action(...args, context);
         return typeof result === 'number' ? result : 0;
-    } catch (e: any) {
+    } catch (e) {
         if (e instanceof CliCommandExit) {
             return e.exitCode;
         }
@@ -121,12 +117,26 @@ function addOption(command: Command, option: CliCommandOption): void {
     command.option(buildOptionFlags(option), option.description, option.defaultValue);
 }
 
+/**
+ * Reads the value of each shared option in scope. A value supplied on the
+ * command line always beats a default, whichever level declared it, so a group
+ * option carrying a `defaultValue` cannot discard what the user typed.
+ */
 function readSharedValues(sharedOptions: SharedOption[]): Record<string, any> {
     const values: Record<string, any> = {};
+    const supplied = new Set<string>();
     for (const { owner, attributeName } of sharedOptions) {
-        if (owner.getOptionValueSource(attributeName) !== undefined) {
-            values[attributeName] = owner.getOptionValue(attributeName);
+        const source = owner.getOptionValueSource(attributeName);
+        if (source === undefined) {
+            continue;
         }
+        if (source === 'default' && (supplied.has(attributeName) || attributeName in values)) {
+            continue;
+        }
+        if (source !== 'default') {
+            supplied.add(attributeName);
+        }
+        values[attributeName] = owner.getOptionValue(attributeName);
     }
     return values;
 }
@@ -136,6 +146,11 @@ function readSharedValues(sharedOptions: SharedOption[]): Record<string, any> {
  * example the built-in `vendure plugins --json` when a plugin also registers a
  * shared `--json`. Commander gives the value to the shared option, so copy it
  * onto the command to keep both readings of the flag in agreement.
+ *
+ * This relies on Commander's `opts()` handing back its own `_optionValues`
+ * rather than a copy, so writing here is visible in the options object it has
+ * already passed to the action. `registerCommands() shares one value between a
+ * shared option and a command option of the same name` pins that assumption.
  */
 function fillSharedValues(command: Command, sharedOptions: SharedOption[]): void {
     for (const { owner, attributeName } of sharedOptions) {

--- a/packages/cli/src/shared/command-registry.ts
+++ b/packages/cli/src/shared/command-registry.ts
@@ -25,12 +25,6 @@ export function registerCommands(
     commands: CliCommandNode[],
     rootOptions: CliCommandOption[] = [],
 ): void {
-    // Commander accepts an option anywhere on the command line once the
-    // command that declares it has been reached, so `vendure --token X foo`
-    // and `vendure foo --token X` are equivalent. Listing those options as
-    // "Global Options" keeps subcommand help complete.
-    program.configureHelp({ showGlobalOptions: true });
-
     const sharedOptions = declareOptions(program, rootOptions);
     for (const node of commands) {
         registerNode(program, node, [], sharedOptions);
@@ -62,7 +56,7 @@ function registerNode(
     declareOptions(command, node.options ?? []);
 
     command.action(async (...args: any[]) => {
-        fillSharedValues(command, sharedOptions);
+        fillSharedValues(command, commanderOptions(args), sharedOptions);
         const context: CliCommandContext = {
             inheritedOptions: readSharedValues(sharedOptions),
             commandPath,
@@ -124,21 +118,25 @@ function addOption(command: Command, option: CliCommandOption): void {
  */
 function readSharedValues(sharedOptions: SharedOption[]): Record<string, any> {
     const values: Record<string, any> = {};
-    const supplied = new Set<string>();
     for (const { owner, attributeName } of sharedOptions) {
         const source = owner.getOptionValueSource(attributeName);
         if (source === undefined) {
             continue;
         }
-        if (source === 'default' && (supplied.has(attributeName) || attributeName in values)) {
+        if (source === 'default' && attributeName in values) {
             continue;
-        }
-        if (source !== 'default') {
-            supplied.add(attributeName);
         }
         values[attributeName] = owner.getOptionValue(attributeName);
     }
     return values;
+}
+
+/**
+ * Commander calls an action with the positional arguments, then the parsed
+ * options, then the Command.
+ */
+function commanderOptions(args: any[]): Record<string, any> {
+    return args[args.length - 2] ?? {};
 }
 
 /**
@@ -147,12 +145,15 @@ function readSharedValues(sharedOptions: SharedOption[]): Record<string, any> {
  * shared `--json`. Commander gives the value to the shared option, so copy it
  * onto the command to keep both readings of the flag in agreement.
  *
- * This relies on Commander's `opts()` handing back its own `_optionValues`
- * rather than a copy, so writing here is visible in the options object it has
- * already passed to the action. `registerCommands() shares one value between a
- * shared option and a command option of the same name` pins that assumption.
+ * The value is written into the options object Commander passed to the action,
+ * so this does not depend on `opts()` returning its internal store by
+ * reference. It is also set on the Command, for an action that reads it there.
  */
-function fillSharedValues(command: Command, sharedOptions: SharedOption[]): void {
+function fillSharedValues(
+    command: Command,
+    options: Record<string, any>,
+    sharedOptions: SharedOption[],
+): void {
     for (const { owner, attributeName } of sharedOptions) {
         const sharedSource = owner.getOptionValueSource(attributeName);
         if (sharedSource === undefined) {
@@ -165,6 +166,8 @@ function fillSharedValues(command: Command, sharedOptions: SharedOption[]): void
         if (localSource !== undefined && localSource !== 'default') {
             continue;
         }
-        command.setOptionValueWithSource(attributeName, owner.getOptionValue(attributeName), sharedSource);
+        const value = owner.getOptionValue(attributeName);
+        command.setOptionValueWithSource(attributeName, value, sharedSource);
+        options[attributeName] = value;
     }
 }

--- a/packages/cli/src/shared/command-registry.ts
+++ b/packages/cli/src/shared/command-registry.ts
@@ -1,70 +1,155 @@
 import { Command } from 'commander';
 
-import { CliCommandDefinition, CliCommandOption } from './cli-command-definition';
+import {
+    CliCommandContext,
+    CliCommandDefinition,
+    CliCommandNode,
+    CliCommandOption,
+    isCliCommandGroup,
+} from './cli-command-definition';
 import { CliCommandExit } from './cli-command-exit';
+import { buildOptionFlags, parseOptionFlags } from './cli-command-options';
 
-export function registerCommands(program: Command, commands: CliCommandDefinition[]): void {
-    commands.forEach(commandDef => {
-        const command = program.command(commandDef.name).description(commandDef.description);
+/**
+ * An option declared on an ancestor of a command. Commander stores the parsed
+ * value on the command that declares the option, so the owner is kept here to
+ * read the value back when the action runs.
+ */
+interface SharedOption {
+    attributeName: string;
+    owner: Command;
+}
 
-        // Add positional arguments if defined
-        if (commandDef.arguments) {
-            for (const arg of commandDef.arguments) {
-                const syntax = arg.required ? `<${arg.name}>` : `[${arg.name}]`;
-                command.argument(syntax, arg.description);
-            }
+export function registerCommands(
+    program: Command,
+    commands: CliCommandNode[],
+    rootOptions: CliCommandOption[] = [],
+): void {
+    // Commander accepts an option anywhere on the command line once the
+    // command that declares it has been reached, so `vendure --token X foo`
+    // and `vendure foo --token X` are equivalent. Listing those options as
+    // "Global Options" keeps subcommand help complete.
+    program.configureHelp({ showGlobalOptions: true });
+
+    const sharedOptions = declareOptions(program, rootOptions);
+    for (const node of commands) {
+        registerNode(program, node, [], sharedOptions);
+    }
+}
+
+function registerNode(
+    parent: Command,
+    node: CliCommandNode,
+    path: string[],
+    sharedOptions: SharedOption[],
+): void {
+    const command = parent.command(node.name).description(node.description);
+    const commandPath = [...path, node.name];
+
+    if (isCliCommandGroup(node)) {
+        const groupOptions = [...sharedOptions, ...declareOptions(command, node.options ?? [])];
+        for (const subcommand of node.subcommands) {
+            registerNode(command, subcommand, commandPath, groupOptions);
         }
+        // A group has no action: Commander prints its help and exits non-zero
+        // when it is run without a subcommand.
+        return;
+    }
 
-        command.action(async (...args: any[]) => {
-            // Commander passes positional args first, then the options object last.
-            // Exit is owned by the host so plugins can wrap built-in actions.
-            try {
-                const result = await commandDef.action(...args);
-                process.exit(typeof result === 'number' ? result : 0);
-            } catch (e: any) {
-                if (e instanceof CliCommandExit) {
-                    process.exit(e.exitCode);
-                }
-                const message = e?.message ?? String(e);
-                process.stderr.write(`${message}\n`);
-                process.exit(1);
-            }
-        });
+    for (const arg of node.arguments ?? []) {
+        command.argument(arg.required ? `<${arg.name}>` : `[${arg.name}]`, arg.description);
+    }
+    declareOptions(command, node.options ?? []);
 
-        // Add options if they exist
-        if (commandDef.options) {
-            commandDef.options.forEach(option => {
-                addOption(command, option);
-
-                // Add sub-options if they exist
-                if (option.subOptions) {
-                    option.subOptions.forEach(subOption => {
-                        // Create a version of the sub-option with indented description
-                        const indentedSubOption = {
-                            ...subOption,
-                            description: `  └─ ${subOption.description}`,
-                        };
-                        addOption(command, indentedSubOption);
-                    });
-                }
-            });
-        }
+    command.action(async (...args: any[]) => {
+        fillSharedValues(command, sharedOptions);
+        const context: CliCommandContext = {
+            inheritedOptions: readSharedValues(sharedOptions),
+            commandPath,
+        };
+        // Exit is owned by the host so plugins can wrap built-in actions.
+        process.exit(await runAction(node.action, args, context));
     });
 }
 
+/**
+ * Runs a command action and turns its outcome into an exit code. Commander
+ * passes positional args first, then the options object and the Command
+ * instance; the host appends the context.
+ */
+async function runAction(
+    action: CliCommandDefinition['action'],
+    args: any[],
+    context: CliCommandContext,
+): Promise<number> {
+    try {
+        const result = await action(...args, context);
+        return typeof result === 'number' ? result : 0;
+    } catch (e: any) {
+        if (e instanceof CliCommandExit) {
+            return e.exitCode;
+        }
+        process.stderr.write(`${e instanceof Error ? e.message : String(e)}\n`);
+        return 1;
+    }
+}
+
+/**
+ * Declares options on a command and describes them for any descendants, which
+ * inherit them when the command is a group or the root program.
+ */
+function declareOptions(command: Command, options: CliCommandOption[]): SharedOption[] {
+    const declared: SharedOption[] = [];
+    for (const option of options) {
+        addOption(command, option);
+        declared.push({ attributeName: parseOptionFlags(option).attributeName, owner: command });
+
+        for (const subOption of option.subOptions ?? []) {
+            // Indent the description so the help output shows the nesting.
+            const indentedSubOption = { ...subOption, description: `  └─ ${subOption.description}` };
+            addOption(command, indentedSubOption);
+            declared.push({
+                attributeName: parseOptionFlags(indentedSubOption).attributeName,
+                owner: command,
+            });
+        }
+    }
+    return declared;
+}
+
 function addOption(command: Command, option: CliCommandOption): void {
-    const parts: string[] = [];
-    if (option.short) {
-        parts.push(option.short);
+    command.option(buildOptionFlags(option), option.description, option.defaultValue);
+}
+
+function readSharedValues(sharedOptions: SharedOption[]): Record<string, any> {
+    const values: Record<string, any> = {};
+    for (const { owner, attributeName } of sharedOptions) {
+        if (owner.getOptionValueSource(attributeName) !== undefined) {
+            values[attributeName] = owner.getOptionValue(attributeName);
+        }
     }
-    parts.push(option.long);
+    return values;
+}
 
-    let optionString = parts.join(', ');
-
-    // Handle optional options which expect a value by converting <value> to [value]
-    if (!option.required) {
-        optionString = optionString.replace(/<([^>]+)>/g, '[$1]');
+/**
+ * A command may declare an option with the same flag as a shared option, for
+ * example the built-in `vendure plugins --json` when a plugin also registers a
+ * shared `--json`. Commander gives the value to the shared option, so copy it
+ * onto the command to keep both readings of the flag in agreement.
+ */
+function fillSharedValues(command: Command, sharedOptions: SharedOption[]): void {
+    for (const { owner, attributeName } of sharedOptions) {
+        const sharedSource = owner.getOptionValueSource(attributeName);
+        if (sharedSource === undefined) {
+            continue;
+        }
+        if (!command.options.some(option => option.attributeName() === attributeName)) {
+            continue;
+        }
+        const localSource = command.getOptionValueSource(attributeName);
+        if (localSource !== undefined && localSource !== 'default') {
+            continue;
+        }
+        command.setOptionValueWithSource(attributeName, owner.getOptionValue(attributeName), sharedSource);
     }
-
-    command.option(optionString, option.description, option.defaultValue);
 }


### PR DESCRIPTION
Extends the CLI plugin API added in #5139 so a plugin can register nested command trees, options shared across commands, and additions to commands another plugin already owns — without embedding a second Commander program.

## Nested commands

```ts
export default defineCliPlugin({
    id: '@example/cloud-cli-plugin',
    // Added to `vendure` itself, so every command accepts them
    rootOptions: [{ long: '--token <token>', description: 'API token', required: true }],
    commands: [
        {
            name: 'config',
            description: 'Manage configuration',
            // Shared by every command in this group
            options: [{ long: '--profile <name>', description: 'Profile', required: true }],
            subcommands: [
                {
                    name: 'server',
                    description: 'Server configuration',
                    subcommands: [
                        {
                            name: 'set',
                            description: 'Set a value',
                            arguments: [
                                { name: 'key', description: 'Key', required: true },
                                { name: 'value', description: 'Value', required: true },
                            ],
                            action: async (key, value, options, command, context) => {
                                context.inheritedOptions.token;
                                context.commandPath; // ['config', 'server', 'set']
                                return 0;
                            },
                        },
                    ],
                },
            ],
        },
    ],
});
```

- `CliCommandGroupDefinition` is a node with `subcommands` and no action. Groups nest to any depth, and running one without a subcommand prints its help and exits 1.
- `CliPlugin.rootOptions` and a group's `options` are the two shared scopes.
- `CliCommandContext` is appended after Commander's own action arguments, so a command reads shared values from `context.inheritedOptions` rather than `process.argv`. Keys are the long flag without `--`, camel-cased.

## Composing command overrides

Replacement alone cannot express what is already shipping. `vendure-platform` overrides `dev` on its `major` branch by spreading `builtinCommands.dev`, appending `--rotate-credential`, and calling `builtinCommands.dev.action`. `@vendure/cloud` will need to wrap `dev` too, and with replacement only, whichever plugin is listed last wins and the other's option and behaviour disappear.

The cause is that the wrapper binds the built-in action **statically**, at module load. Two plugins doing that both capture Core's original action, so composition is impossible by construction. `extendCommands` inverts that binding:

```ts
export default defineCliPlugin({
    id: '@example/platform-cli-plugin',
    commands: [],
    extendCommands: [
        {
            command: 'dev',
            description: 'Run Vendure in development mode with linked credentials',
            options: [{ long: '--rotate-credential', description: 'Replace the stored credential' }],
            decorate:
                ({ command, next }) =>
                async (...args) => {
                    // `command` is the command as composed so far
                    return withCredential(await resolveCredential(), () => next(...args));
                },
        },
    ],
});
```

`decorate` runs once, at registration, and receives `next` (the action of the command as composed so far) and `command` (that definition, so a plugin can see what others already contributed). Because `next` is handed in rather than imported, the second plugin wraps the first plugin's composed action instead of Core's.

**Order.** Extensions are applied in `vendure.cli.plugins` order, so the last listed plugin is the outermost wrapper and its decorator runs first. With `["@example/platform", "@example/cloud"]`, one `vendure dev` calls Cloud → Platform → the built-in, each exactly once. Reverse the list and the roles swap, including which plugin sees the other's option in its `command` argument.

**Merging.** Options are appended keeping every earlier one. An extension cannot add positional arguments: Commander allocates one action slot per declared positional, so an appended argument would shift the options, `Command` and context an existing action expects. A description replaces the one in help, and when two plugins set it the last listed wins with a stderr notice naming both. An extension can target a nested path (`['config','server','set']` or `'config server set'`), and can add options and a description to a command group, which has no action to decorate.

**Replacing vs extending.** `replaces: true` still takes a command over completely. A plugin cannot replace a command another plugin has already extended, because that would discard their contribution; listing the replacing plugin first works, and later plugins then extend the replacement.

## Shared options

Shared options are declared once, on the command that owns them. Commander already accepts an option anywhere on the command line once the declaring command has been reached, so no option is duplicated onto descendants and these are equivalent:

```bash
vendure --token abc config server set apiPort 3001
vendure config server set apiPort 3001 --token abc
```

Help stays complete at every level: the host enables Commander's `showGlobalOptions`, so a subcommand lists its own options followed by the inherited ones under `Global Options`.

Because the declaring command wins the parse, a command that declares the same flag as a shared option would otherwise never see a value. The host copies the value onto that command, so the built-in `vendure plugins --json` keeps working alongside a plugin's shared `--json`. The two must agree on whether a value follows the flag, which is checked at registration.

## Collisions

A plugin is applied to a draft first, so it is registered whole or not at all, and every conflict it causes is reported together on stderr. It is rejected when it declares:

- a top-level command name a built-in or earlier plugin already provides, without `replaces: true`;
- a replacement of a command another plugin has extended;
- an extension of a path where nothing is registered, or a `decorate` on a command group;
- an option added by an extension that the command already declares, or one that a group above or below the target already shares;
- a shared option an earlier plugin already registered, one that reads back under the same name (`--api-token` and `--apiToken` both store as `apiToken`), or one of `-h`, `--help`, `-V`, `--version`;
- a shared option that disagrees with an existing command option of the same flag about whether it takes a value;
- any command named `plugins`, replaced or extended.

A `decorate` that throws while being applied is reported the same way. Built-in commands are registered before plugins are applied, so `vendure plugins remove <package>` stays reachable whether a plugin fails to load, fails to register, or has a broken decorator.

## Behaviour changes

- Replacing an existing command now requires `replaces: true`. Previously any name match replaced silently with a stderr notice.
- The `plugins` command is reserved: no plugin may replace or extend it, because it is the documented way to disable a plugin that misbehaves.
- The program is now named `vendure` via `.name()`. Commander was deriving it from the binary filename, so subcommand help said `Usage: cli config server set ...`.

All three only affect the unreleased 3.8 API.

## Tests

- `command-registry.spec.ts`: 21 tests over a nested fixture tree — execution at two and three levels, positional arguments, shared options before and after the command path, repeated options, defaults, group scoping, root/parent/leaf help, a group run bare, unknown subcommands and options, missing arguments, exit codes.
- `command-extensions.spec.ts`: 33 tests for composition — wrapper order and once-only execution in both activation orders, option merging, what each decorator is handed, immutability of the extended definition, nested paths, and every collision and validation rule.
- `command-registry-store.spec.ts`: registration, shared-option collisions, and `defineCliPlugin` validation.
- `cli-plugin-commands.e2e-spec.ts`: 21 tests spawning the built CLI against a temporary project. Executes `project list`, `config server set`, `backup db list`, `restore db`, asserting receipt of `--token`, `--project`, `--environment` and `--json`, plus help, invalid input, both collision kinds, deliberate replacement, and recovery.
- `cli-plugin-extensions.e2e-spec.ts`: 10 tests with fixtures standing in for Platform and Cloud, both extending the real built-in `dev`. One invocation runs both wrappers and the built-in; `dev --help` shows both plugins' options alongside Core's; ordering is checked in both activation orders; a broken decorator is skipped with the other plugin intact and `vendure plugins remove` still working.

`dev bogus` drives the built-in end to end without spawning a server: the built-in rejects an unknown target, reports it through the CLI logger and returns 1.

Checked: `packages/cli` build, 424 unit tests, 81 e2e tests, eslint on the changed files with zero errors, and `bun run test:mdx` in `docs`.

## Follow-up in vendure-platform

`libs/cli/src/plugin.ts` on `major` needs to move `dev` from `commands` to `extendCommands`, and `libs/cli/src/dev-command.ts` needs `builtinAction` supplied from the decorator's `next` rather than the static `builtinCommands.dev.action` default. Details are in the issue thread; no change is required for it to keep working on the current API, since this PR is additive apart from the `replaces: true` requirement.


---

## Intended squash commit body

The branch commits predate the review that asked for this and are not being rewritten. The squash commit that lands on `minor` should carry:

```
feat(cli): add nested command trees, shared options and command extensions to the plugin API

Extends the CLI plugin API added in #5139 so a plugin can register nested
command trees, options shared across commands, and additions to commands
another plugin already owns.

Relates to #5264
```

This work tracks Linear CLO-637; there is no GitHub issue for it, so there is nothing for `Fixes #N` to reference. #5264 is the spec-file typechecking gap this PR uncovered, filed separately. Open to opening a tracking issue instead if a `Fixes` line is wanted — see the review thread.

