### PR TITLE
feat(core): allow field resolver enhancers to be configured

### DIFF
--- a/docs/docs/guides/developer-guide/the-api-layer/index.mdx
+++ b/docs/docs/guides/developer-guide/the-api-layer/index.mdx
@@ -196,6 +196,14 @@ export const config: VendureConfig = {
 };
 ```
 
+:::note
+Guards are the only enhancer applied to field resolvers (those declared with `@ResolveField()`) by default,
+so a globally-registered interceptor or exception filter will not fire when a field resolver runs. If you
+need it to, opt in with the
+[`apiOptions.fieldResolverEnhancers`](/reference/typescript-api/configuration/api-options#fieldresolverenhancers)
+config property.
+:::
+
 
 
 ### Apollo Server plugins

--- a/docs/docs/reference/typescript-api/configuration/api-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/api-options.mdx
@@ -2,7 +2,7 @@
 title: "ApiOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="84" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="85" packageName="@vendure/core" />
 
 The ApiOptions define how the Vendure GraphQL APIs are exposed, as well as allowing the API layer
 to be extended with middleware.
@@ -27,6 +27,7 @@ interface ApiOptions {
     middleware?: Middleware[];
     trustProxy?: TrustProxyOptions;
     apolloServerPlugins?: ApolloServerPlugin[];
+    fieldResolverEnhancers?: Enhancer[];
     introspection?: boolean;
     inputValidation?: {
         /**
@@ -217,6 +218,37 @@ allow the extension of the Apollo Server, which is the underlying GraphQL server
 
 Apollo plugins can be used e.g. to perform custom data transformations on incoming operations or outgoing
 data.
+### fieldResolverEnhancers
+
+<MemberInfo kind="property" type={`Enhancer[]`} default={`['guards']`}  since="3.8.0"  />
+
+Controls which NestJS enhancers are applied to GraphQL field resolvers, i.e. resolvers
+declared with `@ResolveField()`. The value is passed through to the `@nestjs/graphql`
+module option of the same name, and applies to both the Shop API and the Admin API.
+
+The default of `['guards']` is what makes the [Allow](/reference/typescript-api/request/allow-decorator#allow) decorator work on a field
+resolver. Interceptors and exception filters are left out because a field resolver runs
+once per resolved field rather than once per operation, so a list query which resolves the
+field on each of 100 items would run every global interceptor 100 extra times.
+
+The consequence of that default is easy to miss: an interceptor registered by a plugin
+with Nest's `APP_INTERCEPTOR` token (or an exception filter registered with `APP_FILTER`)
+runs for top-level queries and mutations only. On a `@ResolveField()` resolver it never
+fires, and nothing is logged to say so. Add `'interceptors'` if a plugin of yours depends
+on one seeing field resolution.
+
+Note that enabling an enhancer here also enables Vendure's own interceptors and exception
+filter on every resolved field, so measure the effect on your heaviest list queries.
+
+*Example*
+
+```ts
+const config: VendureConfig = {
+  apiOptions: {
+    fieldResolverEnhancers: ['guards', 'interceptors'],
+  },
+};
+```
 ### introspection
 
 <MemberInfo kind="property" type={`boolean`} default={`true`}  since="1.5.0"  />

--- a/packages/core/e2e/field-resolver-enhancers.e2e-spec.ts
+++ b/packages/core/e2e/field-resolver-enhancers.e2e-spec.ts
@@ -1,0 +1,96 @@
+import { mergeConfig } from '@vendure/core';
+import { createTestEnvironment, SimpleGraphQLClient } from '@vendure/testing';
+import gql from 'graphql-tag';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { initialData } from '../../../e2e-common/e2e-initial-data';
+import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
+
+import { GlobalInterceptorPlugin } from './fixtures/test-plugins/with-global-interceptor';
+
+const GET_PRODUCT_WITH_PROBE = gql`
+    query GetProductWithProbe {
+        products(options: { take: 1 }) {
+            items {
+                id
+                interceptorProbe
+            }
+        }
+    }
+`;
+
+const GET_INTERCEPTED_FIELDS = gql`
+    query GetInterceptedFields {
+        interceptedFields
+    }
+`;
+
+/**
+ * Resolves the probe field on a Product and returns the list of `Type.field` pairs which the
+ * plugin's global APP_INTERCEPTOR was invoked for.
+ */
+async function resolveProbeAndGetInterceptedFields(adminClient: SimpleGraphQLClient) {
+    const { products } = await adminClient.query(GET_PRODUCT_WITH_PROBE);
+    expect(products.items[0].interceptorProbe).toBe('probed');
+
+    const { interceptedFields } = await adminClient.query(GET_INTERCEPTED_FIELDS);
+    return interceptedFields as string[];
+}
+
+describe('apiOptions.fieldResolverEnhancers (default)', () => {
+    const { server, adminClient } = createTestEnvironment(
+        mergeConfig(testConfig(), { plugins: [GlobalInterceptorPlugin] }),
+    );
+
+    beforeAll(async () => {
+        await server.init({
+            initialData,
+            productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-minimal.csv'),
+            customerCount: 1,
+        });
+        await adminClient.asSuperAdmin();
+    }, TEST_SETUP_TIMEOUT_MS);
+
+    afterAll(async () => {
+        await server.destroy();
+    });
+
+    it('does not run a global interceptor for a field resolver', async () => {
+        const interceptedFields = await resolveProbeAndGetInterceptedFields(adminClient);
+
+        expect(interceptedFields).toContain('Query.products');
+        expect(interceptedFields).not.toContain('Product.interceptorProbe');
+    });
+});
+
+describe('apiOptions.fieldResolverEnhancers with "interceptors"', () => {
+    const { server, adminClient } = createTestEnvironment(
+        mergeConfig(testConfig(), {
+            apiOptions: {
+                fieldResolverEnhancers: ['guards', 'interceptors'],
+            },
+            plugins: [GlobalInterceptorPlugin],
+        }),
+    );
+
+    beforeAll(async () => {
+        await server.init({
+            initialData,
+            productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-minimal.csv'),
+            customerCount: 1,
+        });
+        await adminClient.asSuperAdmin();
+    }, TEST_SETUP_TIMEOUT_MS);
+
+    afterAll(async () => {
+        await server.destroy();
+    });
+
+    it('runs a global interceptor for a field resolver', async () => {
+        const interceptedFields = await resolveProbeAndGetInterceptedFields(adminClient);
+
+        expect(interceptedFields).toContain('Query.products');
+        expect(interceptedFields).toContain('Product.interceptorProbe');
+    });
+});

--- a/packages/core/e2e/fixtures/test-plugins/with-global-interceptor.ts
+++ b/packages/core/e2e/fixtures/test-plugins/with-global-interceptor.ts
@@ -1,0 +1,70 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { GqlContextType, GqlExecutionContext, Query, ResolveField, Resolver } from '@nestjs/graphql';
+import { VendurePlugin } from '@vendure/core';
+import { GraphQLResolveInfo } from 'graphql';
+import gql from 'graphql-tag';
+import { Observable } from 'rxjs';
+
+/**
+ * Records the `Type.field` of every GraphQL resolver which the interceptor below was
+ * invoked for, so that a test can assert whether or not field resolvers were included.
+ */
+@Injectable()
+export class InterceptedFieldLog {
+    readonly intercepted: string[] = [];
+}
+
+@Injectable()
+export class RecordingInterceptor implements NestInterceptor {
+    constructor(private log: InterceptedFieldLog) {}
+
+    intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+        if (context.getType<GqlContextType>() === 'graphql') {
+            const info = GqlExecutionContext.create(context).getInfo<GraphQLResolveInfo>();
+            this.log.intercepted.push(`${info.parentType.name}.${info.fieldName}`);
+        }
+        return next.handle();
+    }
+}
+
+@Resolver()
+export class InterceptedFieldsQueryResolver {
+    constructor(private log: InterceptedFieldLog) {}
+
+    @Query()
+    interceptedFields() {
+        return this.log.intercepted;
+    }
+}
+
+@Resolver('Product')
+export class ProductProbeFieldResolver {
+    @ResolveField()
+    interceptorProbe() {
+        return 'probed';
+    }
+}
+
+@VendurePlugin({
+    adminApiExtensions: {
+        resolvers: [InterceptedFieldsQueryResolver, ProductProbeFieldResolver],
+        schema: gql`
+            extend type Query {
+                interceptedFields: [String!]!
+            }
+
+            extend type Product {
+                interceptorProbe: String!
+            }
+        `,
+    },
+    providers: [
+        InterceptedFieldLog,
+        {
+            provide: APP_INTERCEPTOR,
+            useClass: RecordingInterceptor,
+        },
+    ],
+})
+export class GlobalInterceptorPlugin {}

--- a/packages/core/src/api/config/configure-graphql-module.ts
+++ b/packages/core/src/api/config/configure-graphql-module.ts
@@ -102,7 +102,7 @@ async function createGraphQLOptions(
         typeDefs: printSchema(builtSchema),
         include: [options.resolverModule],
         inheritResolversFromInterfaces: true,
-        fieldResolverEnhancers: ['guards'],
+        fieldResolverEnhancers: configService.apiOptions.fieldResolverEnhancers ?? ['guards'],
         resolvers,
         // We no longer rely on the upload facility bundled with Apollo Server, and instead
         // manually configure the graphql-upload package. See https://github.com/vendurehq/vendure/issues/396

--- a/packages/core/src/config/default-config.ts
+++ b/packages/core/src/config/default-config.ts
@@ -101,6 +101,7 @@ export const defaultConfig: RuntimeVendureConfig = {
         middleware: [],
         introspection: true,
         apolloServerPlugins: [],
+        fieldResolverEnhancers: ['guards'],
         inputValidation: {
             requiredFieldValidation: true,
         },

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -2,6 +2,7 @@ import { ApolloServerPlugin, CSRFPreventionOptions } from '@apollo/server';
 import { RenderPageOptions } from '@apollographql/graphql-playground-html';
 import { DynamicModule, Type } from '@nestjs/common';
 import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
+import type { Enhancer } from '@nestjs/graphql';
 import { LanguageCode } from '@vendure/common/lib/generated-types';
 import { ValidationContext } from 'graphql';
 import { DataSourceOptions } from 'typeorm';
@@ -289,6 +290,39 @@ export interface ApiOptions {
      * @default []
      */
     apolloServerPlugins?: ApolloServerPlugin[];
+    /**
+     * @description
+     * Controls which NestJS enhancers are applied to GraphQL field resolvers, i.e. resolvers
+     * declared with `@ResolveField()`. The value is passed through to the `@nestjs/graphql`
+     * module option of the same name, and applies to both the Shop API and the Admin API.
+     *
+     * The default of `['guards']` is what makes the {@link Allow} decorator work on a field
+     * resolver. Interceptors and exception filters are left out because a field resolver runs
+     * once per resolved field rather than once per operation, so a list query which resolves the
+     * field on each of 100 items would run every global interceptor 100 extra times.
+     *
+     * The consequence of that default is easy to miss: an interceptor registered by a plugin
+     * with Nest's `APP_INTERCEPTOR` token (or an exception filter registered with `APP_FILTER`)
+     * runs for top-level queries and mutations only. On a `@ResolveField()` resolver it never
+     * fires, and nothing is logged to say so. Add `'interceptors'` if a plugin of yours depends
+     * on one seeing field resolution.
+     *
+     * Note that enabling an enhancer here also enables Vendure's own interceptors and exception
+     * filter on every resolved field, so measure the effect on your heaviest list queries.
+     *
+     * @example
+     * ```ts
+     * const config: VendureConfig = {
+     *   apiOptions: {
+     *     fieldResolverEnhancers: ['guards', 'interceptors'],
+     *   },
+     * };
+     * ```
+     *
+     * @default ['guards']
+     * @since 3.8.0
+     */
+    fieldResolverEnhancers?: Enhancer[];
     /**
      * @description
      * Controls whether introspection of the GraphQL APIs is enabled. For production, it is recommended to disable


### PR DESCRIPTION
# Description

Closes #5268.

Adds `apiOptions.fieldResolverEnhancers`, so that the NestJS enhancers applied to GraphQL field resolvers can be configured.

`configure-graphql-module.ts` hardcoded `fieldResolverEnhancers: ['guards']` for both the Shop API and the Admin API. That means an interceptor a plugin registers with Nest's `APP_INTERCEPTOR` token — or an exception filter registered with `APP_FILTER` — runs for top-level queries and mutations and never for a `@ResolveField()` resolver. Nothing fails and nothing is logged, so the only symptom is a missing side effect. We hit this twice on the same project, and unit tests stayed green both times because they call the resolver method directly and bypass Nest's enhancer pipeline.

The default is deliberately unchanged. Nest documents this as a performance tradeoff and it is a real one: with `interceptors` enabled every global interceptor runs once per resolved field, and Vendure's own interceptors are in that set. So this only makes the choice available, and documents what the default leaves out.

Changes:

- `ApiOptions.fieldResolverEnhancers?: Enhancer[]` (Nest's own `Enhancer` type, imported as a type-only import so the `@nestjs/graphql` barrel is not pulled in at require time), `@since 3.8.0`.
- `defaultConfig` sets `['guards']`; `configure-graphql-module.ts` reads it from `configService.apiOptions`, matching how `introspection` and `csrfPrevention` are already handled there. Both APIs pick it up.
- A note in the "Global NestJS middleware" section of the API layer guide, since that page currently says these middleware classes apply "to all requests".

Verification:

- `packages/core/e2e/field-resolver-enhancers.e2e-spec.ts` — a plugin registers a global interceptor that records every `Type.field` it fires for, and resolves a `@ResolveField()` probe on `Product`. One server on the default config, one with `['guards', 'interceptors']`. Both pass; reverting the source change makes the second test fail, as it should.
- `packages/core`: `bun run test` — 1518 passed. `e2e` for `auth`, `plugin`, `apollo-server-plugin`, `csrf-prevention` — 44 passed.
- `bun run docs:generate-typescript-docs` (only the reference pages whose content actually changed are included; the sourceLine-only renumbering churn it also produces is left out).

# Breaking changes

None. The default value is the previously hardcoded one.

# Screenshots

N/A.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791189317&installation_model_id=20193&pr_number=5269&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5269&signature=91280f8ee584e7caf8c65c16038ce67163e2fdb62795e066b31fd8a24f62b128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->