### PR TITLE
docs(core): correct health check docs to match actual behaviour

### DIFF
--- a/docs/docs/guides/core-concepts/healthchecks/index.mdx
+++ b/docs/docs/guides/core-concepts/healthchecks/index.mdx
@@ -1,60 +1,121 @@
 ---
-title: "Health Checks"
-metaTitle: "Health Check Endpoint for Monitoring Vendure"
-metaDescription: "How Vendure exposes a /health endpoint for monitoring system dependencies like the database and external services."
+title: 'Health Checks'
+metaTitle: 'Health Check Endpoint for Monitoring Vendure'
+metaDescription: 'What the Vendure /health endpoint reports, and how to configure liveness and readiness probes for your deployment.'
 ---
 
-Vendure exposes a **`/health`** endpoint that reports the status of critical system dependencies.
-This endpoint is essential for production deployments where load balancers, container orchestrators,
-and monitoring tools need to know whether the application is healthy and ready to serve traffic.
+Vendure exposes a **`/health`** endpoint on the server. It is a plain REST route (not GraphQL) which
+responds as soon as the application is running and accepting HTTP requests:
 
-## How it works
+```text
+REQUEST: GET http://localhost:3000/health
+```
 
-Each configured health check strategy probes a specific dependency and reports back with a status.
-The `/health` endpoint aggregates all strategy results into a single response.
+```json
+{
+    "status": "ok"
+}
+```
 
-A healthy response indicates that all dependencies are reachable and functioning correctly. If any
-strategy reports a failure, the endpoint returns an unhealthy status, signaling that the system
-may not be able to serve requests reliably.
+The response is unconditional. `/health` does not query the database, and it does not check any other
+dependency. It tells you one thing: this process is up and its HTTP server is responding.
 
-## Built-in strategies
+:::warning[Changed in v3.6.0]
 
