### PR TITLE
feat(cli): support commands that have both an action and subcommands

### DIFF
--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -549,10 +549,9 @@ commands without loading the plugin.
 
 ### Nested commands
 
-A command entry that has `subcommands` instead of an `action` is a group. A
-group only exists to hold the commands below it. Running it without a
-subcommand prints its help to stderr and exits 1. Groups can be nested to any
-depth.
+A command entry that has `subcommands` and no `action` is a group. A group only
+exists to hold the commands below it. Running it without a subcommand prints its
+help to stderr and exits 1. Groups can be nested to any depth.
 
 ```ts
 import type { Command } from 'commander';
@@ -615,6 +614,53 @@ by the CLI at every level, so `vendure --help` lists `config`,
 lists the arguments and the options that are valid there. Unknown subcommands,
 unknown options and missing arguments fail through the CLI's normal error path
 with exit code 1.
+
+### Commands that run and also hold subcommands
+
+A command may declare an `action` and `subcommands` together. Running it on its
+own runs the action; naming one of its subcommands runs that instead. Use this
+where a command already exists and needs commands underneath it without changing
+what the bare command does.
+
+```ts
+commands: [
+    {
+        name: 'deploy',
+        description: 'Deploy the application',
+        options: [{ long: '--env <name>', description: 'Target environment', required: true }],
+        action: async (options, command, context) => {
+            // `vendure deploy --env staging`
+            return 0;
+        },
+        subcommands: [
+            {
+                name: 'plan',
+                description: 'Show what a deploy would change',
+                // `vendure deploy plan --env staging`
+                action: async (options, command, context) => {
+                    console.log(context.inheritedOptions.env); // 'staging'
+                    return 0;
+                },
+            },
+        ],
+    },
+],
+```
+
+Its `options` are shared with every command below it, the same as a group's, so
+`--env` above reaches `deploy plan` through `context.inheritedOptions`. The
+command itself reads `--env` from its own options argument.
+
+The CLI resolves the first operand against the subcommand names before it
+considers the action, so a subcommand always wins. An operand that names no
+subcommand is reported as an unknown command rather than reaching the action, so
+`vendure deploy plann` fails instead of deploying.
+
+That protection needs a spare operand to catch. A command that declares
+`arguments` as well as `subcommands` cannot tell a mistyped subcommand from a
+value — with `arguments: [{ name: 'target' }]`, `vendure deploy plann` deploys
+`plann`. Prefer options to positional arguments on a command that has
+subcommands.
 
 ### Extending an existing command
 
@@ -727,7 +773,8 @@ they belong to:
 
 - `rootOptions` on the plugin are added to `vendure` itself, so every command
   can be given them.
-- `options` on a command group apply to every command inside that group.
+- `options` on a command that has subcommands apply to every command below it,
+  whether that command is a group or runs an action of its own.
 
 A shared option can be given anywhere on the command line once the command that
 declares it has been reached. These two are equivalent — same flag, same value,

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -651,16 +651,19 @@ Its `options` are shared with every command below it, the same as a group's, so
 `--env` above reaches `deploy plan` through `context.inheritedOptions`. The
 command itself reads `--env` from its own options argument.
 
-The CLI resolves the first operand against the subcommand names before it
-considers the action, so a subcommand always wins. An operand that names no
-subcommand is reported as an unknown command rather than reaching the action, so
-`vendure deploy plann` fails instead of deploying.
+A command that has subcommands cannot also declare `arguments`. The first word
+after the command name would be ambiguous, since it could equally name a
+subcommand or fill an argument, so declaring both is rejected when the plugin is
+registered. Take an option instead.
 
-That protection needs a spare operand to catch. A command that declares
-`arguments` as well as `subcommands` cannot tell a mistyped subcommand from a
-value — with `arguments: [{ name: 'target' }]`, `vendure deploy plann` deploys
-`plann`. Prefer options to positional arguments on a command that has
-subcommands.
+That means a word which names no subcommand is always a mistake, and it is
+reported as an unknown command rather than reaching the action:
+
+```bash
+$ npx vendure deploy plann
+error: unknown command 'plann'
+(Did you mean plan?)
+```
 
 ### Extending an existing command
 

--- a/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
@@ -169,18 +169,33 @@ describe('CLI plugin commands that also have subcommands', () => {
     it('keeps the shared root options in scope below a runnable parent', async () => {
         const result = await project.runCliCommand(['deploy', 'plan', '--token', 'tok', '--json']);
 
-        expect(parseCloudResult(result.stdout).inherited).toMatchObject({ token: 'tok', json: true });
+        expect(parseCloudResult(result.stdout).inherited).toEqual({ token: 'tok', json: true });
     });
 
-    it('rejects a mistyped subcommand rather than running the parent', async () => {
+    it('reports a mistyped subcommand rather than running the parent', async () => {
         const result = await project.runCliCommand(['deploy', 'plann'], { expectError: true });
 
         expect(result.exitCode).not.toBe(0);
-        expect(result.stderr).toContain('too many arguments');
+        expect(result.stderr).toContain("unknown command 'plann'");
         expect(result.stdout).not.toContain('CLOUD_RESULT');
     });
 
-    it('lists a runnable parent subcommands and its own options in help', async () => {
+    it('keeps a help subcommand on a command that has an action', async () => {
+        const result = await project.runCliCommand(['deploy', 'help']);
+
+        expect(result.stdout).toMatch(/^\s+plan\s+Show what a deploy would change$/m);
+        expect(result.stdout).not.toContain('CLOUD_RESULT');
+    });
+
+    it('lists the subcommands of a runnable parent nested inside a group', async () => {
+        const result = await project.runCliCommand(['backup', 'db', '--help']);
+
+        expect(result.stdout).toContain('Usage: vendure backup db');
+        expect(result.stdout).toMatch(/^\s+list\s+List database backups$/m);
+        expect(result.stdout).toMatch(/^\s+status\s+Show the status of a backup$/m);
+    });
+
+    it("lists a runnable parent's subcommands and its own options in help", async () => {
         const result = await project.runCliCommand(['deploy', '--help']);
 
         expect(result.stdout).toContain('Usage: vendure deploy [options] [command]');

--- a/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
@@ -177,6 +177,8 @@ describe('CLI plugin commands that also have subcommands', () => {
 
         expect(result.exitCode).not.toBe(0);
         expect(result.stderr).toContain("unknown command 'plann'");
+        // The same suggestion a command group gives for the same mistake.
+        expect(result.stderr).toContain('(Did you mean plan?)');
         expect(result.stdout).not.toContain('CLOUD_RESULT');
     });
 
@@ -185,6 +187,20 @@ describe('CLI plugin commands that also have subcommands', () => {
 
         expect(result.stdout).toMatch(/^\s+plan\s+Show what a deploy would change$/m);
         expect(result.stdout).not.toContain('CLOUD_RESULT');
+    });
+
+    it('rejects a plugin whose command has both arguments and subcommands', async () => {
+        const broken = createTestProject('cli-plugin-ambiguous-parent');
+        try {
+            installCliPluginFixture(broken, 'ambiguous-parent-cli-plugin');
+            const result = await broken.runCliCommand(['--help']);
+
+            expect(result.stderr).toContain('declares both positional arguments and subcommands');
+            // The plugin is skipped rather than taking the CLI down with it.
+            expect(result.stdout).toContain('plugins');
+        } finally {
+            broken.cleanup();
+        }
     });
 
     it('lists the subcommands of a runnable parent nested inside a group', async () => {

--- a/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
@@ -116,6 +116,81 @@ describe('CLI plugin nested commands', () => {
     });
 });
 
+describe('CLI plugin commands that also have subcommands', () => {
+    let project: CliTestProject;
+
+    beforeAll(() => {
+        project = createTestProject('cli-plugin-runnable-parent');
+        installCliPluginFixture(project, 'cloud-cli-plugin');
+    });
+
+    afterAll(() => {
+        project?.cleanup();
+    });
+
+    it('runs the parent action when no subcommand is given', async () => {
+        const result = await project.runCliCommand(['deploy', '--env', 'staging']);
+
+        expect(result.exitCode).toBe(0);
+        const parsed = parseCloudResult(result.stdout);
+        expect(parsed.command).toEqual(['deploy']);
+        expect(parsed.options).toEqual({ env: 'staging' });
+    });
+
+    it('runs a subcommand of a runnable parent', async () => {
+        const plan = await project.runCliCommand(['deploy', 'plan']);
+        const teardown = await project.runCliCommand(['deploy', 'teardown']);
+
+        expect(parseCloudResult(plan.stdout).command).toEqual(['deploy', 'plan']);
+        expect(parseCloudResult(teardown.stdout).command).toEqual(['deploy', 'teardown']);
+    });
+
+    it('shares a parent option with its subcommands', async () => {
+        const result = await project.runCliCommand(['deploy', 'plan', '--env', 'staging']);
+
+        const parsed = parseCloudResult(result.stdout);
+        expect(parsed.inherited.env).toBe('staging');
+        // The parent owns the option, so it is not one of the subcommand's own.
+        expect(parsed.options).toEqual({});
+    });
+
+    it('runs a runnable parent nested inside a group, and its subcommands', async () => {
+        const db = await project.runCliCommand(['backup', 'db', '--label', 'nightly']);
+        const list = await project.runCliCommand(['backup', 'db', 'list']);
+        const status = await project.runCliCommand(['backup', 'db', 'status', '--label', 'nightly']);
+
+        expect(parseCloudResult(db.stdout).command).toEqual(['backup', 'db']);
+        expect(parseCloudResult(db.stdout).options).toEqual({ label: 'nightly' });
+        expect(parseCloudResult(list.stdout).command).toEqual(['backup', 'db', 'list']);
+        expect(parseCloudResult(status.stdout).command).toEqual(['backup', 'db', 'status']);
+        expect(parseCloudResult(status.stdout).inherited.label).toBe('nightly');
+    });
+
+    it('keeps the shared root options in scope below a runnable parent', async () => {
+        const result = await project.runCliCommand(['deploy', 'plan', '--token', 'tok', '--json']);
+
+        expect(parseCloudResult(result.stdout).inherited).toMatchObject({ token: 'tok', json: true });
+    });
+
+    it('rejects a mistyped subcommand rather than running the parent', async () => {
+        const result = await project.runCliCommand(['deploy', 'plann'], { expectError: true });
+
+        expect(result.exitCode).not.toBe(0);
+        expect(result.stderr).toContain('too many arguments');
+        expect(result.stdout).not.toContain('CLOUD_RESULT');
+    });
+
+    it('lists a runnable parent subcommands and its own options in help', async () => {
+        const result = await project.runCliCommand(['deploy', '--help']);
+
+        expect(result.stdout).toContain('Usage: vendure deploy [options] [command]');
+        expect(result.stdout).toMatch(/^\s+plan\s+Show what a deploy would change$/m);
+        expect(result.stdout).toMatch(/^\s+teardown\s+Tear the deployment down$/m);
+        expect(result.stdout).toMatch(/^\s+--env /m);
+        expect(result.stdout).toContain('Global Options:');
+    });
+});
+
 describe('CLI plugin help output', () => {
     let project: CliTestProject;
 
@@ -137,6 +212,7 @@ describe('CLI plugin help output', () => {
         expect(result.stdout).toMatch(/^\s+config \[options\]\s+Manage Cloud configuration$/m);
         expect(result.stdout).toMatch(/^\s+backup\s+Manage backups$/m);
         expect(result.stdout).toMatch(/^\s+restore\s+Restore from a backup$/m);
+        expect(result.stdout).toMatch(/^\s+deploy \[options\]\s+Deploy the application$/m);
         for (const option of ['--token', '--project', '--environment', '--json']) {
             expect(result.stdout).toMatch(new RegExp(`^\\s+${option}`, 'm'));
         }

--- a/packages/cli/e2e/fixtures/cli-plugins/ambiguous-parent-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/ambiguous-parent-cli-plugin/cli-plugin.js
@@ -1,0 +1,25 @@
+/**
+ * A CLI plugin whose command declares both positional arguments and
+ * subcommands. The first word after `deploy` would be ambiguous, so the plugin
+ * is rejected when it is loaded.
+ */
+const { defineCliPlugin } = require('@vendure/cli');
+
+module.exports = defineCliPlugin({
+    id: '@vendure-e2e/ambiguous-parent-cli-plugin',
+    commands: [
+        {
+            name: 'deploy',
+            description: 'Deploy the application',
+            arguments: [{ name: 'target', description: 'What to deploy' }],
+            action: async () => 0,
+            subcommands: [
+                {
+                    name: 'plan',
+                    description: 'Show what a deploy would change',
+                    action: async () => 0,
+                },
+            ],
+        },
+    ],
+});

--- a/packages/cli/e2e/fixtures/cli-plugins/ambiguous-parent-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/ambiguous-parent-cli-plugin/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "@vendure-e2e/ambiguous-parent-cli-plugin",
+    "version": "1.0.0",
+    "private": true,
+    "main": "cli-plugin.js",
+    "vendure": {
+        "cliPlugin": "./cli-plugin.js",
+        "cliCommands": [
+            "deploy"
+        ]
+    }
+}

--- a/packages/cli/e2e/fixtures/cli-plugins/cloud-cli-plugin/cli-plugin.js
+++ b/packages/cli/e2e/fixtures/cli-plugins/cloud-cli-plugin/cli-plugin.js
@@ -1,7 +1,8 @@
 /**
  * A CLI plugin shaped like the Vendure Cloud command surface: nested command
- * trees plus options shared by every command. Each action prints what the host
- * handed it, so the e2e tests can assert on it.
+ * trees, commands that run an action and also parent subcommands, plus options
+ * shared by every command. Each action prints what the host handed it, so the
+ * e2e tests can assert on it.
  */
 const { defineCliPlugin } = require('@vendure/cli');
 
@@ -69,14 +70,41 @@ module.exports = defineCliPlugin({
             subcommands: [
                 {
                     name: 'db',
-                    description: 'Database backups',
+                    description: 'Back the database up',
+                    options: [
+                        { long: '--label <name>', description: 'Label for the backup', required: true },
+                    ],
+                    action: async (options, command, context) => report(context, options),
                     subcommands: [
                         {
                             name: 'list',
                             description: 'List database backups',
                             action: async (options, command, context) => report(context, options),
                         },
+                        {
+                            name: 'status',
+                            description: 'Show the status of a backup',
+                            action: async (options, command, context) => report(context, options),
+                        },
                     ],
+                },
+            ],
+        },
+        {
+            name: 'deploy',
+            description: 'Deploy the application',
+            options: [{ long: '--env <name>', description: 'Environment to deploy to', required: true }],
+            action: async (options, command, context) => report(context, options),
+            subcommands: [
+                {
+                    name: 'plan',
+                    description: 'Show what a deploy would change',
+                    action: async (options, command, context) => report(context, options),
+                },
+                {
+                    name: 'teardown',
+                    description: 'Tear the deployment down',
+                    action: async (options, command, context) => report(context, options),
                 },
             ],
         },

--- a/packages/cli/e2e/fixtures/cli-plugins/cloud-cli-plugin/package.json
+++ b/packages/cli/e2e/fixtures/cli-plugins/cloud-cli-plugin/package.json
@@ -9,7 +9,8 @@
             "project",
             "config",
             "backup",
-            "restore"
+            "restore",
+            "deploy"
         ]
     }
 }

--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -23,12 +23,20 @@ interface CliCommandDefinition {
     options?: CliCommandOption[]; // Optional array of command options
     replaces?: boolean; // Deliberately replace a command of the same name
     action: (...args: any[]) => Promise<void | number>; // Command implementation
+    subcommands?: CliCommandNode[]; // Commands nested under this one
 }
 ```
 
