### PR TITLE
fix(core): bound SubscribableJob.updates() by timeoutMs

### DIFF
--- a/packages/core/src/job-queue/subscribable-job.spec.ts
+++ b/packages/core/src/job-queue/subscribable-job.spec.ts
@@ -1,0 +1,136 @@
+import { JobState } from '@vendure/common/lib/generated-types';
+import { lastValueFrom } from 'rxjs';
+import { toArray } from 'rxjs/operators';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { JobQueueStrategy } from '../config/job-queue/job-queue-strategy';
+import { Logger } from '../config/logger/vendure-logger';
+
+import { Job } from './job';
+import { SubscribableJob } from './subscribable-job';
+
+const TIMEOUT_RESULT = 'Job subscription timed out. The job may still be running';
+
+/**
+ * Returns a fresh Job instance with the same values, mirroring the way a real strategy
+ * hydrates a new entity on each `findOne()` call.
+ */
+function snapshot(job: Job): Job {
+    return new Job({
+        id: job.id,
+        queueName: job.queueName,
+        data: job.data,
+        state: job.state,
+        progress: job.progress,
+        result: job.result,
+        error: job.error,
+        retries: job.retries,
+        attempts: job.attempts,
+    });
+}
+
+/**
+ * A minimal inspectable strategy backed by a single mutable Job instance, so that a test
+ * can drive the job through its states by hand.
+ */
+function setup() {
+    const job = new Job({ id: 1, queueName: 'test', data: {} });
+    const findOne = vi.fn().mockImplementation(() => Promise.resolve(snapshot(job)));
+    const strategy = {
+        findOne,
+        findMany: vi.fn(),
+        findManyById: vi.fn(),
+        removeSettledJobs: vi.fn(),
+    } as unknown as JobQueueStrategy;
+    return { job, findOne, subscribableJob: new SubscribableJob(job, strategy) };
+}
+
+function tick(ms: number): Promise<void> {
+    return new Promise<void>(resolve => setTimeout(resolve, ms));
+}
+
+describe('SubscribableJob', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('updates()', () => {
+        it('emits updates until the job settles', async () => {
+            const { job, subscribableJob } = setup();
+            job.start();
+            setTimeout(() => job.complete('job result'), 60);
+
+            const startedAt = Date.now();
+            const updates = await lastValueFrom(
+                subscribableJob.updates({ pollInterval: 20, timeoutMs: 5000 }).pipe(toArray()),
+            );
+
+            expect(updates.map(u => u.state)).toEqual([JobState.RUNNING, JobState.COMPLETED]);
+            expect(updates[updates.length - 1].result).toBe('job result');
+            // The stream must complete as soon as the job settles rather than hanging
+            // around until `timeoutMs` elapses.
+            expect(Date.now() - startedAt).toBeLessThan(2000);
+        });
+
+        it('times out after timeoutMs even once updates have been emitted', async () => {
+            // Without a total-wait bound this test hangs: the job emits a RUNNING update
+            // and then never settles, so the stream never completes.
+            const { job, subscribableJob } = setup();
+            job.start();
+            const logError = vi.spyOn(Logger, 'error').mockImplementation(() => undefined);
+
+            const startedAt = Date.now();
+            const updates = await lastValueFrom(
+                subscribableJob.updates({ pollInterval: 20, timeoutMs: 200 }).pipe(toArray()),
+            );
+            const elapsed = Date.now() - startedAt;
+
+            expect(updates.map(u => u.state)).toEqual([JobState.RUNNING, JobState.RUNNING]);
+            expect(updates[0].result).toBeUndefined();
+            expect(updates[1].result).toBe(TIMEOUT_RESULT);
+            expect(elapsed).toBeGreaterThanOrEqual(190);
+            expect(elapsed).toBeLessThan(2000);
+            // The timeout still logs exactly what it logged before this fix.
+            expect(logError).toHaveBeenCalledTimes(1);
+            expect(logError).toHaveBeenCalledWith(
+                'Job 1 SubscribableJob update polling timed out after 200ms. The job may still be running.',
+            );
+        });
+
+        it('times out when the job never emits any update at all', async () => {
+            const { findOne, subscribableJob } = setup();
+            findOne.mockImplementation(() => Promise.resolve(undefined));
+
+            const updates = await lastValueFrom(
+                subscribableJob.updates({ pollInterval: 20, timeoutMs: 200 }).pipe(toArray()),
+            );
+
+            expect(updates.length).toBe(1);
+            expect(updates[0].result).toBe(TIMEOUT_RESULT);
+        });
+
+        it('stops polling once the timeout has elapsed', async () => {
+            const { job, findOne, subscribableJob } = setup();
+            job.start();
+
+            await lastValueFrom(
+                subscribableJob.updates({ pollInterval: 20, timeoutMs: 200 }).pipe(toArray()),
+            );
+            const callsWhenTimedOut = findOne.mock.calls.length;
+
+            await tick(200);
+
+            expect(findOne.mock.calls.length).toBe(callsWhenTimedOut);
+        });
+
+        it('errors on a failed job when errorOnFail is not disabled', async () => {
+            const { job, subscribableJob } = setup();
+            job.start();
+            setTimeout(() => job.fail(new Error('job failed')), 60);
+
+            await expect(
+                lastValueFrom(subscribableJob.updates({ pollInterval: 20, timeoutMs: 5000 }).pipe(toArray())),
+            ).rejects.toThrowError('job failed');
+        });
+    });
+});