-Vendure ships with two health check strategies out of the box:
+Earlier versions aggregated the results of the strategies in `systemOptions.healthChecks` into this
+response, so a failing database check would make `/health` return a 503. That behaviour was removed in
+v3.6.0. The strategies are no longer executed, `systemOptions.healthChecks` has no effect on the
+response, and the whole mechanism will be removed in v4.0.0. See
+[#4441](https://github.com/vendurehq/vendure/issues/4441) for the reasoning.
 
-- **`TypeORMHealthCheckStrategy`** — verifies that the database connection is alive by executing
-  a simple query. Since the database is the most critical dependency for any Vendure instance,
-  this strategy is enabled by default.
+:::
 
-- **`HttpHealthCheckStrategy`** — checks the availability of an external HTTP service. This is
-  useful when your Vendure instance depends on external APIs, such as a payment gateway or a
-  third-party inventory system.
+## Liveness and readiness are different questions
 
-## Configuration
+Container orchestrators ask two separate questions, and it is worth being deliberate about which one
+you are answering.
 
-Health checks are configured via the `systemOptions.healthChecks` property in the
-[`VendureConfig`](/reference/typescript-api/configuration/vendure-config/). You can enable or disable
-individual strategies and configure their parameters to match your infrastructure.
+A **liveness** probe asks "is this process wedged, and would restarting it help?" A **readiness** probe
+asks "should this instance receive traffic right now?" Answering both with the same dependency-aware
+check is the failure mode that motivated removing the built-in checks. Suppose `/health` had verified
+the database and you wired it to your load balancer's target-group check. The database gets slow for a
+minute. Every instance fails the check at the same moment, because they all share that database. The
+balancer takes them all out and starts replacements, which cold-boot for a minute or more into the same
+slow database and fail the same check. A brief database blip becomes a full outage, and the restarts
+never had any chance of fixing it — restarting an application process cannot repair a database.
 
-## Use cases
+So: probe the application for whether the application is stuck, and monitor the database as a database.
+Kubernetes' own
+[probe documentation](https://kubernetes.io/docs/tasks/configure-pods-containers/configure-liveness-readiness-startup-probes/)
+makes the same point — liveness probes should not check dependencies.
 
-The `/health` endpoint serves several important operational purposes:
+## Configuring probes
 
-- **Load balancer probes** — configure your load balancer to poll `/health` and route traffic
-  only to healthy instances.
-- **Container orchestration** — use the endpoint as a Kubernetes liveness or readiness probe
-  to automatically restart unhealthy pods or delay traffic until the application is ready.
-- **Monitoring dashboards** — integrate with monitoring tools to track uptime and get alerted
-  when dependencies become unreachable.
+`/health` is well suited to a liveness probe and to a load balancer's "is this target reachable" check.
 
-## Custom strategies
+```yaml
+livenessProbe:
+    httpGet:
+        path: /health
+        port: 3000
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    failureThreshold: 3
+```
 
-When your application has dependencies beyond the database and HTTP services, you can implement
-the `HealthCheckStrategy` interface to create custom checks. For example, a custom strategy might
-verify connectivity to a Redis cache, an Elasticsearch cluster, or a message broker.
+Vendure can take a while to bootstrap, so give it room. Prefer a `startupProbe` if your Kubernetes
+version supports it, which lets you be patient at boot without making the liveness probe slow to react
+later:
 
-Custom strategies are added to the same `systemOptions.healthChecks` configuration array alongside
-the built-in strategies, and their results are included in the aggregated `/health` response.
+```yaml
+startupProbe:
+    httpGet:
+        path: /health
+        port: 3000
+    periodSeconds: 5
+    failureThreshold: 30
+```
+
+For readiness, the same endpoint is a reasonable default. If you genuinely need traffic gated on the
+database being reachable, implement that check yourself in a plugin controller, point only the
+readiness probe at it, and leave the liveness probe on `/health`. Be aware that you are re-introducing
+the correlated-failure risk described above, so pair it with a generous `failureThreshold`.
+
+## The worker
+
+The worker does not serve the Vendure API, but it can start a minimal HTTP server for health checks.
+Call `startHealthCheckServer()` after bootstrapping:
+
+```ts
+bootstrapWorker(config)
+    .then(worker => worker.startJobQueue())
+    .then(worker => worker.startHealthCheckServer({ port: 3020 }))
+    .catch(err => {
+        console.log(err);
+    });
+```
+
+This serves `/health` on the given port, returning `{ "status": "ok" }`. Like the server endpoint it is
+unconditional — it tells you the worker process is alive, not that it is successfully processing jobs.
+The route can be changed via the `route` option of
+[`WorkerHealthCheckConfig`](/reference/typescript-api/worker/worker-health-check-config/).
+
+## Migrating from the built-in health checks
+
+If you have custom [`HealthCheckStrategy`](/reference/typescript-api/health-check/health-check-strategy/)
+implementations or plugins calling
+[`HealthCheckRegistryService`](/reference/typescript-api/health-check/health-check-registry-service/),
+they are already inert — remove them, and set `systemOptions.healthChecks` to `[]` to silence the
+startup deprecation warning.
+
+Move what those checks were doing to the layer that can act on the result:
+
+- Monitor the database with your database provider's own metrics and alerting.
+- Monitor external HTTP dependencies with an uptime checker that probes them directly, rather than
+  through Vendure.
+- Alert a human on those signals. Do not wire them to anything that restarts application containers.
 
 ## Further reading
 
-- [Production configuration guide](/deployment/production-configuration/) — deploying Vendure with proper health checks and monitoring
+- [Using Docker](/deployment/using-docker/) — health check configuration for containerised deployments
+- [Production configuration guide](/deployment/production-configuration/)

--- a/docs/docs/guides/deployment/using-docker.mdx
+++ b/docs/docs/guides/deployment/using-docker.mdx
@@ -174,22 +174,21 @@ REQUEST: GET http://localhost:3000/health
  
 ```json
 {
-  "status": "ok",
-  "info": {
-    "database": {
-      "status": "up"
-    }
-  },
-  "error": {},
-  "details": {
-    "database": {
-      "status": "up"
-    }
-  }
+  "status": "ok"
 }
 ```
 
-You can also add your own health checks by creating plugins that make use of the [HealthCheckRegistryService](/reference/typescript-api/health-check/health-check-registry-service/).
+The response is unconditional — it confirms the process is up and serving HTTP, and does not check the
+database or any other dependency. That makes it a good liveness probe, and a poor substitute for
+monitoring your dependencies. See the [health checks guide](/core-concepts/healthchecks/) for why the
+distinction matters and how to configure probes.
+
+:::note
+
+Before v3.6.0 this response also included the aggregated results of the strategies configured in
+`systemOptions.healthChecks`. Those strategies are no longer executed.
+
+:::
 
 ### Worker
 

--- a/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "RuntimeVendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1469" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1473" packageName="@vendure/core" />
 
 This interface represents the VendureConfig object available at run-time, i.e. the user-supplied
 config values have been merged with the [defaultConfig](/reference/typescript-api/configuration/default-config#defaultconfig) values.

--- a/docs/docs/reference/typescript-api/configuration/system-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/system-options.mdx
@@ -19,10 +19,14 @@ interface SystemOptions {
 
 ### healthChecks
 
-<MemberInfo kind="property" type={`<a href='/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy'>HealthCheckStrategy</a>[]`} default={`[<a href='/reference/typescript-api/health-check/type-ormhealth-check-strategy#typeormhealthcheckstrategy'>TypeORMHealthCheckStrategy</a>]`}  since="1.6.0"  />
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy'>HealthCheckStrategy</a>[]`} default={`[]`}  since="1.6.0"  />
 
-Defines an array of [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) instances which are used by the `/health` endpoint to verify
-that any critical systems which the Vendure server depends on are also healthy.
+Defines an array of [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) instances which were used by the `/health` endpoint
+to verify that any critical systems which the Vendure server depends on are also healthy.
+
+Since v3.6.0 these strategies are no longer executed and the value of this option has no effect on
+the `/health` response, which is now an unconditional `{ "status": "ok" }`. Setting it to a non-empty
+array logs a deprecation warning on startup.
 ### errorHandlers
 
 <MemberInfo kind="property" type={`<a href='/reference/typescript-api/errors/error-handler-strategy#errorhandlerstrategy'>ErrorHandlerStrategy</a>[]`} default={`[]`}  since="2.2.0"  />

--- a/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "VendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1322" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1326" packageName="@vendure/core" />
 
 All possible configuration options are defined by the
 [`VendureConfig`](https://github.com/vendurehq/vendure/blob/master/packages/core/src/config/vendure-config.ts) interface.

--- a/docs/docs/reference/typescript-api/health-check/health-check-registry-service.mdx
+++ b/docs/docs/reference/typescript-api/health-check/health-check-registry-service.mdx
@@ -2,16 +2,20 @@
 title: "HealthCheckRegistryService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/health-check/health-check-registry.service.ts" sourceLine="42" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/health-check/health-check-registry.service.ts" sourceLine="46" packageName="@vendure/core" />
 
-This service is used to register health indicator functions to be included in the
-health check. Health checks can be used by automated services such as Kubernetes
-to determine the state of applications it is running. They are also useful for
-administrators to get an overview of the health of all the parts of the
-Vendure stack.
+This service was used to register health indicator functions to be included in the
+health check.
 
-Plugins which rely on external services (web services, databases etc.) can make use of this
-service to add a check for that dependency to the Vendure health check.
+:::warning
+
+Since v3.6.0 registered indicators are never executed — the `/health` endpoint no longer runs
+them — and the Admin UI "system status" view which displayed them has been removed. Calling
+this service has no observable effect, and it will be removed in v4.0.0. Monitor external
+dependencies from your infrastructure instead — see the
+[health check guide](/core-concepts/healthchecks/).
+
+:::
 
 
 Since v1.6.0, the preferred way to implement a custom health check is by creating a new [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy)
@@ -50,9 +54,8 @@ class HealthCheckRegistryService {
 
 <MemberInfo kind="method" type={`(fn: <a href='/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction'>HealthIndicatorFunction</a> | <a href='/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction'>HealthIndicatorFunction</a>[]) => `}   />
 
-Registers one or more [HealthIndicatorFunction](/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction)s to be added to the
-health check endpoint. The indicator will also appear in the Admin UI's
-"system status" view.
+Registers one or more [HealthIndicatorFunction](/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction)s. Since v3.6.0 the registered
+functions are never called.
 
 
 </div>

--- a/docs/docs/reference/typescript-api/health-check/health-check-strategy.mdx
+++ b/docs/docs/reference/typescript-api/health-check/health-check-strategy.mdx
@@ -2,23 +2,18 @@
 title: "HealthCheckStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/system/health-check-strategy.ts" sourceLine="46" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/system/health-check-strategy.ts" sourceLine="41" packageName="@vendure/core" />
 
-This strategy defines health checks which are included as part of the
-`/health` endpoint. They should only be used to monitor _critical_ systems
-on which proper functioning of the Vendure server depends.
+This strategy defines health checks which were included as part of the
+`/health` endpoint.
 
-Custom strategies should be added to the `systemOptions.healthChecks` array.
-By default, Vendure includes the `TypeORMHealthCheckStrategy`, so if you set the value of the `healthChecks`
-array, be sure to include it manually.
+:::warning
 
-Vendure also ships with the [HttpHealthCheckStrategy](/reference/typescript-api/health-check/http-health-check-strategy#httphealthcheckstrategy), which is convenient
-for adding a health check dependent on an HTTP ping.
-
-:::info
-
-This is configured via the `systemOptions.healthChecks` property of
-your VendureConfig.
+Since v3.6.0 the strategies configured in `systemOptions.healthChecks` are **no longer
+executed**: the `/health` endpoint always responds with `{ "status": "ok" }` as soon as the
+server is accepting requests. Configuring a strategy has no effect on the response, and the
+whole mechanism will be removed in v4.0.0. Monitor critical dependencies from your
+infrastructure instead — see the [health check guide](/core-concepts/healthchecks/).
 
 :::
 
@@ -55,8 +50,9 @@ interface HealthCheckStrategy extends InjectableStrategy {
 
 <MemberInfo kind="method" type={`() => <a href='/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction'>HealthIndicatorFunction</a>`}   />
 
-Should return a [HealthIndicatorFunction](/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction) which performs the check
-and resolves to a status payload.
+Retained for backwards compatibility. Since v3.6.0 this method is never
+called: the `/health` endpoint does not execute the returned
+[HealthIndicatorFunction](/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction).
 
 
 </div>

--- a/docs/docs/reference/typescript-api/health-check/http-health-check-strategy.mdx
+++ b/docs/docs/reference/typescript-api/health-check/http-health-check-strategy.mdx
@@ -2,9 +2,16 @@
 title: "HttpHealthCheckStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/health-check/http-health-check-strategy.ts" sourceLine="45" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/health-check/http-health-check-strategy.ts" sourceLine="52" packageName="@vendure/core" />
 
 A [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) used to check health by pinging a url.
+
+:::warning
+
+Since v3.6.0 this strategy is never executed, so adding it to `systemOptions.healthChecks`
+has no effect on the `/health` response.
+
+:::
 
 *Example*
 

--- a/docs/docs/reference/typescript-api/health-check/type-ormhealth-check-strategy.mdx
+++ b/docs/docs/reference/typescript-api/health-check/type-ormhealth-check-strategy.mdx
@@ -2,11 +2,17 @@
 title: "TypeORMHealthCheckStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/health-check/typeorm-health-check-strategy.ts" sourceLine="42" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/health-check/typeorm-health-check-strategy.ts" sourceLine="48" packageName="@vendure/core" />
 
-A [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) used to check the health of the database. This health
-check is included by default, but can be customized by explicitly adding it to the
-`systemOptions.healthChecks` array:
+A [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) used to check the health of the database.
+
+:::warning
+
+Since v3.6.0 this strategy is never executed, so adding it to `systemOptions.healthChecks`
+has no effect on the `/health` response. To detect an unreachable database, probe it from
+your infrastructure rather than through the application.
+
+:::
 
 *Example*
 

--- a/packages/core/e2e/health-check.e2e-spec.ts
+++ b/packages/core/e2e/health-check.e2e-spec.ts
@@ -1,0 +1,73 @@
+import {
+    HealthCheckRegistryService,
+    HealthCheckStrategy,
+    HealthIndicatorFunction,
+    mergeConfig,
+    PluginCommonModule,
+    VendurePlugin,
+} from '@vendure/core';
+import { createTestEnvironment } from '@vendure/testing';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { initialData } from '../../../e2e-common/e2e-initial-data';
+import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
+
+function throwingIndicator(): HealthIndicatorFunction {
+    return () => {
+        throw new Error('this indicator must never be invoked');
+    };
+}
+
+/** Configured via `systemOptions.healthChecks`. */
+class AlwaysFailingHealthCheckStrategy implements HealthCheckStrategy {
+    getHealthIndicator(): HealthIndicatorFunction {
+        throw new Error('this strategy must never be invoked');
+    }
+}
+
+/** Registered via the older {@link HealthCheckRegistryService} route. */
+@VendurePlugin({
+    imports: [PluginCommonModule],
+})
+class RegistersFailingIndicatorPlugin {
+    constructor(registry: HealthCheckRegistryService) {
+        registry.registerIndicatorFunction(throwingIndicator());
+    }
+}
+
+const config = mergeConfig(testConfig(), {
+    systemOptions: {
+        healthChecks: [new AlwaysFailingHealthCheckStrategy()],
+    },
+    plugins: [RegistersFailingIndicatorPlugin],
+});
+
+const HEALTH_URL = `http://localhost:${config.apiOptions.port}/health`;
+
+describe('health check endpoint', () => {
+    const { server } = createTestEnvironment(config);
+
+    beforeAll(async () => {
+        await server.init({
+            initialData,
+            productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-minimal.csv'),
+            customerCount: 1,
+        });
+    }, TEST_SETUP_TIMEOUT_MS);
+
+    afterAll(async () => {
+        await server.destroy();
+    });
+
+    // `/health` is a liveness signal: it reports that this process is serving HTTP and deliberately
+    // does not gate on any dependency. Both of the health check mechanisms deprecated in v3.6.0 are
+    // registered above with indicators that throw, and neither may influence the response. Were they
+    // still executed, a single degraded dependency would fail this check on every instance at once.
+    it('responds 200 with an ok status despite failing health checks being registered', async () => {
+        const res = await fetch(HEALTH_URL);
+
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toEqual({ status: 'ok' });
+    });
+});

--- a/packages/core/src/config/system/health-check-strategy.ts
+++ b/packages/core/src/config/system/health-check-strategy.ts
@@ -3,21 +3,16 @@ import { InjectableStrategy } from '../../common/types/injectable-strategy';
 
 /**
  * @description
- * This strategy defines health checks which are included as part of the
- * `/health` endpoint. They should only be used to monitor _critical_ systems
- * on which proper functioning of the Vendure server depends.
+ * This strategy defines health checks which were included as part of the
+ * `/health` endpoint.
  *
- * Custom strategies should be added to the `systemOptions.healthChecks` array.
- * By default, Vendure includes the `TypeORMHealthCheckStrategy`, so if you set the value of the `healthChecks`
- * array, be sure to include it manually.
+ * :::warning
  *
- * Vendure also ships with the {@link HttpHealthCheckStrategy}, which is convenient
- * for adding a health check dependent on an HTTP ping.
- *
- * :::info
- *
- * This is configured via the `systemOptions.healthChecks` property of
- * your VendureConfig.
+ * Since v3.6.0 the strategies configured in `systemOptions.healthChecks` are **no longer
+ * executed**: the `/health` endpoint always responds with `{ "status": "ok" }` as soon as the
+ * server is accepting requests. Configuring a strategy has no effect on the response, and the
+ * whole mechanism will be removed in v4.0.0. Monitor critical dependencies from your
+ * infrastructure instead — see the [health check guide](/core-concepts/healthchecks/).
  *
  * :::
  *
@@ -46,8 +41,9 @@ import { InjectableStrategy } from '../../common/types/injectable-strategy';
 export interface HealthCheckStrategy extends InjectableStrategy {
     /**
      * @description
-     * Should return a {@link HealthIndicatorFunction} which performs the check
-     * and resolves to a status payload.
+     * Retained for backwards compatibility. Since v3.6.0 this method is never
+     * called: the `/health` endpoint does not execute the returned
+     * {@link HealthIndicatorFunction}.
      */
     getHealthIndicator(): HealthIndicatorFunction;
 }

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -1281,10 +1281,14 @@ export interface EntityOptions {
 export interface SystemOptions {
     /**
      * @description
-     * Defines an array of {@link HealthCheckStrategy} instances which are used by the `/health` endpoint to verify
-     * that any critical systems which the Vendure server depends on are also healthy.
+     * Defines an array of {@link HealthCheckStrategy} instances which were used by the `/health` endpoint
+     * to verify that any critical systems which the Vendure server depends on are also healthy.
      *
-     * @default [TypeORMHealthCheckStrategy]
+     * Since v3.6.0 these strategies are no longer executed and the value of this option has no effect on
+     * the `/health` response, which is now an unconditional `{ "status": "ok" }`. Setting it to a non-empty
+     * array logs a deprecation warning on startup.
+     *
+     * @default []
      * @since 1.6.0
      * @deprecated Use infrastructure-level health checks (e.g. Kubernetes probes, Docker healthchecks,
      * load balancer checks) instead of application-level health checks. The application should not

--- a/packages/core/src/health-check/health-check-registry.service.ts
+++ b/packages/core/src/health-check/health-check-registry.service.ts
@@ -2,14 +2,18 @@ import { HealthIndicatorFunction } from './terminus-compat';
 
 /**
  * @description
- * This service is used to register health indicator functions to be included in the
- * health check. Health checks can be used by automated services such as Kubernetes
- * to determine the state of applications it is running. They are also useful for
- * administrators to get an overview of the health of all the parts of the
- * Vendure stack.
+ * This service was used to register health indicator functions to be included in the
+ * health check.
  *
- * Plugins which rely on external services (web services, databases etc.) can make use of this
- * service to add a check for that dependency to the Vendure health check.
+ * :::warning
+ *
+ * Since v3.6.0 registered indicators are never executed — the `/health` endpoint no longer runs
+ * them — and the Admin UI "system status" view which displayed them has been removed. Calling
+ * this service has no observable effect, and it will be removed in v4.0.0. Monitor external
+ * dependencies from your infrastructure instead — see the
+ * [health check guide](/core-concepts/healthchecks/).
+ *
+ * :::
  *
  *
  * Since v1.6.0, the preferred way to implement a custom health check is by creating a new {@link HealthCheckStrategy}
@@ -48,9 +52,8 @@ export class HealthCheckRegistryService {
 
     /**
      * @description
-     * Registers one or more {@link HealthIndicatorFunction}s to be added to the
-     * health check endpoint. The indicator will also appear in the Admin UI's
-     * "system status" view.
+     * Registers one or more {@link HealthIndicatorFunction}s. Since v3.6.0 the registered
+     * functions are never called.
      *
      * @deprecated Use infrastructure-level health checks instead. This method will be removed in v4.0.0.
      */

--- a/packages/core/src/health-check/http-health-check-strategy.ts
+++ b/packages/core/src/health-check/http-health-check-strategy.ts
@@ -23,6 +23,13 @@ export interface HttpHealthCheckOptions {
  * @description
  * A {@link HealthCheckStrategy} used to check health by pinging a url.
  *
+ * :::warning
+ *
+ * Since v3.6.0 this strategy is never executed, so adding it to `systemOptions.healthChecks`
+ * has no effect on the `/health` response.
+ *
+ * :::
+ *
  * @example
  * ```ts
  * import { HttpHealthCheckStrategy, TypeORMHealthCheckStrategy } from '\@vendure/core';

--- a/packages/core/src/health-check/typeorm-health-check-strategy.ts
+++ b/packages/core/src/health-check/typeorm-health-check-strategy.ts
@@ -14,9 +14,15 @@ export interface TypeORMHealthCheckOptions {
 
 /**
  * @description
- * A {@link HealthCheckStrategy} used to check the health of the database. This health
- * check is included by default, but can be customized by explicitly adding it to the
- * `systemOptions.healthChecks` array:
+ * A {@link HealthCheckStrategy} used to check the health of the database.
+ *
+ * :::warning
+ *
+ * Since v3.6.0 this strategy is never executed, so adding it to `systemOptions.healthChecks`
+ * has no effect on the `/health` response. To detect an unreachable database, probe it from
+ * your infrastructure rather than through the application.
+ *
+ * :::
  *
  * @example
  * ```ts


### PR DESCRIPTION
# Description

Fixes #5270.

Since v3.6.0 (#4442) the `/health` endpoint returns an unconditional `{ "status": "ok" }` and the strategies configured in `systemOptions.healthChecks` are never executed. The documentation was not updated to match. It still describes `/health` as aggregating strategy results and returning an unhealthy status when a dependency is down, and the Docker guide still shows the old Terminus `info` / `error` / `details` response envelope with a `database` indicator.

The gap is quiet and expensive. You read the guide, conclude `/health` verifies the database, and point your load balancer's target-group check at it — believing you have a readiness check that pulls a bad instance out of rotation. You do not. Anyone upgrading from before 3.6.0 has the inverse problem: their custom `HealthCheckStrategy` silently stopped running, and the docs still say it works.

This corrects the docs rather than changing any behaviour:

- Rewrites the Health Checks guide around what `/health` actually is — a liveness signal — and records why the built-in checks were removed, including the liveness/readiness distinction and a `startupProbe` note (Vendure's boot time makes a naive `livenessProbe` restart pods mid-startup).
- Adds a migration section for existing custom strategies.
- Fixes the sample response in the Docker guide.
- Fixes the JSDoc feeding the API reference, including `@default` on `systemOptions.healthChecks`, which claimed `[TypeORMHealthCheckStrategy]` where the real default is `[]`, and the `HealthCheckRegistryService` claim that indicators appear in an Admin UI view that was removed in the same PR.
- Adds an e2e spec pinning the contract: `/health` returns 200 `{ "status": "ok" }` while both a throwing `HealthCheckStrategy` and a throwing indicator registered via `HealthCheckRegistryService` are configured. There was no test covering the route, which is part of why the divergence went unnoticed.

Reference `.mdx` files were regenerated with `bun run docs:generate-typescript-docs`.

Targets `master` since this corrects already-released behaviour.

# Breaking changes

None. Documentation, JSDoc and a new test only; no runtime behaviour changes.

# Screenshots

n/a

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791189881&installation_model_id=20193&pr_number=5271&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5271&signature=5b60f4f75bf4529a07a5dc8b66f883068e6eb4e5dccece54d9caee776324df6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->