### PR TITLE
fix(job-queue-plugin): avoid loading retained payloads during startup indexing

### DIFF
--- a/packages/job-queue-plugin/e2e/job-list-index.e2e-spec.ts
+++ b/packages/job-queue-plugin/e2e/job-list-index.e2e-spec.ts
@@ -1,0 +1,94 @@
+import { ProcessContext } from '@vendure/core';
+import { Queue } from 'bullmq';
+import Redis from 'ioredis';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { JobListIndexService } from '../src/bullmq/job-list-index.service';
+
+const PREFIX = 'job-index-migration-test';
+const connection = {
+    host: '127.0.0.1',
+    port: process.env.CI ? +(process.env.E2E_REDIS_PORT || 6379) : 6379,
+    maxRetriesPerRequest: null,
+};
+
+describe('JobListIndexService startup migration', () => {
+    const redis = new Redis(connection);
+    const queue = new Queue('vendure-job-queue', { connection, prefix: PREFIX });
+    const service = new JobListIndexService({ workerOptions: { prefix: PREFIX } }, {
+        isServer: false,
+    } as ProcessContext);
+    Object.assign(service, { redis, queue });
+
+    async function clearTestKeys() {
+        const keys = await redis.keys(`${PREFIX}:*`);
+        if (keys.length > 0) {
+            await redis.del(...keys);
+        }
+    }
+
+    beforeEach(clearTestKeys);
+    afterEach(() => vi.restoreAllMocks());
+    afterAll(async () => {
+        await queue.close();
+        await clearTestKeys();
+        await redis.quit();
+    });
+
+    // #5296: indexing needs metadata, never the retained job payloads.
+    it('merges retained metadata in bounded reads without deserializing job data', async () => {
+        const pipeline = redis.pipeline();
+        for (let i = 0; i < 205; i++) {
+            pipeline.hset(queue.toKey(String(i)), {
+                name: i % 2 === 0 ? 'search' : 'email',
+                timestamp: String(i),
+                data: 'must not be parsed as JSON',
+                returnvalue: 'must not be parsed as JSON',
+            });
+            pipeline.zadd(queue.toKey('completed'), i, String(i));
+        }
+        // A job can disappear between reading the IDs and fetching its metadata.
+        pipeline.zadd(queue.toKey('completed'), 205, 'deleted');
+        pipeline.hset(queue.toKey('invalid'), { name: 'invalid', timestamp: 'not-a-number' });
+        pipeline.zadd(queue.toKey('completed'), 206, 'invalid');
+        pipeline.hset(queue.toKey('incomplete'), { name: 'incomplete' });
+        pipeline.zadd(queue.toKey('completed'), 207, 'incomplete');
+        pipeline.hset(queue.toKey('failed-job'), { name: 'search', timestamp: '42' });
+        pipeline.zadd(queue.toKey('failed'), 42, 'failed-job');
+        pipeline.zadd(queue.toKey('queue:search:completed'), 0, '0');
+        await pipeline.exec();
+
+        const getJobs = vi.spyOn(queue, 'getJobs');
+        const readMetadata = redis.hmget.bind(redis);
+        let pending = 0;
+        let maxPending = 0;
+        const hmget = vi.spyOn(redis, 'hmget').mockImplementation((key, ...fields) => {
+            pending++;
+            maxPending = Math.max(maxPending, pending);
+            return readMetadata(key, ...fields).finally(() => pending--);
+        });
+
+        await service.migrateExistingJobs();
+
+        expect(getJobs).not.toHaveBeenCalled();
+        expect(hmget).toHaveBeenCalledTimes(209);
+        expect(maxPending).toBeLessThanOrEqual(100);
+        expect(hmget.mock.calls.every(args => args[1] === 'name' && args[2] === 'timestamp')).toBe(true);
+        for (const name of ['search', 'email']) {
+            const expected = Array.from({ length: 205 }, (_, i) => i)
+                .filter(i => (i % 2 === 0 ? 'search' : 'email') === name)
+                .flatMap(i => [String(i), String(i)]);
+            expect(await redis.zrange(queue.toKey(`queue:${name}:completed`), 0, -1, 'WITHSCORES')).toEqual(
+                expected,
+            );
+        }
+        expect(await redis.zrange(queue.toKey('queue:search:failed'), 0, -1, 'WITHSCORES')).toEqual([
+            'failed-job',
+            '42',
+        ]);
+        expect((await redis.smembers(queue.toKey('queue-names'))).sort()).toEqual(['email', 'search']);
+
+        await service.migrateExistingJobs();
+        expect(await redis.zcard(queue.toKey('queue:search:completed'))).toBe(103);
+    });
+});

