### PR TITLE
fix(dashboard): keep column filters AND-ed with the list search term

### DIFF
--- a/docs/docs/reference/dashboard/list-views/list-page.mdx
+++ b/docs/docs/reference/dashboard/list-views/list-page.mdx
@@ -245,6 +245,11 @@ handling.
 Allows you to customize how the search term is used in the list query options.
 For instance, when you want the term to filter on specific fields.
 
+The returned filter is merged with the column & faceted filters, so when the term should
+match any of several fields, group those fields in an `_or` block. Setting a page-level
+`filterOperator: 'OR'` would instead OR together _every_ top-level condition, including
+the column filters.
+
 *Example*
 
 ```tsx
@@ -254,9 +259,11 @@ For instance, when you want the term to filter on specific fields.
    listQuery={administratorListDocument}
    onSearchTermChange={searchTerm => {
      return {
-       firstName: { contains: searchTerm },
-       lastName: { contains: searchTerm },
-       emailAddress: { contains: searchTerm },
+       _or: [
+         { firstName: { contains: searchTerm } },
+         { lastName: { contains: searchTerm } },
+         { emailAddress: { contains: searchTerm } },
+       ],
      };
    }}
  />

--- a/packages/dashboard/e2e/tests/catalog/product-list.spec.ts
+++ b/packages/dashboard/e2e/tests/catalog/product-list.spec.ts
@@ -353,6 +353,47 @@ test.describe('Product List', () => {
             ).toBeVisible();
         });
 
+        // #5272 — verifies that product search and column filters combine with AND semantics
+        test('should keep column filters applied when a search term is entered', async ({ page }) => {
+            const lp = listPage(page);
+            await lp.goto();
+            await lp.expectLoaded();
+
+            const initialCount = await lp.getRows().count();
+
+            // Filter down to the 3 products with "Camera" in the name
+            await lp.openAddFilterMenu();
+            const dropdown = page.locator('[data-slot="dropdown-menu-content"]');
+            await dropdown.getByRole('menuitem', { name: /name/i }).click();
+
+            const dialog = page.locator('[role="dialog"]');
+            await dialog.getByPlaceholder('Enter filter value...').fill('Camera');
+            const filterResponse = page.waitForResponse(
+                resp => resp.url().includes('/admin-api') && resp.status() === 200,
+            );
+            await dialog.getByRole('button', { name: 'Apply filter' }).click();
+            await filterResponse;
+            await lp.expectRowCount(3);
+
+            // Searching within that filter must AND the two, not OR them
+            await lp.search('Lens');
+            await lp.expectRowCount(1);
+            await expect(lp.getRows().filter({ hasText: 'Camera Lens' })).toHaveCount(1);
+            await expect(lp.getRows().filter({ hasText: 'Instant Camera' })).toHaveCount(0);
+
+            // Clearing the search must restore the filtered set
+            await lp.clearSearch();
+            await lp.expectRowCount(3);
+
+            // Clearing the filter must restore the initial set
+            const clearResponse = page.waitForResponse(
+                resp => resp.url().includes('/admin-api') && resp.status() === 200,
+            );
+            await page.getByRole('button', { name: 'Clear all' }).click();
+            await clearResponse;
+            await lp.expectRowCount(initialCount);
+        });
+
         test('should clear an applied filter via the clear all button', async ({ page }) => {
             const lp = listPage(page);
             await lp.goto();

--- a/packages/dashboard/src/app/routes/_authenticated/_administrators/administrators.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_administrators/administrators.tsx
@@ -25,19 +25,13 @@ function AdministratorListPage() {
             onSearchTermChange={searchTerm => {
                 return searchTerm
                     ? {
-                          firstName: { contains: searchTerm },
-                          lastName: { contains: searchTerm },
-                          emailAddress: { contains: searchTerm },
+                          _or: [
+                              { firstName: { contains: searchTerm } },
+                              { lastName: { contains: searchTerm } },
+                              { emailAddress: { contains: searchTerm } },
+                          ],
                       }
                     : {};
-            }}
-            transformVariables={variables => {
-                return {
-                    options: {
-                        ...variables.options,
-                        filterOperator: 'OR',
-                    },
-                };
             }}
             additionalColumns={{
                 name: {

--- a/packages/dashboard/src/app/routes/_authenticated/_countries/countries.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_countries/countries.tsx
@@ -28,19 +28,9 @@ function CountryListPage() {
             onSearchTermChange={searchTerm => {
                 return searchTerm
                     ? {
-                          name: { contains: searchTerm },
-                          code: { contains: searchTerm },
+                          _or: [{ name: { contains: searchTerm } }, { code: { contains: searchTerm } }],
                       }
                     : {};
-            }}
-            transformVariables={variables => {
-                return {
-                    ...variables,
-                    options: {
-                        ...variables.options,
-                        filterOperator: 'OR',
-                    },
-                };
             }}
             customizeColumns={{
                 name: {

--- a/packages/dashboard/src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
@@ -93,12 +93,10 @@ export function CustomerGroupMembersTable({
                 }}
                 onSearchTermChange={searchTerm => {
                     return {
-                        lastName: {
-                            contains: searchTerm,
-                        },
-                        emailAddress: {
-                            contains: searchTerm,
-                        },
+                        _or: [
+                            { lastName: { contains: searchTerm } },
+                            { emailAddress: { contains: searchTerm } },
+                        ],
                     };
                 }}
                 additionalColumns={{

--- a/packages/dashboard/src/app/routes/_authenticated/_customers/customers.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_customers/customers.tsx
@@ -24,19 +24,13 @@ function CustomerListPage() {
             onSearchTermChange={searchTerm => {
                 return searchTerm
                     ? {
-                          lastName: { contains: searchTerm },
-                          emailAddress: { contains: searchTerm },
-                          phoneNumber: { contains: searchTerm },
+                          _or: [
+                              { lastName: { contains: searchTerm } },
+                              { emailAddress: { contains: searchTerm } },
+                              { phoneNumber: { contains: searchTerm } },
+                          ],
                       }
                     : {};
-            }}
-            transformVariables={variables => {
-                return {
-                    options: {
-                        ...variables.options,
-                        filterOperator: 'OR',
-                    },
-                };
             }}
             route={Route}
             customizeColumns={{

--- a/packages/dashboard/src/app/routes/_authenticated/_product-variants/product-variants.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_product-variants/product-variants.tsx
@@ -88,18 +88,9 @@ function ProductListPage() {
             onSearchTermChange={searchTerm => {
                 return searchTerm
                     ? {
-                          name: { contains: searchTerm },
-                          sku: { contains: searchTerm },
+                          _or: [{ name: { contains: searchTerm } }, { sku: { contains: searchTerm } }],
                       }
                     : {};
-            }}
-            transformVariables={variables => {
-                return {
-                    options: {
-                        ...variables.options,
-                        filterOperator: 'OR',
-                    },
-                };
             }}
             route={Route}
         ></ListPage>

--- a/packages/dashboard/src/app/routes/_authenticated/_products/products.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/products.tsx
@@ -56,9 +56,11 @@ function ProductListPage() {
             onSearchTermChange={searchTerm => {
                 return searchTerm
                     ? {
-                          name: { contains: searchTerm },
-                          slug: { contains: searchTerm },
-                          sku: { contains: searchTerm },
+                          _or: [
+                              { name: { contains: searchTerm } },
+                              { slug: { contains: searchTerm } },
+                              { sku: { contains: searchTerm } },
+                          ],
                       }
                     : {};
             }}
@@ -76,14 +78,6 @@ function ProductListPage() {
                     title: t`Facet values`,
                     component: FacetValueFacetedFilter,
                 },
-            }}
-            transformVariables={variables => {
-                return {
-                    options: {
-                        ...variables.options,
-                        filterOperator: 'OR',
-                    },
-                };
             }}
             defaultSort={[{ id: 'updatedAt', desc: true }]}
             defaultVisibility={{

--- a/packages/dashboard/src/app/routes/_authenticated/_promotions/promotions.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_promotions/promotions.tsx
@@ -38,18 +38,9 @@ function PromotionListPage() {
             onSearchTermChange={searchTerm => {
                 return searchTerm
                     ? {
-                          name: { contains: searchTerm },
-                          couponCode: { contains: searchTerm },
+                          _or: [{ name: { contains: searchTerm } }, { couponCode: { contains: searchTerm } }],
                       }
                     : {};
-            }}
-            transformVariables={variables => {
-                return {
-                    options: {
-                        ...variables.options,
-                        filterOperator: 'OR' as const,
-                    },
-                };
             }}
             customizeColumns={{
                 name: {

--- a/packages/dashboard/src/lib/framework/page/list-page.stories.tsx
+++ b/packages/dashboard/src/lib/framework/page/list-page.stories.tsx
@@ -148,21 +148,7 @@ export const WithSearch: Story = {
         },
         onSearchTermChange: (searchTerm: string) => {
             return {
-                name: {
-                    contains: searchTerm,
-                },
-                code: {
-                    contains: searchTerm,
-                },
-            };
-        },
-        transformVariables: (variables: any) => {
-            return {
-                ...variables,
-                options: {
-                    ...variables.options,
-                    filterOperator: 'OR',
-                },
+                _or: [{ name: { contains: searchTerm } }, { code: { contains: searchTerm } }],
             };
         },
         customizeColumns: {
@@ -222,21 +208,7 @@ export const Complete: Story = {
         },
         onSearchTermChange: (searchTerm: string) => {
             return {
-                name: {
-                    contains: searchTerm,
-                },
-                code: {
-                    contains: searchTerm,
-                },
-            };
-        },
-        transformVariables: (variables: any) => {
-            return {
-                ...variables,
-                options: {
-                    ...variables.options,
-                    filterOperator: 'OR',
-                },
+                _or: [{ name: { contains: searchTerm } }, { code: { contains: searchTerm } }],
             };
         },
         customizeColumns: {

--- a/packages/dashboard/src/lib/framework/page/list-page.tsx
+++ b/packages/dashboard/src/lib/framework/page/list-page.tsx
@@ -140,6 +140,11 @@ export interface ListPageProps<
      * Allows you to customize how the search term is used in the list query options.
      * For instance, when you want the term to filter on specific fields.
      *
+     * The returned filter is merged with the column & faceted filters, so when the term should
+     * match any of several fields, group those fields in an `_or` block. Setting a page-level
+     * `filterOperator: 'OR'` would instead OR together _every_ top-level condition, including
+     * the column filters.
+     *
      * @example
      * ```tsx
      *  <ListPage
