### PR TITLE
fix(core): allow sorting by localeText custom fields (#5199)

### DIFF
--- a/packages/core/src/service/helpers/list-query-builder/parse-sort-params.spec.ts
+++ b/packages/core/src/service/helpers/list-query-builder/parse-sort-params.spec.ts
@@ -116,6 +116,30 @@ describe('parseSortParams()', () => {
         });
     });
 
+    it('works with localized custom fields of type localeText', () => {
+        const connection = new MockConnection();
+        connection.setColumns(Product, [{ propertyName: 'id' }]);
+        connection.setRelations(Product, [{ propertyName: 'translations', type: ProductTranslation }]);
+        connection.setColumns(ProductTranslation, [{ propertyName: 'id' }, { propertyName: 'summary' }]);
+
+        const sortParams: SortParameter<Product & { summary: any }> = {
+            summary: 'ASC',
+        };
+        const productCustomFields: CustomFieldConfig[] = [{ name: 'summary', type: 'localeText' }];
+
+        const result = parseSortParams(
+            connection as any,
+            Product,
+            sortParams,
+            {},
+            undefined,
+            productCustomFields,
+        );
+        expect(result).toEqual({
+            'product__translations.customFields.summary': 'ASC',
+        });
+    });
+
     it('throws if an invalid field is passed', () => {
         const connection = new MockConnection();
         connection.setColumns(Product, [{ propertyName: 'id' }, { propertyName: 'image' }]);

--- a/packages/core/src/service/helpers/list-query-builder/parse-sort-params.ts
+++ b/packages/core/src/service/helpers/list-query-builder/parse-sort-params.ts
@@ -46,9 +46,10 @@ export function parseSortParams<T extends VendureEntity>(
             const translationsAlias = connection.namingStrategy.joinTableName(alias, 'translations', '', '');
 
             const pathParts = [translationsAlias];
-            const isLocaleStringCustomField =
-                customFields?.find(f => f.name === key)?.type === 'localeString';
-            if (isLocaleStringCustomField) {
+            const customFieldDef = customFields?.find(f => f.name === key);
+            const isLocalizedCustomField =
+                customFieldDef?.type === 'localeString' || customFieldDef?.type === 'localeText';
+            if (isLocalizedCustomField) {
                 pathParts.push('customFields');
             }
             pathParts.push(key);


### PR DESCRIPTION
# Description

Fixes #5199.

### Problem
In `packages/core/src/service/helpers/list-query-builder/parse-sort-params.ts`, sorting paths on localized custom fields only appended `customFields` if the field definition was strictly `type === 'localeString'`. For `localeText` custom fields, `customFields` was omitted, resolving to an invalid column path like `product__translations.summary` instead of `product__translations.customFields.summary`. TypeORM subsequently threw `TypeError: Cannot read properties of undefined (reading 'databaseName')`.

### Solution
- Checked for both `localeString` and `localeText` custom fields when constructing localized translation sort paths.
- Added a unit test in `packages/core/src/service/helpers/list-query-builder/parse-sort-params.spec.ts` verifying that sorting on `localeText` custom fields resolves correctly to the `customFields.<name>` column path.

# Breaking changes

None.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791145966&installation_model_id=20193&pr_number=5266&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5266&signature=f670861c1545e9d99f2b45489c0adb78640fec94d692c9a71b9302a5c550b816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->