--- a/packages/job-queue-plugin/src/bullmq/job-list-index.service.ts
+++ b/packages/job-queue-plugin/src/bullmq/job-list-index.service.ts
@@ -201,15 +201,29 @@ export class JobListIndexService {
                     continue;
                 }
                 try {
-                    const jobs = await this.queue.getJobs([state], 0, counts[state]);
-                    if (!jobs) {
-                        Logger.error(`getJobs returned undefined for state ${state}`, loggerCtx);
-                        continue;
+                    // Snapshot IDs, then read only the metadata needed for indexing. Loading full
+                    // jobs here deserializes every retained payload and can exhaust the worker heap.
+                    const queue = this.queue;
+                    const jobIds = await queue.getRanges([state], 0, counts[state]);
+                    const jobs: Array<Pick<Job, 'id' | 'name' | 'timestamp'>> = [];
+                    for (let i = 0; i < jobIds.length; i += this.BATCH_SIZE) {
+                        const batch = jobIds.slice(i, i + this.BATCH_SIZE);
+                        const metadata = await Promise.all(
+                            batch.map(id => this.redis.hmget(queue.toKey(id), 'name', 'timestamp')),
+                        );
+                        for (let j = 0; j < batch.length; j++) {
+                            const [name, timestamp] = metadata[j];
+                            // Jobs may have been removed since their IDs were read.
+                            if (name == null || timestamp == null || !Number.isFinite(Number(timestamp))) {
+                                continue;
+                            }
+                            jobs.push({ id: batch[j], name, timestamp: Number(timestamp) });
+                        }
                     }
                     Logger.debug(`Retrieved ${jobs.length} jobs for state ${state}`, loggerCtx);
 
                     // Group jobs by queue name
-                    const jobsByQueue = new Map<string, Job[]>();
+                    const jobsByQueue = new Map<string, Array<Pick<Job, 'id' | 'name' | 'timestamp'>>>();
                     for (const job of jobs) {
                         if (!job) {
                             Logger.error('Null job found in results', loggerCtx);


### PR DESCRIPTION
# Description

Fixes #5296.

Startup indexing currently deserializes every retained job payload, which can exhaust the worker heap. Snapshot job IDs and fetch only names/timestamps in batches of 100, preserving existing index merging and job history.

Adds a Redis-backed regression test for bounded metadata reads, custom prefixes, existing indexes, deleted/incomplete jobs, timestamp zero, and repeated migration. Payloads are deliberately unparsable to detect accidental deserialization.

Validation: regression fails before the fix; all 17 job-queue plugin e2e tests pass afterward. Plugin/dependency builds and changed-file lint pass. The broader `tsc --noEmit -p tsconfig.json` check reports identical existing errors on untouched master and this branch.

# Breaking changes

None.

# Screenshots

Not applicable.

# Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
- [x] I have added or updated test cases
- [x] I have updated the README if needed (no documentation change needed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791297022&installation_model_id=20193&pr_number=5297&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5297&signature=520e8d3e9bb4c8c3711dc50e9b6c00a7501b602b53619188cb3c0b116bc02291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->