### PR TITLE
docs(core): document that /health no longer runs health check strategies

### DIFF
--- a/docs/docs/guides/core-concepts/healthchecks/index.mdx
+++ b/docs/docs/guides/core-concepts/healthchecks/index.mdx
@@ -1,60 +1,32 @@
 ---
 title: "Health Checks"
 metaTitle: "Health Check Endpoint for Monitoring Vendure"
-metaDescription: "How Vendure exposes a /health endpoint for monitoring system dependencies like the database and external services."
+metaDescription: "What the Vendure /health endpoint reports and how to use it as a liveness probe."
 ---
 
-Vendure exposes a **`/health`** endpoint that reports the status of critical system dependencies.
-This endpoint is essential for production deployments where load balancers, container orchestrators,
-and monitoring tools need to know whether the application is healthy and ready to serve traffic.
+Vendure exposes a **`/health`** endpoint on the server. It is a plain REST route which returns
+`{ "status": "ok" }` as soon as the application is accepting HTTP requests.
 
-## How it works
+The response is unconditional. `/health` does not check the database or any other dependency. It only
+tells you that this process is running and serving HTTP, which is what a liveness probe needs.
 
-Each configured health check strategy probes a specific dependency and reports back with a status.
-The `/health` endpoint aggregates all strategy results into a single response.
+:::warning[Changed in v3.6.0]
 