@@ -148,9 +153,11 @@ export interface ListPageProps<
      *    listQuery={administratorListDocument}
      *    onSearchTermChange={searchTerm => {
      *      return {
-     *        firstName: { contains: searchTerm },
-     *        lastName: { contains: searchTerm },
-     *        emailAddress: { contains: searchTerm },
+     *        _or: [
+     *          { firstName: { contains: searchTerm } },
+     *          { lastName: { contains: searchTerm } },
+     *          { emailAddress: { contains: searchTerm } },
+     *        ],
      *      };
      *    }}
      *  />


### PR DESCRIPTION
# Description

Fixes #5272.

Fixes the dashboard list pages OR-ing away the active column filters as soon as you type in the search box.

Six list pages implement "search matches name OR slug OR sku" by setting a page-level `filterOperator: 'OR'` through `transformVariables`. That operator joins *every* top-level condition in the filter object, and `PaginatedListDataTable` merges the column/faceted filters into that same object (`{ ...filter, ...searchFilter }`). So a search term plus a column filter produces `name ~ term OR slug ~ term OR sku ~ term OR <column filter>`, which matches almost everything.

The fix is to express the search as an explicit `_or` group inside the filter and drop the page-level `filterOperator`. `_or` is part of the generated `FilterParameter` input types and `parse-filter-params.ts` already turns it into a nested `WhereGroup`, so `_and` (column filters) and `_or` (search) at the same level are AND-ed as intended.

