### PR TITLE
feat(dashboard): add defaultColumnFilters to ListPage

### DIFF
--- a/docs/docs/reference/dashboard/list-views/data-table.mdx
+++ b/docs/docs/reference/dashboard/list-views/data-table.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## DataTable
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/components/data-table/data-table.tsx" sourceLine="258" packageName="@vendure/dashboard" since="3.4.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/components/data-table/data-table.tsx" sourceLine="259" packageName="@vendure/dashboard" since="3.4.0" />
 
 A data table which includes sorting, filtering, pagination, bulk actions, column controls etc.
 
@@ -21,7 +21,7 @@ Parameters
 
 ## DataTableProps
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/components/data-table/data-table.tsx" sourceLine="129" packageName="@vendure/dashboard" since="3.4.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/components/data-table/data-table.tsx" sourceLine="130" packageName="@vendure/dashboard" since="3.4.0" />
 
 Props for configuring the [DataTable](/reference/dashboard/list-views/data-table#datatable).
 

--- a/docs/docs/reference/dashboard/list-views/list-page.mdx
+++ b/docs/docs/reference/dashboard/list-views/list-page.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## ListPage
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/list-page.tsx" sourceLine="524" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/list-page.tsx" sourceLine="581" packageName="@vendure/dashboard" since="3.3.0" />
 
 Auto-generates a list page with columns generated based on the provided query document fields.
 
@@ -103,7 +103,7 @@ Parameters
 
 ## ListPageProps
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/list-page.tsx" sourceLine="37" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/list-page.tsx" sourceLine="38" packageName="@vendure/dashboard" since="3.3.0" />
 
 Props to configure the [ListPage](/reference/dashboard/list-views/list-page#listpage) component.
 
@@ -121,6 +121,7 @@ interface ListPageProps<T extends TypedDocumentNode<U, V>, U extends ListQuerySh
     additionalColumns?: AC;
     defaultColumnOrder?: (keyof ListQueryFields<T> | keyof AC | CustomFieldKeysOfItem<ListQueryFields<T>>)[];
     defaultSort?: SortingState;
+    defaultColumnFilters?: ColumnFiltersState;
     defaultVisibility?: Partial<
         Record<keyof ListQueryFields<T> | keyof AC | CustomFieldKeysOfItem<ListQueryFields<T>>, boolean>
     >;
@@ -377,6 +378,33 @@ Allows you to specify the default sorting applied to the table.
 
 ```tsx
 defaultSort={[{ id: 'updatedAt', desc: true }]}
+```
+### defaultColumnFilters
+
+<MemberInfo kind="property" type={`ColumnFiltersState`}  since="3.8.0"  />
+
+Allows you to specify column filters which are applied when the current user has not
+yet configured any filters for this page. They behave exactly as if the user had set
+them: they show up as active filter chips, and can be edited or removed.
+
+Once the user edits the filters, their choice is persisted and these defaults are no
+longer applied — including when the user removes every filter. Clearing the filters is
+persisted as a deliberate choice, so the defaults do not reappear on the next visit.
+
+Requires `pageId` to be set, since the persisted table settings are what distinguishes
+"not configured yet" from "cleared by the user". Without a `pageId` the filters live
+only in the URL, which cannot express that difference, and the defaults are ignored.
+
+*Example*
+
+```tsx
+ <ListPage
+   pageId="product-list"
+   listQuery={productListQuery}
+   title="Products"
+   // hide archived products until the user says otherwise
+   defaultColumnFilters={[{ id: 'isArchived', value: { eq: false } }]}
+ />
 ```
 ### defaultVisibility
 

--- a/packages/dashboard/e2e/tests/components/list-page-filter-persistence.spec.ts
+++ b/packages/dashboard/e2e/tests/components/list-page-filter-persistence.spec.ts
@@ -1,0 +1,154 @@
+import { type Page, expect, test } from '@playwright/test';
+
+import { BaseListPage } from '../../page-objects/list-page.base.js';
+
+// Must match `LS_KEY_USER_SETTINGS` in src/lib/constants.ts. Inlined rather than imported:
+// that module pulls in the generated GraphQL schema enums, which do not belong in the
+// Playwright process.
+const USER_SETTINGS_KEY = 'vendure-user-settings';
+const PAGE_ID = 'product-list';
+
+/**
+ * Reads the saved column filters for a page. `saved` is what distinguishes "no value has
+ * been saved" from a saved `null` — the "user cleared every filter" sentinel — since
+ * `undefined` cannot survive the trip out of `page.evaluate` and both arrive as `null`.
+ */
+async function readSavedColumnFilters(page: Page, pageId: string) {
+    return page.evaluate(
+        ([key, id]) => {
+            const settings = JSON.parse(localStorage.getItem(key) || '{}');
+            const tableSettings = settings.tableSettings?.[id] ?? {};
+            return {
+                saved: Object.prototype.hasOwnProperty.call(tableSettings, 'columnFilters'),
+                value: tableSettings.columnFilters ?? null,
+            };
+        },
+        [USER_SETTINGS_KEY, pageId] as const,
+    );
+}
+
+/**
+ * Puts the page back into the "user has never configured filters here" state that a
+ * first-time visitor sees. The stored auth state is shared between tests, so the saved
+ * settings cannot be assumed to be empty at the start of a test.
+ */
+async function resetSavedTableSettings(page: Page, pageId: string) {
+    await page.evaluate(
+        ([key, id]) => {
+            const settings = JSON.parse(localStorage.getItem(key) || '{}');
+            if (settings.tableSettings) {
+                delete settings.tableSettings[id];
+            }
+            localStorage.setItem(key, JSON.stringify(settings));
+        },
+        [USER_SETTINGS_KEY, pageId] as const,
+    );
+}
+
+/**
+ * Waits for the products list query itself to come back, rather than for any admin-api
+ * response — the dashboard has other requests in flight (user settings, saved views), and
+ * matching one of those would let the assertions run against a list that has not refreshed.
+ *
+ * Returns the pending wait, so callers can register it before the action that triggers the
+ * refetch; awaiting it afterwards would race the response.
+ */
+function waitForProductList(page: Page) {
+    return page.waitForResponse(
+        resp =>
+            resp.url().includes('/admin-api') &&
+            resp.request().postData()?.includes('ProductList') === true &&
+            resp.status() === 200,
+    );
+}
+
+function productList(page: Page) {
+    return new BaseListPage(page, {
+        path: '/products',
+        title: 'Products',
+        newButtonLabel: 'New Product',
+    });
+}
+
+async function applyNameFilter(page: Page, value: string) {
+    const lp = productList(page);
+    await lp.openAddFilterMenu();
+    const dropdown = page.locator('[data-slot="dropdown-menu-content"]');
+    await expect(dropdown).toBeVisible();
+    await dropdown.getByRole('menuitem', { name: /name/i }).click();
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible();
+    await dialog.getByPlaceholder('Enter filter value...').fill(value);
+    await Promise.all([
+        waitForProductList(page),
+        dialog.getByRole('button', { name: 'Apply filter' }).click(),
+    ]);
+}
+
+test.describe('List page column filter persistence', () => {
+    // #5294 — `ListPage`'s `defaultColumnFilters` applies a page's default filters only until
+    // the user configures their own, which requires the saved table settings to tell "never
+    // configured filters here" apart from "cleared every filter". Both used to be an empty
+    // array, because the data table reported its filter state on mount and the list page
+    // persisted whatever it was told. Merely visiting now saves nothing at all.
+    test('should not save a filter state merely because the list page was visited', async ({ page }) => {
+        const lp = productList(page);
+        await lp.goto();
+        await lp.expectLoaded();
+
+        // Start from a clean slate, then load the page as a first-time visitor would.
+        await resetSavedTableSettings(page, PAGE_ID);
+        await page.reload();
+        await lp.expectLoaded();
+        await lp.expectRowsLoaded();
+
+        const savedFilters = await readSavedColumnFilters(page, PAGE_ID);
+        expect(savedFilters.saved).toBe(false);
+    });
+
+    // #5294 — clearing every filter is a deliberate choice and has to be saved as such, so
+    // that a page's `defaultColumnFilters` are not re-applied on the next visit. It is saved
+    // as `null` rather than `[]`, which is the value older versions wrote on mount and so
+    // cannot mean anything.
+    test('should save cleared filters as null and keep it across a reload', async ({ page }) => {
+        const lp = productList(page);
+        await lp.goto();
+        await lp.expectLoaded();
+
+        await resetSavedTableSettings(page, PAGE_ID);
+        await page.reload();
+        await lp.expectLoaded();
+        await lp.expectRowsLoaded();
+
+        const initialCount = await lp.getRows().count();
+
+        await applyNameFilter(page, 'Camera');
+        const filteredCount = await lp.getRows().count();
+        expect(filteredCount).toBeLessThan(initialCount);
+
+        const afterFiltering = await readSavedColumnFilters(page, PAGE_ID);
+        expect(afterFiltering.saved).toBe(true);
+        expect(afterFiltering.value).toHaveLength(1);
+
+        await Promise.all([
+            waitForProductList(page),
+            page.getByRole('button', { name: 'Clear all' }).click(),
+        ]);
+        await lp.expectRowCount(initialCount);
+
+        // Saved as `null`: the user has configured the filters and chosen to have none.
+        const afterClearing = await readSavedColumnFilters(page, PAGE_ID);
+        expect(afterClearing.saved).toBe(true);
+        expect(afterClearing.value).toBeNull();
+
+        await page.reload();
+        await lp.expectLoaded();
+        await lp.expectRowsLoaded();
+        await lp.expectRowCount(initialCount);
+
+        const afterReload = await readSavedColumnFilters(page, PAGE_ID);
+        expect(afterReload.saved).toBe(true);
+        expect(afterReload.value).toBeNull();
+    });
+});

--- a/packages/dashboard/src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
@@ -53,7 +53,9 @@ export function FacetValuesTable({ facetId, registerRefresher, title }: Readonly
         ? (tableSettings?.columnVisibility ?? defaultVisibility)
         : defaultVisibility;
     const columnOrder = pageId ? (tableSettings?.columnOrder ?? []) : ['name', 'code'];
-    const columnFilters = pageId ? tableSettings?.columnFilters : [];
+    // `null` is the saved "user cleared every filter" state; this table declares no default
+    // filters, so it and an absent value both mean the same thing here.
+    const columnFilters = pageId ? (tableSettings?.columnFilters ?? []) : [];
 
     return (
         <PaginatedListDataTable

--- a/packages/dashboard/src/lib/components/data-table/data-table-column-filters.spec.ts
+++ b/packages/dashboard/src/lib/components/data-table/data-table-column-filters.spec.ts
@@ -1,0 +1,32 @@
+import { ColumnFiltersState } from '@tanstack/react-table';
+import { describe, expect, it } from 'vitest';
+
+import { columnFiltersEqual } from './data-table-column-filters.js';
+
+describe('columnFiltersEqual', () => {
+    const filters: ColumnFiltersState = [{ id: 'isArchived', value: { eq: false } }];
+
+    it('treats a re-rendered copy of the same filters as unchanged', () => {
+        // The DataTable reports a filter change by persisting it, so an initial render — or any
+        // re-render that hands over an equivalent array — must not look like a user edit.
+        expect(columnFiltersEqual(filters, [{ id: 'isArchived', value: { eq: false } }])).toBe(true);
+    });
+
+    it('treats two empty filter states as unchanged', () => {
+        expect(columnFiltersEqual([], [])).toBe(true);
+    });
+
+    it('treats clearing all filters as a change', () => {
+        // The counterpart to the above: going from some filters to none is a deliberate user
+        // action and must be reported, so that it can be persisted as "cleared".
+        expect(columnFiltersEqual(filters, [])).toBe(false);
+    });
+
+    it('treats a changed filter value as a change', () => {
+        expect(columnFiltersEqual(filters, [{ id: 'isArchived', value: { eq: true } }])).toBe(false);
+    });
+
+    it('treats an added filter as a change', () => {
+        expect(columnFiltersEqual([], filters)).toBe(false);
+    });
+});

--- a/packages/dashboard/src/lib/components/data-table/data-table-column-filters.ts
+++ b/packages/dashboard/src/lib/components/data-table/data-table-column-filters.ts
@@ -1,0 +1,17 @@
+import type { ColumnFiltersState } from '@tanstack/react-table';
+
+/**
+ * Compares two column filter states by value. The DataTable keeps its filters in React
+ * state, so a re-render can produce a new array with identical contents; only a change
+ * in content means the user actually edited the filters.
+ *
+ * Consumers persist the filters they are told about, so reporting a no-op change would
+ * write an empty filter state on mount and make "never configured filters on this page"
+ * indistinguishable from "cleared every filter" — see `ListPage`'s `defaultColumnFilters`.
+ *
+ * Deliberately not exported from the package barrel: this is an internal detail of the
+ * DataTable, not public API.
+ */
+export function columnFiltersEqual(a: ColumnFiltersState, b: ColumnFiltersState): boolean {
+    return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/packages/dashboard/src/lib/components/data-table/data-table.tsx
+++ b/packages/dashboard/src/lib/components/data-table/data-table.tsx
@@ -35,6 +35,7 @@ import React, { Suspense, useEffect, useMemo, useRef } from 'react';
 import { AddFilterMenu } from './add-filter-menu.js';
 import { ActiveFiltersPopover } from './data-table-active-filters-popover.js';
 import { DataTableBulkActions, getRowItemId } from './data-table-bulk-actions.js';
+import { columnFiltersEqual } from './data-table-column-filters.js';
 import { DataTableProvider } from './data-table-context.js';
 import { createPaginationState, syncPaginationState } from './data-table-pagination-state.js';
 import {
@@ -434,20 +435,21 @@ export function DataTable<TData>({
     }, [onPageChange, searchTerm]);
 
     useEffect(() => {
+        // `prevColumnFiltersRef` starts out holding the initial filter state, so this also
+        // covers the mount run: the filters the table was given are not a change the user
+        // made, and reporting them would persist them as if they were.
+        if (columnFiltersEqual(prevColumnFiltersRef.current, columnFilters)) {
+            return;
+        }
+        prevColumnFiltersRef.current = columnFilters;
         onFilterChange?.(tableRef.current, columnFilters);
-        if (
-            page &&
-            page > 1 &&
-            itemsPerPage &&
-            JSON.stringify(prevColumnFiltersRef.current) !== JSON.stringify(columnFilters)
-        ) {
+        if (page && page > 1 && itemsPerPage) {
             // Set the page back to 1 when filters change
             setPagination({
                 ...pagination,
                 pageIndex: 0,
             });
         }
-        prevColumnFiltersRef.current = columnFilters;
     }, [columnFilters]);
 
     const handleSearchChange = (value: string) => {

--- a/packages/dashboard/src/lib/framework/page/list-page.spec.tsx
+++ b/packages/dashboard/src/lib/framework/page/list-page.spec.tsx
@@ -6,6 +6,14 @@ import { ListPage } from './list-page.js';
 // Capture the props ListPage forwards to PaginatedListDataTable.
 const captured: { props?: Record<string, any> } = {};
 
+// Lets each test control the user settings ListPage reads its persisted table state from,
+// whether those settings have finished resolving, and observe what it writes back.
+const mocks = vi.hoisted(() => ({
+    settings: {} as Record<string, any>,
+    settingsReady: true,
+    setTableSettings: vi.fn(),
+}));
+
 vi.mock('@/vdb/components/shared/paginated-list-data-table.js', () => ({
     PaginatedListDataTable: (props: Record<string, any>) => {
         captured.props = props;
@@ -22,7 +30,11 @@ vi.mock('../layout-engine/page-layout.js', () => ({
 }));
 
 vi.mock('@/vdb/hooks/use-user-settings.js', () => ({
-    useUserSettings: () => ({ setTableSettings: vi.fn(), settings: {} }),
+    useUserSettings: () => ({
+        setTableSettings: mocks.setTableSettings,
+        settings: mocks.settings,
+        settingsReady: mocks.settingsReady,
+    }),
 }));
 
 vi.mock('@tanstack/react-router', () => ({
@@ -38,6 +50,9 @@ describe('ListPage prop forwarding', () => {
 
     beforeEach(() => {
         captured.props = undefined;
+        mocks.settings = {};
+        mocks.settingsReady = true;
+        mocks.setTableSettings.mockClear();
     });
 
     it('forwards transformQueryKey, disableViewOptions and includeSelectionColumn to PaginatedListDataTable', () => {
@@ -58,5 +73,153 @@ describe('ListPage prop forwarding', () => {
         expect(captured.props?.transformQueryKey).toBe(transformQueryKey);
         expect(captured.props?.disableViewOptions).toBe(true);
         expect(captured.props?.includeSelectionColumn).toBe(false);
+    });
+});
+
+describe('ListPage defaultColumnFilters', () => {
+    const defaultColumnFilters = [{ id: 'isArchived', value: { eq: false } }];
+
+    // The table `onFilterChange` is handed; only its state is read, to build the URL search.
+    const tableStub = () =>
+        ({
+            getState: () => ({ pagination: { pageIndex: 0, pageSize: 10 }, sorting: [], columnFilters: [] }),
+        }) as any;
+
+    const baseProps = {
+        route: { useSearch: () => ({}), fullPath: '/' } as any,
+        title: 'Test',
+        listQuery: {} as any,
+        pageId: 'test-list',
+        defaultColumnFilters,
+    };
+
+    beforeEach(() => {
+        captured.props = undefined;
+        mocks.settings = {};
+        mocks.settingsReady = true;
+        mocks.setTableSettings.mockClear();
+    });
+
+    it('applies the defaults when the user has not configured filters for the page', () => {
+        renderToStaticMarkup(<ListPage {...baseProps} />);
+
+        expect(captured.props?.columnFilters).toEqual(defaultColumnFilters);
+    });
+
+    it('applies the defaults when the page has table settings but no saved filters', () => {
+        mocks.settings = { tableSettings: { 'test-list': { pageSize: 25 } } };
+
+        renderToStaticMarkup(<ListPage {...baseProps} />);
+
+        expect(captured.props?.columnFilters).toEqual(defaultColumnFilters);
+    });
+
+    it('prefers the filters the user has saved over the defaults', () => {
+        const userFilters = [{ id: 'name', value: { contains: 'shoe' } }];
+        mocks.settings = { tableSettings: { 'test-list': { columnFilters: userFilters } } };
+
+        renderToStaticMarkup(<ListPage {...baseProps} />);
+
+        expect(captured.props?.columnFilters).toEqual(userFilters);
+    });
+
+    // `null` is the saved "the user cleared every filter here" state. That is a deliberate
+    // choice, so the defaults must not come back on the next visit or remount.
+    it('does not re-apply the defaults once the user has cleared all filters', () => {
+        mocks.settings = { tableSettings: { 'test-list': { columnFilters: null } } };
+
+        renderToStaticMarkup(<ListPage {...baseProps} />);
+
+        expect(captured.props?.columnFilters).toEqual([]);
+    });
+
+    // An empty array is what dashboard versions before this feature saved for a page merely
+    // by rendering it, since the data table reported its filter state on mount. It is
+    // indistinguishable from a deliberate clear made by those versions, so it means neither
+    // and is read as "no preference" — otherwise the defaults would never reach any user who
+    // had already visited the page, which is every existing user.
+    it('applies the defaults over an empty saved filter state left by an older version', () => {
+        mocks.settings = { tableSettings: { 'test-list': { columnFilters: [] } } };
+
+        renderToStaticMarkup(<ListPage {...baseProps} />);
+
+        expect(captured.props?.columnFilters).toEqual(defaultColumnFilters);
+    });
+
+    it('saves an emptied filter set as null rather than an empty array', () => {
+        renderToStaticMarkup(<ListPage {...baseProps} />);
+
+        captured.props?.onFilterChange(tableStub(), []);
+
+        expect(mocks.setTableSettings).toHaveBeenCalledWith('test-list', 'columnFilters', null);
+    });
+
+    it('saves a non-empty filter set as it is', () => {
+        const userFilters = [{ id: 'name', value: { contains: 'shoe' } }];
+
+        renderToStaticMarkup(<ListPage {...baseProps} />);
+
+        captured.props?.onFilterChange(tableStub(), userFilters);
+
+        expect(mocks.setTableSettings).toHaveBeenCalledWith('test-list', 'columnFilters', userFilters);
+    });
+
+    // The `null` sentinel is written for every page, not only those declaring defaults: it is
+    // what the store means by "cleared" now, and a page can gain defaults later.
+    it('saves an emptied filter set as null on pages with no defaults', () => {
+        renderToStaticMarkup(<ListPage {...baseProps} defaultColumnFilters={undefined} />);
+
+        captured.props?.onFilterChange(tableStub(), []);
+
+        expect(mocks.setTableSettings).toHaveBeenCalledWith('test-list', 'columnFilters', null);
+    });
+
+    it('ignores the defaults when no pageId is set, since there is nowhere to persist a change', () => {
+        renderToStaticMarkup(<ListPage {...baseProps} pageId={undefined} />);
+
+        expect(captured.props?.columnFilters).toBeUndefined();
+    });
+
+    it('leaves pages without defaults unaffected', () => {
+        renderToStaticMarkup(<ListPage {...baseProps} defaultColumnFilters={undefined} />);
+
+        expect(captured.props?.columnFilters).toBeUndefined();
+    });
+
+    // The data table seeds its filter state from `columnFilters` once, on mount, while the
+    // user settings resolve asynchronously. Mounting it before the settings have resolved
+    // would show the default filter chips over a list that is still being fetched unfiltered.
+    it('does not mount the data table until the user settings have resolved', () => {
+        mocks.settingsReady = false;
+
+        renderToStaticMarkup(<ListPage {...baseProps} />);
+
+        expect(captured.props).toBeUndefined();
+    });
+
+    it('mounts the data table once the user settings have resolved', () => {
+        mocks.settingsReady = true;
+
+        renderToStaticMarkup(<ListPage {...baseProps} />);
+
+        expect(captured.props?.columnFilters).toEqual(defaultColumnFilters);
+    });
+
+    // The gate is scoped to the new feature, so pages that do not use it mount exactly as
+    // they did before, regardless of where the settings have got to.
+    it('still mounts the data table for pages with no defaults while settings are resolving', () => {
+        mocks.settingsReady = false;
+
+        renderToStaticMarkup(<ListPage {...baseProps} defaultColumnFilters={undefined} />);
+
+        expect(captured.props).toBeDefined();
+    });
+
+    it('still mounts the data table for pages with no pageId while settings are resolving', () => {
+        mocks.settingsReady = false;
+
+        renderToStaticMarkup(<ListPage {...baseProps} pageId={undefined} />);
+
+        expect(captured.props).toBeDefined();
     });
 });

--- a/packages/dashboard/src/lib/framework/page/list-page.tsx
+++ b/packages/dashboard/src/lib/framework/page/list-page.tsx
@@ -15,6 +15,7 @@ import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { AnyRoute, AnyRouter, useNavigate } from '@tanstack/react-router';
 import { ColumnFiltersState, SortingState, Table } from '@tanstack/react-table';
 import { TableOptions } from '@tanstack/table-core';
+import { useEffect } from 'react';
 
 import { BulkActionsInput } from '@/vdb/framework/extension-api/types/index.js';
 import {
@@ -274,6 +275,33 @@ export interface ListPageProps<
     defaultSort?: SortingState;
     /**
      * @description
+     * Allows you to specify column filters which are applied when the current user has not
+     * yet configured any filters for this page. They behave exactly as if the user had set
+     * them: they show up as active filter chips, and can be edited or removed.
+     *
+     * Once the user edits the filters, their choice is persisted and these defaults are no
+     * longer applied — including when the user removes every filter. Clearing the filters is
+     * persisted as a deliberate choice, so the defaults do not reappear on the next visit.
+     *
+     * Requires `pageId` to be set, since the persisted table settings are what distinguishes
+     * "not configured yet" from "cleared by the user". Without a `pageId` the filters live
+     * only in the URL, which cannot express that difference, and the defaults are ignored.
+     *
+     * @example
+     * ```tsx
+     *  <ListPage
+     *    pageId="product-list"
+     *    listQuery={productListQuery}
+     *    title="Products"
+     *    // hide archived products until the user says otherwise
+     *    defaultColumnFilters={[{ id: 'isArchived', value: { eq: false } }]}
+     *  />
+     * ```
+     * @since 3.8.0
+     */
+    defaultColumnFilters?: ColumnFiltersState;
+    /**
+     * @description
      * Allows you to specify the default columns that are visible in the table.
      * If you set them to `true`, then only those will show by default. If you set them to `false`,
      * then _all other_ columns will be visible by default.
@@ -431,6 +459,35 @@ export interface ListPageProps<
 }
 
 /**
+ * Resolves the filters a list page should start with from the user's saved filters for the
+ * page and the route's `defaultColumnFilters`. The defaults apply only until the user has
+ * expressed a preference, which the saved value encodes in three states:
+ *
+ * - `null` — the user cleared every filter here. A deliberate choice, so no filters, and the
+ *   defaults stay away. This is what clearing all the filters persists (see `onFilterChange`).
+ * - a non-empty array — the user's own filters, which win.
+ * - absent, or `[]` — no preference, so the defaults apply. An empty array is what dashboard
+ *   versions before `defaultColumnFilters` wrote for a page merely by rendering it, so it may
+ *   equally be a deliberate clear made back then; the two are indistinguishable and treating
+ *   them as "no preference" is what lets the defaults reach users who already have that entry.
+ *
+ * Returns `undefined` rather than `[]` when nothing applies, leaving the prop absent exactly
+ * as it was before this resolution existed.
+ */
+function resolveColumnFilters(
+    savedColumnFilters: ColumnFiltersState | null | undefined,
+    defaultColumnFilters: ColumnFiltersState | undefined,
+): ColumnFiltersState | undefined {
+    if (savedColumnFilters === null) {
+        return [];
+    }
+    if (savedColumnFilters?.length) {
+        return savedColumnFilters;
+    }
+    return defaultColumnFilters;
+}
+
+/**
  * @description
  * Auto-generates a list page with columns generated based on the provided query document fields.
  *
@@ -536,6 +593,7 @@ export function ListPage<
     additionalColumns,
     defaultColumnOrder,
     defaultSort,
+    defaultColumnFilters,
     route: routeOrFn,
     defaultVisibility,
     onSearchTermChange,
@@ -558,8 +616,21 @@ export function ListPage<
     const route = typeof routeOrFn === 'function' ? routeOrFn() : routeOrFn;
     const routeSearch = route.useSearch();
     const navigate = useNavigate<AnyRouter>({ from: route.fullPath });
-    const { setTableSettings, settings } = useUserSettings();
+    const { setTableSettings, settings, settingsReady } = useUserSettings();
     const tableSettings = pageId ? settings.tableSettings?.[pageId] : undefined;
+
+    // `defaultColumnFilters` is a silent no-op without a `pageId`, so say so in development
+    // rather than leaving the author to wonder why their defaults never show up.
+    useEffect(() => {
+        if (process.env.NODE_ENV !== 'production' && defaultColumnFilters && !pageId) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `ListPage: "defaultColumnFilters" was set without a "pageId", so it has no effect. ` +
+                    `The persisted table settings are what tell "not configured yet" apart from ` +
+                    `"cleared by the user", and there are none without a "pageId".`,
+            );
+        }
+    }, [defaultColumnFilters, pageId]);
 
     const pagination = {
         page: routeSearch.page ? Number.parseInt(routeSearch.page) : 1,
@@ -570,7 +641,18 @@ export function ListPage<
 
     // Column visibility/order user-settings merging is owned by useViewOptionDefaults inside
     // PaginatedListDataTable, so only raw code defaults are passed down here.
-    const columnFilters = pageId ? tableSettings?.columnFilters : routeSearch.filters;
+    const columnFilters = pageId
+        ? resolveColumnFilters(tableSettings?.columnFilters, defaultColumnFilters)
+        : routeSearch.filters;
+
+    // The DataTable seeds its filter state from `columnFilters` once, on mount. The user
+    // settings resolve asynchronously — the local values are in effect until the server-side
+    // SettingsStore responds and replaces them — so a table mounted before that keeps filters
+    // that no longer match the persisted state. With `defaultColumnFilters` that becomes
+    // user-visible: the default chips would be on screen while the list query ran unfiltered.
+    // So hold the table back until the settings have resolved, but only on pages that use the
+    // feature, leaving every other list page mounting exactly as before.
+    const awaitingSettings = !!defaultColumnFilters && !!pageId && !settingsReady;
 
     const sorting: SortingState = (routeSearch.sort ?? '')
         .split(',')
@@ -636,7 +718,11 @@ export function ListPage<
         onFilterChange: (table: Table<any>, filters: ColumnFiltersState) => {
             persistListStateToUrl(table, { filters });
             if (pageId) {
-                setTableSettings(pageId, 'columnFilters', filters);
+                // An empty filter set is saved as `null`, not `[]`: the user removing every
+                // filter is a preference, and it has to be distinguishable from the `[]` that
+                // older dashboard versions wrote for a page just by rendering it. See
+                // `resolveColumnFilters`.
+                setTableSettings(pageId, 'columnFilters', filters.length ? filters : null);
             }
         },
         onColumnVisibilityChange: (table: Table<any>, columnVisibility: any) => {
@@ -662,12 +748,14 @@ export function ListPage<
             <PageActionBar dropdownMenuItems={dropdownMenuItems}>{children}</PageActionBar>
             <PageLayout>
                 <FullWidthPageBlock blockId="list-table">
-                    <PaginatedListDataTable
-                        {...commonTableProps}
-                        enableViews
-                        onReorder={onReorder}
-                        disableDragAndDrop={disableDragAndDrop}
-                    />
+                    {awaitingSettings ? null : (
+                        <PaginatedListDataTable
+                            {...commonTableProps}
+                            enableViews
+                            onReorder={onReorder}
+                            disableDragAndDrop={disableDragAndDrop}
+                        />
+                    )}
                 </FullWidthPageBlock>
             </PageLayout>
         </Page>

--- a/packages/dashboard/src/lib/providers/user-settings.spec.tsx
+++ b/packages/dashboard/src/lib/providers/user-settings.spec.tsx
@@ -1,0 +1,134 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LS_KEY_USER_SETTINGS } from '@/vdb/constants.js';
+
+import {
+    UserSettings,
+    UserSettingsContext,
+    UserSettingsContextType,
+    UserSettingsProvider,
+} from './user-settings.js';
+
+const mocks = vi.hoisted(() => ({
+    serverSettings: null as unknown,
+    saved: [] as unknown[],
+}));
+
+vi.mock('../graphql/api.js', () => ({
+    api: {
+        query: () => Promise.resolve({ getSettingsStoreValue: mocks.serverSettings }),
+        mutate: (_doc: unknown, variables: any) => {
+            mocks.saved.push(variables.input.value);
+            return Promise.resolve({ setSettingsStoreValue: { result: 'UPDATED' } });
+        },
+    },
+}));
+
+/**
+ * `tableSettings[pageId].columnFilters` uses `null` to mean "the user cleared every filter
+ * on this page", as distinct from an absent value and from the `[]` written by dashboard
+ * versions that saved the filter state on mount. See `ListPage`'s `resolveColumnFilters`.
+ *
+ * Both persistence paths have to carry that value through unchanged — `null` survives
+ * `JSON.stringify` in a way that a deleted key or `undefined` would not, which is why the
+ * sentinel is a value rather than an absence.
+ */
+describe('UserSettingsProvider cleared column filters', () => {
+    let container: HTMLDivElement;
+    let root: Root;
+    let latest: UserSettingsContextType | undefined;
+
+    function Probe() {
+        latest = React.useContext(UserSettingsContext);
+        return null;
+    }
+
+    async function renderProvider() {
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        await act(async () => {
+            root.render(
+                <QueryClientProvider client={queryClient}>
+                    <UserSettingsProvider>
+                        <Probe />
+                    </UserSettingsProvider>
+                </QueryClientProvider>,
+            );
+        });
+        // Let the settings query resolve and the resulting save effect run.
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 0));
+        });
+    }
+
+    function readLocalStorageSettings(): UserSettings {
+        return JSON.parse(localStorage.getItem(LS_KEY_USER_SETTINGS) || '{}');
+    }
+
+    beforeEach(() => {
+        (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+        localStorage.clear();
+        mocks.serverSettings = null;
+        mocks.saved = [];
+        latest = undefined;
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        root = createRoot(container);
+    });
+
+    afterEach(() => {
+        act(() => root.unmount());
+        container.remove();
+    });
+
+    it('carries a null columnFilters through from localStorage', async () => {
+        localStorage.setItem(
+            LS_KEY_USER_SETTINGS,
+            JSON.stringify({ tableSettings: { 'product-list': { columnFilters: null, pageSize: 25 } } }),
+        );
+
+        await renderProvider();
+
+        expect(latest?.settings.tableSettings?.['product-list']).toEqual({
+            columnFilters: null,
+            pageSize: 25,
+        });
+    });
+
+    it('carries a null columnFilters through from the server payload', async () => {
+        // The server copy replaces the local one wholesale once it arrives, so it has to
+        // preserve the sentinel just as the local seed does.
+        mocks.serverSettings = {
+            tableSettings: { 'product-list': { columnFilters: null, pageSize: 50 } },
+        };
+
+        await renderProvider();
+
+        expect(latest?.settings.tableSettings?.['product-list']).toEqual({
+            columnFilters: null,
+            pageSize: 50,
+        });
+        // Nothing changed, so nothing was written back.
+        expect(mocks.saved).toHaveLength(0);
+    });
+
+    it('persists a null columnFilters written through setTableSettings', async () => {
+        await renderProvider();
+
+        await act(async () => {
+            latest?.setTableSettings('product-list', 'columnFilters', null);
+        });
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 0));
+        });
+
+        expect(readLocalStorageSettings().tableSettings?.['product-list']).toEqual({
+            columnFilters: null,
+        });
+        const lastSaved = mocks.saved.at(-1) as UserSettings | undefined;
+        expect(lastSaved?.tableSettings?.['product-list']).toEqual({ columnFilters: null });
+    });
+});

--- a/packages/dashboard/src/lib/providers/user-settings.tsx
+++ b/packages/dashboard/src/lib/providers/user-settings.tsx
@@ -12,7 +12,19 @@ import { Theme } from './theme-provider.js';
 export interface TableSettings {
     columnVisibility?: Record<string, boolean>;
     columnOrder?: string[];
-    columnFilters?: ColumnFiltersState;
+    /**
+     * @description
+     * The column filters the user has configured for this table. Three states are
+     * meaningful, which is what lets `ListPage`'s `defaultColumnFilters` apply only until
+     * the user has expressed a preference:
+     *
+     * - absent, or `[]`: no preference. An empty array is written by dashboard versions
+     *   before `defaultColumnFilters` existed, which saved the filter state on mount, so it
+     *   cannot be told apart from a deliberate clear made back then and means neither.
+     * - `null`: the user cleared every filter here. Written from that version on.
+     * - a non-empty array: the user's own filters.
+     */
+    columnFilters?: ColumnFiltersState | null;
     pageSize?: number;
 }
 


### PR DESCRIPTION
# Description

Closes #5294.

Adds a `defaultColumnFilters` prop to `ListPage`, so a route can declare column filters that apply until the user configures their own:

https://github.com/vendurehq/vendure/blob/18ca3a955955abe99528b737cdec21d034ab9311/packages/dashboard/src/lib/framework/page/list-page.tsx#L278-L288

`ListPage` already accepts `defaultSort`, `defaultVisibility` and `defaultColumnOrder`, but there is no equivalent for filters. Our case: a store of ~1000 products, some of which are models that are permanently gone and will never restock. A small plugin flags those as archived — deliberately not deletion, and not "disabled" either, because archived products stay live on the storefront as sold-out pages. They are indexed by Google and still bring in organic traffic, so removing them would 404 indexed URLs and burn that SEO value. In the admin product list, though, they are pure noise: day-to-day catalog work never touches them. So the list wants to open with an `isArchived = false` column filter applied, while an admin who does need an archived model — to un-archive one that has restocked, say — just clears the filter. Without this prop the only way to get that default is to patch `@vendure/dashboard` itself, which is what we do today.

```tsx
<ListPage
    pageId="product-list"
    title="Products"
    listQuery={productListQuery}
    // hide archived products until the user says otherwise
    defaultColumnFilters={[{ id: 'isArchived', value: { eq: false } }]}
/>
```

The defaults behave exactly as if the user had set them: they render as active filter chips, and can be edited or removed.

## The behaviour contract

1. **Defaults apply on a first visit.** A user who has never configured filters on the page gets the route's defaults.
2. **User edits win and persist.** Once the user changes the filters, their choice is saved and the defaults are no longer consulted.
3. **Clearing all filters persists as cleared.** Removing every filter is a deliberate choice, saved as such — the defaults do not come back on the next visit or remount.
4. **Changing a route's defaults does not clobber existing user state.** A user who already configured filters keeps them; only users with no filter state of their own see the new defaults.

## Making point 3 possible

Point 3 is the interesting one, and it needed a fix below the new prop.

Filters for a page are saved in the user settings under `tableSettings[pageId].columnFilters` (`providers/user-settings.tsx`), the same store that holds `columnVisibility`, `columnOrder` and `pageSize`. There is a precedent for how to express a default there — `useViewOptionDefaults` resolves the saved column order against the code defaults with `??`, so the *absence* of a saved value is what marks the defaults as still applicable:

https://github.com/vendurehq/vendure/blob/9a2ad2bf3ded595bc95ffcbf34a94c8645e662ef/packages/dashboard/src/lib/hooks/use-view-option-defaults.ts#L33-L38

That rule could not hold for filters, because `DataTable` fired `onFilterChange` from an effect that also ran on mount:

https://github.com/vendurehq/vendure/blob/9a2ad2bf3ded595bc95ffcbf34a94c8645e662ef/packages/dashboard/src/lib/components/data-table/data-table.tsx#L436-L451

Merely visiting a list page therefore reported the initial filter state and `ListPage` persisted it, so "has never configured filters here" and "has cleared every filter" both ended up as `[]`. Under those conditions a `persisted?.length ? persisted : defaults` check re-applies the defaults over a state the user deliberately cleared, on every remount — and, since the first visit freezes whatever the defaults were into the user's settings, a route that later changes its defaults can never deliver them.

So `DataTable` now reports filter changes only when the filters actually change (`columnFiltersEqual`, which also replaces the duplicated inline `JSON.stringify` comparison in the same effect):

https://github.com/vendurehq/vendure/blob/18ca3a955955abe99528b737cdec21d034ab9311/packages/dashboard/src/lib/components/data-table/data-table.tsx#L437-L445

The mount run now reports nothing, so visiting a page saves no filter state at all.

Applying a saved view still reports its filters directly (`DataTableProvider.handleApplyView`), including an empty set, which is correct — the user chose that view.

## The `[]` already out there

Fixing the mount-time write fixes the state written from here on, but not the state that is already saved. Every user who has ever opened a list page has an empty `columnFilters` entry for it, written by the old unguarded effect. If `[]` meant "cleared", the new prop would be inert on any existing installation for precisely the users it is meant for; it would only ever work for a brand-new account.

Rather than rewrite those entries, `columnFilters` carries a third state. An emptied filter set is now saved as `null`:

https://github.com/vendurehq/vendure/blob/18ca3a955955abe99528b737cdec21d034ab9311/packages/dashboard/src/lib/framework/page/list-page.tsx#L718-L727

and resolution reads all three:

https://github.com/vendurehq/vendure/blob/18ca3a955955abe99528b737cdec21d034ab9311/packages/dashboard/src/lib/framework/page/list-page.tsx#L477-L488

| Saved `columnFilters` | Meaning | Resolves to |
| --- | --- | --- |
| absent | user has never configured filters here | `defaultColumnFilters` |
| `[]` | no preference — see below | `defaultColumnFilters` |
| `null` | user cleared every filter | `[]` |
| `[...]` | user's own filters | the saved filters |

`[]` is read as *no preference* rather than as a clear. It is what the old mount-time write produced, and a deliberate clear made by that same version produced exactly the same value, so the two are indistinguishable — it cannot honestly be read as either, and reading it as "no preference" is what lets the defaults reach users who already carry it. From this version on nothing writes `[]` for a page: a clear writes `null`, and merely visiting writes nothing.

The `null` is written on every page, not only those declaring defaults. It is what the store means by "cleared" now, it costs nothing on a page with no defaults, and a page can gain defaults later. `null` rather than deleting the key, because the sentinel has to survive `JSON.stringify` on the way to `localStorage` and the SettingsStore, which `undefined` would not.

There is one visible consequence, worth stating plainly: **a user who really had cleared every filter on a page that later declares defaults sees those defaults one more time, and clears them once more.** That second clear writes `null` and sticks. On a page with no `defaultColumnFilters` the distinction is invisible either way.

Nothing already stored is rewritten, there is no version stamp, no migration ladder, and no write burst on first load after the upgrade. The only change to `user-settings.tsx` is the type and its docstring.

## Asynchronous settings and the mount gate

`DataTable` seeds its filter state from props once, on mount. The user settings resolve asynchronously, so a table that mounts before the server-side SettingsStore responds keeps filter state that the arriving settings may contradict. That divergence between the chips and the query is pre-existing, and on pages without defaults it is invisible in practice; with defaults it is not, because the default chips would sit on screen while the list query ran unfiltered.

The settings provider already exposes `settingsReady` for exactly this, with a docstring telling one-shot consumers to wait for it. `ListPage` now does: it defers mounting the data table until `settingsReady`, **only** when both `defaultColumnFilters` and `pageId` are set. Scoping the gate to the new feature means no existing list page changes how it mounts. A narrower prop→state sync effect inside `DataTable` was considered instead and rejected: `columnFilters` arrives as a fresh array on every render, so the effect would also fire on the re-render caused by the user's own edit — at which point the prop still holds the pre-persistence value and the edit would be reverted under them.

While the gate is closed the block renders nothing. A loading skeleton would read better than an empty block, and `DataTable` already has one — but it is driven by `isLoading` on a *mounted* table, and mounting the table is precisely what the gate exists to prevent, so using it would mean duplicating the skeleton markup in `ListPage`. Left minimal on purpose; happy to add one if you would prefer it.

The residual limitation is unchanged and left as it was: on a list page **without** `defaultColumnFilters`, a table that mounts before the server settings arrive still keeps whatever filter state it was seeded with. Fixing that generally means reconciling props into `DataTable`'s state, which is a larger change than this PR should carry.

# Breaking changes

None. The new prop is optional, and pages that do not use it behave as before.

Two behavioural changes beyond the new prop:

- Visiting a list page no longer writes an empty `columnFilters` entry into the user's saved table settings.
- Clearing every filter on a list page now saves `null` where it previously saved `[]`. `TableSettings['columnFilters']` widens to `ColumnFiltersState | null` accordingly. No saved settings are read differently on upgrade except that an existing `[]` stops suppressing a page's defaults, and nothing already stored is rewritten.

`onColumnVisibilityChange` and `onPageChange` emit on mount in the same way `onFilterChange` used to, and are deliberately left alone here. Neither currently has a consumer that needs to distinguish "never set" from "set to the default", so changing them would be scope this PR does not need; the same guard would apply if that changes.

## Tests

Each half of the change is covered by tests that fail without it. Against a naive `persisted ?? defaults` resolution, the `null` and legacy-`[]` unit tests both fail; against a naive `setTableSettings(pageId, 'columnFilters', filters)` write, the two `null`-persistence unit tests fail and the e2e clear-all test fails with `Received: []`. The mount-gate test fails without the gate, and the "visiting saves nothing" e2e fails without the `DataTable` mount fix. The existing filter e2e suites (`catalog/product-list.spec.ts`, `regression/issue-4730-*`, 20 tests) pass unchanged, twice over.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791237235&installation_model_id=20193&pr_number=5295&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5295&signature=86852f140a88745cce92f874e7191af112db6e16658eea2e7f0869c8777fa7d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