--- a/packages/core/src/job-queue/subscribable-job.ts
+++ b/packages/core/src/job-queue/subscribable-job.ts
@@ -2,8 +2,8 @@ import { JobState } from '@vendure/common/lib/generated-types';
 import { pick } from '@vendure/common/lib/pick';
 import { notNullOrUndefined } from '@vendure/common/lib/shared-utils';
 import ms from 'ms';
-import { interval, Observable, race, timer } from 'rxjs';
-import { distinctUntilChanged, filter, map, switchMap, takeWhile, tap } from 'rxjs/operators';
+import { concat, defer, EMPTY, interval, Observable, of, timer } from 'rxjs';
+import { distinctUntilChanged, filter, map, switchMap, takeUntil, takeWhile, tap } from 'rxjs/operators';
 
 import { InternalServerError } from '../common/error/errors';
 import { Logger } from '../config/index';
@@ -38,7 +38,9 @@ export type JobUpdateOptions = {
      */
     pollInterval?: number;
     /**
-     * Polling timeout in milliseconds. Defaults to 1 hour
+     * The maximum time in milliseconds to wait for the job to settle. Once this time has
+     * elapsed, the subscription is ended whether or not any updates have already been
+     * emitted. Defaults to 1 hour
      */
     timeoutMs?: number;
     /**
@@ -77,6 +79,9 @@ export class SubscribableJob<T extends JobData<T> = any> extends Job<T> {
      *
      * Polling interval, timeout and other options may be configured with an options arguments {@link JobUpdateOptions}.
      *
+     * The `timeoutMs` option bounds the whole subscription: if the job has not settled by then, polling
+     * stops, a final update with a `result` of "Job subscription timed out. The job may still be running"
+     * is emitted, and the stream completes.
      */
     updates(options?: JobUpdateOptions): Observable<JobUpdate<T>> {
         const pollInterval = Math.max(50, options?.pollInterval ?? 200);
@@ -112,31 +117,44 @@ export class SubscribableJob<T extends JobData<T> = any> extends Job<T> {
                 }),
                 map(job => pick(job, ['id', 'state', 'progress', 'result', 'error', 'data'])),
             );
