### PR TITLE
docs: align commit message examples with the enforced commitlint rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,7 +274,7 @@ After implementing your changes, stage the changes and commit them. Refer to the
 
 ```
 git add .
-git commit -m "type(scope): Message in present tense"
+git commit -m "type(scope): message in present tense"
 ```
 
 ### Creating a pull request
@@ -354,8 +354,12 @@ myNewApi: number;
 This repo uses [Conventional Commits](https://www.conventionalcommits.org).
 
 ```
-type(scope): Message in present tense
+type(scope): message in present tense
 ```
+
+The subject must not start with a capital letter: `@commitlint/config-conventional` rejects sentence-case,
+start-case, pascal-case and upper-case subjects.
+
 `type` may be one of:
 * **feat** (new feature)
 * **fix** (bug fix)
@@ -380,7 +384,7 @@ type(scope): Message in present tense
 If a commit affects more than one package, separate them with a comma:
 
 ```
-fix(core,common): Fix the thing
+fix(core,common): fix the thing
 ```
 
 If a commit applies to no particular package (e.g. a tooling change in the root package.json), the scope can be omitted.
@@ -394,7 +398,7 @@ Please also make your pull request against the `major` branch rather than `maste
 Example:
 
 ```
-feat(core): Add new field to Customer
+feat(core): add new field to Customer
 
 Relates to #123. This commit adds the "foo" field to the Custom entity.
 


### PR DESCRIPTION
# Description

The commit message examples in CONTRIBUTING.md use a capitalised subject, but `@commitlint/config-conventional` (the config in the root `package.json`, which the "Lint PR title" workflow runs via `bunx commitlint`) forbids exactly that. Following the docs produces:

```
✖   subject must not be sentence-case, start-case, pascal-case, upper-case [subject-case]
```

I hit this on the first CI run of #5269, whose title (`feat(core): Allow field resolver enhancers to be configured`) was written to match the `feat(core): Add new field to Customer` example in CONTRIBUTING.md.

This lowercases the three example subjects and the `type(scope): message in present tense` template, and adds one line stating that the subject must not start with a capital letter. Recently merged PRs already follow this (e.g. `fix(core): scope promotion migration history to orders`, `perf(core): remove the per-request stock query stampede`), so this only brings the docs in line with the enforced rule and current practice.

All three edited examples now pass `bunx commitlint`.

Side note, not fixed here: the husky v4 `commit-msg` hook exits with `Unknown package manager: bun` and never runs commitlint locally, so a bad subject is currently only caught by the PR title workflow.

# Breaking changes

None, docs only.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791207456&installation_model_id=20193&pr_number=5290&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5290&signature=6705b654904c41ff5e0f139108c72307e7c9daec1ac4e93025e4905519fd5d78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->