-A command that groups further commands declares `subcommands` instead of an
-action. Groups can be nested to any depth, and running one without a subcommand
-prints its help.
+A command that groups further commands declares `subcommands` and no action.
+Groups can be nested to any depth, and running one without a subcommand prints
+its help.
+
+A command may also declare `subcommands` alongside its own action, for a command
+that both runs and holds commands below it, e.g. `vendure deploy` with
+`vendure deploy plan` under it. Running it without a subcommand runs its action.
+Either way its `options` are shared with every command below it, and it cannot
+declare positional `arguments`, since the first word after the command name
+would then be ambiguous.
 
 ```typescript
 interface CliCommandGroupDefinition {

--- a/packages/cli/src/shared/__tests__/run-cli.ts
+++ b/packages/cli/src/shared/__tests__/run-cli.ts
@@ -20,6 +20,15 @@ export interface CliRun {
     stdout: string;
     /** Commander's own errors plus anything the host or action wrote to stderr. */
     stderr: string;
+    /**
+     * Only what Commander wrote through the output it was configured with. Kept
+     * apart from {@link processStderr} so a test can tell an error reported
+     * through Commander from one written straight to the process, which look
+     * identical in {@link stderr}.
+     */
+    commanderStderr: string;
+    /** Only what was written straight to `process.stderr`, bypassing Commander. */
+    processStderr: string;
 }
 
 /**
@@ -32,7 +41,8 @@ export async function runCli(
     argv: string[],
 ): Promise<CliRun> {
     let stdout = '';
-    let stderr = '';
+    let commanderStderr = '';
+    let processStderr = '';
 
     const program = new Command();
     program.name('vendure').exitOverride();
@@ -43,7 +53,7 @@ export async function runCli(
             stdout += str;
         },
         writeErr: str => {
-            stderr += str;
+            commanderStderr += str;
         },
     });
     registerCommands(program, commands, sharedOptions);
@@ -52,7 +62,7 @@ export async function runCli(
         throw new ExitSignal(code ?? 0);
     }) as never);
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(str => {
-        stderr += String(str);
+        processStderr += String(str);
         return true;
     });
     const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(str => {
@@ -77,5 +87,11 @@ export async function runCli(
         stdoutSpy.mockRestore();
     }
 
-    return { exitCode, stdout, stderr };
+    return {
+        exitCode,
+        stdout,
+        stderr: commanderStderr + processStderr,
+        commanderStderr,
+        processStderr,
+    };
 }

--- a/packages/cli/src/shared/cli-command-definition.ts
+++ b/packages/cli/src/shared/cli-command-definition.ts
@@ -29,8 +29,8 @@ export interface CliCommandArgument {
 
 /**
  * Values of the shared options that are in scope for a command, i.e. the root
- * options registered by a CLI plugin plus the options of every command group
- * the command is nested in.
+ * options registered by a CLI plugin plus the options of every command the
+ * command is nested in.
  *
  * The CLI host builds this from the parsed command line and passes it to the
  * action as the final argument, so a command never has to read or reparse
@@ -44,8 +44,9 @@ export interface CliCommandArgument {
 export interface CliCommandContext<TInheritedOptions extends Record<string, any> = Record<string, any>> {
     /**
      * Values of the shared options in scope. A shared option is declared at
-     * exactly one level — a flag declared on a group that an ancestor already
-     * shares is rejected at registration — so values do not compete. Where a
+     * exactly one level — a flag declared on a command with subcommands that an
+     * ancestor already shares is rejected at registration — so values do not
+     * compete. Where a
      * command declares the same flag as a shared option, both read the same
      * value. A value supplied on the command line always beats a default.
      * Options that were neither supplied nor given a default value are omitted.
@@ -94,17 +95,20 @@ export interface CliCommandDefinition {
      * Commands nested under this one, e.g. the `plan` in `vendure deploy plan`.
      * Unlike a {@link CliCommandGroupDefinition}, the command keeps an action
      * of its own: running it without a subcommand runs that action rather than
-     * printing help.
+     * printing help. Its `options` are shared with every command below it —
+     * see {@link hasCliSubcommands}.
      *
-     * Its `options` are shared with every command below it, exactly as a
-     * group's are, and reach their actions through
-     * {@link CliCommandContext.inheritedOptions}.
+     * Commander resolves the first operand against the subcommand names before
+     * it considers the action, so a subcommand always wins over a positional
+     * argument that would have taken the same value. An operand that matched no
+     * subcommand is reported as an unknown command instead of reaching the
+     * action — but only while there is no positional argument left for it to
+     * fill.
      *
-     * The first argument is matched against the subcommand names before the
-     * action is considered, so a positional argument declared here can never
-     * take the value of a subcommand name. An argument beyond the declared
-     * positionals is rejected rather than passed to the action, so a mistyped
-     * subcommand cannot silently run the parent.
+     * A command that declares `arguments` as well as `subcommands` therefore
+     * cannot tell a mistyped subcommand from a value: `vendure deploy plann`
+     * runs the deploy with `plann` as its argument. Prefer options to positional
+     * arguments on a command that has subcommands.
      *
      * @since 3.8.0
      */
@@ -155,16 +159,18 @@ export type CliCommandNode = CliCommandDefinition | CliCommandGroupDefinition;
 /**
  * A node that has commands nested under it, whether or not it also runs an
  * action of its own.
- *
- * @since 3.8.0
  */
 export type CliCommandParent = CliCommandNode & { subcommands: CliCommandNode[] };
 
 /**
- * Whether a node has commands nested under it. A parent shares its options
- * with every command below it whether or not it runs an action, so this rather
- * than {@link isCliCommandGroup} is what the option and tree-walking rules key
- * on.
+ * Whether a node has commands nested under it.
+ *
+ * A node with subcommands shares its own `options` with every command below it,
+ * whether or not it also runs an action. That is why `registerCommands` passes
+ * them down as shared options, why `assertCliPlugin` applies the stricter
+ * shadowing rule to such a node, and why the collision checks in
+ * `CommandRegistry` treat its options as shared. Those all call this rather than
+ * {@link isCliCommandGroup}, which answers a narrower question.
  */
 export function hasCliSubcommands(node: CliCommandNode): node is CliCommandParent {
     return Array.isArray(node.subcommands);

--- a/packages/cli/src/shared/cli-command-definition.ts
+++ b/packages/cli/src/shared/cli-command-definition.ts
@@ -90,6 +90,25 @@ export interface CliCommandDefinition {
      * without a premature exit.
      */
     action: CliCommandAction;
+    /**
+     * Commands nested under this one, e.g. the `plan` in `vendure deploy plan`.
+     * Unlike a {@link CliCommandGroupDefinition}, the command keeps an action
+     * of its own: running it without a subcommand runs that action rather than
+     * printing help.
+     *
+     * Its `options` are shared with every command below it, exactly as a
+     * group's are, and reach their actions through
+     * {@link CliCommandContext.inheritedOptions}.
+     *
+     * The first argument is matched against the subcommand names before the
+     * action is considered, so a positional argument declared here can never
+     * take the value of a subcommand name. An argument beyond the declared
+     * positionals is rejected rather than passed to the action, so a mistyped
+     * subcommand cannot silently run the parent.
+     *
+     * @since 3.8.0
+     */
+    subcommands?: CliCommandNode[];
 }
 
 /**
@@ -102,7 +121,8 @@ export type CliCommandAction = (...args: any[]) => Promise<void | number>;
 /**
  * A command that exists only to group subcommands, e.g. the `config` in
  * `vendure config server set`. A group has no action of its own: running it
- * without a subcommand prints its help.
+ * without a subcommand prints its help. For a command that has subcommands
+ * *and* runs an action, see {@link CliCommandDefinition.subcommands}.
  *
  * @since 3.8.0
  */
@@ -125,15 +145,46 @@ export interface CliCommandGroupDefinition {
 }
 
 /**
- * A node in a CLI command tree: either a command that runs an action, or a
- * group of further commands.
+ * A node in a CLI command tree: a command that runs an action, a group of
+ * further commands, or a command that does both.
  *
  * @since 3.8.0
  */
 export type CliCommandNode = CliCommandDefinition | CliCommandGroupDefinition;
 
+/**
+ * A node that has commands nested under it, whether or not it also runs an
+ * action of its own.
+ *
+ * @since 3.8.0
+ */
+export type CliCommandParent = CliCommandNode & { subcommands: CliCommandNode[] };
+
+/**
+ * Whether a node has commands nested under it. A parent shares its options
+ * with every command below it whether or not it runs an action, so this rather
+ * than {@link isCliCommandGroup} is what the option and tree-walking rules key
+ * on.
+ */
+export function hasCliSubcommands(node: CliCommandNode): node is CliCommandParent {
+    return Array.isArray(node.subcommands);
+}
+
+/**
+ * Whether a node runs an action of its own. True of a plain command and of a
+ * command that also has subcommands; false of a pure group.
+ */
+export function isRunnableCliCommand(node: CliCommandNode): node is CliCommandDefinition {
+    return typeof (node as CliCommandDefinition).action === 'function';
+}
+
+/**
+ * Whether a node exists only to group subcommands. A command that has both an
+ * action and subcommands is not a group: see
+ * {@link CliCommandDefinition.subcommands}.
+ */
 export function isCliCommandGroup(node: CliCommandNode): node is CliCommandGroupDefinition {
-    return Array.isArray((node as CliCommandGroupDefinition).subcommands);
+    return hasCliSubcommands(node) && !isRunnableCliCommand(node);
 }
 
 /**

--- a/packages/cli/src/shared/cli-command-definition.ts
+++ b/packages/cli/src/shared/cli-command-definition.ts
@@ -98,17 +98,14 @@ export interface CliCommandDefinition {
      * printing help. Its `options` are shared with every command below it —
      * see {@link hasCliSubcommands}.
      *
-     * Commander resolves the first operand against the subcommand names before
-     * it considers the action, so a subcommand always wins over a positional
-     * argument that would have taken the same value. An operand that matched no
-     * subcommand is reported as an unknown command instead of reaching the
-     * action — but only while there is no positional argument left for it to
-     * fill.
+     * A command with subcommands cannot also declare `arguments`: the first word
+     * after the command name would be ambiguous, since it could equally name a
+     * subcommand or fill an argument. Declaring both is rejected when the plugin
+     * is registered. Take options instead, which are never ambiguous.
      *
-     * A command that declares `arguments` as well as `subcommands` therefore
-     * cannot tell a mistyped subcommand from a value: `vendure deploy plann`
-     * runs the deploy with `plann` as its argument. Prefer options to positional
-     * arguments on a command that has subcommands.
+     * A word that names no subcommand is therefore always a mistake, and is
+     * reported as an unknown command rather than reaching the action, exactly as
+     * it would be on a group.
      *
      * @since 3.8.0
      */
@@ -166,11 +163,9 @@ export type CliCommandParent = CliCommandNode & { subcommands: CliCommandNode[] 
  * Whether a node has commands nested under it.
  *
  * A node with subcommands shares its own `options` with every command below it,
- * whether or not it also runs an action. That is why `registerCommands` passes
- * them down as shared options, why `assertCliPlugin` applies the stricter
- * shadowing rule to such a node, and why the collision checks in
- * `CommandRegistry` treat its options as shared. Those all call this rather than
- * {@link isCliCommandGroup}, which answers a narrower question.
+ * whether or not it also runs an action. That is the distinction the option
+ * scoping and tree walking need, and it is wider than {@link isCliCommandGroup},
+ * which excludes a node that runs an action of its own.
  */
 export function hasCliSubcommands(node: CliCommandNode): node is CliCommandParent {
     return Array.isArray(node.subcommands);
@@ -203,6 +198,10 @@ export interface CliCommandDecoratorInput {
      * The command as it stands before this decorator: the original definition
      * plus every extension already applied to it. Read its `options`,
      * `arguments` and `description` to see what other plugins have contributed.
+     *
+     * This is a frozen deep copy, so `subcommands` tells a decorator whether the
+     * command it is wrapping has commands nested under it without handing over
+     * the nodes the registry goes on to use. Writing to any part of it throws.
      */
     command: Readonly<CliCommandDefinition>;
     /**

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -181,14 +181,12 @@ function assertNode(
         return;
     }
 
-    // A parent shares its options with every command below it whether or not it
-    // runs an action, so the shadowing rule applies to both shapes.
     assertDoesNotShadow(pluginId, label, ownOptions, inheritedOptions);
     const action = (node as Partial<CliCommandDefinition>).action;
     if (action !== undefined && typeof action !== 'function') {
         throw new TypeError(
             `CLI plugin "${pluginId}" command "${label}" declares an action that is not a function. ` +
-                `Omit it to make "${label}" a command group.`,
+                `Give it one, or remove it so that "${label}" only groups the commands below it.`,
         );
     }
     if (node.subcommands.length === 0) {
@@ -240,10 +238,10 @@ function assertSubOptionDepth(pluginId: string, options: CliCommandOption[], con
 }
 
 /**
- * A command may repeat a flag one of its groups shares — the host copies the
- * value onto it — but only if both agree on whether a value follows the flag.
- * Otherwise the group consumes the flag and hands the command a value its own
- * declaration says it will never see.
+ * A command with no subcommands may repeat a flag one of its ancestors shares —
+ * the host copies the value onto it — but only if both agree on whether a value
+ * follows the flag. Otherwise the ancestor consumes the flag and hands the
+ * command a value its own declaration says it will never see.
  */
 function assertMatchesInheritedShape(
     pluginId: string,
@@ -273,8 +271,9 @@ function assertMatchesInheritedShape(
 }
 
 /**
- * A group's options are shared with everything below it, so two levels sharing
- * one flag would leave the value's owner ambiguous. A leaf may repeat a shared
+ * A node with subcommands shares its options with everything below it (see
+ * {@link hasCliSubcommands}), so two levels sharing one flag would leave the
+ * value's owner ambiguous. A command with no subcommands may repeat a shared
  * flag: the host copies the value onto it, so both readings agree.
  */
 function assertDoesNotShadow(

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -3,7 +3,7 @@ import {
     CliCommandExtension,
     CliCommandNode,
     CliCommandOption,
-    isCliCommandGroup,
+    hasCliSubcommands,
 } from './cli-command-definition';
 import { describeOption, parseOptionFlags, withSubOptions } from './cli-command-options';
 
@@ -28,9 +28,9 @@ export interface CliPlugin {
      */
     id: string;
     /**
-     * Commands to register. Each entry is either a command with an action, or a
-     * group of subcommands. A top-level name that a built-in or an earlier
-     * plugin already provides is rejected unless the command sets
+     * Commands to register. Each entry is a command with an action, a group of
+     * subcommands, or a command that has both. A top-level name that a built-in
+     * or an earlier plugin already provides is rejected unless the command sets
      * `replaces: true`.
      */
     commands: CliCommandNode[];
@@ -171,7 +171,7 @@ function assertNode(
     const ownOptions = node.options ?? [];
     assertUniqueOptions(pluginId, ownOptions, `options of command "${label}"`);
 
-    if (!isCliCommandGroup(node)) {
+    if (!hasCliSubcommands(node)) {
         assertMatchesInheritedShape(pluginId, label, ownOptions, inheritedOptions);
         if (typeof node.action !== 'function') {
             throw new TypeError(
@@ -181,16 +181,20 @@ function assertNode(
         return;
     }
 
+    // A parent shares its options with every command below it whether or not it
+    // runs an action, so the shadowing rule applies to both shapes.
     assertDoesNotShadow(pluginId, label, ownOptions, inheritedOptions);
-    if (typeof (node as Partial<CliCommandDefinition>).action === 'function') {
-        throw new Error(
-            `CLI plugin "${pluginId}" command "${label}" declares both subcommands and an action. ` +
-                `A command group has no action of its own: move it into a subcommand.`,
+    const action = (node as Partial<CliCommandDefinition>).action;
+    if (action !== undefined && typeof action !== 'function') {
+        throw new TypeError(
+            `CLI plugin "${pluginId}" command "${label}" declares an action that is not a function. ` +
+                `Omit it to make "${label}" a command group.`,
         );
     }
     if (node.subcommands.length === 0) {
         throw new Error(
-            `CLI plugin "${pluginId}" command group "${label}" must provide at least one subcommand`,
+            `CLI plugin "${pluginId}" command "${label}" declares "subcommands" but provides none. ` +
+                `Give it at least one subcommand, or drop the array.`,
         );
     }
     assertNodes(pluginId, node.subcommands, commandPath, [...inheritedOptions, ...ownOptions]);

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -195,6 +195,14 @@ function assertNode(
                 `Give it at least one subcommand, or drop the array.`,
         );
     }
+    if ((node as Partial<CliCommandDefinition>).arguments?.length) {
+        throw new Error(
+            `CLI plugin "${pluginId}" command "${label}" declares both positional arguments and ` +
+                `subcommands. The first word after "${label}" would be ambiguous, since it could name ` +
+                `a subcommand or fill an argument. Take an option instead, or move the arguments into ` +
+                `a subcommand.`,
+        );
+    }
     assertNodes(pluginId, node.subcommands, commandPath, [...inheritedOptions, ...ownOptions]);
 }
 

--- a/packages/cli/src/shared/command-extensions.spec.ts
+++ b/packages/cli/src/shared/command-extensions.spec.ts
@@ -4,6 +4,7 @@ import { runCli } from './__tests__/run-cli';
 import {
     CliCommandDefinition,
     CliCommandGroupDefinition,
+    CliCommandNode,
     CliCommandOption,
     readCommandContext,
 } from './cli-command-definition';
@@ -1569,6 +1570,113 @@ describe('Command extensions: runnable parent commands', () => {
         expect(trace).toEqual(['core:plan']);
     });
 
+    it('shows a decorator that the command it wraps has subcommands', () => {
+        const registry = registryWithDeploy();
+        let seen: string[] | undefined;
+        let leafSeen: unknown = 'unset';
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: PLATFORM_ID,
+                commands: [],
+                extendCommands: [
+                    {
+                        command: 'deploy',
+                        decorate: ({ command, next }) => {
+                            seen = command.subcommands?.map(node => node.name);
+                            return next;
+                        },
+                    },
+                    {
+                        command: 'dev',
+                        decorate: ({ command, next }) => {
+                            leafSeen = command.subcommands;
+                            return next;
+                        },
+                    },
+                ],
+            }),
+        );
+
+        expect(seen).toEqual(['plan']);
+        // A command with no subcommands is distinguishable from one that has them.
+        expect(leafSeen).toBeUndefined();
+    });
+
+    it('does not let a decorator reach the registered subcommands', () => {
+        const registry = registryWithDeploy();
+        let received: Readonly<CliCommandDefinition> | undefined;
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: PLATFORM_ID,
+                commands: [],
+                extendCommands: [
+                    {
+                        command: 'deploy',
+                        decorate: ({ command, next }) => {
+                            received = command;
+                            return next;
+                        },
+                    },
+                ],
+            }),
+        );
+
+        const child = received?.subcommands?.[0] as CliCommandDefinition;
+        expect(() => {
+            child.description = 'hijacked';
+        }).toThrow();
+        expect(() => {
+            (received?.subcommands as CliCommandNode[]).push({
+                name: 'extra',
+                description: 'Extra',
+                action: async () => 0,
+            });
+        }).toThrow();
+
+        const registered = registry.get('deploy') as CliCommandDefinition;
+        expect(registered.subcommands?.map(node => node.name)).toEqual(['plan']);
+        expect(registered.subcommands?.[0].description).toBe('Show what a deploy would change');
+    });
+
+    it('replaces a runnable parent, subtree and all', async () => {
+        const registry = registryWithDeploy();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@example/replacer',
+                commands: [
+                    {
+                        name: 'deploy',
+                        description: 'Deploy somewhere else',
+                        replaces: true,
+                        action: async () => {
+                            trace.push('replacement:deploy');
+                            return 0;
+                        },
+                        subcommands: [
+                            {
+                                name: 'verify',
+                                description: 'Verify the deployment',
+                                action: async () => {
+                                    trace.push('replacement:verify');
+                                    return 0;
+                                },
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        await runCli(registry.toArray(), registry.getRootOptions(), ['deploy']);
+        await runCli(registry.toArray(), registry.getRootOptions(), ['deploy', 'verify']);
+        // The subcommand the replaced command had is gone with it.
+        const stale = await runCli(registry.toArray(), registry.getRootOptions(), ['deploy', 'plan']);
+
+        expect(trace).toEqual(['replacement:deploy', 'replacement:verify']);
+        expect(stale.exitCode).toBe(1);
+        expect(stale.stderr).toContain("unknown command 'plan'");
+    });
+
     it('still rejects decorating a command group, which has no action', () => {
         const registry = registryWithDeploy();
         const plugin = defineCliPlugin({
@@ -1668,9 +1776,8 @@ describe('Command extensions: runnable parent commands', () => {
         // Named as a command rather than a command group: it runs an action of
         // its own, but shares its options in the same way.
         expect(() => registry.applyPlugin(plugin)).toThrow(
-            /added to the command "vendure deploy" is already a shared option/,
+            /added to the command "vendure deploy" is already a shared option[\s\S]+cannot be shared at two levels/,
         );
-        expect(() => registry.applyPlugin(plugin)).toThrow(/cannot be shared at two levels/);
     });
 
     it('rejects a runnable parent declaring a flag the root already shares', () => {

--- a/packages/cli/src/shared/command-extensions.spec.ts
+++ b/packages/cli/src/shared/command-extensions.spec.ts
@@ -1473,3 +1473,196 @@ describe('Reserved short flags', () => {
         expect(() => registry.applyPlugin(rival)).toThrow(/already registered by @a\/first/);
     });
 });
+
+describe('Command extensions: runnable parent commands', () => {
+    /**
+     * The shape the hosted Cloud CLI registers: `deploy` runs an action of its
+     * own and also parents `plan`.
+     */
+    function cloudDeployPlugin() {
+        return defineCliPlugin({
+            id: CLOUD_ID,
+            commands: [
+                {
+                    name: 'deploy',
+                    description: 'Deploy the application',
+                    options: [{ long: '--env <name>', description: 'Target environment', required: true }],
+                    action: async () => {
+                        trace.push('core:deploy');
+                        return 0;
+                    },
+                    subcommands: [
+                        {
+                            name: 'plan',
+                            description: 'Show what a deploy would change',
+                            action: async () => {
+                                trace.push('core:plan');
+                                return 0;
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+    }
+
+    function registryWithDeploy(): CommandRegistry {
+        const registry = registryWithCore();
+        registry.applyPlugin(cloudDeployPlugin());
+        return registry;
+    }
+
+    it('decorates the action of a command that also has subcommands', async () => {
+        const registry = registryWithDeploy();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: PLATFORM_ID,
+                commands: [],
+                extendCommands: [
+                    {
+                        command: 'deploy',
+                        decorate:
+                            ({ next }) =>
+                            async (...args: any[]) => {
+                                trace.push('platform:before');
+                                return next(...args);
+                            },
+                    },
+                ],
+            }),
+        );
+
+        await runCli(registry.toArray(), registry.getRootOptions(), ['deploy']);
+
+        expect(trace).toEqual(['platform:before', 'core:deploy']);
+    });
+
+    it('leaves the subcommands of a decorated command in place', async () => {
+        const registry = registryWithDeploy();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: PLATFORM_ID,
+                commands: [],
+                extendCommands: [
+                    {
+                        command: 'deploy',
+                        decorate:
+                            ({ next }) =>
+                            async (...args: any[]) => {
+                                trace.push('platform:before');
+                                return next(...args);
+                            },
+                    },
+                ],
+            }),
+        );
+
+        await runCli(registry.toArray(), registry.getRootOptions(), ['deploy', 'plan']);
+
+        // The decorator wraps the parent action only, so running a subcommand
+        // does not go through it.
+        expect(trace).toEqual(['core:plan']);
+    });
+
+    it('still rejects decorating a command group, which has no action', () => {
+        const registry = registryWithDeploy();
+        const plugin = defineCliPlugin({
+            id: '@example/group',
+            commands: [],
+            extendCommands: [{ command: 'config', decorate: ({ next }) => next }],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/is a command group and has no action/);
+    });
+
+    it('extends a command nested under a runnable parent', async () => {
+        const registry = registryWithDeploy();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: PLATFORM_ID,
+                commands: [],
+                extendCommands: [
+                    {
+                        command: ['deploy', 'plan'],
+                        description: 'Show what a deploy would change, in detail',
+                        decorate:
+                            ({ next }) =>
+                            async (...args: any[]) => {
+                                trace.push('platform:plan');
+                                return next(...args);
+                            },
+                    },
+                ],
+            }),
+        );
+
+        await runCli(registry.toArray(), registry.getRootOptions(), ['deploy', 'plan']);
+
+        expect(trace).toEqual(['platform:plan', 'core:plan']);
+    });
+
+    it('shares an option added to a runnable parent with its subcommands', async () => {
+        const registry = registryWithDeploy();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: PLATFORM_ID,
+                commands: [],
+                extendCommands: [
+                    {
+                        command: 'deploy',
+                        options: [{ long: '--dry-run', description: 'Do not apply anything' }],
+                    },
+                ],
+            }),
+        );
+
+        const help = await runCli(registry.toArray(), registry.getRootOptions(), [
+            'deploy',
+            'plan',
+            '--help',
+        ]);
+
+        expect(help.stdout).toContain('Global Options:');
+        expect(help.stdout).toMatch(/^\s+--dry-run /m);
+    });
+
+    it('rejects an option added to a runnable parent that is already shared at the root', () => {
+        const registry = registryWithDeploy();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/root',
+                rootOptions: [{ long: '--dry-run', description: 'Do not apply anything' }],
+                commands: [],
+            }),
+        );
+
+        const plugin = defineCliPlugin({
+            id: '@b/parent',
+            commands: [],
+            extendCommands: [
+                {
+                    command: 'deploy',
+                    options: [{ long: '--dry-run', description: 'Do not apply anything' }],
+                },
+            ],
+        });
+
+        // Named as a command rather than a command group: it runs an action of
+        // its own, but shares its options in the same way.
+        expect(() => registry.applyPlugin(plugin)).toThrow(
+            /added to the command "vendure deploy" is already a shared option/,
+        );
+        expect(() => registry.applyPlugin(plugin)).toThrow(/cannot be shared at two levels/);
+    });
+
+    it('rejects a shared root option that a runnable parent already shares', () => {
+        const registry = registryWithDeploy();
+        const plugin = defineCliPlugin({
+            id: '@b/root',
+            rootOptions: [{ long: '--env <name>', description: 'Environment', required: true }],
+            commands: [],
+        });
+
+        expect(() => registry.applyPlugin(plugin)).toThrow(/already shared by the command "vendure deploy"/);
+    });
+});

--- a/packages/cli/src/shared/command-extensions.spec.ts
+++ b/packages/cli/src/shared/command-extensions.spec.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { runCli } from './__tests__/run-cli';
-import { CliCommandDefinition, CliCommandGroupDefinition, CliCommandOption } from './cli-command-definition';
+import {
+    CliCommandDefinition,
+    CliCommandGroupDefinition,
+    CliCommandOption,
+    readCommandContext,
+} from './cli-command-definition';
 import { defineCliPlugin } from './cli-plugin';
 import { CliPluginRegistrationError, CommandRegistry } from './command-registry-store';
 
@@ -1603,11 +1608,21 @@ describe('Command extensions: runnable parent commands', () => {
 
     it('shares an option added to a runnable parent with its subcommands', async () => {
         const registry = registryWithDeploy();
+        let inherited: Record<string, any> | undefined;
         registry.applyPlugin(
             defineCliPlugin({
                 id: PLATFORM_ID,
                 commands: [],
                 extendCommands: [
+                    {
+                        command: ['deploy', 'plan'],
+                        decorate:
+                            ({ next }) =>
+                            async (...args: any[]) => {
+                                inherited = readCommandContext(args).inheritedOptions;
+                                return next(...args);
+                            },
+                    },
                     {
                         command: 'deploy',
                         options: [{ long: '--dry-run', description: 'Do not apply anything' }],
@@ -1616,12 +1631,15 @@ describe('Command extensions: runnable parent commands', () => {
             }),
         );
 
+        await runCli(registry.toArray(), registry.getRootOptions(), ['deploy', 'plan', '--dry-run']);
+
+        expect(inherited).toEqual({ dryRun: true });
+
         const help = await runCli(registry.toArray(), registry.getRootOptions(), [
             'deploy',
             'plan',
             '--help',
         ]);
-
         expect(help.stdout).toContain('Global Options:');
         expect(help.stdout).toMatch(/^\s+--dry-run /m);
     });
@@ -1653,6 +1671,21 @@ describe('Command extensions: runnable parent commands', () => {
             /added to the command "vendure deploy" is already a shared option/,
         );
         expect(() => registry.applyPlugin(plugin)).toThrow(/cannot be shared at two levels/);
+    });
+
+    it('rejects a runnable parent declaring a flag the root already shares', () => {
+        const registry = registryWithCore();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@a/root',
+                rootOptions: [{ long: '--env <name>', description: 'Environment', required: true }],
+                commands: [],
+            }),
+        );
+
+        expect(() => registry.applyPlugin(cloudDeployPlugin())).toThrow(
+            /on the command "vendure deploy" is already a shared option/,
+        );
     });
 
     it('rejects a shared root option that a runnable parent already shares', () => {

--- a/packages/cli/src/shared/command-registry-store.spec.ts
+++ b/packages/cli/src/shared/command-registry-store.spec.ts
@@ -4,7 +4,13 @@ import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { builtinCommands } from '../commands/builtins';
-import { CliCommandDefinition, CliCommandGroupDefinition, isCliCommandGroup } from './cli-command-definition';
+import {
+    CliCommandDefinition,
+    CliCommandGroupDefinition,
+    hasCliSubcommands,
+    isCliCommandGroup,
+    isRunnableCliCommand,
+} from './cli-command-definition';
 import { defineCliPlugin } from './cli-plugin';
 import { CliPluginRegistrationError, CommandRegistry } from './command-registry-store';
 import {
@@ -433,9 +439,8 @@ describe('defineCliPlugin() with nested commands', () => {
             ],
         });
 
-        const deploy = plugin.commands[0] as CliCommandDefinition;
-        expect(typeof deploy.action).toBe('function');
-        expect(deploy.subcommands?.map(node => node.name)).toEqual(['plan', 'teardown']);
+        const deploy = plugin.commands[0];
+        expect(isRunnableCliCommand(deploy) && hasCliSubcommands(deploy)).toBe(true);
     });
 
     it('accepts a runnable command with subcommands nested inside a group', () => {
@@ -464,11 +469,69 @@ describe('defineCliPlugin() with nested commands', () => {
             ],
         });
 
-        const backup = plugin.commands[0] as CliCommandGroupDefinition;
-        const db = backup.subcommands[0] as CliCommandDefinition;
-        expect(typeof backup.action).toBe('undefined');
-        expect(typeof db.action).toBe('function');
-        expect(db.subcommands?.map(node => node.name)).toEqual(['list', 'status']);
+        const backup = plugin.commands[0];
+        const db = (backup as CliCommandGroupDefinition).subcommands[0];
+        expect(isCliCommandGroup(backup)).toBe(true);
+        expect(isRunnableCliCommand(db) && hasCliSubcommands(db)).toBe(true);
+    });
+
+    it('rejects positional arguments on a command that has subcommands', () => {
+        // The first word after the command would be ambiguous: it could name a
+        // subcommand or fill the argument.
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/ambiguous',
+                commands: [
+                    {
+                        name: 'deploy',
+                        description: 'Deploy the application',
+                        arguments: [{ name: 'target', description: 'What to deploy' }],
+                        action: async () => 0,
+                        subcommands: [
+                            { name: 'plan', description: 'Show what would change', action: async () => 0 },
+                        ],
+                    },
+                ],
+            }),
+        ).toThrow(/declares both positional arguments and subcommands/);
+    });
+
+    it('rejects positional arguments on a command group', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/ambiguous',
+                commands: [
+                    {
+                        name: 'backup',
+                        description: 'Manage backups',
+                        arguments: [{ name: 'target', description: 'What to back up' }],
+                        subcommands: [
+                            { name: 'db', description: 'Back the database up', action: async () => 0 },
+                        ],
+                    } as any,
+                ],
+            }),
+        ).toThrow(/declares both positional arguments and subcommands/);
+    });
+
+    it('accepts an empty arguments array alongside subcommands', () => {
+        // Only a declared positional is ambiguous; an empty array declares none.
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/empty-args',
+                commands: [
+                    {
+                        name: 'deploy',
+                        description: 'Deploy the application',
+                        arguments: [],
+                        action: async () => 0,
+                        subcommands: [
+                            { name: 'plan', description: 'Show what would change', action: async () => 0 },
+                        ],
+                    },
+                ],
+            }),
+        ).not.toThrow();
     });
 
     it('rejects a runnable parent that declares subcommands but provides none', () => {

--- a/packages/cli/src/shared/command-registry-store.spec.ts
+++ b/packages/cli/src/shared/command-registry-store.spec.ts
@@ -412,20 +412,113 @@ describe('defineCliPlugin() with nested commands', () => {
         ).toThrow(/at least one subcommand/);
     });
 
-    it('rejects a command group that also declares an action', () => {
+    it('accepts a command that has both an action and subcommands', () => {
+        const plugin = defineCliPlugin({
+            id: '@vendure/cloud',
+            commands: [
+                {
+                    name: 'deploy',
+                    description: 'Deploy the application',
+                    options: [{ long: '--env <name>', description: 'Target environment', required: true }],
+                    action: async () => 0,
+                    subcommands: [
+                        {
+                            name: 'plan',
+                            description: 'Show what a deploy would change',
+                            action: async () => 0,
+                        },
+                        { name: 'teardown', description: 'Tear the deployment down', action: async () => 0 },
+                    ],
+                },
+            ],
+        });
+
+        expect(plugin.commands).toHaveLength(1);
+    });
+
+    it('accepts a runnable command with subcommands nested inside a group', () => {
+        const plugin = defineCliPlugin({
+            id: '@vendure/cloud',
+            commands: [
+                {
+                    name: 'backup',
+                    description: 'Manage backups',
+                    subcommands: [
+                        {
+                            name: 'db',
+                            description: 'Back the database up',
+                            action: async () => 0,
+                            subcommands: [
+                                { name: 'list', description: 'List database backups', action: async () => 0 },
+                                {
+                                    name: 'status',
+                                    description: 'Show the status of a backup',
+                                    action: async () => 0,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+
+        expect(plugin.commands).toHaveLength(1);
+    });
+
+    it('rejects a runnable parent that declares subcommands but provides none', () => {
         expect(() =>
             defineCliPlugin({
-                id: '@example/both',
+                id: '@example/empty',
                 commands: [
                     {
-                        name: 'project',
-                        description: 'Manage projects',
-                        subcommands: [{ name: 'list', description: 'List projects', action: async () => 0 }],
+                        name: 'deploy',
+                        description: 'Deploy the application',
                         action: async () => 0,
-                    } as any,
+                        subcommands: [],
+                    },
                 ],
             }),
-        ).toThrow(/declares both subcommands and an action/);
+        ).toThrow(/at least one subcommand/);
+    });
+
+    it('rejects an action that is not a function alongside subcommands', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/broken',
+                commands: [
+                    {
+                        name: 'deploy',
+                        description: 'Deploy the application',
+                        action: 'run it' as any,
+                        subcommands: [
+                            { name: 'plan', description: 'Show what would change', action: async () => 0 },
+                        ],
+                    },
+                ],
+            }),
+        ).toThrow(/declares an action that is not a function/);
+    });
+
+    it('rejects a runnable parent that shares a flag an ancestor already shares', () => {
+        // Its options reach every command below it, so the rule that applies is
+        // the group's, not the leaf's.
+        expect(() =>
+            defineCliPlugin({
+                id: '@example/shadow',
+                rootOptions: [{ long: '--token <token>', description: 'API token', required: true }],
+                commands: [
+                    {
+                        name: 'deploy',
+                        description: 'Deploy the application',
+                        options: [{ long: '--token <token>', description: 'Deploy token', required: true }],
+                        action: async () => 0,
+                        subcommands: [
+                            { name: 'plan', description: 'Show what would change', action: async () => 0 },
+                        ],
+                    },
+                ],
+            }),
+        ).toThrow(/already a shared option/);
     });
 
     it('rejects a nested command without an action', () => {

--- a/packages/cli/src/shared/command-registry-store.spec.ts
+++ b/packages/cli/src/shared/command-registry-store.spec.ts
@@ -433,7 +433,9 @@ describe('defineCliPlugin() with nested commands', () => {
             ],
         });
 
-        expect(plugin.commands).toHaveLength(1);
+        const deploy = plugin.commands[0] as CliCommandDefinition;
+        expect(typeof deploy.action).toBe('function');
+        expect(deploy.subcommands?.map(node => node.name)).toEqual(['plan', 'teardown']);
     });
 
     it('accepts a runnable command with subcommands nested inside a group', () => {
@@ -462,7 +464,11 @@ describe('defineCliPlugin() with nested commands', () => {
             ],
         });
 
-        expect(plugin.commands).toHaveLength(1);
+        const backup = plugin.commands[0] as CliCommandGroupDefinition;
+        const db = backup.subcommands[0] as CliCommandDefinition;
+        expect(typeof backup.action).toBe('undefined');
+        expect(typeof db.action).toBe('function');
+        expect(db.subcommands?.map(node => node.name)).toEqual(['list', 'status']);
     });
 
     it('rejects a runnable parent that declares subcommands but provides none', () => {

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -213,12 +213,12 @@ export class CommandRegistry {
             if (!isSameOption(declared.option, parsed)) {
                 continue;
             }
-            if (hasCliSubcommands(declared.declaredBy)) {
+            if (declared.sharedBy) {
                 // The mirror of the check in draftCommand. Without it the rule
                 // would depend on which of the two plugins is listed first.
                 conflicts.push(
                     `Shared option "${describeOption(option)}" is already shared by ` +
-                        `${describeCommand(declared.declaredBy, declared.path)}. ` +
+                        `${describeCommand(declared.sharedBy, declared.path)}. ` +
                         `${SUBTREE_SHARING_EXPLANATION}`,
                 );
             } else if (!takesSameValue(declared.option, option)) {
@@ -300,10 +300,10 @@ function commandOptionConflicts(draft: RegistryState, node: CliCommandNode): str
         if (!shared) {
             continue;
         }
-        if (hasCliSubcommands(declared.declaredBy)) {
+        if (declared.sharedBy) {
             conflicts.push(
                 `Option "${describeOption(declared.option)}" on ` +
-                    `${describeCommand(declared.declaredBy, declared.path)} is already ` +
+                    `${describeCommand(declared.sharedBy, declared.path)} is already ` +
                     `a shared option registered by ${shared.source ?? 'the CLI'}. ` +
                     `${SUBTREE_SHARING_EXPLANATION}`,
             );
@@ -389,14 +389,13 @@ interface ExtensionOptionScope {
     ancestors: CliCommandOption[];
     own: CliCommandOption[];
     path: string[];
-    label: string;
     /**
      * Set when the target has subcommands, and so shares an added option with
      * everything below it.
      */
     subtree?: {
-        /** The target itself, which the messages below name. */
-        target: CliCommandNode;
+        /** Which kind of command the target is, for the wording below. */
+        kind: SharingCommandKind;
         /** Options that commands below the target share with their own subtrees. */
         parents: Array<{ path: string[]; option: CliCommandOption }>;
         /** Options declared by commands below the target that share nothing. */
@@ -414,16 +413,16 @@ function extensionOptionConflicts(
     target: CliCommandNode,
     path: string[],
 ): string[] {
+    const kind = sharingKind(target);
     const scope: ExtensionOptionScope = {
         ancestors: ancestorSharedOptions(draft, path),
         own: withSubOptions(target.options ?? []),
         path,
-        label: path.join(' '),
         // Extending a command that has subcommands shares the option with
         // everything below it, so the subtree matters as much as the ancestors.
-        subtree: hasCliSubcommands(target)
+        subtree: kind
             ? {
-                  target,
+                  kind,
                   parents: descendantParentOptions(target, path),
                   leaves: descendantLeafOptions(target, path),
               }
@@ -442,7 +441,8 @@ function addedOptionConflicts(
 ): string[] {
     const parsed = parseOptionFlags(option);
     const name = describeOption(option);
-    const { label, subtree } = scope;
+    const { subtree } = scope;
+    const label = scope.path.join(' ');
     const conflicts: string[] = [];
 
     for (const flag of [parsed.long, parsed.short]) {
@@ -457,7 +457,7 @@ function addedOptionConflicts(
     }
 
     if (subtree) {
-        const targetName = describeCommand(subtree.target, scope.path);
+        const targetName = describeCommand(subtree.kind, scope.path);
         const parentBelow = subtree.parents.find(existing => isSameOption(existing.option, parsed));
         if (parentBelow) {
             conflicts.push(
@@ -488,7 +488,7 @@ function addedOptionConflicts(
     }
     if (subtree) {
         conflicts.push(
-            `Option "${name}" added to ${describeCommand(subtree.target, scope.path)} is already a ` +
+            `Option "${name}" added to ${describeCommand(subtree.kind, scope.path)} is already a ` +
                 `shared option ("${describeOption(sharedOption)}"). ${SUBTREE_SHARING_EXPLANATION}`,
         );
     } else if (!takesSameValue(sharedOption, option)) {
@@ -527,16 +527,30 @@ function extendNode(target: CliCommandNode, extension: CliCommandExtension): Cli
 }
 
 function freezeCommand(command: CliCommandDefinition): Readonly<CliCommandDefinition> {
-    // A decorator wraps an action, so it is not shown the commands nested under
-    // one. Passing them would hand it the live nodes the registry goes on to
-    // use, which no amount of freezing at this level would protect.
-    const { subcommands, ...rest } = command;
-    // The arrays are copied as well as frozen: freezing makes a mutating
-    // decorator fail loudly, and copying means it could not have reached the
-    // registered definition even if it did not.
-    const frozenOptions = rest.options && (Object.freeze([...rest.options]) as CliCommandOption[]);
-    const frozenArguments = rest.arguments && (Object.freeze([...rest.arguments]) as CliCommandArgument[]);
-    return Object.freeze({ ...rest, options: frozenOptions, arguments: frozenArguments });
+    return freezeNode(command) as Readonly<CliCommandDefinition>;
+}
+
+/**
+ * A frozen deep copy of a node, for handing to a decorator.
+ *
+ * Everything is copied as well as frozen: freezing makes a mutating decorator
+ * fail loudly, and copying means it could not have reached the registered
+ * definition even if it did not. Recursing is what lets `subcommands` be shown
+ * at all — a decorator can see that the command it wraps has commands nested
+ * under it without holding the nodes the registry goes on to use.
+ */
+function freezeNode(node: CliCommandNode): Readonly<CliCommandNode> {
+    const copy = { ...node } as CliCommandDefinition;
+    if (copy.options) {
+        copy.options = Object.freeze([...copy.options]) as CliCommandOption[];
+    }
+    if (copy.arguments) {
+        copy.arguments = Object.freeze([...copy.arguments]) as CliCommandArgument[];
+    }
+    if (hasCliSubcommands(node)) {
+        copy.subcommands = Object.freeze(node.subcommands.map(freezeNode)) as CliCommandNode[];
+    }
+    return Object.freeze(copy);
 }
 
 function findNodeAtPath(node: CliCommandNode, path: string[]): CliCommandNode | undefined {
@@ -581,16 +595,20 @@ function findRootOption(draft: RegistryState, parsed: ParsedCliOption): Register
 interface DeclaredOption {
     path: string[];
     option: CliCommandOption;
-    /** The command that declares it, which decides whether it is shared. */
-    declaredBy: CliCommandNode;
+    /**
+     * Set when the declaring command has subcommands, and so shares the option
+     * with all of them. Which kind of command it is only affects the wording.
+     */
+    sharedBy?: SharingCommandKind;
 }
 
 function listCommandOptions(nodes: CliCommandNode[], path: string[] = []): DeclaredOption[] {
     const declared: DeclaredOption[] = [];
     for (const node of nodes) {
         const commandPath = [...path, node.name];
+        const sharedBy = sharingKind(node);
         for (const option of withSubOptions(node.options ?? [])) {
-            declared.push({ path: commandPath, option, declaredBy: node });
+            declared.push({ path: commandPath, option, sharedBy });
         }
         if (hasCliSubcommands(node)) {
             declared.push(...listCommandOptions(node.subcommands, commandPath));
@@ -600,12 +618,25 @@ function listCommandOptions(nodes: CliCommandNode[], path: string[] = []): Decla
 }
 
 /**
- * How a command is named in an error message. Only a command with no action of
- * its own is a group, but every command with subcommands shares its options
- * with them in the same way.
+ * What a command that shares its options with its subtree is: a group, or a
+ * command that also runs an action. Undefined for one that shares nothing,
+ * which is any command with no subcommands.
  */
-function describeCommand(node: CliCommandNode, path: string[]): string {
-    return `the command ${isCliCommandGroup(node) ? 'group ' : ''}"vendure ${path.join(' ')}"`;
+type SharingCommandKind = 'group' | 'command';
+
+function sharingKind(node: CliCommandNode): SharingCommandKind | undefined {
+    if (!hasCliSubcommands(node)) {
+        return undefined;
+    }
+    return isCliCommandGroup(node) ? 'group' : 'command';
+}
+
+/**
+ * How a command that shares its options is named in an error message. Only one
+ * with no action of its own is a group, but both share in the same way.
+ */
+function describeCommand(kind: SharingCommandKind, path: string[]): string {
+    return `the command ${kind === 'group' ? 'group ' : ''}"vendure ${path.join(' ')}"`;
 }
 
 /**

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -4,19 +4,23 @@ import {
     CliCommandArgument,
     CliCommandDefinition,
     CliCommandExtension,
-    CliCommandGroupDefinition,
     CliCommandNode,
     CliCommandOption,
+    CliCommandParent,
+    hasCliSubcommands,
     isCliCommandGroup,
+    isRunnableCliCommand,
 } from './cli-command-definition';
 import { describeOption, ParsedCliOption, parseOptionFlags, withSubOptions } from './cli-command-options';
 import { CliPlugin, normalizeCommandPath } from './cli-plugin';
 
 /**
- * Why a flag cannot be shared by a group and by something above or below it.
+ * Why a flag cannot be shared by a command that has subcommands and by
+ * something above or below it.
  */
-const GROUP_SHARING_EXPLANATION =
-    'A group shares its options with everything below it, so the same flag cannot be shared at two levels.';
+const SUBTREE_SHARING_EXPLANATION =
+    'A command with subcommands shares its options with all of them, so the same flag cannot be ' +
+    'shared at two levels.';
 
 /**
  * Flags the CLI host owns. A plugin that took one of these would break
@@ -209,12 +213,12 @@ export class CommandRegistry {
             if (!isSameOption(declared.option, parsed)) {
                 continue;
             }
-            if (declared.isGroupOption) {
+            if (declared.sharedBy) {
                 // The mirror of the check in draftCommand. Without it the rule
                 // would depend on which of the two plugins is listed first.
                 conflicts.push(
-                    `Shared option "${describeOption(option)}" is already shared by the command group ` +
-                        `"vendure ${declared.path.join(' ')}". ${GROUP_SHARING_EXPLANATION}`,
+                    `Shared option "${describeOption(option)}" is already shared by ` +
+                        `${declared.sharedBy}. ${SUBTREE_SHARING_EXPLANATION}`,
                 );
             } else if (!takesSameValue(declared.option, option)) {
                 conflicts.push(
@@ -295,11 +299,11 @@ function commandOptionConflicts(draft: RegistryState, node: CliCommandNode): str
         if (!shared) {
             continue;
         }
-        if (declared.isGroupOption) {
+        if (declared.sharedBy) {
             conflicts.push(
-                `Option "${describeOption(declared.option)}" on the command group ${where} is already ` +
+                `Option "${describeOption(declared.option)}" on ${declared.sharedBy} is already ` +
                     `a shared option registered by ${shared.source ?? 'the CLI'}. ` +
-                    `${GROUP_SHARING_EXPLANATION}`,
+                    `${SUBTREE_SHARING_EXPLANATION}`,
             );
         } else if (!takesSameValue(shared.option, declared.option)) {
             conflicts.push(
@@ -338,7 +342,7 @@ function draftExtension(
         return;
     }
 
-    if (isCliCommandGroup(target) && extension.decorate) {
+    if (extension.decorate && !isRunnableCliCommand(target)) {
         conflicts.push(
             `"vendure ${label}" is a command group and has no action to decorate. Extend one of its ` +
                 `subcommands instead.`,
@@ -376,16 +380,25 @@ function draftExtension(
 
 /**
  * The options an added option has to agree with: the target's own, those
- * shared by the groups above it, and — when the target is a group — those
- * declared anywhere below it.
+ * shared by the commands above it, and — when the target has subcommands —
+ * those declared anywhere below it.
  */
 interface ExtensionOptionScope {
     ancestors: CliCommandOption[];
-    descendantGroups: Array<{ path: string[]; option: CliCommandOption }>;
-    descendantLeaves: Array<{ path: string[]; option: CliCommandOption }>;
     own: CliCommandOption[];
-    targetIsGroup: boolean;
     label: string;
+    /**
+     * Set when the target has subcommands, and so shares an added option with
+     * everything below it.
+     */
+    subtree?: {
+        /** How the target is named in an error message. */
+        describedAs: string;
+        /** Options that commands below the target share with their own subtrees. */
+        parents: Array<{ path: string[]; option: CliCommandOption }>;
+        /** Options declared by commands below the target that share nothing. */
+        leaves: Array<{ path: string[]; option: CliCommandOption }>;
+    };
 }
 
 /**
@@ -398,16 +411,19 @@ function extensionOptionConflicts(
     target: CliCommandNode,
     path: string[],
 ): string[] {
-    const targetIsGroup = isCliCommandGroup(target);
     const scope: ExtensionOptionScope = {
-        // Extending a group shares the option with everything below it, so the
-        // subtree matters as much as the ancestors.
         ancestors: ancestorSharedOptions(draft, path),
-        descendantGroups: targetIsGroup ? descendantGroupOptions(target, path) : [],
-        descendantLeaves: targetIsGroup ? descendantLeafOptions(target, path) : [],
         own: withSubOptions(target.options ?? []),
-        targetIsGroup,
         label: path.join(' '),
+        // Extending a command that has subcommands shares the option with
+        // everything below it, so the subtree matters as much as the ancestors.
+        subtree: hasCliSubcommands(target)
+            ? {
+                  describedAs: describeCommand(target, path),
+                  parents: descendantParentOptions(target, path),
+                  leaves: descendantLeafOptions(target, path),
+              }
+            : undefined,
     };
 
     return withSubOptions(extension.options ?? []).flatMap(option =>
@@ -422,8 +438,7 @@ function addedOptionConflicts(
 ): string[] {
     const parsed = parseOptionFlags(option);
     const name = describeOption(option);
-    const { label } = scope;
-    const group = `the command group "vendure ${label}"`;
+    const { label, subtree } = scope;
     const conflicts: string[] = [];
 
     for (const flag of [parsed.long, parsed.short]) {
@@ -437,25 +452,27 @@ function addedOptionConflicts(
         conflicts.push(`Option "${name}" is already declared on "vendure ${label}".`);
     }
 
-    const descendantGroup = scope.descendantGroups.find(existing => isSameOption(existing.option, parsed));
-    if (descendantGroup) {
-        conflicts.push(
-            `Option "${name}" added to ${group} is already shared by ` +
-                `"vendure ${descendantGroup.path.join(' ')}" below it. ${GROUP_SHARING_EXPLANATION}`,
-        );
-        return conflicts;
-    }
+    if (subtree) {
+        const parentBelow = subtree.parents.find(existing => isSameOption(existing.option, parsed));
+        if (parentBelow) {
+            conflicts.push(
+                `Option "${name}" added to ${subtree.describedAs} is already shared by ` +
+                    `"vendure ${parentBelow.path.join(' ')}" below it. ${SUBTREE_SHARING_EXPLANATION}`,
+            );
+            return conflicts;
+        }
 
-    const leafBelow = scope.descendantLeaves.find(
-        existing => isSameOption(existing.option, parsed) && !takesSameValue(existing.option, option),
-    );
-    if (leafBelow) {
-        conflicts.push(
-            `Option "${name}" added to ${group} is not compatible with ` +
-                `"${describeOption(leafBelow.option)}" on "vendure ${leafBelow.path.join(' ')}" below it: ` +
-                `one takes a value and the other does not.`,
+        const leafBelow = subtree.leaves.find(
+            existing => isSameOption(existing.option, parsed) && !takesSameValue(existing.option, option),
         );
-        return conflicts;
+        if (leafBelow) {
+            conflicts.push(
+                `Option "${name}" added to ${subtree.describedAs} is not compatible with ` +
+                    `"${describeOption(leafBelow.option)}" on "vendure ${leafBelow.path.join(' ')}" below ` +
+                    `it: one takes a value and the other does not.`,
+            );
+            return conflicts;
+        }
     }
 
     const sharedOption =
@@ -464,10 +481,10 @@ function addedOptionConflicts(
     if (!sharedOption) {
         return conflicts;
     }
-    if (scope.targetIsGroup) {
+    if (subtree) {
         conflicts.push(
-            `Option "${name}" added to ${group} is already a shared option ` +
-                `("${describeOption(sharedOption)}"). ${GROUP_SHARING_EXPLANATION}`,
+            `Option "${name}" added to ${subtree.describedAs} is already a shared option ` +
+                `("${describeOption(sharedOption)}"). ${SUBTREE_SHARING_EXPLANATION}`,
         );
     } else if (!takesSameValue(sharedOption, option)) {
         conflicts.push(
@@ -482,10 +499,12 @@ function extendNode(target: CliCommandNode, extension: CliCommandExtension): Cli
     const options = [...(target.options ?? []), ...(extension.options ?? [])];
     const description = extension.description ?? target.description;
 
-    if (isCliCommandGroup(target)) {
+    if (!isRunnableCliCommand(target)) {
         return { ...target, description, options: options.length > 0 ? options : undefined };
     }
 
+    // The spread carries any subcommands through, so extending a runnable
+    // parent leaves the tree below it as it was.
     const command: CliCommandDefinition = {
         ...target,
         description,
@@ -511,14 +530,21 @@ function freezeCommand(command: CliCommandDefinition): Readonly<CliCommandDefini
     const frozenOptions = command.options && (Object.freeze([...command.options]) as CliCommandOption[]);
     const frozenArguments =
         command.arguments && (Object.freeze([...command.arguments]) as CliCommandArgument[]);
-    return Object.freeze({ ...command, options: frozenOptions, arguments: frozenArguments });
+    const frozenSubcommands =
+        command.subcommands && (Object.freeze([...command.subcommands]) as CliCommandNode[]);
+    return Object.freeze({
+        ...command,
+        options: frozenOptions,
+        arguments: frozenArguments,
+        subcommands: frozenSubcommands,
+    });
 }
 
 function findNodeAtPath(node: CliCommandNode, path: string[]): CliCommandNode | undefined {
     if (path.length === 0) {
         return node;
     }
-    if (!isCliCommandGroup(node)) {
+    if (!hasCliSubcommands(node)) {
         return undefined;
     }
     const child = node.subcommands.find(subcommand => subcommand.name === path[0]);
@@ -528,7 +554,7 @@ function findNodeAtPath(node: CliCommandNode, path: string[]): CliCommandNode | 
 /**
  * Rebuilds the tree with the node at `path` replaced. The caller must have
  * resolved `path` with {@link findNodeAtPath} first, which is what guarantees
- * every node above the replacement is a group.
+ * every node above the replacement has subcommands.
  */
 function replaceNodeAtPath(
     node: CliCommandNode,
@@ -538,10 +564,10 @@ function replaceNodeAtPath(
     if (path.length === 0) {
         return replacement;
     }
-    const group = node as CliCommandGroupDefinition;
+    const parent = node as CliCommandParent;
     return {
-        ...group,
-        subcommands: group.subcommands.map(subcommand =>
+        ...parent,
+        subcommands: parent.subcommands.map(subcommand =>
             subcommand.name === path[0]
                 ? replaceNodeAtPath(subcommand, path.slice(1), replacement)
                 : subcommand,
@@ -556,19 +582,22 @@ function findRootOption(draft: RegistryState, parsed: ParsedCliOption): Register
 interface DeclaredOption {
     path: string[];
     option: CliCommandOption;
-    /** Group options are shared with every command below them. */
-    isGroupOption: boolean;
+    /**
+     * How the declaring command is named in an error message, when it has
+     * subcommands and so shares the option with all of them.
+     */
+    sharedBy?: string;
 }
 
 function listCommandOptions(nodes: CliCommandNode[], path: string[] = []): DeclaredOption[] {
     const declared: DeclaredOption[] = [];
     for (const node of nodes) {
         const commandPath = [...path, node.name];
-        const isGroupOption = isCliCommandGroup(node);
+        const sharedBy = hasCliSubcommands(node) ? describeCommand(node, commandPath) : undefined;
         for (const option of withSubOptions(node.options ?? [])) {
-            declared.push({ path: commandPath, option, isGroupOption });
+            declared.push({ path: commandPath, option, sharedBy });
         }
-        if (isCliCommandGroup(node)) {
+        if (hasCliSubcommands(node)) {
             declared.push(...listCommandOptions(node.subcommands, commandPath));
         }
     }
@@ -576,46 +605,55 @@ function listCommandOptions(nodes: CliCommandNode[], path: string[] = []): Decla
 }
 
 /**
- * Options that groups below `node` share with their own subtrees. An option
+ * How a command is named in an error message. Only a command with no action of
+ * its own is a group, but every command with subcommands shares its options
+ * with them in the same way.
+ */
+function describeCommand(node: CliCommandNode, path: string[]): string {
+    return `the command ${isCliCommandGroup(node) ? 'group ' : ''}"vendure ${path.join(' ')}"`;
+}
+
+/**
+ * Options that commands below `node` share with their own subtrees. An option
  * added to `node` would be shared with them, so the same flag cannot appear in
  * both places.
  */
-function descendantGroupOptions(
+function descendantParentOptions(
     node: CliCommandNode,
     path: string[],
 ): Array<{ path: string[]; option: CliCommandOption }> {
-    if (!isCliCommandGroup(node)) {
+    if (!hasCliSubcommands(node)) {
         return [];
     }
     const found: Array<{ path: string[]; option: CliCommandOption }> = [];
     for (const subcommand of node.subcommands) {
         const subPath = [...path, subcommand.name];
-        if (isCliCommandGroup(subcommand)) {
+        if (hasCliSubcommands(subcommand)) {
             for (const option of withSubOptions(subcommand.options ?? [])) {
                 found.push({ path: subPath, option });
             }
-            found.push(...descendantGroupOptions(subcommand, subPath));
+            found.push(...descendantParentOptions(subcommand, subPath));
         }
     }
     return found;
 }
 
 /**
- * Options declared by the commands below `node`. A group option is shared with
- * all of them, so the shapes have to agree even though repeating the flag is
- * allowed.
+ * Options declared by the commands below `node` that have no subcommands of
+ * their own. An option shared by `node` reaches all of them, so the shapes have
+ * to agree even though repeating the flag is allowed.
  */
 function descendantLeafOptions(
     node: CliCommandNode,
     path: string[],
 ): Array<{ path: string[]; option: CliCommandOption }> {
-    if (!isCliCommandGroup(node)) {
+    if (!hasCliSubcommands(node)) {
         return [];
     }
     const found: Array<{ path: string[]; option: CliCommandOption }> = [];
     for (const subcommand of node.subcommands) {
         const subPath = [...path, subcommand.name];
-        if (isCliCommandGroup(subcommand)) {
+        if (hasCliSubcommands(subcommand)) {
             found.push(...descendantLeafOptions(subcommand, subPath));
         } else {
             for (const option of withSubOptions(subcommand.options ?? [])) {
@@ -627,14 +665,14 @@ function descendantLeafOptions(
 }
 
 /**
- * Options shared with the command at `path` by the groups above it. Together
+ * Options shared with the command at `path` by the commands above it. Together
  * with the root options these are the shared options in scope there.
  */
 function ancestorSharedOptions(draft: RegistryState, path: string[]): CliCommandOption[] {
     const options: CliCommandOption[] = [];
     let node = draft.commands.get(path[0])?.node;
     for (let i = 0; i < path.length - 1 && node; i++) {
-        if (!isCliCommandGroup(node)) {
+        if (!hasCliSubcommands(node)) {
             break;
         }
         options.push(...withSubOptions(node.options ?? []));

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -213,12 +213,13 @@ export class CommandRegistry {
             if (!isSameOption(declared.option, parsed)) {
                 continue;
             }
-            if (declared.sharedBy) {
+            if (hasCliSubcommands(declared.declaredBy)) {
                 // The mirror of the check in draftCommand. Without it the rule
                 // would depend on which of the two plugins is listed first.
                 conflicts.push(
                     `Shared option "${describeOption(option)}" is already shared by ` +
-                        `${declared.sharedBy}. ${SUBTREE_SHARING_EXPLANATION}`,
+                        `${describeCommand(declared.declaredBy, declared.path)}. ` +
+                        `${SUBTREE_SHARING_EXPLANATION}`,
                 );
             } else if (!takesSameValue(declared.option, option)) {
                 conflicts.push(
@@ -299,9 +300,10 @@ function commandOptionConflicts(draft: RegistryState, node: CliCommandNode): str
         if (!shared) {
             continue;
         }
-        if (declared.sharedBy) {
+        if (hasCliSubcommands(declared.declaredBy)) {
             conflicts.push(
-                `Option "${describeOption(declared.option)}" on ${declared.sharedBy} is already ` +
+                `Option "${describeOption(declared.option)}" on ` +
+                    `${describeCommand(declared.declaredBy, declared.path)} is already ` +
                     `a shared option registered by ${shared.source ?? 'the CLI'}. ` +
                     `${SUBTREE_SHARING_EXPLANATION}`,
             );
@@ -386,14 +388,15 @@ function draftExtension(
 interface ExtensionOptionScope {
     ancestors: CliCommandOption[];
     own: CliCommandOption[];
+    path: string[];
     label: string;
     /**
      * Set when the target has subcommands, and so shares an added option with
      * everything below it.
      */
     subtree?: {
-        /** How the target is named in an error message. */
-        describedAs: string;
+        /** The target itself, which the messages below name. */
+        target: CliCommandNode;
         /** Options that commands below the target share with their own subtrees. */
         parents: Array<{ path: string[]; option: CliCommandOption }>;
         /** Options declared by commands below the target that share nothing. */
@@ -414,12 +417,13 @@ function extensionOptionConflicts(
     const scope: ExtensionOptionScope = {
         ancestors: ancestorSharedOptions(draft, path),
         own: withSubOptions(target.options ?? []),
+        path,
         label: path.join(' '),
         // Extending a command that has subcommands shares the option with
         // everything below it, so the subtree matters as much as the ancestors.
         subtree: hasCliSubcommands(target)
             ? {
-                  describedAs: describeCommand(target, path),
+                  target,
                   parents: descendantParentOptions(target, path),
                   leaves: descendantLeafOptions(target, path),
               }
@@ -453,10 +457,11 @@ function addedOptionConflicts(
     }
 
     if (subtree) {
+        const targetName = describeCommand(subtree.target, scope.path);
         const parentBelow = subtree.parents.find(existing => isSameOption(existing.option, parsed));
         if (parentBelow) {
             conflicts.push(
-                `Option "${name}" added to ${subtree.describedAs} is already shared by ` +
+                `Option "${name}" added to ${targetName} is already shared by ` +
                     `"vendure ${parentBelow.path.join(' ')}" below it. ${SUBTREE_SHARING_EXPLANATION}`,
             );
             return conflicts;
@@ -467,7 +472,7 @@ function addedOptionConflicts(
         );
         if (leafBelow) {
             conflicts.push(
-                `Option "${name}" added to ${subtree.describedAs} is not compatible with ` +
+                `Option "${name}" added to ${targetName} is not compatible with ` +
                     `"${describeOption(leafBelow.option)}" on "vendure ${leafBelow.path.join(' ')}" below ` +
                     `it: one takes a value and the other does not.`,
             );
@@ -483,8 +488,8 @@ function addedOptionConflicts(
     }
     if (subtree) {
         conflicts.push(
-            `Option "${name}" added to ${subtree.describedAs} is already a shared option ` +
-                `("${describeOption(sharedOption)}"). ${SUBTREE_SHARING_EXPLANATION}`,
+            `Option "${name}" added to ${describeCommand(subtree.target, scope.path)} is already a ` +
+                `shared option ("${describeOption(sharedOption)}"). ${SUBTREE_SHARING_EXPLANATION}`,
         );
     } else if (!takesSameValue(sharedOption, option)) {
         conflicts.push(
@@ -503,8 +508,6 @@ function extendNode(target: CliCommandNode, extension: CliCommandExtension): Cli
         return { ...target, description, options: options.length > 0 ? options : undefined };
     }
 
-    // The spread carries any subcommands through, so extending a runnable
-    // parent leaves the tree below it as it was.
     const command: CliCommandDefinition = {
         ...target,
         description,
@@ -524,20 +527,16 @@ function extendNode(target: CliCommandNode, extension: CliCommandExtension): Cli
 }
 
 function freezeCommand(command: CliCommandDefinition): Readonly<CliCommandDefinition> {
+    // A decorator wraps an action, so it is not shown the commands nested under
+    // one. Passing them would hand it the live nodes the registry goes on to
+    // use, which no amount of freezing at this level would protect.
+    const { subcommands, ...rest } = command;
     // The arrays are copied as well as frozen: freezing makes a mutating
     // decorator fail loudly, and copying means it could not have reached the
     // registered definition even if it did not.
-    const frozenOptions = command.options && (Object.freeze([...command.options]) as CliCommandOption[]);
-    const frozenArguments =
-        command.arguments && (Object.freeze([...command.arguments]) as CliCommandArgument[]);
-    const frozenSubcommands =
-        command.subcommands && (Object.freeze([...command.subcommands]) as CliCommandNode[]);
-    return Object.freeze({
-        ...command,
-        options: frozenOptions,
-        arguments: frozenArguments,
-        subcommands: frozenSubcommands,
-    });
+    const frozenOptions = rest.options && (Object.freeze([...rest.options]) as CliCommandOption[]);
+    const frozenArguments = rest.arguments && (Object.freeze([...rest.arguments]) as CliCommandArgument[]);
+    return Object.freeze({ ...rest, options: frozenOptions, arguments: frozenArguments });
 }
 
 function findNodeAtPath(node: CliCommandNode, path: string[]): CliCommandNode | undefined {
@@ -582,20 +581,16 @@ function findRootOption(draft: RegistryState, parsed: ParsedCliOption): Register
 interface DeclaredOption {
     path: string[];
     option: CliCommandOption;
-    /**
-     * How the declaring command is named in an error message, when it has
-     * subcommands and so shares the option with all of them.
-     */
-    sharedBy?: string;
+    /** The command that declares it, which decides whether it is shared. */
+    declaredBy: CliCommandNode;
 }
 
 function listCommandOptions(nodes: CliCommandNode[], path: string[] = []): DeclaredOption[] {
     const declared: DeclaredOption[] = [];
     for (const node of nodes) {
         const commandPath = [...path, node.name];
-        const sharedBy = hasCliSubcommands(node) ? describeCommand(node, commandPath) : undefined;
         for (const option of withSubOptions(node.options ?? [])) {
-            declared.push({ path: commandPath, option, sharedBy });
+            declared.push({ path: commandPath, option, declaredBy: node });
         }
         if (hasCliSubcommands(node)) {
             declared.push(...listCommandOptions(node.subcommands, commandPath));

--- a/packages/cli/src/shared/command-registry.spec.ts
+++ b/packages/cli/src/shared/command-registry.spec.ts
@@ -379,11 +379,11 @@ describe('registerCommands() with runnable parent commands', () => {
         expect(result.stderr).toContain("unknown option '--env'");
     });
 
-    it('rejects an argument that names no subcommand rather than running the parent', async () => {
+    it('reports an argument that names no subcommand rather than running the parent', async () => {
         const result = await runCli(runnableParentCommands(), rootOptions, ['deploy', 'plann']);
 
         expect(result.exitCode).toBe(1);
-        expect(result.stderr).toContain('too many arguments');
+        expect(result.stderr).toContain("unknown command 'plann'");
         expect(calls).toHaveLength(0);
     });
 
@@ -403,6 +403,46 @@ describe('registerCommands() with runnable parent commands', () => {
         expect(calls[1].commandPath).toEqual(['deploy', 'plan']);
     });
 
+    it('cannot tell a mistyped subcommand from a value when a positional is declared', async () => {
+        // The operand fills `target` before it is ever spare, so the guard above
+        // has nothing to report. This is why the contract tells an author to
+        // prefer options to positional arguments on a command with subcommands.
+        const commands: CliCommandNode[] = [
+            recordingLeaf('deploy', 'Deploy the application', {
+                arguments: [{ name: 'target', description: 'What to deploy' }],
+                subcommands: [recordingLeaf('plan', 'Show what a deploy would change')],
+            }),
+        ];
+
+        const result = await runCli(commands, [], ['deploy', 'plann']);
+
+        expect(result.exitCode).toBe(0);
+        expect(calls[0].commandPath).toEqual(['deploy']);
+        expect(calls[0].positionals).toEqual(['plann']);
+    });
+
+    it('reports a second argument that names no subcommand', async () => {
+        const commands: CliCommandNode[] = [
+            recordingLeaf('deploy', 'Deploy the application', {
+                arguments: [{ name: 'target', description: 'What to deploy' }],
+                subcommands: [recordingLeaf('plan', 'Show what a deploy would change')],
+            }),
+        ];
+
+        const result = await runCli(commands, [], ['deploy', 'api', 'plann']);
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("unknown command 'plann'");
+        expect(calls).toHaveLength(0);
+    });
+
+    it('keeps the help subcommand that Commander omits once a command has an action', async () => {
+        const result = await runCli(runnableParentCommands(), rootOptions, ['deploy', 'help']);
+
+        expect(calls).toHaveLength(0);
+        expect(result.stdout).toMatch(/^\s+plan\s+Show what a deploy would change$/m);
+    });
+
     it('uses the numeric result of a parent action as the exit code', async () => {
         const commands: CliCommandNode[] = [
             {
@@ -417,7 +457,7 @@ describe('registerCommands() with runnable parent commands', () => {
         expect(result.exitCode).toBe(3);
     });
 
-    it('lists a runnable parent subcommands and options in its help', async () => {
+    it("lists a runnable parent's subcommands and options in its help", async () => {
         const result = await runCli(runnableParentCommands(), rootOptions, ['deploy', '--help']);
 
         expect(result.stdout).toContain('Usage: vendure deploy [options] [command]');
@@ -426,6 +466,14 @@ describe('registerCommands() with runnable parent commands', () => {
         expect(result.stdout).toMatch(/^\s+--env /m);
         expect(result.stdout).toContain('Global Options:');
         expect(result.stdout).toMatch(/^\s+--token /m);
+    });
+
+    it('lists the subcommands of a runnable parent nested inside a group', async () => {
+        const result = await runCli(runnableParentCommands(), rootOptions, ['backup', 'db', '--help']);
+
+        expect(result.stdout).toContain('Usage: vendure backup db');
+        expect(result.stdout).toMatch(/^\s+list\s+List database backups$/m);
+        expect(result.stdout).toMatch(/^\s+status\s+Show the status of a backup$/m);
     });
 });
 

--- a/packages/cli/src/shared/command-registry.spec.ts
+++ b/packages/cli/src/shared/command-registry.spec.ts
@@ -277,6 +277,158 @@ describe('registerCommands() with nested commands', () => {
     });
 });
 
+/**
+ * The two shapes the hosted Cloud CLI needs: `deploy`, which runs an action of
+ * its own and parents `plan` and `teardown`; and `backup db`, which does the
+ * same one level down, inside the pure `backup` group.
+ */
+function runnableParentCommands(): CliCommandNode[] {
+    return [
+        recordingLeaf('deploy', 'Deploy the application', {
+            options: [{ long: '--env <name>', description: 'Target environment', required: true }],
+            subcommands: [
+                recordingLeaf('plan', 'Show what a deploy would change'),
+                recordingLeaf('teardown', 'Tear the deployment down'),
+            ],
+        }),
+        {
+            name: 'backup',
+            description: 'Manage backups',
+            subcommands: [
+                recordingLeaf('db', 'Back the database up', {
+                    subcommands: [
+                        recordingLeaf('list', 'List database backups'),
+                        recordingLeaf('status', 'Show the status of a backup'),
+                    ],
+                }),
+            ],
+        },
+    ];
+}
+
+describe('registerCommands() with runnable parent commands', () => {
+    it('runs the parent action when no subcommand is given', async () => {
+        const result = await runCli(runnableParentCommands(), rootOptions, ['deploy']);
+
+        expect(result.exitCode).toBe(0);
+        expect(calls).toHaveLength(1);
+        expect(calls[0].commandPath).toEqual(['deploy']);
+    });
+
+    it('runs the subcommand rather than the parent action', async () => {
+        await runCli(runnableParentCommands(), rootOptions, ['deploy', 'plan']);
+        await runCli(runnableParentCommands(), rootOptions, ['deploy', 'teardown']);
+
+        expect(calls.map(call => call.commandPath)).toEqual([
+            ['deploy', 'plan'],
+            ['deploy', 'teardown'],
+        ]);
+    });
+
+    it('runs a runnable parent nested inside a group, and its subcommands', async () => {
+        await runCli(runnableParentCommands(), rootOptions, ['backup', 'db']);
+        await runCli(runnableParentCommands(), rootOptions, ['backup', 'db', 'list']);
+        await runCli(runnableParentCommands(), rootOptions, ['backup', 'db', 'status']);
+
+        expect(calls.map(call => call.commandPath)).toEqual([
+            ['backup', 'db'],
+            ['backup', 'db', 'list'],
+            ['backup', 'db', 'status'],
+        ]);
+    });
+
+    it('passes a runnable parent its own options', async () => {
+        await runCli(runnableParentCommands(), rootOptions, ['deploy', '--env', 'staging']);
+
+        expect(calls[0].options).toEqual({ env: 'staging' });
+    });
+
+    it('shares a runnable parent option with its subcommands, given before the subcommand', async () => {
+        await runCli(runnableParentCommands(), rootOptions, ['deploy', '--env', 'staging', 'plan']);
+
+        expect(calls[0].commandPath).toEqual(['deploy', 'plan']);
+        expect(calls[0].inheritedOptions.env).toBe('staging');
+        // The parent option is shared, not one of the subcommand's own.
+        expect(calls[0].options).toEqual({});
+    });
+
+    it('shares a runnable parent option with its subcommands, given after the subcommand', async () => {
+        await runCli(runnableParentCommands(), rootOptions, ['deploy', 'plan', '--env', 'staging']);
+
+        expect(calls[0].inheritedOptions.env).toBe('staging');
+    });
+
+    it('shares root options with a runnable parent and with its subcommands', async () => {
+        await runCli(runnableParentCommands(), rootOptions, ['deploy', '--token', 'tok']);
+        await runCli(runnableParentCommands(), rootOptions, ['backup', 'db', 'list', '--token', 'tok']);
+
+        expect(calls[0].inheritedOptions).toEqual({ token: 'tok' });
+        expect(calls[1].inheritedOptions).toEqual({ token: 'tok' });
+    });
+
+    it('does not offer a runnable parent option outside its subtree', async () => {
+        const result = await runCli(runnableParentCommands(), rootOptions, [
+            'backup',
+            'db',
+            'list',
+            '--env',
+            'staging',
+        ]);
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("unknown option '--env'");
+    });
+
+    it('rejects an argument that names no subcommand rather than running the parent', async () => {
+        const result = await runCli(runnableParentCommands(), rootOptions, ['deploy', 'plann']);
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain('too many arguments');
+        expect(calls).toHaveLength(0);
+    });
+
+    it('gives a subcommand name precedence over a positional argument', async () => {
+        const commands: CliCommandNode[] = [
+            recordingLeaf('deploy', 'Deploy the application', {
+                arguments: [{ name: 'target', description: 'What to deploy' }],
+                subcommands: [recordingLeaf('plan', 'Show what a deploy would change')],
+            }),
+        ];
+
+        await runCli(commands, [], ['deploy', 'api']);
+        await runCli(commands, [], ['deploy', 'plan']);
+
+        expect(calls[0].commandPath).toEqual(['deploy']);
+        expect(calls[0].positionals).toEqual(['api']);
+        expect(calls[1].commandPath).toEqual(['deploy', 'plan']);
+    });
+
+    it('uses the numeric result of a parent action as the exit code', async () => {
+        const commands: CliCommandNode[] = [
+            {
+                name: 'deploy',
+                description: 'Deploy the application',
+                action: async () => 3,
+                subcommands: [recordingLeaf('plan', 'Show what a deploy would change')],
+            },
+        ];
+        const result = await runCli(commands, [], ['deploy']);
+
+        expect(result.exitCode).toBe(3);
+    });
+
+    it('lists a runnable parent subcommands and options in its help', async () => {
+        const result = await runCli(runnableParentCommands(), rootOptions, ['deploy', '--help']);
+
+        expect(result.stdout).toContain('Usage: vendure deploy [options] [command]');
+        expect(result.stdout).toMatch(/^\s+plan\s+Show what a deploy would change$/m);
+        expect(result.stdout).toMatch(/^\s+teardown\s+Tear the deployment down$/m);
+        expect(result.stdout).toMatch(/^\s+--env /m);
+        expect(result.stdout).toContain('Global Options:');
+        expect(result.stdout).toMatch(/^\s+--token /m);
+    });
+});
+
 describe('registerCommands() help output', () => {
     it('lists top-level commands and shared options in root help', async () => {
         const result = await runCli(cloudCommands(), rootOptions, ['--help']);

--- a/packages/cli/src/shared/command-registry.spec.ts
+++ b/packages/cli/src/shared/command-registry.spec.ts
@@ -24,10 +24,11 @@ beforeEach(() => {
 });
 
 /**
- * A leaf that records what the host handed to it. The context is always the
- * final argument, after Commander's positionals, options and Command.
+ * A command that records what the host handed to it, with or without
+ * subcommands of its own. The context is always the final argument, after
+ * Commander's positionals, options and Command.
  */
-function recordingLeaf(
+function recordingCommand(
     name: string,
     description: string,
     extra: Partial<CliCommandDefinition> = {},
@@ -62,7 +63,7 @@ function cloudCommands(): CliCommandNode[] {
         {
             name: 'project',
             description: 'Manage projects',
-            subcommands: [recordingLeaf('list', 'List projects')],
+            subcommands: [recordingCommand('list', 'List projects')],
         },
         {
             name: 'config',
@@ -73,7 +74,7 @@ function cloudCommands(): CliCommandNode[] {
                     name: 'server',
                     description: 'Server configuration',
                     subcommands: [
-                        recordingLeaf('set', 'Set a server config value', {
+                        recordingCommand('set', 'Set a server config value', {
                             arguments: [
                                 { name: 'key', description: 'Key', required: true },
                                 { name: 'value', description: 'Value', required: true },
@@ -90,7 +91,7 @@ function cloudCommands(): CliCommandNode[] {
                 {
                     name: 'db',
                     description: 'Database backups',
-                    subcommands: [recordingLeaf('list', 'List database backups')],
+                    subcommands: [recordingCommand('list', 'List database backups')],
                 },
             ],
         },
@@ -98,7 +99,7 @@ function cloudCommands(): CliCommandNode[] {
             name: 'restore',
             description: 'Restore from a backup',
             subcommands: [
-                recordingLeaf('db', 'Restore the database', {
+                recordingCommand('db', 'Restore the database', {
                     arguments: [{ name: 'backupId', description: 'Backup id', required: true }],
                 }),
             ],
@@ -238,7 +239,7 @@ describe('registerCommands() with nested commands', () => {
                 name: 'project',
                 description: 'Manage projects',
                 subcommands: [
-                    recordingLeaf('list', 'List projects', {
+                    recordingCommand('list', 'List projects', {
                         options: [{ long: '--limit <n>', description: 'Maximum results', required: true }],
                     }),
                 ],
@@ -252,7 +253,7 @@ describe('registerCommands() with nested commands', () => {
 
     it('gives a command its own value when it declares the same flag as a shared option', async () => {
         const commands: CliCommandNode[] = [
-            recordingLeaf('plugins', 'Manage CLI plugins', {
+            recordingCommand('plugins', 'Manage CLI plugins', {
                 options: [{ long: '--json', description: 'Output JSON' }],
             }),
         ];
@@ -266,7 +267,7 @@ describe('registerCommands() with nested commands', () => {
         // The flag written before the command is consumed by the shared option,
         // so only the host copying it onto the command keeps both in step.
         const commands: CliCommandNode[] = [
-            recordingLeaf('plugins', 'Manage CLI plugins', {
+            recordingCommand('plugins', 'Manage CLI plugins', {
                 options: [{ long: '--json', description: 'Output JSON' }],
             }),
         ];
@@ -284,21 +285,21 @@ describe('registerCommands() with nested commands', () => {
  */
 function runnableParentCommands(): CliCommandNode[] {
     return [
-        recordingLeaf('deploy', 'Deploy the application', {
+        recordingCommand('deploy', 'Deploy the application', {
             options: [{ long: '--env <name>', description: 'Target environment', required: true }],
             subcommands: [
-                recordingLeaf('plan', 'Show what a deploy would change'),
-                recordingLeaf('teardown', 'Tear the deployment down'),
+                recordingCommand('plan', 'Show what a deploy would change'),
+                recordingCommand('teardown', 'Tear the deployment down'),
             ],
         }),
         {
             name: 'backup',
             description: 'Manage backups',
             subcommands: [
-                recordingLeaf('db', 'Back the database up', {
+                recordingCommand('db', 'Back the database up', {
                     subcommands: [
-                        recordingLeaf('list', 'List database backups'),
-                        recordingLeaf('status', 'Show the status of a backup'),
+                        recordingCommand('list', 'List database backups'),
+                        recordingCommand('status', 'Show the status of a backup'),
                     ],
                 }),
             ],
@@ -379,7 +380,7 @@ describe('registerCommands() with runnable parent commands', () => {
         expect(result.stderr).toContain("unknown option '--env'");
     });
 
-    it('reports an argument that names no subcommand rather than running the parent', async () => {
+    it('reports a word that names no subcommand rather than running the parent', async () => {
         const result = await runCli(runnableParentCommands(), rootOptions, ['deploy', 'plann']);
 
         expect(result.exitCode).toBe(1);
@@ -387,53 +388,19 @@ describe('registerCommands() with runnable parent commands', () => {
         expect(calls).toHaveLength(0);
     });
 
-    it('gives a subcommand name precedence over a positional argument', async () => {
-        const commands: CliCommandNode[] = [
-            recordingLeaf('deploy', 'Deploy the application', {
-                arguments: [{ name: 'target', description: 'What to deploy' }],
-                subcommands: [recordingLeaf('plan', 'Show what a deploy would change')],
-            }),
-        ];
+    it('reports it the way a group does, through Commander and with a suggestion', async () => {
+        // The point of the shape is that it behaves like a group, so the two
+        // have to agree on the message, the channel and the exit code.
+        const parent = await runCli(runnableParentCommands(), rootOptions, ['deploy', 'plann']);
+        const group = await runCli(runnableParentCommands(), rootOptions, ['backup', 'dbb']);
 
-        await runCli(commands, [], ['deploy', 'api']);
-        await runCli(commands, [], ['deploy', 'plan']);
-
-        expect(calls[0].commandPath).toEqual(['deploy']);
-        expect(calls[0].positionals).toEqual(['api']);
-        expect(calls[1].commandPath).toEqual(['deploy', 'plan']);
-    });
-
-    it('cannot tell a mistyped subcommand from a value when a positional is declared', async () => {
-        // The operand fills `target` before it is ever spare, so the guard above
-        // has nothing to report. This is why the contract tells an author to
-        // prefer options to positional arguments on a command with subcommands.
-        const commands: CliCommandNode[] = [
-            recordingLeaf('deploy', 'Deploy the application', {
-                arguments: [{ name: 'target', description: 'What to deploy' }],
-                subcommands: [recordingLeaf('plan', 'Show what a deploy would change')],
-            }),
-        ];
-
-        const result = await runCli(commands, [], ['deploy', 'plann']);
-
-        expect(result.exitCode).toBe(0);
-        expect(calls[0].commandPath).toEqual(['deploy']);
-        expect(calls[0].positionals).toEqual(['plann']);
-    });
-
-    it('reports a second argument that names no subcommand', async () => {
-        const commands: CliCommandNode[] = [
-            recordingLeaf('deploy', 'Deploy the application', {
-                arguments: [{ name: 'target', description: 'What to deploy' }],
-                subcommands: [recordingLeaf('plan', 'Show what a deploy would change')],
-            }),
-        ];
-
-        const result = await runCli(commands, [], ['deploy', 'api', 'plann']);
-
-        expect(result.exitCode).toBe(1);
-        expect(result.stderr).toContain("unknown command 'plann'");
-        expect(calls).toHaveLength(0);
+        expect(parent.stderr).toContain('(Did you mean plan?)');
+        expect(group.stderr).toContain('(Did you mean db?)');
+        expect(parent.exitCode).toBe(group.exitCode);
+        // Written through the output Commander was configured with, not
+        // straight to the process, which is what `runCli` records separately.
+        expect(parent.commanderStderr).toContain("unknown command 'plann'");
+        expect(parent.processStderr).toBe('');
     });
 
     it('keeps the help subcommand that Commander omits once a command has an action', async () => {
@@ -443,13 +410,51 @@ describe('registerCommands() with runnable parent commands', () => {
         expect(result.stdout).toMatch(/^\s+plan\s+Show what a deploy would change$/m);
     });
 
+    it('does not list a second help when the plugin declares its own', async () => {
+        const commands: CliCommandNode[] = [
+            recordingCommand('deploy', 'Deploy the application', {
+                subcommands: [
+                    recordingCommand('plan', 'Show what a deploy would change'),
+                    recordingCommand('help', 'Explain how deploying works'),
+                ],
+            }),
+        ];
+
+        const result = await runCli(commands, [], ['deploy', '--help']);
+
+        expect(result.stdout).toMatch(/^\s+help\s+Explain how deploying works$/m);
+        expect(result.stdout).not.toContain('help [command]');
+    });
+
+    it('runs a pure group nested under a runnable parent', async () => {
+        const commands: CliCommandNode[] = [
+            recordingCommand('deploy', 'Deploy the application', {
+                subcommands: [
+                    {
+                        name: 'config',
+                        description: 'Deployment configuration',
+                        subcommands: [recordingCommand('show', 'Show the configuration')],
+                    },
+                ],
+            }),
+        ];
+
+        await runCli(commands, [], ['deploy']);
+        await runCli(commands, [], ['deploy', 'config', 'show']);
+        const group = await runCli(commands, [], ['deploy', 'config']);
+
+        expect(calls.map(call => call.commandPath)).toEqual([['deploy'], ['deploy', 'config', 'show']]);
+        expect(group.exitCode).toBe(1);
+        expect(group.stderr).toContain('Usage: vendure deploy config');
+    });
+
     it('uses the numeric result of a parent action as the exit code', async () => {
         const commands: CliCommandNode[] = [
             {
                 name: 'deploy',
                 description: 'Deploy the application',
                 action: async () => 3,
-                subcommands: [recordingLeaf('plan', 'Show what a deploy would change')],
+                subcommands: [recordingCommand('plan', 'Show what a deploy would change')],
             },
         ];
         const result = await runCli(commands, [], ['deploy']);

--- a/packages/cli/src/shared/command-registry.ts
+++ b/packages/cli/src/shared/command-registry.ts
@@ -5,7 +5,8 @@ import {
     CliCommandContext,
     CliCommandNode,
     CliCommandOption,
-    isCliCommandGroup,
+    hasCliSubcommands,
+    isRunnableCliCommand,
 } from './cli-command-definition';
 import { CliCommandExit } from './cli-command-exit';
 import { buildOptionFlags, parseOptionFlags } from './cli-command-options';
@@ -39,21 +40,35 @@ function registerNode(
 ): void {
     const command = parent.command(node.name).description(node.description);
     const commandPath = [...path, node.name];
+    // Narrowed up front: a node may both run an action and have subcommands.
+    const runnable = isRunnableCliCommand(node) ? node : undefined;
+    const subcommands = hasCliSubcommands(node) ? node.subcommands : undefined;
 
-    if (isCliCommandGroup(node)) {
-        const groupOptions = [...sharedOptions, ...declareOptions(command, node.options ?? [])];
-        for (const subcommand of node.subcommands) {
-            registerNode(command, subcommand, commandPath, groupOptions);
+    for (const arg of runnable?.arguments ?? []) {
+        command.argument(arg.required ? `<${arg.name}>` : `[${arg.name}]`, arg.description);
+    }
+    const ownOptions = declareOptions(command, node.options ?? []);
+
+    if (subcommands) {
+        // A parent shares its options with everything below it whether or not
+        // it runs an action of its own.
+        const inheritedOptions = [...sharedOptions, ...ownOptions];
+        for (const subcommand of subcommands) {
+            registerNode(command, subcommand, commandPath, inheritedOptions);
         }
+        if (runnable) {
+            // Commander looks for a subcommand and otherwise falls back to the
+            // action, so without this a mistyped subcommand would be taken as a
+            // stray operand and silently run the parent.
+            command.allowExcessArguments(false);
+        }
+    }
+
+    if (!runnable) {
         // A group has no action: Commander prints its help and exits non-zero
         // when it is run without a subcommand.
         return;
     }
-
-    for (const arg of node.arguments ?? []) {
-        command.argument(arg.required ? `<${arg.name}>` : `[${arg.name}]`, arg.description);
-    }
-    declareOptions(command, node.options ?? []);
 
     command.action(async (...args: any[]) => {
         fillSharedValues(command, commanderOptions(args), sharedOptions);
@@ -62,7 +77,7 @@ function registerNode(
             commandPath,
         };
         // Exit is owned by the host so plugins can wrap built-in actions.
-        process.exit(await runAction(node.action, args, context));
+        process.exit(await runAction(runnable.action, args, context));
     });
 }
 
@@ -86,7 +101,7 @@ async function runAction(action: CliCommandAction, args: any[], context: CliComm
 
 /**
  * Declares options on a command and describes them for any descendants, which
- * inherit them when the command is a group or the root program.
+ * inherit them when the command has subcommands or is the root program.
  */
 function declareOptions(command: Command, options: CliCommandOption[]): SharedOption[] {
     const declared: SharedOption[] = [];

--- a/packages/cli/src/shared/command-registry.ts
+++ b/packages/cli/src/shared/command-registry.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import {
     CliCommandAction,
     CliCommandContext,
+    CliCommandDefinition,
     CliCommandNode,
     CliCommandOption,
     hasCliSubcommands,
@@ -40,7 +41,6 @@ function registerNode(
 ): void {
     const command = parent.command(node.name).description(node.description);
     const commandPath = [...path, node.name];
-    // Narrowed up front: a node may both run an action and have subcommands.
     const runnable = isRunnableCliCommand(node) ? node : undefined;
     const subcommands = hasCliSubcommands(node) ? node.subcommands : undefined;
 
@@ -50,17 +50,18 @@ function registerNode(
     const ownOptions = declareOptions(command, node.options ?? []);
 
     if (subcommands) {
-        // A parent shares its options with everything below it whether or not
-        // it runs an action of its own.
+        // A node with subcommands shares its options with every command below
+        // it; hasCliSubcommands explains why.
         const inheritedOptions = [...sharedOptions, ...ownOptions];
         for (const subcommand of subcommands) {
             registerNode(command, subcommand, commandPath, inheritedOptions);
         }
         if (runnable) {
-            // Commander looks for a subcommand and otherwise falls back to the
-            // action, so without this a mistyped subcommand would be taken as a
-            // stray operand and silently run the parent.
-            command.allowExcessArguments(false);
+            // Commander leaves out its implicit `help` subcommand when a command
+            // has an action, so without this `vendure deploy help` would not work
+            // the way `vendure config help` does. A `help` the plugin declared
+            // itself wins, and no second one is added.
+            command.addHelpCommand();
         }
     }
 
@@ -71,6 +72,14 @@ function registerNode(
     }
 
     command.action(async (...args: any[]) => {
+        const unknownSubcommand = subcommands ? strayOperand(command, runnable) : undefined;
+        if (unknownSubcommand !== undefined) {
+            // Commander tries the subcommand names before it falls back to this
+            // action, so an operand still spare here matched none of them.
+            // Reporting it is what stops `vendure deploy plann` deploying.
+            process.stderr.write(`error: unknown command '${unknownSubcommand}'\n`);
+            process.exit(1);
+        }
         fillSharedValues(command, commanderOptions(args), sharedOptions);
         const context: CliCommandContext = {
             inheritedOptions: readSharedValues(sharedOptions),
@@ -79,6 +88,20 @@ function registerNode(
         // Exit is owned by the host so plugins can wrap built-in actions.
         process.exit(await runAction(runnable.action, args, context));
     });
+}
+
+/**
+ * The first operand Commander has no home for: past the positional arguments the
+ * command declares, and — because Commander resolves subcommands first — not the
+ * name of one of its subcommands either.
+ *
+ * A command that declares both `arguments` and `subcommands` cannot tell a
+ * mistyped subcommand from a value, because the operand fills a positional
+ * before it is ever spare. Only a command with no positional left over is
+ * protected.
+ */
+function strayOperand(command: Command, node: CliCommandDefinition): string | undefined {
+    return command.args[node.arguments?.length ?? 0];
 }
 
 /**
@@ -130,9 +153,9 @@ function addOption(command: Command, option: CliCommandOption): void {
  * Reads the value of each shared option in scope.
  *
  * No two entries can share a name: registration rejects a flag shared by both
- * a group and the root, or by a group and one of its ancestors, whichever
- * order the plugins load in. So there is nothing here to resolve — an option
- * has one owner, and that owner holds its value.
+ * the root and a command with subcommands, or by two such commands on the same
+ * branch, whichever order the plugins load in. So there is nothing here to
+ * resolve — an option has one owner, and that owner holds its value.
  */
 function readSharedValues(sharedOptions: SharedOption[]): Record<string, any> {
     const values: Record<string, any> = {};

--- a/packages/cli/src/shared/command-registry.ts
+++ b/packages/cli/src/shared/command-registry.ts
@@ -3,7 +3,6 @@ import { Command } from 'commander';
 import {
     CliCommandAction,
     CliCommandContext,
-    CliCommandDefinition,
     CliCommandNode,
     CliCommandOption,
     hasCliSubcommands,
@@ -57,11 +56,19 @@ function registerNode(
             registerNode(command, subcommand, commandPath, inheritedOptions);
         }
         if (runnable) {
-            // Commander leaves out its implicit `help` subcommand when a command
+            // A command with subcommands takes no positional arguments, so any
+            // operand left here is a mistyped subcommand for the action below to
+            // reject. Said explicitly because Commander's own default for this
+            // has changed between major versions.
+            command.allowExcessArguments(true);
+            // Commander leaves out its implicit `help` subcommand once a command
             // has an action, so without this `vendure deploy help` would not work
-            // the way `vendure config help` does. A `help` the plugin declared
-            // itself wins, and no second one is added.
-            command.addHelpCommand();
+            // the way `vendure config help` does. Skipped when the plugin
+            // declares its own `help`, which Commander would otherwise list
+            // twice.
+            if (!subcommands.some(subcommand => subcommand.name === 'help')) {
+                command.addHelpCommand();
+            }
         }
     }
 
@@ -72,13 +79,13 @@ function registerNode(
     }
 
     command.action(async (...args: any[]) => {
-        const unknownSubcommand = subcommands ? strayOperand(command, runnable) : undefined;
-        if (unknownSubcommand !== undefined) {
+        if (subcommands && command.args.length > 0) {
             // Commander tries the subcommand names before it falls back to this
-            // action, so an operand still spare here matched none of them.
-            // Reporting it is what stops `vendure deploy plann` deploying.
-            process.stderr.write(`error: unknown command '${unknownSubcommand}'\n`);
-            process.exit(1);
+            // action, and a command with subcommands declares no arguments, so a
+            // word still sitting here named no subcommand. Reporting it through
+            // Commander is what stops `vendure deploy plann` deploying, and gives
+            // the same message and "did you mean" hint that a group gives.
+            reportUnknownSubcommand(command);
         }
         fillSharedValues(command, commanderOptions(args), sharedOptions);
         const context: CliCommandContext = {
@@ -91,17 +98,24 @@ function registerNode(
 }
 
 /**
- * The first operand Commander has no home for: past the positional arguments the
- * command declares, and — because Commander resolves subcommands first — not the
- * name of one of its subcommands either.
+ * Reports a word that named no subcommand, the way Commander reports one on a
+ * command that has no action of its own.
  *
- * A command that declares both `arguments` and `subcommands` cannot tell a
- * mistyped subcommand from a value, because the operand fills a positional
- * before it is ever spare. Only a command with no positional left over is
- * protected.
+ * `unknownCommand` assembles the "did you mean" hint from the visible
+ * subcommands and routes through `Command#error`, so the message, the output
+ * channel configured by `configureOutput` and the exit code all match what a
+ * group produces. Commander calls it itself but has never declared it in its
+ * typings, hence the cast. The fallback keeps the channel and exit code right,
+ * losing only the hint, should a later version drop it.
  */