-            const timeout$ = timer(timeoutMs).pipe(
-                tap(i => {
+            return defer(() => {
+                let jobSettled = false;
+                // `takeUntil` bounds the entire subscription by `timeoutMs` rather than just the
+                // wait for the first update, and unsubscribes from `updates$` at the deadline so
+                // that no polling interval is left running.
+                //
+                // The `tap` sits upstream of the `takeUntil`, so its `complete` callback fires only
+                // when the job itself reaches a terminal state. A `takeUntil` cut-off unsubscribes
+                // from the source rather than completing it, which is how the two cases are told
+                // apart: only a job that never settled gets the timeout update appended.
+                const boundedUpdates$ = updates$.pipe(
+                    tap({
+                        complete: () => {
+                            jobSettled = true;
+                        },
+                    }),
+                    takeUntil(timer(timeoutMs)),
+                );
+                const timedOut$ = defer(() => {
+                    if (jobSettled) {
+                        return EMPTY;
+                    }
                     Logger.error(
                         `Job ${
                             this.id ?? ''
                         } SubscribableJob update polling timed out after ${timeoutMs}ms. The job may still be running.`,
                     );
-                }),
-                map(
-                    () =>
-                        ({
-                            id: this.id,
-                            state: JobState.RUNNING,
-                            data: this.data,
-                            error: this.error,
-                            progress: this.progress,
-                            result: 'Job subscription timed out. The job may still be running',
-                        }) satisfies JobUpdate<any>,
-                ),
-            );
-
-            // Use race() to return whichever observable emits first and follow it to completion.
-            // - If updates$ emits first, it will continue emitting until the job settles
-            // - If timeout$ emits first, it will emit the timeout message and complete
-            return race(updates$, timeout$) as Observable<JobUpdate<T>>;
+                    return of({
+                        id: this.id,
+                        state: JobState.RUNNING,
+                        data: this.data,
+                        error: this.error,
+                        progress: this.progress,
+                        result: 'Job subscription timed out. The job may still be running',
+                    } satisfies JobUpdate<any>);
+                });
+                return concat(boundedUpdates$, timedOut$);
+            }) as Observable<JobUpdate<T>>;
         }
     }
 }


### PR DESCRIPTION
# Description

Fixes #5284.

Fixes a defect in `SubscribableJob.updates()`: the `timeoutMs` option does not bound the total wait. Verified on `@vendure/core` 3.7.2 in production and re-verified against current `master` (`523b573`).

`updates()` composed the poll and the timeout with `race(updates$, timeout$)`. `race` picks a winner on the **first** emission and permanently discards the loser, so as soon as the job reported `RUNNING` the timeout branch was gone and polling ran until the job settled — however long that took. `timeoutMs` therefore bounded only the wait for the *first* update, not the overall wait its name and docstring promise.

The fix bounds the whole subscription with `takeUntil(timer(timeoutMs))` and appends the timeout update only when the job did not settle:

```ts
const boundedUpdates$ = updates$.pipe(
    tap({ complete: () => { jobSettled = true; } }),
    takeUntil(timer(timeoutMs)),
);
return concat(boundedUpdates$, timedOut$);
```

The `tap` sits **upstream** of the `takeUntil`, so its `complete` callback fires only when the job itself reached a terminal state — a `takeUntil` cut-off unsubscribes the source rather than completing it. That is how the two cases are told apart, and it is also what stops the polling interval at the deadline instead of leaving it orphaned.

**The observable contract is unchanged.** On timeout the stream still emits the same synthetic update (`state: RUNNING`, `result: 'Job subscription timed out. The job may still be running'`), still logs the same `Logger.error` message (now pinned by a test), and still **completes rather than throwing**.

### Related issues

- **#3397** (`"SubscribableJob update polling timed out" crashes server`) — its fix replaced a `throw` inside the poll with the non-throwing `race(updates$, timeout$)` shape. This PR keeps that non-throwing contract intact; the timeout still emits-and-completes.
- **#4112** (`job.updates() Observable completes after first emission`) — caused by the interim `merge(updates$, timeout$).pipe(take(1))` shape, fixed in #4120 by returning to `race`. Restoring `race` is exactly what reintroduced the unbounded wait.

