### PR TITLE
fix(core): do not record promotions that apply no discount

### DIFF
--- a/docs/docs/guides/core-concepts/promotions/index.mdx
+++ b/docs/docs/guides/core-concepts/promotions/index.mdx
@@ -260,6 +260,10 @@ function lineContainsIds(ids: ID[], line: OrderLine): boolean {
 export class FreeGiftPromotionPlugin {}
 ```
 
+:::note[Promotions which discount nothing are not recorded]
+A Promotion is only recorded on `Order.promotions` — and therefore only consumes its `usageLimit` and `perCustomerUsageLimit` — if it actually adjusted an OrderLine or a ShippingLine. The exception is a Promotion with at least one action defining `onActivate`/`onDeactivate`: the free gift action above returns `0` from `execute()` until its side effect has added the gift line, so such a Promotion is kept whatever it discounts. If you write a custom action which delivers its benefit by mutating the Order inside `execute()` and returns `0`, declare a no-op `onActivate` so that the Promotion continues to be recorded.
+:::
+
 ### Dependency relationships
 
 It is possible to establish dependency relationships between a PromotionAction and one or more PromotionConditions.

--- a/packages/core/e2e/order-promotion.e2e-spec.ts
+++ b/packages/core/e2e/order-promotion.e2e-spec.ts
@@ -2218,6 +2218,93 @@ describe('Promotions applied to Orders', () => {
         });
     });
 
+    describe('promotion which applies no discount', () => {
+        const couponCode = 'NO_DISCOUNT_ON_THIS_CART';
+        let promotion: PromotionFragment;
+
+        beforeAll(async () => {
+            promotion = await createPromotion({
+                enabled: true,
+                name: '50% off item-5000 only',
+                couponCode,
+                perCustomerUsageLimit: 1,
+                conditions: [],
+                actions: [
+                    {
+                        code: productsPercentageDiscount.code,
+                        arguments: [
+                            { name: 'discount', value: '50' },
+                            {
+                                name: 'productVariantIds',
+                                value: `["${getVariantBySlug('item-5000').id}"]`,
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
+
+        afterAll(async () => {
+            await deletePromotion(promotion.id);
+        });
+
+        function addGuestCustomerToOrder() {
+            return shopClient.query(setCustomerDocument, {
+                input: {
+                    emailAddress: 'no-discount-guest@test.com',
+                    firstName: 'No Discount',
+                    lastName: 'Customer',
+                },
+            });
+        }
+
+        it('is not added to the Order and does not consume a usage', async () => {
+            await shopClient.asAnonymousUser();
+            await shopClient.query(addItemToOrderDocument, {
+                // Not one of the Promotion's ProductVariants, so the action discounts nothing
+                productVariantId: getVariantBySlug('item-1000').id,
+                quantity: 1,
+            });
+            const { setCustomerForOrder } = await addGuestCustomerToOrder();
+            orderResultGuard.assertSuccess(setCustomerForOrder);
+
+            const { applyCouponCode } = await shopClient.query(applyCouponCodeDocument, { couponCode });
+            orderResultGuard.assertSuccess(applyCouponCode);
+
+            // The customer typed the code, so it stays on the Order even though it discounts nothing
+            expect(applyCouponCode.couponCodes).toEqual([couponCode]);
+            expect(applyCouponCode.discounts).toEqual([]);
+            const orderCode = applyCouponCode.code;
+
+            await proceedToArrangingPayment(shopClient);
+            const order = await addPaymentToOrder(shopClient, testSuccessfulPaymentMethod);
+            orderResultGuard.assertSuccess(order);
+            expect(order.state).toBe('PaymentSettled');
+
+            const { orderByCode } = await shopClient.query(getOrderPromotionsByCodeDocument, {
+                code: orderCode,
+            });
+            expect(orderByCode!.promotions).toEqual([]);
+
+            // The customer's single allowed usage is still available
+            await shopClient.asAnonymousUser();
+            await shopClient.query(addItemToOrderDocument, {
+                productVariantId: getVariantBySlug('item-5000').id,
+                quantity: 1,
+            });
+            const { setCustomerForOrder: setCustomerForSecondOrder } = await addGuestCustomerToOrder();
+            orderResultGuard.assertSuccess(setCustomerForSecondOrder);
+
+            const { applyCouponCode: secondUse } = await shopClient.query(applyCouponCodeDocument, {
+                couponCode,
+            });
+            orderResultGuard.assertSuccess(secondUse);
+
+            expect(secondUse.discounts.length).toBe(1);
+            expect(secondUse.totalWithTax).toBe(3000);
+        });
+    });
+
     // https://github.com/vendurehq/vendure/issues/710
     it('removes order-level discount made invalid by removing OrderLine', async () => {
         const promotion = await createPromotion({

--- a/packages/core/src/config/promotion/promotion-action.ts
+++ b/packages/core/src/config/promotion/promotion-action.ts
@@ -306,6 +306,17 @@ export abstract class PromotionAction<
         this.onDeactivateFn = config.onDeactivate;
     }
 
+    /**
+     * @description
+     * Whether this action defines any of the side-effect functions. Such an action can have an
+     * effect on the Order (adding a free gift, say) without producing a price adjustment.
+     *
+     * @internal
+     */
+    get hasSideEffects(): boolean {
+        return !!(this.onActivateFn || this.onDeactivateFn);
+    }
+
     /** @internal */
     abstract execute(...arg: any[]): number | Promise<number>;
 

--- a/packages/core/src/entity/promotion/promotion.entity.ts
+++ b/packages/core/src/entity/promotion/promotion.entity.ts
@@ -147,6 +147,18 @@ export class Promotion
      */
     @Column() priorityScore: number;
 
+    /**
+     * @description
+     * Whether any of this Promotion's actions define a side effect (`onActivate` / `onDeactivate`).
+     * Such a Promotion can benefit the Order without producing a price adjustment - the free gift
+     * action being the canonical example - so it counts as applied even when it discounts nothing.
+     *
+     * @internal
+     */
+    get hasSideEffects(): boolean {
+        return this.actions.some(action => this.allActions[action.code]?.hasSideEffects);
+    }
+
     async apply(
         ctx: RequestContext,
         args: ApplyOrderActionArgs | ApplyOrderItemActionArgs | ApplyShippingActionArgs,

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.spec.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.spec.ts
@@ -1517,6 +1517,197 @@ describe('OrderCalculator', () => {
                 expect(order.subTotal).toBe(1350);
             });
         });
+
+        describe('promotions which apply no discount', () => {
+            // Models the common "facet exclusions" setup: the conditions pass for the whole Order,
+            // but the action discounts only some of the items.
+            const discountExpensiveItemsAction = new PromotionItemAction({
+                code: 'discount_expensive_items_action',
+                description: [{ languageCode: LanguageCode.en, value: '' }],
+                args: {},
+                execute(ctx, orderLine) {
+                    return 1000 <= orderLine.unitPrice ? -100 : 0;
+                },
+            });
+
+            const neverDiscountAction = new PromotionItemAction({
+                code: 'never_discount_action',
+                description: [{ languageCode: LanguageCode.en, value: '' }],
+                args: {},
+                execute() {
+                    return 0;
+                },
+            });
+
+            const sideEffectAction = new PromotionItemAction({
+                code: 'side_effect_action',
+                description: [{ languageCode: LanguageCode.en, value: '' }],
+                args: {},
+                execute() {
+                    return 0;
+                },
+                // The benefit of this action is delivered by the side effect, not by a discount.
+                onActivate: () => undefined,
+            });
+
+            function createItemPromotion(action: PromotionItemAction, id = 1) {
+                return new Promotion({
+                    id,
+                    name: `Test promotion ${id}`,
+                    conditions: [{ code: alwaysTrueCondition.code, args: [] }],
+                    promotionConditions: [alwaysTrueCondition],
+                    actions: [{ code: action.code, args: [] }],
+                    promotionActions: [action],
+                });
+            }
+
+            it('is not added to the Order', async () => {
+                const ctx = createRequestContext({ pricesIncludeTax: false });
+                const order = createOrder({
+                    ctx,
+                    lines: [
+                        {
+                            listPrice: 100,
+                            taxCategory: taxCategoryStandard,
+                            quantity: 1,
+                        },
+                    ],
+                });
+
+                await orderCalculator.applyPriceAdjustments(ctx, order, [
+                    createItemPromotion(discountExpensiveItemsAction),
+                ]);
+
+                expect(order.discounts.length).toBe(0);
+                expect(order.promotions).toEqual([]);
+            });
+
+            it('is added to the Order when it discounts at least one line', async () => {
+                const ctx = createRequestContext({ pricesIncludeTax: false });
+                const order = createOrder({
+                    ctx,
+                    lines: [
+                        {
+                            listPrice: 100,
+                            taxCategory: taxCategoryStandard,
+                            quantity: 1,
+                        },
+                        {
+                            listPrice: 2000,
+                            taxCategory: taxCategoryStandard,
+                            quantity: 1,
+                        },
+                    ],
+                });
+
+                await orderCalculator.applyPriceAdjustments(ctx, order, [
+                    createItemPromotion(discountExpensiveItemsAction),
+                ]);
+
+                expect(order.discounts.length).toBe(1);
+                expect(order.promotions.map(p => p.id)).toEqual([1]);
+            });
+
+            it('is removed without removing the other Promotions on the Order', async () => {
+                const ctx = createRequestContext({ pricesIncludeTax: false });
+                const order = createOrder({
+                    ctx,
+                    lines: [
+                        {
+                            listPrice: 2000,
+                            taxCategory: taxCategoryStandard,
+                            quantity: 1,
+                        },
+                    ],
+                });
+
+                await orderCalculator.applyPriceAdjustments(ctx, order, [
+                    createItemPromotion(discountExpensiveItemsAction, 1),
+                    createItemPromotion(neverDiscountAction, 2),
+                ]);
+
+                expect(order.discounts.length).toBe(1);
+                expect(order.promotions.map(p => p.id)).toEqual([1]);
+            });
+
+            it('is removed from the Order once it no longer discounts anything', async () => {
+                const ctx = createRequestContext({ pricesIncludeTax: false });
+                const promotion = createItemPromotion(discountExpensiveItemsAction);
+                const order = createOrder({
+                    ctx,
+                    lines: [
+                        {
+                            listPrice: 2000,
+                            taxCategory: taxCategoryStandard,
+                            quantity: 1,
+                        },
+                    ],
+                });
+
+                await orderCalculator.applyPriceAdjustments(ctx, order, [promotion]);
+                expect(order.promotions.map(p => p.id)).toEqual([1]);
+
+                order.lines[0].listPrice = 100;
+                await orderCalculator.applyPriceAdjustments(ctx, order, [promotion]);
+
+                expect(order.discounts.length).toBe(0);
+                expect(order.promotions).toEqual([]);
+            });
+
+            it('is added to the Order when it only discounts shipping', async () => {
+                const ctx = createRequestContext({ pricesIncludeTax: false });
+                const promotion = new Promotion({
+                    id: 2,
+                    name: 'Free shipping',
+                    conditions: [{ code: alwaysTrueCondition.code, args: [] }],
+                    promotionConditions: [alwaysTrueCondition],
+                    actions: [{ code: freeShippingAction.code, args: [] }],
+                    promotionActions: [freeShippingAction],
+                });
+                const order = createOrder({
+                    ctx,
+                    lines: [
+                        {
+                            listPrice: 100,
+                            taxCategory: taxCategoryStandard,
+                            quantity: 1,
+                        },
+                    ],
+                });
+                order.shippingLines = [
+                    new ShippingLine({
+                        shippingMethodId: mockShippingMethodId,
+                        adjustments: [],
+                    }),
+                ];
+
+                await orderCalculator.applyPriceAdjustments(ctx, order, [promotion]);
+
+                expect(order.shipping).toBe(0);
+                expect(order.promotions.map(p => p.id)).toEqual([2]);
+            });
+
+            it('is added to the Order when its action has a side effect', async () => {
+                const ctx = createRequestContext({ pricesIncludeTax: false });
+                const order = createOrder({
+                    ctx,
+                    lines: [
+                        {
+                            listPrice: 100,
+                            taxCategory: taxCategoryStandard,
+                            quantity: 1,
+                        },
+                    ],
+                });
+
+                await orderCalculator.applyPriceAdjustments(ctx, order, [
+                    createItemPromotion(sideEffectAction),
+                ]);
+
+                expect(order.discounts.length).toBe(0);
+                expect(order.promotions.map(p => p.id)).toEqual([1]);
+            });
+        });
     });
 
     describe('surcharges', () => {

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.ts
@@ -113,6 +113,7 @@ export class OrderCalculator {
             await this.applyShippingPromotions(ctx, order, promotions);
         }
         this.calculateOrderTotals(order);
+        this.removeIneffectivePromotions(order);
         return order;
     }
 
@@ -386,5 +387,36 @@ export class OrderCalculator {
         if (order.promotions && !order.promotions.find(p => idsAreEqual(p.id, promotion.id))) {
             order.promotions.push(promotion);
         }
+    }
+
+    /**
+     * Promotions are added to the Order as soon as their conditions pass, since a Promotion which
+     * discounts nothing on one OrderLine may still discount a later line, the Order total or the
+     * shipping. Once everything has been applied, any Promotion which ended up adjusting nothing
+     * at all is removed again: `Order.promotions` is what the usage limits are counted from, so a
+     * Promotion the customer got no benefit from must not consume a usage.
+     *
+     * Promotions whose actions define side effects are kept regardless, as their benefit (a free
+     * gift, say) is not expressed as an adjustment amount - and on the first pass the side effect
+     * has not run yet, so there is nothing to discount.
+     */
+    private removeIneffectivePromotions(order: Order) {
+        if (!order.promotions?.length) {
+            return;
+        }
+        const adjustmentSources = new Set<string>();
+        for (const line of order.lines) {
+            for (const adjustment of line.adjustments ?? []) {
+                adjustmentSources.add(adjustment.adjustmentSource);
+            }
+        }
+        for (const shippingLine of order.shippingLines ?? []) {
+            for (const adjustment of shippingLine.adjustments ?? []) {
+                adjustmentSources.add(adjustment.adjustmentSource);
+            }
+        }
+        order.promotions = order.promotions.filter(
+            promotion => adjustmentSources.has(promotion.getSourceId()) || promotion.hasSideEffects,
+        );
     }
 }


### PR DESCRIPTION
# Description

Fixes #5278.

A Promotion whose conditions pass but whose actions produce no adjustment anywhere is still attached to the Order, so it still consumes `usageLimit` / `perCustomerUsageLimit`. The full bug report is at the bottom of this description; the short version is that a customer who applies a coupon and gets no discount can never use that coupon again.

`OrderCalculator.applyPriceAdjustments` now ends with `removeIneffectivePromotions(order)`, which keeps a Promotion on `order.promotions` only if it adjusted an OrderLine or a ShippingLine.

Design notes, in case any of these are the wrong call:

**The check is at the end of the calculation, not at the `addPromotion()` call sites.** There are three of them (`applyOrderItemPromotions`, `applyOrderPromotions`, `applyShippingPromotions`) and a Promotion that discounts nothing on the first OrderLine may still discount the third one, the Order total, or the shipping. Filtering once at the end covers all three targets and leaves the behaviour during the calculation exactly as it was, in case a `PromotionCondition` reads `order.promotions` mid-run.

**"Produced an adjustment" is read from the raw `adjustments` arrays on the lines and shipping lines,** not from `Order.discounts`. Both `OrderLine.addAdjustment()` and `applyShippingPromotions` already refuse to store a zero-amount adjustment, so the presence of an adjustment is itself the signal. Going through `Order.discounts` would have dragged in the quantity and tax maths, which can round a real discount to a zero-amount `Discount` on a fully-cancelled line.

**Promotions with side effects are kept even at zero discount.** This is the subtle case. The documented free-gift plugin (`docs/docs/guides/core-concepts/promotions/index.mdx`) has an action whose `execute()` returns 0 until the gift line exists, and an `onActivate()` that adds it. `PromotionService.runPromotionSideEffects()` decides what to activate by diffing `order.promotions`, so filtering on discount alone would mean the promotion is never recorded, `onActivate` never runs, the gift is never added, and `execute()` keeps returning 0 forever. `PromotionAction.hasSideEffects` and `Promotion.hasSideEffects` were added so the filter can make that exception. Such a promotion consumes a usage even when it discounts nothing, which seems right — the side effect ran.

The case that exemption does not cover is a side effect that runs and *fails*: the documented free-gift `onActivate` logs the error and continues when the gift variant cannot be added, so an Order whose gift was out of stock keeps the promotion and burns a usage having received nothing. Distinguishing that would mean giving `onActivate` a way to report failure back to the calculator, which is a wider API change than this fix. Promotions with side effects therefore keep the old behaviour by design, and only the plain zero-discount case changes.

**No config option or strategy gates the new behaviour.** Recording a promotion the customer received nothing from is not a policy any store would deliberately choose — it is simply the bug — so a flag would preserve it only for the stores that have not noticed yet, and would leave `PromotionService`'s usage counting with two meanings instead of one. The contract is documented in the promotions guide next to the free-gift example, because it does have one consequence for plugin authors: a custom action that delivers its benefit by mutating the Order inside `execute()` and returns 0 should declare a no-op `onActivate` to keep being recorded.

**Coupon codes are untouched.** `order.couponCodes` is separate from `order.promotions`. A code the customer typed stays on the Order even when it discounts nothing: it is still a valid code, `Promotion.test()` still passes, and removing it would be a surprising, unexplained change in the cart. It just no longer counts as a usage. Concretely, a customer can now apply a zero-effect coupon, place the order, and apply the same coupon again on their next order.

**Removal still works.** `applyPriceAdjustments` starts from `order.promotions = []` and rebuilds the list, so the filter is a narrower rebuild, not a new deletion path. A promotion that was never recorded is simply absent from both sides of the `runPromotionSideEffects` diff, and `deactivate()` on a promotion without side-effect functions is a no-op.

Tests:

- `order-calculator.spec.ts` — a new `promotions which apply no discount` block: not added when nothing is discounted; added when one of several lines is discounted; removed without disturbing the other Promotion applied to the same Order; removed once it stops discounting; added when it only discounts shipping; added when its action has a side effect.
- `order-promotion.e2e-spec.ts` — a zero-discount coupon with `perCustomerUsageLimit: 1`: the placed Order has no promotions, and the same customer can apply the coupon again on a cart where it does discount something.

The regression tests fail on `master` (three of the `order-calculator.spec.ts` cases and the e2e case), and the remaining "must still be attached" cases pass either way, so they only guard against over-removal.

Verified with:

```
packages/core $ npm test                      # 82 files, 1257 tests
packages/core $ npm run e2e -- promotion      # 4 files, 100 tests, 1 skipped
packages/core $ npm run e2e -- order          # 21 files, 503 tests, 1 skipped
```

`order-promotion.e2e-spec.ts` and `promotion-side-effects.e2e-spec.ts` were additionally run against postgres 16 and mysql 8 (73 tests each) as well as sqljs.

`tsc -p ./build/tsconfig.build.json --noEmit` is clean, `docs $ npm run test:mdx` passes, and `eslint` on the touched files reports only warnings that are already present on `master`.

# Breaking changes

No API or schema change, but it is a change in current behaviour, so flagging it explicitly:

- `Order.promotions` no longer lists a Promotion that discounted nothing. Any storefront reading that field to decide whether to show "coupon applied" needs `order.couponCodes` instead — which is the accurate source anyway.
- Consequently `usageLimit` and `perCustomerUsageLimit` are consumed less often. This applies to new calculations only: the existing rows in `order_promotions_promotion` are not migrated, so a promotion already exhausted by past zero-discount orders stays exhausted until those orders are recalculated — which in practice means an admin-API order modification, not an upgrade.
- `OrderModifier.modifyOrder` re-runs `applyPriceAdjustments` on a placed Order and saves the result, so a modification that removes the discounted OrderLine now also drops the Promotion and releases the usage. That is arguably the right reading of "this Order no longer benefits from the promotion", but it is a behaviour change worth naming.

Happy to retarget this at `minor` or `major` if you consider that a behaviour break rather than the fix.

# Screenshots

n/a

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

---

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791198797&installation_model_id=20193&pr_number=5279&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5279&signature=cc00ffbd37fdcbd87790c50a12b5518d322ddcf90ca74e1d45987228fec2c4be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->