-function strayOperand(command: Command, node: CliCommandDefinition): string | undefined {
-    return command.args[node.arguments?.length ?? 0];
+function reportUnknownSubcommand(command: Command): never {
+    const commander = command as Command & { unknownCommand?: () => never };
+    if (typeof commander.unknownCommand === 'function') {
+        commander.unknownCommand();
+    }
+    return command.error(`error: unknown command '${command.args[0]}'`, {
+        code: 'commander.unknownCommand',
+    });
 }
 
 /**


### PR DESCRIPTION
# Description

The CLI extension contract could express a command with an action, or a group of subcommands, but not both. `assertNode` rejected any node declaring both, and `isCliCommandGroup` treated every node with a `subcommands` array as a pure group.

The hosted Cloud CLI has two commands that need both shapes: `deploy`, which runs on its own and parents `plan` and `teardown`; and `backup db`, which runs on its own inside the `backup` group and parents `list` and `status`. Changing the public hierarchy to avoid this would break compatibility for existing users of those commands.

`CliCommandDefinition` now takes an optional `subcommands` array, so a command may keep its action and parent further commands. Pure group behaviour is unchanged: a node with subcommands and no action still prints its help and exits non-zero when run without a subcommand.

The single `isCliCommandGroup` check was doing three different jobs, which only coincided because the two shapes could never overlap. They are now separate:

- `hasCliSubcommands` — the node parents further commands. This is what tree walking and option scoping key on.
- `isRunnableCliCommand` — the node has an action. This is what action registration and decoration key on.
- `isCliCommandGroup` — the node has subcommands and no action. Used only for error wording.

A command that has subcommands shares its options with everything below it whether or not it also runs an action, so the stricter group rule applies to the new shape: it may not repeat a flag an ancestor already shares. Conflict messages that used to say "the command group" now say "the command" when the node runs an action of its own.

Three behaviours are worth calling out.

A command that has subcommands may not also declare positional `arguments`. The first word after the command name would be ambiguous, since it could equally name a subcommand or fill an argument, and there is no way to tell the two apart. Declaring both is rejected when the plugin is registered, in keeping with every other ambiguity in this contract. Neither hosted consumer needs the combination: `deploy` and `backup db` both take options only.

That rule is what makes the second one sound. Commander resolves the first word against the subcommand names before it considers the action, so a word that named no subcommand is always a mistake. It is reported through Commander's own `unknownCommand`, which produces the same message, the same "did you mean" suggestion, the same output channel and the same exit code that a group produces for the same mistake:

```
$ vendure deploy plann
error: unknown command 'plann'
(Did you mean plan?)
```

Commander also leaves out its implicit `help` subcommand once a command has an action, so a runnable parent is given one explicitly and `vendure deploy help` works the way `vendure config help` does. It is skipped when the plugin declares its own `help`, which Commander would otherwise list twice.

A decorator extending a runnable parent is given a frozen deep copy, so it can see that the command it wraps has subcommands without being handed the nodes the registry goes on to use.

Two documents said a command entry with `subcommands` is a group, which contradicted the new shape: the CLI guide at `docs/docs/guides/developer-guide/cli/index.mdx` and the package architecture note at `packages/cli/src/README.md`. Both are corrected, and the guide has a section for the new shape.

Relates to CLO-710.

# Breaking changes

None. The new `subcommands` property on `CliCommandDefinition` is optional, and every existing command, group and extension behaves as before. The new word-handling and help behaviour applies only to a command that declares `subcommands` alongside an `action`, which was not previously expressible.

One rule does reach an existing shape: a command *group* may no longer declare positional `arguments` either. Nothing in this repository does, and Commander never gave those arguments to anything, so the rule turns a silent no-op into a registration error.

# Screenshots

n/a

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