Pages fixed: products, product variants, customers, administrators, promotions, countries, and the customer group members table — seven in total.

The members table has the mirror-image version of the bug: it never set `filterOperator`, so its two search fields were left as separate top-level keys and the server AND-ed them. Searching "smith" only matched members whose last name *and* email address both contain the term. The same `_or` group fixes it.

Also updated the `onSearchTermChange` JSDoc example (and its generated reference page) and the two Storybook stories, since they taught the broken pattern to plugin authors.

Before / after, with a `name contains Camera` column filter and `Lens` typed in the search box:

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Uplab/vendure/contrib-assets/images/dashboard-search-or-filter-before.png) | ![after](https://raw.githubusercontent.com/Uplab/vendure/contrib-assets/images/dashboard-search-or-filter-after.png) |

Request sent by the products list in that state:

```diff
  "filter": {
    "_and": [{ "name": { "contains": "Camera" } }],
-   "name": { "contains": "Lens" },
-   "slug": { "contains": "Lens" },
-   "sku": { "contains": "Lens" }
+   "_or": [
+     { "name": { "contains": "Lens" } },
+     { "slug": { "contains": "Lens" } },
+     { "sku": { "contains": "Lens" } }
+   ]
  },
- "filterOperator": "OR"
```

# Breaking changes

None. The filter payload changes shape but the intended semantics ("search any of these fields") are unchanged; only the interaction with column filters is fixed.

# Screenshots

See above.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

Added a dashboard e2e test, `Product List › Data table features › should keep column filters applied when a search term is entered`. It fails on `master` (expected 1 row, received 3) and passes with the fix.

Verification run from `packages/dashboard`:

```
npm run check-types                                    # clean
CI=true VITE_TEST_PORT=5176 npx playwright test \
  --config e2e/playwright.config.ts \
  e2e/tests/catalog/product-list.spec.ts               # 20 passed
CI=true VITE_TEST_PORT=5176 npx playwright test \
  --config e2e/playwright.config.ts \
  e2e/tests/settings/customer-groups.spec.ts \
  e2e/tests/regression/issue-3941-customer-group-removal.spec.ts \
  e2e/tests/regression/issue-4730-list-page-filter-with-empty-search.spec.ts  # 14 passed
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791189887&installation_model_id=20193&pr_number=5273&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5273&signature=6a7c75985a6b57c7982fe22d84b0c5b6bf9635a45d78919d728b70d3bb1907dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
