### PR TITLE
fix(core): apply relevance ordering when search sort input is empty

### DIFF
--- a/packages/core/e2e/default-search-plugin.e2e-spec.ts
+++ b/packages/core/e2e/default-search-plugin.e2e-spec.ts
@@ -168,6 +168,24 @@ describe('Default search plugin', () => {
         expect(result.search.items.map(i => i.productVariantName)).toEqual(expected);
     }
 
+    /**
+     * Clients generated from the GraphQL schema commonly send `sort: {}` when the user has not
+     * selected a sort order. Since an empty object is truthy, this used to be treated as an
+     * explicit sort, which suppressed the relevance ordering that applies when searching by term.
+     */
+    async function testRelevanceSortingWithEmptySortObject(testProducts: TestProducts) {
+        const result = await testProducts({
+            term: 'slr',
+            groupByProduct: true,
+            sort: {},
+        });
+
+        // "Slr Camera" matches on the product name whereas "Camera Lens" only matches in the
+        // description, so the higher-scoring "Slr Camera" must come first, even though it has the
+        // higher productVariantId, which is the fallback ordering used when no score is applied.
+        expect(result.search.items.map(i => i.productName)).toEqual(['Slr Camera', 'Camera Lens']);
+    }
+
     async function testMatchSearchTerm(testProducts: TestProducts) {
         const result = await testProducts({
             term: 'camera',
@@ -685,6 +703,9 @@ describe('Default search plugin', () => {
 
         it('sort price without grouping', () => testSortingNoGrouping(testProductsShop, 'price'));
 
+        it('sorts by relevance when sort is an empty object', () =>
+            testRelevanceSortingWithEmptySortObject(testProductsShop));
+
         it('omits results for disabled ProductVariants', async () => {
             await adminClient.query(updateProductVariantsDocument, {
                 input: [{ id: 'T_3', enabled: false }],
@@ -821,6 +842,9 @@ describe('Default search plugin', () => {
         it('sort name without grouping', () => testSortingNoGrouping(testProductsAdmin, 'name'));
 
         it('sort price without grouping', () => testSortingNoGrouping(testProductsAdmin, 'price'));
+
+        it('sorts by relevance when sort is an empty object', () =>
+            testRelevanceSortingWithEmptySortObject(testProductsAdmin));
 
         describe('updating the index', () => {
             it('updates index when ProductVariants are changed', async () => {

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/mysql-search-strategy.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/mysql-search-strategy.ts
@@ -17,6 +17,7 @@ import {
     createCollectionIdCountMap,
     createFacetIdCountMap,
     createPlaceholderFromId,
+    hasSortParameter,
     mapToSearchResult,
 } from './search-strategy-utils';
 
@@ -100,7 +101,7 @@ export class MysqlSearchStrategy implements SearchStrategy {
 
         this.applyTermAndFilters(ctx, qb, input);
 
-        if (sort) {
+        if (hasSortParameter(sort)) {
             if (sort.name) {
                 qb.addOrderBy('si_productName', sort.name);
             }

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/postgres-search-strategy.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/postgres-search-strategy.ts
@@ -17,6 +17,7 @@ import {
     createCollectionIdCountMap,
     createFacetIdCountMap,
     createPlaceholderFromId,
+    hasSortParameter,
     mapToSearchResult,
 } from './search-strategy-utils';
 
@@ -100,7 +101,7 @@ export class PostgresSearchStrategy implements SearchStrategy {
 
         this.applyTermAndFilters(ctx, qb, input);
 
-        if (sort) {
+        if (hasSortParameter(sort)) {
             if (sort.name) {
                 qb.addOrderBy('"si_productName"', sort.name);
             }

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/search-strategy-utils.spec.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/search-strategy-utils.spec.ts
@@ -1,0 +1,31 @@
+import { SearchResultSortParameter, SortOrder } from '@vendure/common/lib/generated-types';
+import { describe, expect, it } from 'vitest';
+
+import { hasSortParameter } from './search-strategy-utils';
+
+describe('hasSortParameter()', () => {
+    it('returns false when no sort parameter was given', () => {
+        expect(hasSortParameter(undefined)).toBe(false);
+        expect(hasSortParameter(null)).toBe(false);
+    });
+
+    it('returns false for an empty sort object', () => {
+        expect(hasSortParameter({})).toBe(false);
+    });
+
+    it('returns false when all sort fields are null or undefined', () => {
+        // GraphQL can deliver an explicit null at runtime, which the generated input type does not model
+        expect(
+            hasSortParameter({ name: null, price: undefined } as unknown as SearchResultSortParameter),
+        ).toBe(false);
+    });
+
+    it('returns true when at least one sort field is set', () => {
+        expect(hasSortParameter({ name: SortOrder.ASC })).toBe(true);
+        expect(hasSortParameter({ price: SortOrder.DESC })).toBe(true);
+        // GraphQL can deliver an explicit null at runtime, which the generated input type does not model
+        expect(
+            hasSortParameter({ name: null, price: SortOrder.ASC } as unknown as SearchResultSortParameter),
+        ).toBe(true);
+    });
+});

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/search-strategy-utils.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/search-strategy-utils.ts
@@ -5,6 +5,7 @@ import {
     PriceRange,
     SearchResult,
     SearchResultAsset,
+    SearchResultSortParameter,
     SinglePrice,
 } from '@vendure/common/lib/generated-types';
 import { ID } from '@vendure/common/lib/shared-types';
@@ -114,6 +115,18 @@ function parseFocalPoint(focalPoint: any): Coordinate | undefined {
 
 export function createPlaceholderFromId(id: ID): string {
     return '_' + id.toString().replace(/-/g, '_');
+}
+
+/**
+ * Returns true if the given sort parameter actually specifies a field to sort by.
+ *
+ * Clients built with GraphQL code generation commonly send `sort: {}` when the user has
+ * not selected any sort order. Since an empty object is truthy, it must not be treated as
+ * an explicit sort, otherwise no ordering would be applied at all and the relevance
+ * ordering which applies when searching by term would be silently suppressed.
+ */
+export function hasSortParameter(sort?: SearchResultSortParameter | null): sort is SearchResultSortParameter {
+    return sort != null && Object.values(sort).some(value => value != null);
 }
 
 /**

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/sqlite-search-strategy.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/sqlite-search-strategy.ts
@@ -16,6 +16,7 @@ import {
     createCollectionIdCountMap,
     createFacetIdCountMap,
     createPlaceholderFromId,
+    hasSortParameter,
     mapToSearchResult,
 } from './search-strategy-utils';
 
@@ -99,7 +100,7 @@ export class SqliteSearchStrategy implements SearchStrategy {
 
         this.applyTermAndFilters(ctx, qb, input);
 
-        if (sort) {
+        if (hasSortParameter(sort)) {
             if (sort.name) {
                 // TODO: v3 - set the collation on the SearchIndexItem entity
                 qb.addOrderBy('si.productName COLLATE NOCASE', sort.name);


### PR DESCRIPTION
# Description

Fixes #5282.

The `DefaultSearchPlugin` search strategies decide whether to order by relevance like this:

```ts
if (sort) {
    if (sort.name) { /* ... */ }
    if (sort.price) { /* ... */ }
} else if (input.term && input.term.length > this.minTermLength) {
    qb.addOrderBy('score', 'DESC');
}
```

`sort` is the raw `input.sort` object. Clients generated with graphql-codegen commonly send `sort: {}` when the user has not selected a sort order, and `{}` is truthy — so the first branch is taken, neither `sort.name` nor `sort.price` adds an `ORDER BY`, and `score DESC` is never applied.

The relevance score is still computed and returned in the `SELECT`, it just has no effect on the ordering. Results fall back to the deterministic `productVariantId ASC` tiebreaker that is appended afterwards, so a term search returns rows in insertion order rather than by relevance. An exact product-name match can be returned below unrelated items.

All three strategies shared the defect and are fixed together:

- `PostgresSearchStrategy`
- `MysqlSearchStrategy` (MySQL / MariaDB)
- `SqliteSearchStrategy` (SQLite / sql.js)

The fix adds a small shared helper in `search-strategy-utils.ts`:

```ts
export function hasSortParameter(sort?: SearchResultSortParameter | null): sort is SearchResultSortParameter {
    return sort != null && Object.values(sort).some(value => value != null);
}
```

A sort object with no defined fields is now treated as absent. When at least one sort field *is* set, behaviour is exactly as before — including the existing behaviour that an explicit sort takes precedence over the relevance score when a term is also present. That semantic is deliberately left alone.

## Tests

- New e2e case in `default-search-plugin.e2e-spec.ts` (run for both the Shop and Admin APIs): searching `term: 'slr'` with `sort: {}` must return `['Slr Camera', 'Camera Lens']`. `Slr Camera` matches on the product name, `Camera Lens` only in the description, so the higher-scoring product must come first — and it has the *higher* `productVariantId`, so the assertion fails if the ordering falls back to the id tiebreaker.

  The assertion holds on all four supported databases, and the margin is comfortable. Neither fixture product defines option groups, so each has a single default variant whose name equals the product name — `Slr Camera` therefore matches on both `productName` and `productVariantName`, while `Camera Lens` matches only on `description`. Under SQLite that is a flat `3 + 2` against `1`; under Postgres the `ts_rank_cd` terms are weighted `×2` and `×1.5` against `×1`, so `3.5` weighting units against `1`.

  MySQL uses the same `×2` / `×1.5` / `×1` multipliers, but the three `MATCH … AGAINST` terms are scored against three separate FULLTEXT indexes, so their raw values are not comparable across columns in general. They are comparable for this fixture, where the term's document frequency is the same in each of the three columns, and that is what the assertion relies on — a property of the fixture data, not of the strategy.

  Verified by running the suite against sqljs, PostgreSQL 16, MySQL 8.0 and MariaDB — it fails on all of them without the fix and passes on all of them with it.

- New unit test `search-strategy-utils.spec.ts` covering the branch logic directly, including `{}` and `{ name: null }`.

## Verification

```
bun run build:core-common
cd packages/core && bun run test                                        # 1255 passed
cd packages/core && bun run e2e -- default-search-plugin                # sqljs
CI=1 DB=postgres bun run e2e -- default-search-plugin                   # postgres 16
CI=1 DB=mysql    bun run e2e -- default-search-plugin                   # mysql 8.0
CI=1 DB=mariadb  bun run e2e -- default-search-plugin                   # mariadb
bunx eslint packages/core/src/plugin/default-search-plugin/search-strategy/
```

All green. Before the fix, the two new e2e cases fail on every database with `expected [ 'Camera Lens', 'Slr Camera' ] to deeply equal [ 'Slr Camera', 'Camera Lens' ]`.

# Breaking changes

None. Term searches that previously came back in `productVariantId` order when the client sent an empty sort object will now come back ordered by relevance, which is the documented and intended behaviour. Explicit sorts are unaffected.

# Screenshots

n/a

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791198812&installation_model_id=20193&pr_number=5283&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5283&signature=518e05c4c17f30489a052285fd12b9b7dfddceb4cb888a92ce87aa2121944ac1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->