### PR TITLE
fix(core): log stack trace and error class for failed scheduled tasks

### DIFF
--- a/packages/core/e2e/default-scheduler-plugin.e2e-spec.ts
+++ b/packages/core/e2e/default-scheduler-plugin.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { ConfigService, DefaultSchedulerPlugin, mergeConfig, ScheduledTask } from '@vendure/core';
-import { createTestEnvironment } from '@vendure/testing';
+import { createTestEnvironment, TestingLogger } from '@vendure/testing';
 import path from 'path';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
@@ -15,8 +15,11 @@ const MAX_HOLD_MS = 5_000;
 
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
+class EmptyMessageError extends Error {}
+
 describe('Default scheduler plugin', () => {
     const taskSpy = vi.fn();
+    const testingLogger = new TestingLogger(() => vi.fn());
     // One task per hold-window test so DB state can't leak between them.
     const holdSpyBlocking = vi.fn();
     const holdSpyManual = vi.fn();
@@ -32,6 +35,16 @@ describe('Default scheduler plugin', () => {
                         async execute(injector) {
                             taskSpy();
                             return { success: true };
+                        },
+                    }),
+                    new ScheduledTask({
+                        id: 'error-test-job',
+                        description: 'A test job which throws an error with an empty message',
+                        schedule: cron => cron.everySaturdayAt(0, 0),
+                        async execute(injector) {
+                            const error = new EmptyMessageError('');
+                            (error as Error & { cause?: unknown }).cause = 'ECONNRESET';
+                            throw error;
                         },
                     }),
                     new ScheduledTask({
@@ -56,6 +69,7 @@ describe('Default scheduler plugin', () => {
                 runTasksInWorkerOnly: false,
             },
             plugins: [DefaultSchedulerPlugin.init({ manualTriggerCheckInterval: 50 })],
+            logger: testingLogger,
         }),
     );
 
@@ -78,7 +92,7 @@ describe('Default scheduler plugin', () => {
 
     it('get tasks', async () => {
         const { scheduledTasks } = await adminClient.query(getTasksDocument);
-        expect(scheduledTasks.length).toBe(3);
+        expect(scheduledTasks.length).toBe(4);
         const testJob = scheduledTasks.find(t => t.id === 'test-job');
         if (!testJob) throw new Error('test-job not found');
         expect(testJob.description).toBe("A test job that doesn't do anything");
@@ -157,6 +171,29 @@ describe('Default scheduler plugin', () => {
         // Control: cron path inside the same window must still be blocked.
         await strategy.executeTask(task)();
         expect(holdSpyManual).toHaveBeenCalledTimes(2);
+    });
+
+    // #5276
+    it('logs the error class and cause when a task throws an empty-message error', async () => {
+        testingLogger.errorSpy.mockClear();
+
+        const { strategy, task } = getHoldTask(server, 'error-test-job');
+        await strategy.executeTask(task)();
+
+        const call = testingLogger.errorSpy.mock.calls.find((args: any[]) =>
+            String(args[0]).includes('Scheduled task "error-test-job" failed'),
+        );
+        expect(call).toBeDefined();
+
+        const [message, , trace] = call as [string, string | undefined, string | undefined];
+        expect(message).toContain('EmptyMessageError');
+        expect(message).toContain('ECONNRESET');
+        expect(message).toContain('at ');
+        expect(trace).toBeUndefined();
+
+        const { scheduledTasks } = await adminClient.query(getTasksDocument);
+        const errorTask = scheduledTasks.find(t => t.id === 'error-test-job');
+        expect(errorTask?.lastResult).toEqual({ error: 'EmptyMessageError' });
     });
 });
 

--- a/packages/core/src/plugin/default-scheduler-plugin/default-scheduler-strategy.ts
+++ b/packages/core/src/plugin/default-scheduler-plugin/default-scheduler-strategy.ts
@@ -1,6 +1,7 @@
 import { UpdateScheduledTaskInput } from '@vendure/common/lib/generated-types';
 import { Cron } from 'croner';
 import ms, { type StringValue } from 'ms';
+import { inspect } from 'node:util';
 
 import { Injector } from '../../common';
 import { assertFound } from '../../common/utils';
@@ -122,17 +123,13 @@ export class DefaultSchedulerStrategy implements SchedulerStrategy {
             );
             Logger.verbose(`Scheduled task "${task.id}" completed successfully`);
         } catch (error) {
-            let errorMessage = 'Unknown error';
-            if (error instanceof Error) {
-                errorMessage = error.message;
-            }
-            Logger.error(`Scheduled task "${task.id}" failed with error: ${errorMessage}`);
+            Logger.error(`Scheduled task "${task.id}" failed with error: ${inspect(error)}`);
             await this.connection.rawConnection.getRepository(ScheduledTaskRecord).update(
                 { taskId: task.id },
                 {
                     lastExecutedAt: new Date(),
                     lockedAt: null,
-                    lastResult: { error: errorMessage } as any,
+                    lastResult: { error: errorLabel(error) } as any,
                 },
             );
         } finally {
@@ -356,4 +353,15 @@ export class DefaultSchedulerStrategy implements SchedulerStrategy {
             this.tasks.set(taskId, { task: task.task, isRegistered: true });
         }
     }
+}
+
+/**
+ * `constructor.name` rather than `name` because a subclass which does not set `name`
+ * still inherits `'Error'` from `Error.prototype`.
+ */
+function errorLabel(error: unknown): string {
+    if (!(error instanceof Error)) {
+        return 'Unknown error';
+    }
+    return error.message || error.constructor.name;
 }


### PR DESCRIPTION
# Description

Fixes #5276.

When a `ScheduledTask` throws, `DefaultSchedulerStrategy.runTask()` logs `error.message` and nothing else. If the message is empty, the log line ends after the colon.

This is the complete output our production worker gave us for a failing task on 2026-08-24:

```
error Scheduled task "esputnik-sync-contacts" failed with error:
```

No stack, no error class, no `cause`.

## What changed

The failure path now logs `util.inspect(error)`.

Node already renders everything this needs, so there is no hand-rolled formatting in the fix. Checked on both ends of the supported range (`^20.19.0 || >=22.12.0`) — Node v20.19.0 and v24.14.1 produce identical output:

| case | `util.inspect` output |
| --- | --- |
| `class EsputnikSyncError extends Error {}` thrown with `''` | header is `EsputnikSyncError` — the constructor name, even though `error.name` is `'Error'` and the stack header is bare |
| `cause` chain `Error` → `Error` → `'ECONNRESET'` | all three rendered, ending in `[cause]: 'ECONNRESET'` |
| `cause` cycle | `<ref *1>` / `[Circular *1]`, no infinite loop |
| non-`Error` throw (string, plain object, `null`) | `'boom'`, `{ code: 'ECONNRESET', errno: -54 }`, `null` |
| `AggregateError` | `[errors]: [ ... ]` with each sub-error |
| extra own properties | appended, e.g. `{ status: 502, url: '...' }` |

The first version of this PR walked the `cause` chain by hand. As @gabriellbui pointed out in review, that walk stopped as soon as a `cause` was not an `Error` — which is exactly the `error.cause = 'ECONNRESET'` case. `inspect` handles it, so the hand-rolled helper is gone.

**No `trace` argument is passed to `Logger.error` any more.** `DefaultLogger` renders `trace` by appending it to the message (`message + '\n' + trace`), and the `inspect` output already contains the stack, so passing `error.stack` as well would print the stack twice.

**`lastResult` is deliberately *not* the `inspect` output.** That value is persisted on the `scheduled_task` record and surfaced in the Dashboard, where a multi-line stack dump does not belong. It keeps a short single-line label: `error.message`, falling back to the constructor name (`constructor.name` rather than `name`, because a subclass that does not set `name` still inherits `'Error'` from `Error.prototype`). So the Dashboard's error column stops being blank without becoming a wall of text.

## Before / after

Both lines are the real output of the new e2e case, for a task throwing `class EmptyMessageError extends Error {}` with `error.cause = 'ECONNRESET'`.

Before (on `master`):

```
Scheduled task "error-test-job" failed with error:
```

After:

```
Scheduled task "error-test-job" failed with error: EmptyMessageError:
    at Object.execute (.../packages/core/e2e/default-scheduler-plugin.e2e-spec.ts:47:43)
    at ScheduledTask.execute (.../packages/core/src/scheduler/scheduled-task.ts:141:28)
    at DefaultSchedulerStrategy.runTask (.../packages/core/src/plugin/default-scheduler-plugin/default-scheduler-strategy.ts:114:28)
    ... {
  cause: 'ECONNRESET'
}
```

## Tests

Per review, the separate `default-scheduler-strategy.spec.ts` added by the first version of this PR is removed, and coverage lives in the existing `packages/core/e2e/default-scheduler-plugin.e2e-spec.ts` instead: one task that throws an empty-message subclass with a string `cause`, asserted through `TestingLogger.errorSpy`, no mocks beyond the task itself. It also asserts that `trace` is undefined and that `lastResult` is the short `{ error: 'EmptyMessageError' }` label.

The case fails on `master` with `expected 'Scheduled task "error-test-job" failed with error: ' to contain 'EmptyMessageError'`, and passes with the fix.

`packages/core`: e2e spec green (7 tests), unit suite green (82 files, 1251 tests). `bun run build:core-common` green.

# Breaking changes

None. For an error with a non-empty message, the log line keeps the same prefix and gains the stack, any `cause` chain and any extra properties. `lastResult.error` is unchanged except for errors whose message is empty, where it now carries the class name instead of an empty string.

# Screenshots

None — the log output above is the relevant evidence.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
