### PR TITLE
feat(core): expose isBuffered on SubscribableJob

### DIFF
--- a/packages/core/src/job-queue/job-queue.service.spec.ts
+++ b/packages/core/src/job-queue/job-queue.service.spec.ts
@@ -432,6 +432,13 @@ describe('JobQueueService', () => {
 
             const bufferedJobs = testJobBufferStorageStrategy.getBufferedJobs(testJobBuffer.id);
             expect(bufferedJobs.map(j => j.data)).toEqual(['hello', 'world']);
+
+            // The placeholder returned for a buffered job is flagged as such, since it
+            // does not exist in the queue and therefore cannot be subscribed to.
+            expect(testJob1_1.isBuffered).toBe(true);
+            expect(testJob1_2.isBuffered).toBe(true);
+            expect(testJob2_1.isBuffered).toBe(false);
+            expect(testJob2_2.isBuffered).toBe(false);
         });
 
         it('flushes and reduces buffered jobs', async () => {

--- a/packages/core/src/job-queue/job-queue.ts
+++ b/packages/core/src/job-queue/job-queue.ts
@@ -86,6 +86,12 @@ export class JobQueue<Data extends JobData<Data> = object> {
      *   .then(update => update.result),
      *   .catch(err => err.message);
      * ```
+     *
+     * *Note*: if a {@link JobBuffer} collects the job, it is not added to the queue at all and this
+     * method resolves with a placeholder whose {@link SubscribableJob} `isBuffered` flag is `true`.
+     * There is no queued job for such a placeholder to poll, so subscribing to its `updates()` will
+     * yield nothing until the configured `timeoutMs` elapses. Check `isBuffered` before subscribing,
+     * and subscribe instead to the real jobs returned by the `JobQueueService`'s `flush()` method.
      */
     async add(data: Data, options?: JobOptions<Data>): Promise<SubscribableJob<Data>> {
         const job = new Job<any>({
@@ -104,7 +110,7 @@ export class JobQueue<Data extends JobData<Data> = object> {
                 data: job.data,
                 id: 'buffered',
             });
-            return new SubscribableJob(bufferedJob, this.jobQueueStrategy);
+            return SubscribableJob.buffered(bufferedJob, this.jobQueueStrategy);
         }
     }
 }

--- a/packages/core/src/job-queue/subscribable-job.spec.ts
+++ b/packages/core/src/job-queue/subscribable-job.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { JobQueueStrategy } from '../config/job-queue/job-queue-strategy';
+
+import { Job } from './job';
+import { SubscribableJob } from './subscribable-job';
+
+function strategy(): JobQueueStrategy {
+    return {
+        findOne: vi.fn(),
+        findMany: vi.fn(),
+        findManyById: vi.fn(),
+        removeSettledJobs: vi.fn(),
+    } as unknown as JobQueueStrategy;
+}
+
+describe('SubscribableJob', () => {
+    describe('isBuffered', () => {
+        it('defaults to false', () => {
+            const job = new Job({ id: 1, queueName: 'test', data: {} });
+
+            expect(new SubscribableJob(job, strategy()).isBuffered).toBe(false);
+        });
+
+        it('is true for a placeholder built by the buffered() factory', () => {
+            const job = new Job({ id: 'buffered', queueName: 'test', data: {} });
+
+            expect(SubscribableJob.buffered(job, strategy()).isBuffered).toBe(true);
+        });
+    });
+});

--- a/packages/core/src/job-queue/subscribable-job.ts
+++ b/packages/core/src/job-queue/subscribable-job.ts
@@ -57,6 +57,8 @@ export type JobUpdateOptions = {
  * @docsCategory JobQueue
  */
 export class SubscribableJob<T extends JobData<T> = any> extends Job<T> {
+    private _isBuffered = false;
+
     private readonly jobQueueStrategy: JobQueueStrategy;
 
     constructor(job: Job<T>, jobQueueStrategy: JobQueueStrategy) {
@@ -68,6 +70,38 @@ export class SubscribableJob<T extends JobData<T> = any> extends Job<T> {
         };
         super(config);
         this.jobQueueStrategy = jobQueueStrategy;
+    }
+
+    /**
+     * @description
+     * Creates the placeholder returned by `JobQueue.add()` when a {@link JobBuffer} collected
+     * the job instead of adding it to the queue. See {@link SubscribableJob.isBuffered}.
+     *
+     * @since 3.8.0
+     * @internal
+     */
+    static buffered<Data extends JobData<Data>>(
+        job: Job<Data>,
+        jobQueueStrategy: JobQueueStrategy,
+    ): SubscribableJob<Data> {
+        const subscribableJob = new SubscribableJob(job, jobQueueStrategy);
+        subscribableJob._isBuffered = true;
+        return subscribableJob;
+    }
+
+    /**
+     * @description
+     * Will be `true` if this instance is the placeholder returned by the {@link JobQueue}'s `add()` method
+     * for a job which was collected by a {@link JobBuffer} instead of being added to the queue. Such a job
+     * does not exist in any queue yet and has no real id, so there is nothing for `updates()` to poll - it
+     * will emit nothing until `timeoutMs` elapses. Check this flag before subscribing, and subscribe
+     * instead to the real jobs returned by the `JobQueueService`'s `flush()` method.
+     *
+     * @since 3.8.0
+     * @default false
+     */
+    get isBuffered(): boolean {
+        return this._isBuffered;
     }
 
     /**

--- a/packages/telemetry-plugin/src/config/default-method-hooks.ts
+++ b/packages/telemetry-plugin/src/config/default-method-hooks.ts
@@ -67,7 +67,9 @@ export const defaultMethodHooks = [
                 span.setAttribute('job.retries', options?.retries ?? 0);
             },
             post({ result, span }) {
-                span.setAttribute('job.buffered', result.id === 'buffered');
+                // `=== true` because @vendure/core is only a devDependency here: an older
+                // core at runtime has no `isBuffered`, and the attribute must stay a boolean.
+                span.setAttribute('job.buffered', result.isBuffered === true);
             },
         },
     }),


### PR DESCRIPTION
# Description

Closes #5288.

Adds a readonly `isBuffered` flag to `SubscribableJob` so a caller can tell a real, subscribable job from the dead placeholder that `JobQueue.add()` returns when a `JobBuffer` collects the job.

When a `JobBuffer` collects a job, `add()` does not add it to the queue at all. It returns `new SubscribableJob(new Job({ ...job, id: 'buffered' }), …)` — a job that exists in no queue. Subscribing to its `updates()` polls `findOne('buffered')`, which returns `null` forever, so the caller burns the full `timeoutMs` (**1 hour by default**) waiting for a job that will never exist. Nothing in the return type or the docs revealed that the handle was dead.

**Scope: this is the non-breaking half.** The flag is purely additive, and what a placeholder's `updates()` actually does is unchanged. Rationale:

- Making `updates()` error immediately on a placeholder is the *honest* signal, but it converts a (slow, benign) completion into an error for third-party code that subscribes today under `bufferUpdates: true`. See the open question below.
- No core usage subscribes to a placeholder, so nothing in core depends on the current behaviour. `SearchJobBufferService` builds its `SubscribableJob`s from the **real** jobs returned by `flush()`, never from `add()`.
- The flag immediately retires an existing string-sniff: `packages/telemetry-plugin` was comparing `result.id === 'buffered'` against the magic id, and now reads `result.isBuffered`.

**Open question for maintainers** (deliberately not implemented — happy to add it here if you want it): should a buffered placeholder's `updates()` error immediately with something like `"job was buffered; subscribe to the jobs returned by JobQueueService.flush() instead"` rather than silently burning the timeout? It is the better API, but it is a runtime behaviour change for existing subscribers, which is why it is not in this PR.

### How the placeholder is minted

The public constructor signature is **untouched**. Rather than adding a third positional parameter — `new SubscribableJob(bufferedJob, strategy, true)` reads as "what is `true`?", and there is no boolean-positional precedent in `packages/core/src` — the placeholder is created by a named static factory, following the `RequestContext.empty()` / `RequestContext.deserialize()` precedent:

```ts
// job-queue.ts
return SubscribableJob.buffered(bufferedJob, this.jobQueueStrategy);
```

The factory is marked `@internal`: only `JobQueue.add()` should mint placeholders, which is the same reasoning that already marks `JobQueue.start()` and `JobQueue.stop()` `@internal` in that file. Plugin authors consume `isBuffered`, they have no reason to produce a dead handle — and if that ever changes, dropping `@internal` later is non-breaking, whereas adding it is not.

The flag itself is exposed as a getter over a `private _isBuffered` field, matching the `RequestContext` accessor style, so it stays read-only from outside the class.

### Note on `=== true` in the telemetry plugin

`@vendure/core` is only a `devDependency` of `@vendure/telemetry-plugin`, so at runtime the plugin can be paired with an older core whose `SubscribableJob` has no `isBuffered`. `result.isBuffered === true` keeps the span attribute a strict boolean under that version skew instead of writing `undefined`.

### Files changed

| File | Change |
| --- | --- |
| `packages/core/src/job-queue/subscribable-job.ts` | `isBuffered` getter + `@internal` `static buffered()` factory; constructor unchanged |
| `packages/core/src/job-queue/job-queue.ts` | mint the placeholder via `SubscribableJob.buffered()`; document the buffered case on `add()` |
| `packages/core/src/job-queue/subscribable-job.spec.ts` | **new** — flag defaults to `false`, is `true` for a factory-built placeholder |
| `packages/core/src/job-queue/job-queue.service.spec.ts` | assert `isBuffered` on buffered vs. non-buffered jobs |
| `packages/telemetry-plugin/src/config/default-method-hooks.ts` | use `result.isBuffered === true` instead of `result.id === 'buffered'` |

### Verification

```
bun install
bun run build:core-common                                          # ok (also typechecks core)
cd packages/telemetry-plugin && npx tsc -p ./tsconfig.build.json --noEmit   # ok
cd packages/core && npx vitest --config vitest.config.mts --run \
    src/job-queue/subscribable-job.spec.ts \
    src/job-queue/job-queue.service.spec.ts                        # 15 tests passed
npx prettier --check <changed files>                               # ok
npx eslint <changed files>                                         # 0 errors (5 pre-existing warnings in untouched code)
```

### Relationship to the `master` fix

This was split out of a fix PR targeting `master` (`fix(core): bound SubscribableJob.updates() by timeoutMs`), which is now the timeout fix alone. `isBuffered` carries `@since 3.8.0` and is new public API, so per `CONTRIBUTING.md` it belongs on `minor`. The two changes are independent — this one touches neither `updates()` nor its pipeline — but note that both add a `packages/core/src/job-queue/subscribable-job.spec.ts`, so the `master` → `minor` back-merge will want the union of the two files.

# Breaking changes

None.

- `isBuffered` is an added read-only getter.
- The `SubscribableJob` constructor signature is unchanged, so existing third-party construction (e.g. `new SubscribableJob(job, strategy)`) is unaffected and yields `isBuffered === false`.
- `SubscribableJob.buffered()` is an added `@internal` static factory; nothing existing calls it.
- No runtime behaviour changes: a buffered placeholder's `updates()` does exactly what it does today. The one behaviour that *could* change — erroring on a placeholder — is the open question above and is deliberately not implemented.

# Screenshots

n/a

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

---

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791198830&installation_model_id=20193&pr_number=5289&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5289&signature=073b119579859a41fa9e1306cfb01466e6c25baefcebec1cf2fa0a005857a516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->