These two are adjacent but distinct. The `race` ↔ `merge+take(1)` oscillation between the two fixes happened because a single combinator was being asked to do two different jobs: "keep emitting until the job settles" and "stop after `timeoutMs`". `takeUntil` + `concat` satisfies both at once, which is why this shape should not need to swing back.

### Side benefit: this also mitigates the `InMemoryJobQueueStrategy` mutable-`findOne` bug

`InMemoryJobQueueStrategy.findOne()` returns the **stored** `Job` instance rather than a fresh one, and `updates()` de-duplicates with `distinctUntilChanged((a, b) => a?.progress === b?.progress && a?.state === b?.state)`. When `a` and `b` are literally the same mutable object the comparator is always `true`, so every update after the first is suppressed — including the terminal one. On `master` that means `updates()` never sees the job settle and, with the timeout branch already discarded by `race`, hangs **forever**. With this fix the stream is still starved of updates, but it now terminates at `timeoutMs` with the timeout update instead of hanging. The underlying `findOne()` defect is separate and pre-existing; I left it out to keep this diff surgical and am happy to open it separately.

### Files changed

| File | Change |
| --- | --- |
| `packages/core/src/job-queue/subscribable-job.ts` | `takeUntil`-based total timeout; `timeoutMs` doc updates |
| `packages/core/src/job-queue/subscribable-job.spec.ts` | **new** — 5 unit tests |

### Verification

```
bun install
bun run build:core-common                                          # ok (also typechecks core)
cd packages/core && npx vitest --config vitest.config.mts --run \
    src/job-queue/subscribable-job.spec.ts \
    src/job-queue/job-queue.service.spec.ts                        # 18 tests passed
npx prettier --check <changed files>                               # ok
npx eslint <changed files>                                         # 0 errors, 0 warnings
```

The regression test was confirmed to fail without the fix: with `subscribable-job.ts` reverted to `master` and the new spec kept, `times out after timeoutMs even once updates have been emitted` and `stops polling once the timeout has elapsed` both hang and are killed by the 15s test timeout, while `emits updates until the job settles`, `times out when the job never emits any update at all` and `errors on a failed job when errorOnFail is not disabled` still pass — i.e. the new tests target exactly the mid-stream gap and do not re-cover #4112 / #3397.

### Scope note

This PR was originally larger. A second, additive change — a readonly `isBuffered` flag on `SubscribableJob`, carrying `@since 3.8.0` — has been split out into Uplab/vendure#11 against `minor`, since new public API cannot ship from `master`. This PR is now the bug fix alone, and the two are independent: #11 touches neither `updates()` nor its pipeline. Note that both branches add a `packages/core/src/job-queue/subscribable-job.spec.ts`, so the `master` → `minor` back-merge will want the union of the two files.

# Breaking changes

No API break. Nothing is added, removed or retyped; `updates()` keeps its signature, its emitted shape, its `Logger.error` message and its emit-and-complete-rather-than-throw contract.

There is **one behavioural change, and it is the fix itself**: a job that keeps emitting updates but does not settle within `timeoutMs` is now cut off at the deadline, where previously the wait was unbounded once the first update had arrived. A caller who was relying — knowingly or not — on `updates()` streaming past `timeoutMs` will now receive the synthetic timeout update and a completed stream at the deadline. Such callers should pass a larger `timeoutMs` (it defaults to 1 hour). Jobs that settle before the deadline are entirely unaffected.

One shape detail worth flagging so it is not misread as introduced here: the synthetic timeout update carries `this.progress` — the value captured on the `SubscribableJob` instance, not the latest polled progress — so after a mid-stream timeout its `progress` can be staler than the preceding update's. That is the pre-existing shape of the timeout update; this fix only makes it reachable mid-stream as well as from a cold start.

# Screenshots

n/a

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

---

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791198817&installation_model_id=20193&pr_number=5285&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5285&signature=d20a7352a18fa844a274a2d0394f6bab4c493f0cd974b91d50f0de61c0a3c7fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->