-A healthy response indicates that all dependencies are reachable and functioning correctly. If any
-strategy reports a failure, the endpoint returns an unhealthy status, signaling that the system
-may not be able to serve requests reliably.
+Before v3.6.0, `/health` ran the strategies configured in `systemOptions.healthChecks` and returned a
+503 if any of them failed. Since v3.6.0 those strategies are not executed. The strategy classes and
+`HealthCheckRegistryService` will be removed in v4.0.0. Remove any custom strategies and set
+`healthChecks: []` to silence the startup warning. See [#4441](https://github.com/vendurehq/vendure/issues/4441) for the reasoning.
 
-## Built-in strategies
+:::
 
-Vendure ships with two health check strategies out of the box:
+Checking dependencies from the application health endpoint was removed on purpose. If `/health` failed
+whenever the database was slow, an orchestrator would restart every instance at once, and restarting the
+application cannot fix the database. Monitor dependencies with their own alerting and keep the
+application probe shallow.
 
-- **`TypeORMHealthCheckStrategy`** — verifies that the database connection is alive by executing
-  a simple query. Since the database is the most critical dependency for any Vendure instance,
-  this strategy is enabled by default.
-
-- **`HttpHealthCheckStrategy`** — checks the availability of an external HTTP service. This is
-  useful when your Vendure instance depends on external APIs, such as a payment gateway or a
-  third-party inventory system.
-
-## Configuration
-
-Health checks are configured via the `systemOptions.healthChecks` property in the
-[`VendureConfig`](/reference/typescript-api/configuration/vendure-config/). You can enable or disable
-individual strategies and configure their parameters to match your infrastructure.
-
-## Use cases
-
-The `/health` endpoint serves several important operational purposes:
-
-- **Load balancer probes** — configure your load balancer to poll `/health` and route traffic
-  only to healthy instances.
-- **Container orchestration** — use the endpoint as a Kubernetes liveness or readiness probe
-  to automatically restart unhealthy pods or delay traffic until the application is ready.
-- **Monitoring dashboards** — integrate with monitoring tools to track uptime and get alerted
-  when dependencies become unreachable.
-
-## Custom strategies
-
-When your application has dependencies beyond the database and HTTP services, you can implement
-the `HealthCheckStrategy` interface to create custom checks. For example, a custom strategy might
-verify connectivity to a Redis cache, an Elasticsearch cluster, or a message broker.
-
-Custom strategies are added to the same `systemOptions.healthChecks` configuration array alongside
-the built-in strategies, and their results are included in the aggregated `/health` response.
+The worker can serve the same unconditional `/health` response. See the
+[Using Docker guide](/deployment/using-docker/#healthreadiness-checks) for how to enable it.
 
 ## Further reading
 
-- [Production configuration guide](/deployment/production-configuration/) — deploying Vendure with proper health checks and monitoring
+- [Production configuration guide](/deployment/production-configuration/)

--- a/docs/docs/guides/deployment/using-docker.mdx
+++ b/docs/docs/guides/deployment/using-docker.mdx
@@ -174,22 +174,13 @@ REQUEST: GET http://localhost:3000/health
  
 ```json
 {
-  "status": "ok",
-  "info": {
-    "database": {
-      "status": "up"
-    }
-  },
-  "error": {},
-  "details": {
-    "database": {
-      "status": "up"
-    }
-  }
+  "status": "ok"
 }
 ```
 
-You can also add your own health checks by creating plugins that make use of the [HealthCheckRegistryService](/reference/typescript-api/health-check/health-check-registry-service/).
+The response is unconditional and does not check the database or any other dependency. Since v3.6.0 the
+strategies configured in `systemOptions.healthChecks` are no longer executed. See the
+[health checks guide](/core-concepts/healthchecks/) for details.
 
 ### Worker
 

--- a/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "RuntimeVendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1469" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1470" packageName="@vendure/core" />
 
 This interface represents the VendureConfig object available at run-time, i.e. the user-supplied
 config values have been merged with the [defaultConfig](/reference/typescript-api/configuration/default-config#defaultconfig) values.

--- a/docs/docs/reference/typescript-api/configuration/system-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/system-options.mdx
@@ -19,10 +19,11 @@ interface SystemOptions {
 
 ### healthChecks
 
-<MemberInfo kind="property" type={`<a href='/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy'>HealthCheckStrategy</a>[]`} default={`[<a href='/reference/typescript-api/health-check/type-ormhealth-check-strategy#typeormhealthcheckstrategy'>TypeORMHealthCheckStrategy</a>]`}  since="1.6.0"  />
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy'>HealthCheckStrategy</a>[]`} default={`[]`}  since="1.6.0"  />
 
-Defines an array of [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) instances which are used by the `/health` endpoint to verify
-that any critical systems which the Vendure server depends on are also healthy.
+Defines an array of [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) instances. Before v3.6.0 the `/health` endpoint ran these
+strategies to verify that critical systems which the Vendure server depends on were healthy. Since v3.6.0
+the strategies are not executed and this option has no effect on the `/health` response.
 ### errorHandlers
 
 <MemberInfo kind="property" type={`<a href='/reference/typescript-api/errors/error-handler-strategy#errorhandlerstrategy'>ErrorHandlerStrategy</a>[]`} default={`[]`}  since="2.2.0"  />

--- a/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "VendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1322" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1323" packageName="@vendure/core" />
 
 All possible configuration options are defined by the
 [`VendureConfig`](https://github.com/vendurehq/vendure/blob/master/packages/core/src/config/vendure-config.ts) interface.

--- a/docs/docs/reference/typescript-api/health-check/health-check-error.mdx
+++ b/docs/docs/reference/typescript-api/health-check/health-check-error.mdx
@@ -4,8 +4,8 @@ generated: true
 ---
 <GenerationInfo sourceFile="packages/core/src/health-check/terminus-compat.ts" sourceLine="72" packageName="@vendure/core" />
 
-Thrown from a health indicator to signal a failed check. The `causes`
-payload is forwarded to the `/health` response so callers can inspect
+Thrown from a health indicator to signal a failed check. Before v3.6.0 the `causes`
+payload was forwarded to the `/health` response so callers could inspect
 which indicator failed and why. `causes` is intentionally typed as
 `any` (matching terminus) so handlers can pass through arbitrary
 upstream error payloads (HTTP responses, DB driver errors, etc.)

--- a/docs/docs/reference/typescript-api/health-check/health-check-registry-service.mdx
+++ b/docs/docs/reference/typescript-api/health-check/health-check-registry-service.mdx
@@ -2,18 +2,13 @@
 title: "HealthCheckRegistryService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/health-check/health-check-registry.service.ts" sourceLine="36" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/health-check/health-check-registry.service.ts" sourceLine="31" packageName="@vendure/core" />
 
 This service is used to register health indicator functions which, before v3.6.0, were run by the
 `/health` endpoint. Since v3.6.0 registered indicators are not executed, and this service will be
 removed in v4.0.0. See the [health checks guide](/core-concepts/healthchecks/).
 
-Since v1.6.0, the preferred way to implement a custom health check is by creating a new [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy)
-and then passing it to the `systemOptions.healthChecks` array.
-See the [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) docs for an example configuration.
-
-The alternative way to register a health check is by injecting this service directly into your
-plugin module. To use it in your plugin, you'll need to import the [PluginCommonModule](/reference/typescript-api/plugin/plugin-common-module#plugincommonmodule):
+The example below shows how a plugin registered an indicator before v3.6.0:
 
 *Example*
 

--- a/docs/docs/reference/typescript-api/health-check/health-check-registry-service.mdx
+++ b/docs/docs/reference/typescript-api/health-check/health-check-registry-service.mdx
@@ -2,17 +2,11 @@
 title: "HealthCheckRegistryService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/health-check/health-check-registry.service.ts" sourceLine="42" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/health-check/health-check-registry.service.ts" sourceLine="36" packageName="@vendure/core" />
 
-This service is used to register health indicator functions to be included in the
-health check. Health checks can be used by automated services such as Kubernetes
-to determine the state of applications it is running. They are also useful for
-administrators to get an overview of the health of all the parts of the
-Vendure stack.
-
-Plugins which rely on external services (web services, databases etc.) can make use of this
-service to add a check for that dependency to the Vendure health check.
-
+This service is used to register health indicator functions which, before v3.6.0, were run by the
+`/health` endpoint. Since v3.6.0 registered indicators are not executed, and this service will be
+removed in v4.0.0. See the [health checks guide](/core-concepts/healthchecks/).
 
 Since v1.6.0, the preferred way to implement a custom health check is by creating a new [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy)
 and then passing it to the `systemOptions.healthChecks` array.
@@ -50,9 +44,7 @@ class HealthCheckRegistryService {
 
 <MemberInfo kind="method" type={`(fn: <a href='/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction'>HealthIndicatorFunction</a> | <a href='/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction'>HealthIndicatorFunction</a>[]) => `}   />
 
-Registers one or more [HealthIndicatorFunction](/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction)s to be added to the
-health check endpoint. The indicator will also appear in the Admin UI's
-"system status" view.
+Registers one or more [HealthIndicatorFunction](/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction)s. Since v3.6.0 the registered functions are never called.
 
 
 </div>

--- a/docs/docs/reference/typescript-api/health-check/health-check-strategy.mdx
+++ b/docs/docs/reference/typescript-api/health-check/health-check-strategy.mdx
@@ -2,11 +2,13 @@
 title: "HealthCheckStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/system/health-check-strategy.ts" sourceLine="31" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/system/health-check-strategy.ts" sourceLine="33" packageName="@vendure/core" />
 
 This strategy defines health checks which, before v3.6.0, were run by the `/health` endpoint.
 Since v3.6.0 the strategies configured in `systemOptions.healthChecks` are not executed, and this
 interface will be removed in v4.0.0. See the [health checks guide](/core-concepts/healthchecks/).
+
+The example below shows how strategies were configured before v3.6.0.
 
 *Example*
 

--- a/docs/docs/reference/typescript-api/health-check/health-check-strategy.mdx
+++ b/docs/docs/reference/typescript-api/health-check/health-check-strategy.mdx
@@ -2,25 +2,11 @@
 title: "HealthCheckStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/system/health-check-strategy.ts" sourceLine="46" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/system/health-check-strategy.ts" sourceLine="31" packageName="@vendure/core" />
 
-This strategy defines health checks which are included as part of the
-`/health` endpoint. They should only be used to monitor _critical_ systems
-on which proper functioning of the Vendure server depends.
-
-Custom strategies should be added to the `systemOptions.healthChecks` array.
-By default, Vendure includes the `TypeORMHealthCheckStrategy`, so if you set the value of the `healthChecks`
-array, be sure to include it manually.
-
-Vendure also ships with the [HttpHealthCheckStrategy](/reference/typescript-api/health-check/http-health-check-strategy#httphealthcheckstrategy), which is convenient
-for adding a health check dependent on an HTTP ping.
-
-:::info
-
-This is configured via the `systemOptions.healthChecks` property of
-your VendureConfig.
-
-:::
+This strategy defines health checks which, before v3.6.0, were run by the `/health` endpoint.
+Since v3.6.0 the strategies configured in `systemOptions.healthChecks` are not executed, and this
+interface will be removed in v4.0.0. See the [health checks guide](/core-concepts/healthchecks/).
 
 *Example*
 
@@ -56,7 +42,7 @@ interface HealthCheckStrategy extends InjectableStrategy {
 <MemberInfo kind="method" type={`() => <a href='/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction'>HealthIndicatorFunction</a>`}   />
 
 Should return a [HealthIndicatorFunction](/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction) which performs the check
-and resolves to a status payload.
+and resolves to a status payload. Since v3.6.0 this method is never called.
 
 
 </div>

--- a/docs/docs/reference/typescript-api/health-check/http-health-check-strategy.mdx
+++ b/docs/docs/reference/typescript-api/health-check/http-health-check-strategy.mdx
@@ -5,7 +5,7 @@ generated: true
 <GenerationInfo sourceFile="packages/core/src/health-check/http-health-check-strategy.ts" sourceLine="46" packageName="@vendure/core" />
 
 A [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) used to check health by pinging a url. Since v3.6.0 it is not
-executed and will be removed in v4.0.0.
+executed and will be removed in v4.0.0. The example below shows the pre-v3.6.0 configuration:
 
 *Example*
 

--- a/docs/docs/reference/typescript-api/health-check/http-health-check-strategy.mdx
+++ b/docs/docs/reference/typescript-api/health-check/http-health-check-strategy.mdx
@@ -2,9 +2,10 @@
 title: "HttpHealthCheckStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/health-check/http-health-check-strategy.ts" sourceLine="45" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/health-check/http-health-check-strategy.ts" sourceLine="46" packageName="@vendure/core" />
 
-A [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) used to check health by pinging a url.
+A [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) used to check health by pinging a url. Since v3.6.0 it is not
+executed and will be removed in v4.0.0.
 
 *Example*
 

--- a/docs/docs/reference/typescript-api/health-check/type-ormhealth-check-strategy.mdx
+++ b/docs/docs/reference/typescript-api/health-check/type-ormhealth-check-strategy.mdx
@@ -2,10 +2,10 @@
 title: "TypeORMHealthCheckStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/health-check/typeorm-health-check-strategy.ts" sourceLine="41" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/health-check/typeorm-health-check-strategy.ts" sourceLine="39" packageName="@vendure/core" />
 
 A [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) used to check the health of the database. Since v3.6.0 it is not
-executed and will be removed in v4.0.0. It is added via the `systemOptions.healthChecks` array:
+executed and will be removed in v4.0.0. The example below shows the pre-v3.6.0 configuration:
 
 *Example*
 
@@ -17,8 +17,6 @@ export const config = {
   systemOptions: {
     healthChecks:[
         // The default key is "database" and the default timeout is 1000ms
-        // Sometimes this is too short and leads to false negatives in the
-        // /health endpoint.
         new TypeORMHealthCheckStrategy({ key: 'postgres-db', timeout: 5000 }),
     ]
   }

--- a/docs/docs/reference/typescript-api/health-check/type-ormhealth-check-strategy.mdx
+++ b/docs/docs/reference/typescript-api/health-check/type-ormhealth-check-strategy.mdx
@@ -2,11 +2,10 @@
 title: "TypeORMHealthCheckStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/health-check/typeorm-health-check-strategy.ts" sourceLine="42" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/health-check/typeorm-health-check-strategy.ts" sourceLine="41" packageName="@vendure/core" />
 
-A [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) used to check the health of the database. This health
-check is included by default, but can be customized by explicitly adding it to the
-`systemOptions.healthChecks` array:
+A [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) used to check the health of the database. Since v3.6.0 it is not
+executed and will be removed in v4.0.0. It is added via the `systemOptions.healthChecks` array:
 
 *Example*
 

--- a/packages/core/src/config/system/health-check-strategy.ts
+++ b/packages/core/src/config/system/health-check-strategy.ts
@@ -1,26 +1,11 @@
-import { HealthIndicatorFunction } from '../../health-check/terminus-compat';
 import { InjectableStrategy } from '../../common/types/injectable-strategy';
+import { HealthIndicatorFunction } from '../../health-check/terminus-compat';
 
 /**
  * @description
- * This strategy defines health checks which are included as part of the
- * `/health` endpoint. They should only be used to monitor _critical_ systems
- * on which proper functioning of the Vendure server depends.
- *
- * Custom strategies should be added to the `systemOptions.healthChecks` array.
- * By default, Vendure includes the `TypeORMHealthCheckStrategy`, so if you set the value of the `healthChecks`
- * array, be sure to include it manually.
- *
- * Vendure also ships with the {@link HttpHealthCheckStrategy}, which is convenient
- * for adding a health check dependent on an HTTP ping.
- *
- * :::info
- *
- * This is configured via the `systemOptions.healthChecks` property of
- * your VendureConfig.
- *
- * :::
- *
+ * This strategy defines health checks which, before v3.6.0, were run by the `/health` endpoint.
+ * Since v3.6.0 the strategies configured in `systemOptions.healthChecks` are not executed, and this
+ * interface will be removed in v4.0.0. See the [health checks guide](/core-concepts/healthchecks/).
  *
  * @example
  * ```ts
@@ -40,7 +25,7 @@ import { InjectableStrategy } from '../../common/types/injectable-strategy';
  * ```
  *
  * @docsCategory health-check
- * @deprecated Use infrastructure-level health checks (e.g. Kubernetes probes, Docker healthchecks,
+ * @deprecated Not executed since v3.6.0. Use infrastructure-level health checks (e.g. Kubernetes probes, Docker healthchecks,
  * load balancer checks) instead of application-level health checks. This interface will be removed in v4.0.0.
  */
 export interface HealthCheckStrategy extends InjectableStrategy {

--- a/packages/core/src/config/system/health-check-strategy.ts
+++ b/packages/core/src/config/system/health-check-strategy.ts
@@ -7,6 +7,8 @@ import { HealthIndicatorFunction } from '../../health-check/terminus-compat';
  * Since v3.6.0 the strategies configured in `systemOptions.healthChecks` are not executed, and this
  * interface will be removed in v4.0.0. See the [health checks guide](/core-concepts/healthchecks/).
  *
+ * The example below shows how strategies were configured before v3.6.0.
+ *
  * @example
  * ```ts
  * import { HttpHealthCheckStrategy, TypeORMHealthCheckStrategy } from '\@vendure/core';
@@ -32,7 +34,7 @@ export interface HealthCheckStrategy extends InjectableStrategy {
     /**
      * @description
      * Should return a {@link HealthIndicatorFunction} which performs the check
-     * and resolves to a status payload.
+     * and resolves to a status payload. Since v3.6.0 this method is never called.
      */
     getHealthIndicator(): HealthIndicatorFunction;
 }

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -1281,12 +1281,13 @@ export interface EntityOptions {
 export interface SystemOptions {
     /**
      * @description
-     * Defines an array of {@link HealthCheckStrategy} instances which are used by the `/health` endpoint to verify
-     * that any critical systems which the Vendure server depends on are also healthy.
+     * Defines an array of {@link HealthCheckStrategy} instances. Before v3.6.0 the `/health` endpoint ran these
+     * strategies to verify that critical systems which the Vendure server depends on were healthy. Since v3.6.0
+     * the strategies are not executed and this option has no effect on the `/health` response.
      *
-     * @default [TypeORMHealthCheckStrategy]
+     * @default []
      * @since 1.6.0
-     * @deprecated Use infrastructure-level health checks (e.g. Kubernetes probes, Docker healthchecks,
+     * @deprecated Not executed since v3.6.0. Use infrastructure-level health checks (e.g. Kubernetes probes, Docker healthchecks,
      * load balancer checks) instead of application-level health checks. The application should not
      * be responsible for determining its own health. This config option will be removed in v4.0.0.
      */

--- a/packages/core/src/health-check/health-check-registry.service.ts
+++ b/packages/core/src/health-check/health-check-registry.service.ts
@@ -6,12 +6,7 @@ import { HealthIndicatorFunction } from './terminus-compat';
  * `/health` endpoint. Since v3.6.0 registered indicators are not executed, and this service will be
  * removed in v4.0.0. See the [health checks guide](/core-concepts/healthchecks/).
  *
- * Since v1.6.0, the preferred way to implement a custom health check is by creating a new {@link HealthCheckStrategy}
- * and then passing it to the `systemOptions.healthChecks` array.
- * See the {@link HealthCheckStrategy} docs for an example configuration.
- *
- * The alternative way to register a health check is by injecting this service directly into your
- * plugin module. To use it in your plugin, you'll need to import the {@link PluginCommonModule}:
+ * The example below shows how a plugin registered an indicator before v3.6.0:
  *
  * @example
  * ```ts

--- a/packages/core/src/health-check/health-check-registry.service.ts
+++ b/packages/core/src/health-check/health-check-registry.service.ts
@@ -2,15 +2,9 @@ import { HealthIndicatorFunction } from './terminus-compat';
 
 /**
  * @description
- * This service is used to register health indicator functions to be included in the
- * health check. Health checks can be used by automated services such as Kubernetes
- * to determine the state of applications it is running. They are also useful for
- * administrators to get an overview of the health of all the parts of the
- * Vendure stack.
- *
- * Plugins which rely on external services (web services, databases etc.) can make use of this
- * service to add a check for that dependency to the Vendure health check.
- *
+ * This service is used to register health indicator functions which, before v3.6.0, were run by the
+ * `/health` endpoint. Since v3.6.0 registered indicators are not executed, and this service will be
+ * removed in v4.0.0. See the [health checks guide](/core-concepts/healthchecks/).
  *
  * Since v1.6.0, the preferred way to implement a custom health check is by creating a new {@link HealthCheckStrategy}
  * and then passing it to the `systemOptions.healthChecks` array.
@@ -48,9 +42,7 @@ export class HealthCheckRegistryService {
 
     /**
      * @description
-     * Registers one or more {@link HealthIndicatorFunction}s to be added to the
-     * health check endpoint. The indicator will also appear in the Admin UI's
-     * "system status" view.
+     * Registers one or more {@link HealthIndicatorFunction}s. Since v3.6.0 the registered functions are never called.
      *
      * @deprecated Use infrastructure-level health checks instead. This method will be removed in v4.0.0.
      */

--- a/packages/core/src/health-check/http-health-check-strategy.ts
+++ b/packages/core/src/health-check/http-health-check-strategy.ts
@@ -21,7 +21,8 @@ export interface HttpHealthCheckOptions {
 
 /**
  * @description
- * A {@link HealthCheckStrategy} used to check health by pinging a url.
+ * A {@link HealthCheckStrategy} used to check health by pinging a url. Since v3.6.0 it is not
+ * executed and will be removed in v4.0.0.
  *
  * @example
  * ```ts

--- a/packages/core/src/health-check/http-health-check-strategy.ts
+++ b/packages/core/src/health-check/http-health-check-strategy.ts
@@ -22,7 +22,7 @@ export interface HttpHealthCheckOptions {
 /**
  * @description
  * A {@link HealthCheckStrategy} used to check health by pinging a url. Since v3.6.0 it is not
- * executed and will be removed in v4.0.0.
+ * executed and will be removed in v4.0.0. The example below shows the pre-v3.6.0 configuration:
  *
  * @example
  * ```ts

--- a/packages/core/src/health-check/terminus-compat.ts
+++ b/packages/core/src/health-check/terminus-compat.ts
@@ -55,8 +55,8 @@ export type HealthIndicatorFunction = () =>
 
 /**
  * @description
- * Thrown from a health indicator to signal a failed check. The `causes`
- * payload is forwarded to the `/health` response so callers can inspect
+ * Thrown from a health indicator to signal a failed check. Before v3.6.0 the `causes`
+ * payload was forwarded to the `/health` response so callers could inspect
  * which indicator failed and why. `causes` is intentionally typed as
  * `any` (matching terminus) so handlers can pass through arbitrary
  * upstream error payloads (HTTP responses, DB driver errors, etc.)

--- a/packages/core/src/health-check/typeorm-health-check-strategy.ts
+++ b/packages/core/src/health-check/typeorm-health-check-strategy.ts
@@ -15,7 +15,7 @@ export interface TypeORMHealthCheckOptions {
 /**
  * @description
  * A {@link HealthCheckStrategy} used to check the health of the database. Since v3.6.0 it is not
- * executed and will be removed in v4.0.0. It is added via the `systemOptions.healthChecks` array:
+ * executed and will be removed in v4.0.0. The example below shows the pre-v3.6.0 configuration:
  *
  * @example
  * ```ts
@@ -26,8 +26,6 @@ export interface TypeORMHealthCheckOptions {
  *   systemOptions: {
  *     healthChecks:[
  *         // The default key is "database" and the default timeout is 1000ms
- *         // Sometimes this is too short and leads to false negatives in the
- *         // /health endpoint.
  *         new TypeORMHealthCheckStrategy({ key: 'postgres-db', timeout: 5000 }),
  *     ]
  *   }

--- a/packages/core/src/health-check/typeorm-health-check-strategy.ts
+++ b/packages/core/src/health-check/typeorm-health-check-strategy.ts
@@ -14,9 +14,8 @@ export interface TypeORMHealthCheckOptions {
 
 /**
  * @description
- * A {@link HealthCheckStrategy} used to check the health of the database. This health
- * check is included by default, but can be customized by explicitly adding it to the
- * `systemOptions.healthChecks` array:
+ * A {@link HealthCheckStrategy} used to check the health of the database. Since v3.6.0 it is not
+ * executed and will be removed in v4.0.0. It is added via the `systemOptions.healthChecks` array:
  *
  * @example
  * ```ts


### PR DESCRIPTION
# Description

Fixes #5270. Reported by @brmk, supersedes #5271.

Since v3.6.0 (#4442) `/health` returns an unconditional `{ "status": "ok" }` and the strategies in `systemOptions.healthChecks` are not executed. The Health Checks guide, the Docker guide and the JSDoc still described the old aggregated response and the old `[TypeORMHealthCheckStrategy]` default.

Changes:

- Health Checks guide rewritten around the real response, with a "Changed in v3.6.0" note, the reason the dependency checks were removed, and the `healthChecks: []` migration step.
- Docker guide: old Terminus sample response replaced with the real one.
- `@default` on `systemOptions.healthChecks` corrected to `[]`.
- Each deprecated health check class gets one sentence saying it is not executed since v3.6.0. Sentences describing removed behaviour are deleted. The `@deprecated` tags on `SystemOptions.healthChecks` and `HealthCheckStrategy` now state the fact instead of giving advice.
- Reference pages regenerated with `bun run docs:generate-typescript-docs`.

Compared with #5271 this leaves out the probe tutorial, the per-page warning blocks and the e2e test. The reference pages are removed in v4.0.0, so one sentence each is enough.

# Breaking changes

None. Docs and JSDoc only.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791375515&installation_model_id=20193&pr_number=5301&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5301&signature=a43de143070b527e6ac3b964b947e736d6a5c10e888ec870d2870dca10e027b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->