### PR TITLE
fix(dashboard): correct "State" translation across locales to mean condition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,7 +274,7 @@ After implementing your changes, stage the changes and commit them. Refer to the
 
 ```
 git add .
-git commit -m "type(scope): Message in present tense"
+git commit -m "type(scope): message in present tense"
 ```
 
 ### Creating a pull request
@@ -354,8 +354,12 @@ myNewApi: number;
 This repo uses [Conventional Commits](https://www.conventionalcommits.org).
 
 ```
-type(scope): Message in present tense
+type(scope): message in present tense
 ```
+
+The subject must not start with a capital letter: `@commitlint/config-conventional` rejects sentence-case,
+start-case, pascal-case and upper-case subjects.
+
 `type` may be one of:
 * **feat** (new feature)
 * **fix** (bug fix)
@@ -380,7 +384,7 @@ type(scope): Message in present tense
 If a commit affects more than one package, separate them with a comma:
 
 ```
-fix(core,common): Fix the thing
+fix(core,common): fix the thing
 ```
 
 If a commit applies to no particular package (e.g. a tooling change in the root package.json), the scope can be omitted.
@@ -394,7 +398,7 @@ Please also make your pull request against the `major` branch rather than `maste
 Example:
 
 ```
-feat(core): Add new field to Customer
+feat(core): add new field to Customer
 
 Relates to #123. This commit adds the "foo" field to the Custom entity.
 

--- a/docs/docs/guides/core-concepts/healthchecks/index.mdx
+++ b/docs/docs/guides/core-concepts/healthchecks/index.mdx
@@ -1,60 +1,32 @@
 ---
 title: "Health Checks"
 metaTitle: "Health Check Endpoint for Monitoring Vendure"
-metaDescription: "How Vendure exposes a /health endpoint for monitoring system dependencies like the database and external services."
+metaDescription: "What the Vendure /health endpoint reports and how to use it as a liveness probe."
 ---
 
-Vendure exposes a **`/health`** endpoint that reports the status of critical system dependencies.
-This endpoint is essential for production deployments where load balancers, container orchestrators,
-and monitoring tools need to know whether the application is healthy and ready to serve traffic.
+Vendure exposes a **`/health`** endpoint on the server. It is a plain REST route which returns
+`{ "status": "ok" }` as soon as the application is accepting HTTP requests.
 
-## How it works
+The response is unconditional. `/health` does not check the database or any other dependency. It only
+tells you that this process is running and serving HTTP, which is what a liveness probe needs.
 
-Each configured health check strategy probes a specific dependency and reports back with a status.
-The `/health` endpoint aggregates all strategy results into a single response.
+:::warning[Changed in v3.6.0]
 
-A healthy response indicates that all dependencies are reachable and functioning correctly. If any
-strategy reports a failure, the endpoint returns an unhealthy status, signaling that the system
-may not be able to serve requests reliably.
+Before v3.6.0, `/health` ran the strategies configured in `systemOptions.healthChecks` and returned a
+503 if any of them failed. Since v3.6.0 those strategies are not executed. The strategy classes and
+`HealthCheckRegistryService` will be removed in v4.0.0. Remove any custom strategies and set
+`healthChecks: []` to silence the startup warning. See [#4441](https://github.com/vendurehq/vendure/issues/4441) for the reasoning.
 
-## Built-in strategies
+:::
 
-Vendure ships with two health check strategies out of the box:
+Checking dependencies from the application health endpoint was removed on purpose. If `/health` failed
+whenever the database was slow, an orchestrator would restart every instance at once, and restarting the
+application cannot fix the database. Monitor dependencies with their own alerting and keep the
+application probe shallow.
 
-- **`TypeORMHealthCheckStrategy`** — verifies that the database connection is alive by executing
-  a simple query. Since the database is the most critical dependency for any Vendure instance,
-  this strategy is enabled by default.
-
-- **`HttpHealthCheckStrategy`** — checks the availability of an external HTTP service. This is
-  useful when your Vendure instance depends on external APIs, such as a payment gateway or a
-  third-party inventory system.
-
-## Configuration
-
-Health checks are configured via the `systemOptions.healthChecks` property in the
-[`VendureConfig`](/reference/typescript-api/configuration/vendure-config/). You can enable or disable
-individual strategies and configure their parameters to match your infrastructure.
-
-## Use cases
-
-The `/health` endpoint serves several important operational purposes:
-
-- **Load balancer probes** — configure your load balancer to poll `/health` and route traffic
-  only to healthy instances.
-- **Container orchestration** — use the endpoint as a Kubernetes liveness or readiness probe
-  to automatically restart unhealthy pods or delay traffic until the application is ready.
-- **Monitoring dashboards** — integrate with monitoring tools to track uptime and get alerted
-  when dependencies become unreachable.
-
-## Custom strategies
-
-When your application has dependencies beyond the database and HTTP services, you can implement
-the `HealthCheckStrategy` interface to create custom checks. For example, a custom strategy might
-verify connectivity to a Redis cache, an Elasticsearch cluster, or a message broker.
-
-Custom strategies are added to the same `systemOptions.healthChecks` configuration array alongside
-the built-in strategies, and their results are included in the aggregated `/health` response.
+The worker can serve the same unconditional `/health` response. See the
+[Using Docker guide](/deployment/using-docker/#healthreadiness-checks) for how to enable it.
 
 ## Further reading
 
-- [Production configuration guide](/deployment/production-configuration/) — deploying Vendure with proper health checks and monitoring
+- [Production configuration guide](/deployment/production-configuration/)

--- a/docs/docs/guides/core-concepts/promotions/index.mdx
+++ b/docs/docs/guides/core-concepts/promotions/index.mdx
@@ -260,6 +260,10 @@ function lineContainsIds(ids: ID[], line: OrderLine): boolean {
 export class FreeGiftPromotionPlugin {}
 ```
 
+:::note[Promotions which discount nothing are not recorded]
+A Promotion is only recorded on `Order.promotions` — and therefore only consumes its `usageLimit` and `perCustomerUsageLimit` — if it actually adjusted an OrderLine or a ShippingLine. The exception is a Promotion with at least one action defining `onActivate`/`onDeactivate`: the free gift action above returns `0` from `execute()` until its side effect has added the gift line, so such a Promotion is kept whatever it discounts. If you write a custom action which delivers its benefit by mutating the Order inside `execute()` and returns `0`, declare a no-op `onActivate` so that the Promotion continues to be recorded.
+:::
+
 ### Dependency relationships
 
 It is possible to establish dependency relationships between a PromotionAction and one or more PromotionConditions.

--- a/docs/docs/guides/deployment/using-docker.mdx
+++ b/docs/docs/guides/deployment/using-docker.mdx
@@ -174,22 +174,13 @@ REQUEST: GET http://localhost:3000/health
  
 ```json
 {
-  "status": "ok",
-  "info": {
-    "database": {
-      "status": "up"
-    }
-  },
-  "error": {},
-  "details": {
-    "database": {
-      "status": "up"
-    }
-  }
+  "status": "ok"
 }
 ```
 
-You can also add your own health checks by creating plugins that make use of the [HealthCheckRegistryService](/reference/typescript-api/health-check/health-check-registry-service/).
+The response is unconditional and does not check the database or any other dependency. Since v3.6.0 the
+strategies configured in `systemOptions.healthChecks` are no longer executed. See the
+[health checks guide](/core-concepts/healthchecks/) for details.
 
 ### Worker
 

--- a/docs/docs/guides/extending-the-dashboard/localization/index.mdx
+++ b/docs/docs/guides/extending-the-dashboard/localization/index.mdx
@@ -198,7 +198,7 @@ locale. The interface re-renders with your catalog; any string you left untransl
 
 Commit the changed `.po` file(s) (and, for a new language, the `lingui.config.js` and
 `vite/constants.ts` changes) and open a PR against `master`. A translation change is a `fix`, so title
-it accordingly, e.g. `fix(dashboard): Add Ukrainian UI translations`. Translations are always welcome,
+it accordingly, e.g. `fix(dashboard): add Ukrainian UI translations`. Translations are always welcome,
 including partial ones — you don't have to translate every string to contribute.
 
 Two CI checks gate a translation PR: **`dashboard i18n sync`** (runs `lingui extract` and fails if the

--- a/docs/docs/reference/dashboard/list-views/list-page.mdx
+++ b/docs/docs/reference/dashboard/list-views/list-page.mdx
@@ -245,6 +245,11 @@ handling.
 Allows you to customize how the search term is used in the list query options.
 For instance, when you want the term to filter on specific fields.
 
+The returned filter is merged with the column & faceted filters, so when the term should
+match any of several fields, group those fields in an `_or` block. Setting a page-level
+`filterOperator: 'OR'` would instead OR together _every_ top-level condition, including
+the column filters.
+
 *Example*
 
 ```tsx
@@ -254,9 +259,11 @@ For instance, when you want the term to filter on specific fields.
    listQuery={administratorListDocument}
    onSearchTermChange={searchTerm => {
      return {
-       firstName: { contains: searchTerm },
-       lastName: { contains: searchTerm },
-       emailAddress: { contains: searchTerm },
+       _or: [
+         { firstName: { contains: searchTerm } },
+         { lastName: { contains: searchTerm } },
+         { emailAddress: { contains: searchTerm } },
+       ],
      };
    }}
  />

--- a/docs/docs/reference/dashboard/list-views/list-page.mdx
+++ b/docs/docs/reference/dashboard/list-views/list-page.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## ListPage
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/list-page.tsx" sourceLine="502" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/list-page.tsx" sourceLine="509" packageName="@vendure/dashboard" since="3.3.0" />
 
 Auto-generates a list page with columns generated based on the provided query document fields.
 

--- a/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "RuntimeVendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1469" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1470" packageName="@vendure/core" />
 
 This interface represents the VendureConfig object available at run-time, i.e. the user-supplied
 config values have been merged with the [defaultConfig](/reference/typescript-api/configuration/default-config#defaultconfig) values.

--- a/docs/docs/reference/typescript-api/configuration/system-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/system-options.mdx
@@ -19,10 +19,11 @@ interface SystemOptions {
 
 ### healthChecks
 
-<MemberInfo kind="property" type={`<a href='/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy'>HealthCheckStrategy</a>[]`} default={`[<a href='/reference/typescript-api/health-check/type-ormhealth-check-strategy#typeormhealthcheckstrategy'>TypeORMHealthCheckStrategy</a>]`}  since="1.6.0"  />
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy'>HealthCheckStrategy</a>[]`} default={`[]`}  since="1.6.0"  />
 
-Defines an array of [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) instances which are used by the `/health` endpoint to verify
-that any critical systems which the Vendure server depends on are also healthy.
+Defines an array of [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) instances. Before v3.6.0 the `/health` endpoint ran these
+strategies to verify that critical systems which the Vendure server depends on were healthy. Since v3.6.0
+the strategies are not executed and this option has no effect on the `/health` response.
 ### errorHandlers
 
 <MemberInfo kind="property" type={`<a href='/reference/typescript-api/errors/error-handler-strategy#errorhandlerstrategy'>ErrorHandlerStrategy</a>[]`} default={`[]`}  since="2.2.0"  />

--- a/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "VendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1322" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1323" packageName="@vendure/core" />
 
 All possible configuration options are defined by the
 [`VendureConfig`](https://github.com/vendurehq/vendure/blob/master/packages/core/src/config/vendure-config.ts) interface.

--- a/docs/docs/reference/typescript-api/default-search-plugin/mysql-search-strategy.mdx
+++ b/docs/docs/reference/typescript-api/default-search-plugin/mysql-search-strategy.mdx
@@ -2,7 +2,7 @@
 title: "MysqlSearchStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/plugin/default-search-plugin/search-strategy/mysql-search-strategy.ts" sourceLine="28" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/plugin/default-search-plugin/search-strategy/mysql-search-strategy.ts" sourceLine="29" packageName="@vendure/core" />
 
 A weighted fulltext search for MySQL / MariaDB.
 

--- a/docs/docs/reference/typescript-api/default-search-plugin/postgres-search-strategy.mdx
+++ b/docs/docs/reference/typescript-api/default-search-plugin/postgres-search-strategy.mdx
@@ -2,7 +2,7 @@
 title: "PostgresSearchStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/plugin/default-search-plugin/search-strategy/postgres-search-strategy.ts" sourceLine="28" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/plugin/default-search-plugin/search-strategy/postgres-search-strategy.ts" sourceLine="29" packageName="@vendure/core" />
 
 A weighted fulltext search for PostgeSQL.
 

--- a/docs/docs/reference/typescript-api/default-search-plugin/sqlite-search-strategy.mdx
+++ b/docs/docs/reference/typescript-api/default-search-plugin/sqlite-search-strategy.mdx
@@ -2,7 +2,7 @@
 title: "SqliteSearchStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/plugin/default-search-plugin/search-strategy/sqlite-search-strategy.ts" sourceLine="30" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/plugin/default-search-plugin/search-strategy/sqlite-search-strategy.ts" sourceLine="31" packageName="@vendure/core" />
 
 A rather naive search for SQLite / SQL.js. Rather than proper
 full-text searching, it uses a weighted `LIKE "%term%"` operator instead.

--- a/docs/docs/reference/typescript-api/health-check/health-check-error.mdx
+++ b/docs/docs/reference/typescript-api/health-check/health-check-error.mdx
@@ -4,8 +4,8 @@ generated: true
 ---
 <GenerationInfo sourceFile="packages/core/src/health-check/terminus-compat.ts" sourceLine="72" packageName="@vendure/core" />
 
-Thrown from a health indicator to signal a failed check. The `causes`
-payload is forwarded to the `/health` response so callers can inspect
+Thrown from a health indicator to signal a failed check. Before v3.6.0 the `causes`
+payload was forwarded to the `/health` response so callers could inspect
 which indicator failed and why. `causes` is intentionally typed as
 `any` (matching terminus) so handlers can pass through arbitrary
 upstream error payloads (HTTP responses, DB driver errors, etc.)

--- a/docs/docs/reference/typescript-api/health-check/health-check-registry-service.mdx
+++ b/docs/docs/reference/typescript-api/health-check/health-check-registry-service.mdx
@@ -2,24 +2,13 @@
 title: "HealthCheckRegistryService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/health-check/health-check-registry.service.ts" sourceLine="42" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/health-check/health-check-registry.service.ts" sourceLine="31" packageName="@vendure/core" />
 
-This service is used to register health indicator functions to be included in the
-health check. Health checks can be used by automated services such as Kubernetes
-to determine the state of applications it is running. They are also useful for
-administrators to get an overview of the health of all the parts of the
-Vendure stack.
+This service is used to register health indicator functions which, before v3.6.0, were run by the
+`/health` endpoint. Since v3.6.0 registered indicators are not executed, and this service will be
+removed in v4.0.0. See the [health checks guide](/core-concepts/healthchecks/).
 
-Plugins which rely on external services (web services, databases etc.) can make use of this
-service to add a check for that dependency to the Vendure health check.
-
-
-Since v1.6.0, the preferred way to implement a custom health check is by creating a new [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy)
-and then passing it to the `systemOptions.healthChecks` array.
-See the [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) docs for an example configuration.
-
-The alternative way to register a health check is by injecting this service directly into your
-plugin module. To use it in your plugin, you'll need to import the [PluginCommonModule](/reference/typescript-api/plugin/plugin-common-module#plugincommonmodule):
+The example below shows how a plugin registered an indicator before v3.6.0:
 
 *Example*
 
@@ -50,9 +39,7 @@ class HealthCheckRegistryService {
 
 <MemberInfo kind="method" type={`(fn: <a href='/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction'>HealthIndicatorFunction</a> | <a href='/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction'>HealthIndicatorFunction</a>[]) => `}   />
 
-Registers one or more [HealthIndicatorFunction](/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction)s to be added to the
-health check endpoint. The indicator will also appear in the Admin UI's
-"system status" view.
+Registers one or more [HealthIndicatorFunction](/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction)s. Since v3.6.0 the registered functions are never called.
 
 
 </div>

--- a/docs/docs/reference/typescript-api/health-check/health-check-strategy.mdx
+++ b/docs/docs/reference/typescript-api/health-check/health-check-strategy.mdx
@@ -2,25 +2,13 @@
 title: "HealthCheckStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/system/health-check-strategy.ts" sourceLine="46" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/system/health-check-strategy.ts" sourceLine="33" packageName="@vendure/core" />
 
-This strategy defines health checks which are included as part of the
-`/health` endpoint. They should only be used to monitor _critical_ systems
-on which proper functioning of the Vendure server depends.
+This strategy defines health checks which, before v3.6.0, were run by the `/health` endpoint.
+Since v3.6.0 the strategies configured in `systemOptions.healthChecks` are not executed, and this
+interface will be removed in v4.0.0. See the [health checks guide](/core-concepts/healthchecks/).
 
-Custom strategies should be added to the `systemOptions.healthChecks` array.
-By default, Vendure includes the `TypeORMHealthCheckStrategy`, so if you set the value of the `healthChecks`
-array, be sure to include it manually.
-
-Vendure also ships with the [HttpHealthCheckStrategy](/reference/typescript-api/health-check/http-health-check-strategy#httphealthcheckstrategy), which is convenient
-for adding a health check dependent on an HTTP ping.
-
-:::info
-
-This is configured via the `systemOptions.healthChecks` property of
-your VendureConfig.
-
-:::
+The example below shows how strategies were configured before v3.6.0.
 
 *Example*
 
@@ -56,7 +44,7 @@ interface HealthCheckStrategy extends InjectableStrategy {
 <MemberInfo kind="method" type={`() => <a href='/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction'>HealthIndicatorFunction</a>`}   />
 
 Should return a [HealthIndicatorFunction](/reference/typescript-api/health-check/health-indicator-function#healthindicatorfunction) which performs the check
-and resolves to a status payload.
+and resolves to a status payload. Since v3.6.0 this method is never called.
 
 
 </div>

--- a/docs/docs/reference/typescript-api/health-check/http-health-check-strategy.mdx
+++ b/docs/docs/reference/typescript-api/health-check/http-health-check-strategy.mdx
@@ -2,9 +2,10 @@
 title: "HttpHealthCheckStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/health-check/http-health-check-strategy.ts" sourceLine="45" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/health-check/http-health-check-strategy.ts" sourceLine="46" packageName="@vendure/core" />
 
-A [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) used to check health by pinging a url.
+A [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) used to check health by pinging a url. Since v3.6.0 it is not
+executed and will be removed in v4.0.0. The example below shows the pre-v3.6.0 configuration:
 
 *Example*
 

--- a/docs/docs/reference/typescript-api/health-check/type-ormhealth-check-strategy.mdx
+++ b/docs/docs/reference/typescript-api/health-check/type-ormhealth-check-strategy.mdx
@@ -2,11 +2,10 @@
 title: "TypeORMHealthCheckStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/health-check/typeorm-health-check-strategy.ts" sourceLine="42" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/health-check/typeorm-health-check-strategy.ts" sourceLine="39" packageName="@vendure/core" />
 
-A [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) used to check the health of the database. This health
-check is included by default, but can be customized by explicitly adding it to the
-`systemOptions.healthChecks` array:
+A [HealthCheckStrategy](/reference/typescript-api/health-check/health-check-strategy#healthcheckstrategy) used to check the health of the database. Since v3.6.0 it is not
+executed and will be removed in v4.0.0. The example below shows the pre-v3.6.0 configuration:
 
 *Example*
 
@@ -18,8 +17,6 @@ export const config = {
   systemOptions: {
     healthChecks:[
         // The default key is "database" and the default timeout is 1000ms
-        // Sometimes this is too short and leads to false negatives in the
-        // /health endpoint.
         new TypeORMHealthCheckStrategy({ key: 'postgres-db', timeout: 5000 }),
     ]
   }

--- a/docs/docs/reference/typescript-api/promotions/promotion-action.mdx
+++ b/docs/docs/reference/typescript-api/promotions/promotion-action.mdx
@@ -33,7 +33,7 @@ more information.
 </div>
 ## PromotionItemAction
 
-<GenerationInfo sourceFile="packages/core/src/config/promotion/promotion-action.ts" sourceLine="354" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/promotion/promotion-action.ts" sourceLine="365" packageName="@vendure/core" />
 
 Represents a PromotionAction which applies to individual [OrderLine](/reference/typescript-api/entities/order-line#orderline)s.
 
@@ -67,7 +67,7 @@ class PromotionItemAction<T extends ConfigArgs = ConfigArgs, U extends Array<Pro
 </div>
 ## PromotionOrderAction
 
-<GenerationInfo sourceFile="packages/core/src/config/promotion/promotion-action.ts" sourceLine="464" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/promotion/promotion-action.ts" sourceLine="475" packageName="@vendure/core" />
 
 Represents a PromotionAction which applies to the [Order](/reference/typescript-api/entities/order#order) as a whole.
 
@@ -101,7 +101,7 @@ class PromotionOrderAction<T extends ConfigArgs = ConfigArgs, U extends Promotio
 </div>
 ## PromotionShippingAction
 
-<GenerationInfo sourceFile="packages/core/src/config/promotion/promotion-action.ts" sourceLine="506" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/promotion/promotion-action.ts" sourceLine="517" packageName="@vendure/core" />
 
 Represents a PromotionAction which applies to the shipping cost of an Order.
 
@@ -363,7 +363,7 @@ the Shipping, i.e. the number should be negative.
 </div>
 ## PromotionLineAction
 
-<GenerationInfo sourceFile="packages/core/src/config/promotion/promotion-action.ts" sourceLine="409" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/promotion/promotion-action.ts" sourceLine="420" packageName="@vendure/core" />
 
 Represents a PromotionAction which applies to individual [OrderLine](/reference/typescript-api/entities/order-line#orderline)s.
 The difference from PromotionItemAction is that it applies regardless of the Quantity of the OrderLine.

--- a/docs/docs/reference/typescript-api/scheduled-tasks/default-scheduler-strategy.mdx
+++ b/docs/docs/reference/typescript-api/scheduled-tasks/default-scheduler-strategy.mdx
@@ -2,7 +2,7 @@
 title: "DefaultSchedulerStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/plugin/default-scheduler-plugin/default-scheduler-strategy.ts" sourceLine="32" packageName="@vendure/core" since="3.3.0" />
+<GenerationInfo sourceFile="packages/core/src/plugin/default-scheduler-plugin/default-scheduler-strategy.ts" sourceLine="33" packageName="@vendure/core" since="3.3.0" />
 
 The default [SchedulerStrategy](/reference/typescript-api/scheduled-tasks/scheduler-strategy#schedulerstrategy) implementation that uses the database to
 execute scheduled tasks. This strategy is configured when you use the

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -163,7 +163,7 @@
           "title": "Healthchecks",
           "slug": "healthchecks",
           "file": "docs/guides/core-concepts/healthchecks/index.mdx",
-          "lastModified": "2026-05-22T15:41:37+02:00"
+          "lastModified": "2026-09-08T16:41:57+02:00"
         },
         {
           "title": "Auth",
@@ -753,7 +753,7 @@
           "title": "Using Docker",
           "slug": "using-docker",
           "file": "docs/guides/deployment/using-docker.mdx",
-          "lastModified": "2026-05-27T11:00:24+02:00"
+          "lastModified": "2026-09-08T16:41:57+02:00"
         },
         {
           "title": "Horizontal Scaling",
@@ -1432,7 +1432,7 @@
                   "title": "RuntimeVendureConfig",
                   "slug": "runtime-vendure-config",
                   "file": "docs/reference/typescript-api/configuration/runtime-vendure-config.mdx",
-                  "lastModified": "2026-09-01T11:20:23+02:00"
+                  "lastModified": "2026-09-08T16:41:57+02:00"
                 },
                 {
                   "title": "SettingsStoreFields",
@@ -1450,7 +1450,7 @@
                   "title": "SystemOptions",
                   "slug": "system-options",
                   "file": "docs/reference/typescript-api/configuration/system-options.mdx",
-                  "lastModified": "2026-09-01T11:20:23+02:00"
+                  "lastModified": "2026-09-08T16:41:57+02:00"
                 },
                 {
                   "title": "TrustProxyOptions",
@@ -1462,7 +1462,7 @@
                   "title": "VendureConfig",
                   "slug": "vendure-config",
                   "file": "docs/reference/typescript-api/configuration/vendure-config.mdx",
-                  "lastModified": "2026-09-01T11:20:23+02:00"
+                  "lastModified": "2026-09-08T16:41:57+02:00"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -2036,19 +2036,19 @@
                   "title": "HealthCheckError",
                   "slug": "health-check-error",
                   "file": "docs/reference/typescript-api/health-check/health-check-error.mdx",
-                  "lastModified": "2026-05-22T15:41:37+02:00"
+                  "lastModified": "2026-09-08T16:41:57+02:00"
                 },
                 {
                   "title": "HealthCheckRegistryService",
                   "slug": "health-check-registry-service",
                   "file": "docs/reference/typescript-api/health-check/health-check-registry-service.mdx",
-                  "lastModified": "2026-05-22T15:41:37+02:00"
+                  "lastModified": "2026-09-08T16:41:57+02:00"
                 },
                 {
                   "title": "HealthCheckStrategy",
                   "slug": "health-check-strategy",
                   "file": "docs/reference/typescript-api/health-check/health-check-strategy.mdx",
-                  "lastModified": "2026-05-22T15:41:37+02:00"
+                  "lastModified": "2026-09-08T16:41:57+02:00"
                 },
                 {
                   "title": "HealthIndicator",
@@ -2078,13 +2078,13 @@
                   "title": "HttpHealthCheckStrategy",
                   "slug": "http-health-check-strategy",
                   "file": "docs/reference/typescript-api/health-check/http-health-check-strategy.mdx",
-                  "lastModified": "2026-05-22T16:47:46+02:00"
+                  "lastModified": "2026-09-08T16:41:57+02:00"
                 },
                 {
                   "title": "TypeORMHealthCheckStrategy",
                   "slug": "type-ormhealth-check-strategy",
                   "file": "docs/reference/typescript-api/health-check/type-ormhealth-check-strategy.mdx",
-                  "lastModified": "2026-05-22T15:41:37+02:00"
+                  "lastModified": "2026-09-08T16:41:57+02:00"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2810,7 +2810,7 @@
                   "title": "DefaultSchedulerStrategy",
                   "slug": "default-scheduler-strategy",
                   "file": "docs/reference/typescript-api/scheduled-tasks/default-scheduler-strategy.mdx",
-                  "lastModified": "2026-05-04T16:38:19+02:00"
+                  "lastModified": "2026-09-08T07:47:52Z"
                 },
                 {
                   "title": "ScheduledTask",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -49,7 +49,7 @@
           "title": "Promotions",
           "slug": "promotions",
           "file": "docs/guides/core-concepts/promotions/index.mdx",
-          "lastModified": "2026-02-12T16:47:03+01:00"
+          "lastModified": "2026-09-05T13:43:48+03:00"
         },
         {
           "title": "Assets",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -650,7 +650,7 @@
           "title": "Localization",
           "slug": "localization",
           "file": "docs/guides/extending-the-dashboard/localization/index.mdx",
-          "lastModified": "2026-07-31T11:47:50+02:00"
+          "lastModified": "2026-09-08T18:42:12+03:00"
         },
         {
           "title": "Deployment",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1570,13 +1570,13 @@
                   "title": "MysqlSearchStrategy",
                   "slug": "mysql-search-strategy",
                   "file": "docs/reference/typescript-api/default-search-plugin/mysql-search-strategy.mdx",
-                  "lastModified": "2026-01-28T14:49:21+01:00"
+                  "lastModified": "2026-09-08T15:28:16Z"
                 },
                 {
                   "title": "PostgresSearchStrategy",
                   "slug": "postgres-search-strategy",
                   "file": "docs/reference/typescript-api/default-search-plugin/postgres-search-strategy.mdx",
-                  "lastModified": "2026-01-28T14:49:21+01:00"
+                  "lastModified": "2026-09-08T15:28:16Z"
                 },
                 {
                   "title": "SearchStrategy",
@@ -1588,7 +1588,7 @@
                   "title": "SqliteSearchStrategy",
                   "slug": "sqlite-search-strategy",
                   "file": "docs/reference/typescript-api/default-search-plugin/sqlite-search-strategy.mdx",
-                  "lastModified": "2026-01-28T14:49:21+01:00"
+                  "lastModified": "2026-09-08T15:28:16Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -4219,7 +4219,7 @@
                   "title": "ListPage",
                   "slug": "list-page",
                   "file": "docs/reference/dashboard/list-views/list-page.mdx",
-                  "lastModified": "2026-09-07T20:52:51+03:00"
+                  "lastModified": "2026-09-08T10:38:40Z"
                 },
                 {
                   "title": "PaginatedListDataTable",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -4219,7 +4219,7 @@
                   "title": "ListPage",
                   "slug": "list-page",
                   "file": "docs/reference/dashboard/list-views/list-page.mdx",
-                  "lastModified": "2026-08-10T09:00:52Z"
+                  "lastModified": "2026-09-07T20:52:51+03:00"
                 },
                 {
                   "title": "PaginatedListDataTable",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2716,7 +2716,7 @@
                   "title": "Promotion Action",
                   "slug": "promotion-action",
                   "file": "docs/reference/typescript-api/promotions/promotion-action.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-09-08T15:27:18Z"
                 },
                 {
                   "title": "Promotion Condition",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1527,9 +1527,9 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+            "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",

--- a/license/signatures/version1/cla.json
+++ b/license/signatures/version1/cla.json
@@ -1391,6 +1391,14 @@
       "created_at": "2026-09-07T14:12:27Z",
       "repoId": 136938012,
       "pullRequestNo": 5302
+    },
+    {
+      "name": "Ismatulla",
+      "id": 66904522,
+      "comment_id": 5581100301,
+      "created_at": "2026-09-08T07:32:30Z",
+      "repoId": 136938012,
+      "pullRequestNo": 5313
     }
   ]
 }

--- a/packages/cli/src/commands/dev/dev.spec.ts
+++ b/packages/cli/src/commands/dev/dev.spec.ts
@@ -1,7 +1,9 @@
+import { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
     discoverDashboardExtensionDirectories,
@@ -10,6 +12,7 @@ import {
     normalizeDevTarget,
     resolveVendureProjectDirectory,
     shouldRestartOnFileChange,
+    startSupervisedDevProcess,
     waitForDevProcesses,
 } from './dev';
 
@@ -19,6 +22,23 @@ function createTempDir() {
 
 function writePackageJson(dir: string, packageJson: Record<string, any>) {
     writeFileSync(path.join(dir, 'package.json'), JSON.stringify(packageJson, null, 2));
+}
+
+// Stands in for a spawned child process, so that a test can decide exactly how and when it exits.
+class FakeChildProcess extends EventEmitter {
+    exitCode: number | null = null;
+    signalCode: NodeJS.Signals | null = null;
+
+    kill(signal: NodeJS.Signals): boolean {
+        this.close(null, signal);
+        return true;
+    }
+
+    close(code: number | null, signal: NodeJS.Signals | null) {
+        this.exitCode = code;
+        this.signalCode = signal;
+        this.emit('close', code, signal);
+    }
 }
 
 describe('dev command', () => {
@@ -183,12 +203,14 @@ describe('dev command', () => {
             const dashboardDir = path.join(projectDir, 'src', 'plugins', 'reviews', 'dashboard');
 
             expect(
-                shouldRestartOnFileChange(path.join(dashboardDir, 'index.tsx'), projectDir, [dashboardDir]),
+                shouldRestartOnFileChange(path.join(dashboardDir, 'index.tsx'), projectDir, {
+                    dashboardExtensionDirectories: [dashboardDir],
+                }),
             ).toBe(false);
             expect(
-                shouldRestartOnFileChange(path.join(dashboardDir, 'components', 'rating.ts'), projectDir, [
-                    dashboardDir,
-                ]),
+                shouldRestartOnFileChange(path.join(dashboardDir, 'components', 'rating.ts'), projectDir, {
+                    dashboardExtensionDirectories: [dashboardDir],
+                }),
             ).toBe(false);
         });
 
@@ -197,9 +219,9 @@ describe('dev command', () => {
             const dashboardDir = path.join(projectDir, 'src', 'plugins', 'reviews', 'ui');
 
             expect(
-                shouldRestartOnFileChange(path.join(dashboardDir, 'components', 'rating.ts'), projectDir, [
-                    dashboardDir,
-                ]),
+                shouldRestartOnFileChange(path.join(dashboardDir, 'components', 'rating.ts'), projectDir, {
+                    dashboardExtensionDirectories: [dashboardDir],
+                }),
             ).toBe(false);
         });
 
@@ -237,6 +259,22 @@ describe('dev command', () => {
             expect(shouldRestartOnFileChange(path.join(projectDir, 'vite.config.mts'), projectDir)).toBe(
                 false,
             );
+        });
+
+        it('does not restart server or worker processes for paths a caller declares as generated', () => {
+            const projectDir = path.resolve('/project');
+            const generatedDir = path.join(projectDir, 'src', 'gql');
+
+            expect(
+                shouldRestartOnFileChange(path.join(generatedDir, 'graphql.ts'), projectDir, {
+                    reloadIgnoredPaths: [generatedDir],
+                }),
+            ).toBe(false);
+            expect(
+                shouldRestartOnFileChange(path.join(projectDir, 'src', 'vendure-config.ts'), projectDir, {
+                    reloadIgnoredPaths: [generatedDir],
+                }),
+            ).toBe(true);
         });
 
         it('restarts server or worker processes for TypeScript source files and env changes only', () => {
@@ -296,6 +334,122 @@ describe('dev command', () => {
             } finally {
                 rmSync(dir, { recursive: true, force: true });
             }
+        });
+    });
+
+    describe('startSupervisedDevProcess()', () => {
+        const startedProcesses: ManagedDevProcess[] = [];
+        const temporaryDirectories: string[] = [];
+
+        afterEach(() => {
+            for (const startedProcess of startedProcesses) {
+                startedProcess.stop('SIGTERM');
+            }
+            startedProcesses.length = 0;
+            for (const directory of temporaryDirectories) {
+                rmSync(directory, { recursive: true, force: true });
+            }
+            temporaryDirectories.length = 0;
+        });
+
+        function startSupervisor() {
+            const projectDir = createTempDir();
+            temporaryDirectories.push(projectDir);
+            mkdirSync(path.join(projectDir, 'src'), { recursive: true });
+            const children: FakeChildProcess[] = [];
+            const spawnChild = vi.fn(() => {
+                const child = new FakeChildProcess();
+                children.push(child);
+                return child as unknown as ChildProcess;
+            });
+            const supervised = startSupervisedDevProcess(
+                projectDir,
+                getDevProcessDefinitions().server,
+                path.join(projectDir, 'node_modules', '.bin', 'ts-node'),
+                { prefixOutput: false, reloadIgnoredPaths: [], spawnChild },
+            );
+            startedProcesses.push(supervised);
+            return { children, projectDir, spawnChild, supervised };
+        }
+
+        it('leaves the other dev processes running when a supervised child crashes', async () => {
+            const { children, supervised } = startSupervisor();
+            const stopDashboard = vi.fn();
+            const dashboard = new ManagedDevProcess(stopDashboard);
+            const promise = waitForDevProcesses([supervised, dashboard]);
+
+            children[0].close(1, null);
+
+            expect(supervised.hasClosed).toBe(false);
+            expect(stopDashboard).not.toHaveBeenCalled();
+
+            process.emit('SIGINT');
+            dashboard.emitClose(null, 'SIGINT');
+            await expect(promise).resolves.toBe(130);
+        });
+
+        it('respawns a crashed supervised child on the next relevant file change', async () => {
+            const { children, projectDir, spawnChild, supervised } = startSupervisor();
+            const promise = waitForDevProcesses([supervised]);
+            const configPath = path.join(projectDir, 'src', 'vendure-config.ts');
+
+            children[0].close(1, null);
+            expect(spawnChild).toHaveBeenCalledTimes(1);
+
+            // The save is repeated because chokidar reports nothing for a file that appeared
+            // before it finished its initial scan of the directory. A single save that loses that
+            // race is invisible for the rest of the run, however long the test then waits. The
+            // interval is longer than `reloadDebounceMs` so that a save which did land has time to
+            // restart the process before the next one arrives.
+            await vi.waitFor(
+                () => {
+                    writeFileSync(configPath, `export const config = { revision: ${Date.now()} };`);
+                    expect(spawnChild.mock.calls.length).toBeGreaterThanOrEqual(2);
+                },
+                { timeout: 15000, interval: 300 },
+            );
+            expect(supervised.hasClosed).toBe(false);
+
+            process.emit('SIGINT');
+            await expect(promise).resolves.toBe(130);
+        }, 20000);
+
+        it('reports the crash exit code when something else ends the run', async () => {
+            const { children, supervised } = startSupervisor();
+            const dashboard = new ManagedDevProcess(vi.fn());
+            const promise = waitForDevProcesses([supervised, dashboard]);
+
+            children[0].close(1, null);
+            // The Dashboard then exits cleanly on its own, which ends the run while the server is
+            // still crashed. The run must not resolve 0.
+            dashboard.emitClose(0, null);
+
+            await expect(promise).resolves.toBe(1);
+        });
+
+        it('ends the whole run when a supervised child is killed by a signal', async () => {
+            const { children, supervised } = startSupervisor();
+            const stopDashboard = vi.fn();
+            const dashboard = new ManagedDevProcess(stopDashboard);
+            const promise = waitForDevProcesses([supervised, dashboard]);
+
+            children[0].close(null, 'SIGKILL');
+
+            expect(supervised.hasClosed).toBe(true);
+            expect(stopDashboard).toHaveBeenCalledWith('SIGTERM');
+
+            dashboard.emitClose(null, 'SIGTERM');
+            await expect(promise).resolves.toBe(1);
+        });
+
+        it('ends the whole run when a child closes with neither an exit code nor a signal', async () => {
+            const { children, supervised } = startSupervisor();
+            const promise = waitForDevProcesses([supervised]);
+
+            children[0].close(null, null);
+
+            expect(supervised.hasClosed).toBe(true);
+            await expect(promise).resolves.toBe(1);
         });
     });
 

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -35,6 +35,15 @@ export interface DevOptions {
     inspect?: boolean | string;
     inspectBrk?: boolean | string;
     reload?: boolean;
+    /**
+     * Paths that hold generated files, such as the `src/gql` directory a Dashboard Vite plugin
+     * writes GraphQL codegen output into. A change under one of these paths never restarts the
+     * server or the worker, so codegen triggered by an earlier source change does not cause a
+     * second restart of its own.
+     *
+     * A relative path is resolved against the project directory.
+     */
+    reloadIgnoredPaths?: string[];
 }
 
 const validTargets: DevTarget[] = ['all', 'server', 'worker', 'dashboard'];
@@ -70,6 +79,9 @@ export async function devCommand(targetArg?: string, options: DevOptions = {}): 
                 ? (['server', 'worker', 'dashboard'] as const).map(t => devProcessDefinitions[t])
                 : [devProcessDefinitions[target]];
         const prefixOutput = processes.length > 1;
+        const reloadIgnoredPaths = (options.reloadIgnoredPaths ?? []).map(ignoredPath =>
+            path.resolve(projectDir, ignoredPath),
+        );
 
         validateProjectFiles(projectDir, processes);
 
@@ -77,6 +89,7 @@ export async function devCommand(targetArg?: string, options: DevOptions = {}): 
             startDevProcess(projectDir, processDefinition, {
                 prefixOutput,
                 reload: options.reload !== false && processDefinition.reloadOnChange,
+                reloadIgnoredPaths,
             }),
         );
         return await waitForDevProcesses(children, {
@@ -153,7 +166,7 @@ export function resolveVendureProjectDirectory(cwd: string): string {
 function startDevProcess(
     projectDir: string,
     processDefinition: DevProcessDefinition,
-    options: { prefixOutput: boolean; reload: boolean },
+    options: { prefixOutput: boolean; reload: boolean; reloadIgnoredPaths: string[] },
 ): ManagedDevProcess {
     const binPath = resolvePackageBin(processDefinition.packageName, processDefinition.binName, projectDir);
     return options.reload
@@ -203,21 +216,33 @@ function startPlainDevProcess(
     return runningProcess;
 }
 
-function startSupervisedDevProcess(
+export interface SupervisedDevProcessOptions {
+    prefixOutput: boolean;
+    reloadIgnoredPaths: string[];
+    // Tests pass a fake child process here, to drive the supervisor without spawning anything.
+    spawnChild?: typeof spawnDevChild;
+}
+
+export function startSupervisedDevProcess(
     projectDir: string,
     processDefinition: DevProcessDefinition,
     binPath: string,
-    options: { prefixOutput: boolean },
+    options: SupervisedDevProcessOptions,
 ): ManagedDevProcess {
+    const spawnChild = options.spawnChild ?? spawnDevChild;
     let dashboardExtensionDirectories = discoverDashboardExtensionDirectories(projectDir);
     let child: ChildProcess | undefined;
+    let crashExitCode: number | undefined;
     let restartTimer: NodeJS.Timeout | undefined;
     let restarting = false;
     let stopping = false;
+    const reloadPathScope = (): ReloadPathScope => ({
+        dashboardExtensionDirectories,
+        reloadIgnoredPaths: options.reloadIgnoredPaths,
+    });
     const watcher = chokidar.watch(projectDir, {
         ignoreInitial: true,
-        ignored: (filePath: string) =>
-            isAlwaysIgnoredReloadPath(filePath, projectDir, dashboardExtensionDirectories),
+        ignored: (filePath: string) => isAlwaysIgnoredReloadPath(filePath, projectDir, reloadPathScope()),
     });
 
     const runningProcess = new ManagedDevProcess(signal => {
@@ -228,20 +253,50 @@ function startSupervisedDevProcess(
         closeWatcher();
         if (child) {
             stopChildWithGrace(child, signal, restartShutdownGraceMs);
+        } else {
+            // The child crashed, and the close handler left the watcher open so a later file change
+            // could respawn it. Nothing will respawn it now, so report the process closed, carrying
+            // the code the child crashed with. Without this, `waitForDevProcesses` waits forever for
+            // a child that no longer exists.
+            runningProcess.emitClose(crashExitCode ?? 0, null);
         }
     });
 
     const startChild = () => {
-        child = spawnDevChild(projectDir, processDefinition, binPath, options);
-        child.once('error', error => runningProcess.emit('error', error));
-        child.once('close', (code, signal) => {
+        crashExitCode = undefined;
+        const startedChild = spawnChild(projectDir, processDefinition, binPath, options);
+        child = startedChild;
+        startedChild.once('error', error => runningProcess.emit('error', error));
+        startedChild.once('close', (code, signal) => {
+            // Node fires `exit` (which is what `isChildRunning` reads) before `close`, so a file
+            // change between the two can already see this child as not running and start its
+            // replacement directly, ahead of this handler. `child` will have moved on to that
+            // replacement by the time this late `close` arrives; without this check, restarting
+            // below would take it right back off the current child and leave the replacement
+            // running unwatched, the two of them apparently competing for the same port.
+            if (child !== startedChild) {
+                return;
+            }
             if (restarting && !stopping) {
                 restarting = false;
                 startChild();
                 return;
             }
-            closeWatcher();
-            runningProcess.emitClose(code, signal);
+            if (!isRecoverableChildExit(code, signal, stopping)) {
+                closeWatcher();
+                runningProcess.emitClose(code, signal);
+                return;
+            }
+            // Leave the other supervised processes running, and leave the watcher open so that the
+            // next relevant file change respawns this one. Remember the exit code: if the run ends
+            // before the watcher respawns this process, the run failed.
+            child = undefined;
+            crashExitCode = code;
+            writeDevStatus(
+                processDefinition,
+                `The ${processDefinition.target} exited with code ${code}. Waiting for a file change to restart it.`,
+                options,
+            );
         });
     };
 
@@ -253,22 +308,24 @@ function startSupervisedDevProcess(
         if (stopping || runningProcess.hasClosed) {
             return;
         }
+        const runningChild = child && isChildRunning(child) ? child : undefined;
+        const action = runningChild ? 'Restarting' : 'Starting';
         writeDevStatus(
             processDefinition,
-            `Change detected in ${path.relative(projectDir, changedFile)}. Restarting ${processDefinition.target}...`,
+            `Change detected in ${path.relative(projectDir, changedFile)}. ${action} the ${processDefinition.target}...`,
             options,
         );
         dashboardExtensionDirectories = discoverDashboardExtensionDirectories(projectDir);
-        if (!child || !isChildRunning(child)) {
+        if (!runningChild) {
             startChild();
             return;
         }
         restarting = true;
-        stopChildWithGrace(child, 'SIGTERM', restartShutdownGraceMs);
+        stopChildWithGrace(runningChild, 'SIGTERM', restartShutdownGraceMs);
     };
 
     watcher.on('all', (_event, filePath) => {
-        if (!shouldRestartOnFileChange(filePath, projectDir, dashboardExtensionDirectories)) {
+        if (!shouldRestartOnFileChange(filePath, projectDir, reloadPathScope())) {
             return;
         }
         if (restartTimer) {
@@ -322,20 +379,38 @@ export function waitForDevProcesses(
                 }
             }
         };
-        const completeChild = (child: ManagedDevProcess, exitCode: number) => {
+        const runExitCode = (lastExitCode: number): number => {
+            // A signal delivered to the whole run decides the exit code, so Ctrl+C reports 130 even
+            // when a supervised process had crashed and not been respawned.
+            if (shutdownExitCode) {
+                return shutdownExitCode;
+            }
+            // Otherwise the first child to fail on its own decides the exit code. A supervised
+            // process that crashed earlier fails the run this way, when another process then exits
+            // cleanly and ends the run.
+            if (firstNonZeroExitCode) {
+                return firstNonZeroExitCode;
+            }
+            return shutdownExitCode ?? lastExitCode;
+        };
+        // `isOwnFailure` marks an exit code that the child chose for itself, rather than one it was
+        // given by the shutdown. Such a code is recorded even once a shutdown is under way. A
+        // supervised process that crashed earlier reports that crash only when another process ends
+        // the run, by which point the shutdown has already started.
+        const completeChild = (child: ManagedDevProcess, exitCode: number, isOwnFailure: boolean) => {
             if (settledChildren.has(child)) {
                 return;
             }
             settledChildren.add(child);
             remainingChildren--;
+            if (isOwnFailure && exitCode !== 0 && firstNonZeroExitCode === 0) {
+                firstNonZeroExitCode = exitCode;
+            }
             if (!shutdownRequested) {
-                if (exitCode !== 0) {
-                    firstNonZeroExitCode = exitCode;
-                }
                 stopChildren('SIGTERM', exitCode);
             }
             if (remainingChildren === 0) {
-                resolveOnce(firstNonZeroExitCode || (shutdownExitCode ?? exitCode));
+                resolveOnce(runExitCode(exitCode));
             }
         };
         const handleSigint = () => stopChildren('SIGINT', signalToExitCode('SIGINT'));
@@ -347,10 +422,14 @@ export function waitForDevProcesses(
         for (const child of children) {
             child.once('error', error => {
                 options.onError?.(error);
-                completeChild(child, 1);
+                completeChild(child, 1, !shutdownRequested);
             });
             child.once('close', (code, signal) => {
-                completeChild(child, code ?? signalToExitCode(signal) ?? (shutdownRequested ? 0 : 1));
+                completeChild(
+                    child,
+                    code ?? signalToExitCode(signal) ?? (shutdownRequested ? 0 : 1),
+                    signal === null,
+                );
             });
         }
     });
@@ -410,12 +489,32 @@ function isChildRunning(child: ChildProcess): boolean {
     return child.exitCode === null && child.signalCode === null;
 }
 
+// Whether a supervised child that just closed should be left for the watcher to respawn, rather
+// than treated as the whole `dev` run ending. Only a non-zero exit code the child chose for itself
+// qualifies, such as ts-node failing to compile after an edit. A signal means `kill` or a process
+// manager decided the process should stop. A later file change fixes none of the other cases: a
+// zero exit, a close carrying neither a code nor a signal, or a shutdown in progress.
+export function isRecoverableChildExit(
+    code: number | null,
+    signal: NodeJS.Signals | null,
+    stopping: boolean,
+): code is number {
+    return !stopping && signal === null && code !== null && code !== 0;
+}
+
+export interface ReloadPathScope {
+    // Vite reloads these on its own.
+    dashboardExtensionDirectories?: string[];
+    // Already resolved to absolute paths by `devCommand`.
+    reloadIgnoredPaths?: string[];
+}
+
 export function shouldRestartOnFileChange(
     filePath: string,
     projectDir: string,
-    dashboardExtensionDirectories: string[] = [],
+    scope: ReloadPathScope = {},
 ): boolean {
-    if (isAlwaysIgnoredReloadPath(filePath, projectDir, dashboardExtensionDirectories)) {
+    if (isAlwaysIgnoredReloadPath(filePath, projectDir, scope)) {
         return false;
     }
     const fileName = path.basename(filePath);
@@ -432,11 +531,7 @@ export function shouldRestartOnFileChange(
     return reloadFileExtensions.has(path.extname(fileName));
 }
 
-function isAlwaysIgnoredReloadPath(
-    filePath: string,
-    projectDir: string,
-    dashboardExtensionDirectories: string[],
-): boolean {
+function isAlwaysIgnoredReloadPath(filePath: string, projectDir: string, scope: ReloadPathScope): boolean {
     const relativePath = path.relative(projectDir, filePath);
     if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
         return true;
@@ -446,7 +541,10 @@ function isAlwaysIgnoredReloadPath(
     if (parts.some(part => reloadIgnoredDirectories.has(part) || part === '__data__')) {
         return true;
     }
-    return dashboardExtensionDirectories.some(dir => isPathInside(filePath, dir));
+    if (scope.dashboardExtensionDirectories?.some(dir => isPathInside(filePath, dir))) {
+        return true;
+    }
+    return scope.reloadIgnoredPaths?.some(ignoredPath => isPathInside(filePath, ignoredPath)) ?? false;
 }
 
 export function discoverDashboardExtensionDirectories(projectDir: string): string[] {
@@ -480,7 +578,7 @@ function findDashboardMetadataCandidateFiles(projectDir: string): string[] {
         }
         for (const entry of entries) {
             const filePath = path.join(dir, entry.name);
-            if (isAlwaysIgnoredReloadPath(filePath, projectDir, [])) {
+            if (isAlwaysIgnoredReloadPath(filePath, projectDir, {})) {
                 continue;
             }
             if (entry.isDirectory()) {

--- a/packages/core/e2e/default-scheduler-plugin.e2e-spec.ts
+++ b/packages/core/e2e/default-scheduler-plugin.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { ConfigService, DefaultSchedulerPlugin, mergeConfig, ScheduledTask } from '@vendure/core';
-import { createTestEnvironment } from '@vendure/testing';
+import { createTestEnvironment, TestingLogger } from '@vendure/testing';
 import path from 'path';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
@@ -15,8 +15,11 @@ const MAX_HOLD_MS = 5_000;
 
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
+class EmptyMessageError extends Error {}
+
 describe('Default scheduler plugin', () => {
     const taskSpy = vi.fn();
+    const testingLogger = new TestingLogger(() => vi.fn());
     // One task per hold-window test so DB state can't leak between them.
     const holdSpyBlocking = vi.fn();
     const holdSpyManual = vi.fn();
@@ -32,6 +35,16 @@ describe('Default scheduler plugin', () => {
                         async execute(injector) {
                             taskSpy();
                             return { success: true };
+                        },
+                    }),
+                    new ScheduledTask({
+                        id: 'error-test-job',
+                        description: 'A test job which throws an error with an empty message',
+                        schedule: cron => cron.everySaturdayAt(0, 0),
+                        async execute(injector) {
+                            const error = new EmptyMessageError('');
+                            (error as Error & { cause?: unknown }).cause = 'ECONNRESET';
+                            throw error;
                         },
                     }),
                     new ScheduledTask({
@@ -56,6 +69,7 @@ describe('Default scheduler plugin', () => {
                 runTasksInWorkerOnly: false,
             },
             plugins: [DefaultSchedulerPlugin.init({ manualTriggerCheckInterval: 50 })],
+            logger: testingLogger,
         }),
     );
 
@@ -78,7 +92,7 @@ describe('Default scheduler plugin', () => {
 
     it('get tasks', async () => {
         const { scheduledTasks } = await adminClient.query(getTasksDocument);
-        expect(scheduledTasks.length).toBe(3);
+        expect(scheduledTasks.length).toBe(4);
         const testJob = scheduledTasks.find(t => t.id === 'test-job');
         if (!testJob) throw new Error('test-job not found');
         expect(testJob.description).toBe("A test job that doesn't do anything");
@@ -157,6 +171,29 @@ describe('Default scheduler plugin', () => {
         // Control: cron path inside the same window must still be blocked.
         await strategy.executeTask(task)();
         expect(holdSpyManual).toHaveBeenCalledTimes(2);
+    });
+
+    // #5276
+    it('logs the error class and cause when a task throws an empty-message error', async () => {
+        testingLogger.errorSpy.mockClear();
+
+        const { strategy, task } = getHoldTask(server, 'error-test-job');
+        await strategy.executeTask(task)();
+
+        const call = testingLogger.errorSpy.mock.calls.find((args: any[]) =>
+            String(args[0]).includes('Scheduled task "error-test-job" failed'),
+        );
+        expect(call).toBeDefined();
+
+        const [message, , trace] = call as [string, string | undefined, string | undefined];
+        expect(message).toContain('EmptyMessageError');
+        expect(message).toContain('ECONNRESET');
+        expect(message).toContain('at ');
+        expect(trace).toBeUndefined();
+
+        const { scheduledTasks } = await adminClient.query(getTasksDocument);
+        const errorTask = scheduledTasks.find(t => t.id === 'error-test-job');
+        expect(errorTask?.lastResult).toEqual({ error: 'EmptyMessageError' });
     });
 });
 

--- a/packages/core/e2e/default-search-plugin.e2e-spec.ts
+++ b/packages/core/e2e/default-search-plugin.e2e-spec.ts
@@ -168,6 +168,24 @@ describe('Default search plugin', () => {
         expect(result.search.items.map(i => i.productVariantName)).toEqual(expected);
     }
 
+    /**
+     * Clients generated from the GraphQL schema commonly send `sort: {}` when the user has not
+     * selected a sort order. Since an empty object is truthy, this used to be treated as an
+     * explicit sort, which suppressed the relevance ordering that applies when searching by term.
+     */
+    async function testRelevanceSortingWithEmptySortObject(testProducts: TestProducts) {
+        const result = await testProducts({
+            term: 'slr',
+            groupByProduct: true,
+            sort: {},
+        });
+
+        // "Slr Camera" matches on the product name whereas "Camera Lens" only matches in the
+        // description, so the higher-scoring "Slr Camera" must come first, even though it has the
+        // higher productVariantId, which is the fallback ordering used when no score is applied.
+        expect(result.search.items.map(i => i.productName)).toEqual(['Slr Camera', 'Camera Lens']);
+    }
+
     async function testMatchSearchTerm(testProducts: TestProducts) {
         const result = await testProducts({
             term: 'camera',
@@ -685,6 +703,9 @@ describe('Default search plugin', () => {
 
         it('sort price without grouping', () => testSortingNoGrouping(testProductsShop, 'price'));
 
+        it('sorts by relevance when sort is an empty object', () =>
+            testRelevanceSortingWithEmptySortObject(testProductsShop));
+
         it('omits results for disabled ProductVariants', async () => {
             await adminClient.query(updateProductVariantsDocument, {
                 input: [{ id: 'T_3', enabled: false }],
@@ -821,6 +842,9 @@ describe('Default search plugin', () => {
         it('sort name without grouping', () => testSortingNoGrouping(testProductsAdmin, 'name'));
 
         it('sort price without grouping', () => testSortingNoGrouping(testProductsAdmin, 'price'));
+
+        it('sorts by relevance when sort is an empty object', () =>
+            testRelevanceSortingWithEmptySortObject(testProductsAdmin));
 
         describe('updating the index', () => {
             it('updates index when ProductVariants are changed', async () => {

--- a/packages/core/e2e/order-promotion.e2e-spec.ts
+++ b/packages/core/e2e/order-promotion.e2e-spec.ts
@@ -2218,6 +2218,93 @@ describe('Promotions applied to Orders', () => {
         });
     });
 
+    describe('promotion which applies no discount', () => {
+        const couponCode = 'NO_DISCOUNT_ON_THIS_CART';
+        let promotion: PromotionFragment;
+
+        beforeAll(async () => {
+            promotion = await createPromotion({
+                enabled: true,
+                name: '50% off item-5000 only',
+                couponCode,
+                perCustomerUsageLimit: 1,
+                conditions: [],
+                actions: [
+                    {
+                        code: productsPercentageDiscount.code,
+                        arguments: [
+                            { name: 'discount', value: '50' },
+                            {
+                                name: 'productVariantIds',
+                                value: `["${getVariantBySlug('item-5000').id}"]`,
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
+
+        afterAll(async () => {
+            await deletePromotion(promotion.id);
+        });
+
+        function addGuestCustomerToOrder() {
+            return shopClient.query(setCustomerDocument, {
+                input: {
+                    emailAddress: 'no-discount-guest@test.com',
+                    firstName: 'No Discount',
+                    lastName: 'Customer',
+                },
+            });
+        }
+
+        it('is not added to the Order and does not consume a usage', async () => {
+            await shopClient.asAnonymousUser();
+            await shopClient.query(addItemToOrderDocument, {
+                // Not one of the Promotion's ProductVariants, so the action discounts nothing
+                productVariantId: getVariantBySlug('item-1000').id,
+                quantity: 1,
+            });
+            const { setCustomerForOrder } = await addGuestCustomerToOrder();
+            orderResultGuard.assertSuccess(setCustomerForOrder);
+
+            const { applyCouponCode } = await shopClient.query(applyCouponCodeDocument, { couponCode });
+            orderResultGuard.assertSuccess(applyCouponCode);
+
+            // The customer typed the code, so it stays on the Order even though it discounts nothing
+            expect(applyCouponCode.couponCodes).toEqual([couponCode]);
+            expect(applyCouponCode.discounts).toEqual([]);
+            const orderCode = applyCouponCode.code;
+
+            await proceedToArrangingPayment(shopClient);
+            const order = await addPaymentToOrder(shopClient, testSuccessfulPaymentMethod);
+            orderResultGuard.assertSuccess(order);
+            expect(order.state).toBe('PaymentSettled');
+
+            const { orderByCode } = await shopClient.query(getOrderPromotionsByCodeDocument, {
+                code: orderCode,
+            });
+            expect(orderByCode!.promotions).toEqual([]);
+
+            // The customer's single allowed usage is still available
+            await shopClient.asAnonymousUser();
+            await shopClient.query(addItemToOrderDocument, {
+                productVariantId: getVariantBySlug('item-5000').id,
+                quantity: 1,
+            });
+            const { setCustomerForOrder: setCustomerForSecondOrder } = await addGuestCustomerToOrder();
+            orderResultGuard.assertSuccess(setCustomerForSecondOrder);
+
+            const { applyCouponCode: secondUse } = await shopClient.query(applyCouponCodeDocument, {
+                couponCode,
+            });
+            orderResultGuard.assertSuccess(secondUse);
+
+            expect(secondUse.discounts.length).toBe(1);
+            expect(secondUse.totalWithTax).toBe(3000);
+        });
+    });
+
     // https://github.com/vendurehq/vendure/issues/710
     it('removes order-level discount made invalid by removing OrderLine', async () => {
         const promotion = await createPromotion({

--- a/packages/core/src/config/promotion/promotion-action.ts
+++ b/packages/core/src/config/promotion/promotion-action.ts
@@ -306,6 +306,17 @@ export abstract class PromotionAction<
         this.onDeactivateFn = config.onDeactivate;
     }
 
+    /**
+     * @description
+     * Whether this action defines any of the side-effect functions. Such an action can have an
+     * effect on the Order (adding a free gift, say) without producing a price adjustment.
+     *
+     * @internal
+     */
+    get hasSideEffects(): boolean {
+        return !!(this.onActivateFn || this.onDeactivateFn);
+    }
+
     /** @internal */
     abstract execute(...arg: any[]): number | Promise<number>;
 

--- a/packages/core/src/config/system/health-check-strategy.ts
+++ b/packages/core/src/config/system/health-check-strategy.ts
@@ -1,26 +1,13 @@
-import { HealthIndicatorFunction } from '../../health-check/terminus-compat';
 import { InjectableStrategy } from '../../common/types/injectable-strategy';
+import { HealthIndicatorFunction } from '../../health-check/terminus-compat';
 
 /**
  * @description
- * This strategy defines health checks which are included as part of the
- * `/health` endpoint. They should only be used to monitor _critical_ systems
- * on which proper functioning of the Vendure server depends.
+ * This strategy defines health checks which, before v3.6.0, were run by the `/health` endpoint.
+ * Since v3.6.0 the strategies configured in `systemOptions.healthChecks` are not executed, and this
+ * interface will be removed in v4.0.0. See the [health checks guide](/core-concepts/healthchecks/).
  *
- * Custom strategies should be added to the `systemOptions.healthChecks` array.
- * By default, Vendure includes the `TypeORMHealthCheckStrategy`, so if you set the value of the `healthChecks`
- * array, be sure to include it manually.
- *
- * Vendure also ships with the {@link HttpHealthCheckStrategy}, which is convenient
- * for adding a health check dependent on an HTTP ping.
- *
- * :::info
- *
- * This is configured via the `systemOptions.healthChecks` property of
- * your VendureConfig.
- *
- * :::
- *
+ * The example below shows how strategies were configured before v3.6.0.
  *
  * @example
  * ```ts
@@ -40,14 +27,14 @@ import { InjectableStrategy } from '../../common/types/injectable-strategy';
  * ```
  *
  * @docsCategory health-check
- * @deprecated Use infrastructure-level health checks (e.g. Kubernetes probes, Docker healthchecks,
+ * @deprecated Not executed since v3.6.0. Use infrastructure-level health checks (e.g. Kubernetes probes, Docker healthchecks,
  * load balancer checks) instead of application-level health checks. This interface will be removed in v4.0.0.
  */
 export interface HealthCheckStrategy extends InjectableStrategy {
     /**
      * @description
      * Should return a {@link HealthIndicatorFunction} which performs the check
-     * and resolves to a status payload.
+     * and resolves to a status payload. Since v3.6.0 this method is never called.
      */
     getHealthIndicator(): HealthIndicatorFunction;
 }

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -1281,12 +1281,13 @@ export interface EntityOptions {
 export interface SystemOptions {
     /**
      * @description
-     * Defines an array of {@link HealthCheckStrategy} instances which are used by the `/health` endpoint to verify
-     * that any critical systems which the Vendure server depends on are also healthy.
+     * Defines an array of {@link HealthCheckStrategy} instances. Before v3.6.0 the `/health` endpoint ran these
+     * strategies to verify that critical systems which the Vendure server depends on were healthy. Since v3.6.0
+     * the strategies are not executed and this option has no effect on the `/health` response.
      *
-     * @default [TypeORMHealthCheckStrategy]
+     * @default []
      * @since 1.6.0
-     * @deprecated Use infrastructure-level health checks (e.g. Kubernetes probes, Docker healthchecks,
+     * @deprecated Not executed since v3.6.0. Use infrastructure-level health checks (e.g. Kubernetes probes, Docker healthchecks,
      * load balancer checks) instead of application-level health checks. The application should not
      * be responsible for determining its own health. This config option will be removed in v4.0.0.
      */

--- a/packages/core/src/entity/promotion/promotion.entity.ts
+++ b/packages/core/src/entity/promotion/promotion.entity.ts
@@ -147,6 +147,18 @@ export class Promotion
      */
     @Column() priorityScore: number;
 
+    /**
+     * @description
+     * Whether any of this Promotion's actions define a side effect (`onActivate` / `onDeactivate`).
+     * Such a Promotion can benefit the Order without producing a price adjustment - the free gift
+     * action being the canonical example - so it counts as applied even when it discounts nothing.
+     *
+     * @internal
+     */
+    get hasSideEffects(): boolean {
+        return this.actions.some(action => this.allActions[action.code]?.hasSideEffects);
+    }
+
     async apply(
         ctx: RequestContext,
         args: ApplyOrderActionArgs | ApplyOrderItemActionArgs | ApplyShippingActionArgs,

--- a/packages/core/src/health-check/health-check-registry.service.ts
+++ b/packages/core/src/health-check/health-check-registry.service.ts
@@ -2,22 +2,11 @@ import { HealthIndicatorFunction } from './terminus-compat';
 
 /**
  * @description
- * This service is used to register health indicator functions to be included in the
- * health check. Health checks can be used by automated services such as Kubernetes
- * to determine the state of applications it is running. They are also useful for
- * administrators to get an overview of the health of all the parts of the
- * Vendure stack.
+ * This service is used to register health indicator functions which, before v3.6.0, were run by the
+ * `/health` endpoint. Since v3.6.0 registered indicators are not executed, and this service will be
+ * removed in v4.0.0. See the [health checks guide](/core-concepts/healthchecks/).
  *
- * Plugins which rely on external services (web services, databases etc.) can make use of this
- * service to add a check for that dependency to the Vendure health check.
- *
- *
- * Since v1.6.0, the preferred way to implement a custom health check is by creating a new {@link HealthCheckStrategy}
- * and then passing it to the `systemOptions.healthChecks` array.
- * See the {@link HealthCheckStrategy} docs for an example configuration.
- *
- * The alternative way to register a health check is by injecting this service directly into your
- * plugin module. To use it in your plugin, you'll need to import the {@link PluginCommonModule}:
+ * The example below shows how a plugin registered an indicator before v3.6.0:
  *
  * @example
  * ```ts
@@ -48,9 +37,7 @@ export class HealthCheckRegistryService {
 
     /**
      * @description
-     * Registers one or more {@link HealthIndicatorFunction}s to be added to the
-     * health check endpoint. The indicator will also appear in the Admin UI's
-     * "system status" view.
+     * Registers one or more {@link HealthIndicatorFunction}s. Since v3.6.0 the registered functions are never called.
      *
      * @deprecated Use infrastructure-level health checks instead. This method will be removed in v4.0.0.
      */

--- a/packages/core/src/health-check/http-health-check-strategy.ts
+++ b/packages/core/src/health-check/http-health-check-strategy.ts
@@ -21,7 +21,8 @@ export interface HttpHealthCheckOptions {
 
 /**
  * @description
- * A {@link HealthCheckStrategy} used to check health by pinging a url.
+ * A {@link HealthCheckStrategy} used to check health by pinging a url. Since v3.6.0 it is not
+ * executed and will be removed in v4.0.0. The example below shows the pre-v3.6.0 configuration:
  *
  * @example
  * ```ts

--- a/packages/core/src/health-check/terminus-compat.ts
+++ b/packages/core/src/health-check/terminus-compat.ts
@@ -55,8 +55,8 @@ export type HealthIndicatorFunction = () =>
 
 /**
  * @description
- * Thrown from a health indicator to signal a failed check. The `causes`
- * payload is forwarded to the `/health` response so callers can inspect
+ * Thrown from a health indicator to signal a failed check. Before v3.6.0 the `causes`
+ * payload was forwarded to the `/health` response so callers could inspect
  * which indicator failed and why. `causes` is intentionally typed as
  * `any` (matching terminus) so handlers can pass through arbitrary
  * upstream error payloads (HTTP responses, DB driver errors, etc.)

--- a/packages/core/src/health-check/typeorm-health-check-strategy.ts
+++ b/packages/core/src/health-check/typeorm-health-check-strategy.ts
@@ -14,9 +14,8 @@ export interface TypeORMHealthCheckOptions {
 
 /**
  * @description
- * A {@link HealthCheckStrategy} used to check the health of the database. This health
- * check is included by default, but can be customized by explicitly adding it to the
- * `systemOptions.healthChecks` array:
+ * A {@link HealthCheckStrategy} used to check the health of the database. Since v3.6.0 it is not
+ * executed and will be removed in v4.0.0. The example below shows the pre-v3.6.0 configuration:
  *
  * @example
  * ```ts
@@ -27,8 +26,6 @@ export interface TypeORMHealthCheckOptions {
  *   systemOptions: {
  *     healthChecks:[
  *         // The default key is "database" and the default timeout is 1000ms
- *         // Sometimes this is too short and leads to false negatives in the
- *         // /health endpoint.
  *         new TypeORMHealthCheckStrategy({ key: 'postgres-db', timeout: 5000 }),
  *     ]
  *   }

--- a/packages/core/src/plugin/default-scheduler-plugin/default-scheduler-strategy.ts
+++ b/packages/core/src/plugin/default-scheduler-plugin/default-scheduler-strategy.ts
@@ -1,6 +1,7 @@
 import { UpdateScheduledTaskInput } from '@vendure/common/lib/generated-types';
 import { Cron } from 'croner';
 import ms, { type StringValue } from 'ms';
+import { inspect } from 'node:util';
 
 import { Injector } from '../../common';
 import { assertFound } from '../../common/utils';
@@ -122,17 +123,13 @@ export class DefaultSchedulerStrategy implements SchedulerStrategy {
             );
             Logger.verbose(`Scheduled task "${task.id}" completed successfully`);
         } catch (error) {
-            let errorMessage = 'Unknown error';
-            if (error instanceof Error) {
-                errorMessage = error.message;
-            }
-            Logger.error(`Scheduled task "${task.id}" failed with error: ${errorMessage}`);
+            Logger.error(`Scheduled task "${task.id}" failed with error: ${inspect(error)}`);
             await this.connection.rawConnection.getRepository(ScheduledTaskRecord).update(
                 { taskId: task.id },
                 {
                     lastExecutedAt: new Date(),
                     lockedAt: null,
-                    lastResult: { error: errorMessage } as any,
+                    lastResult: { error: errorLabel(error) } as any,
                 },
             );
         } finally {
@@ -356,4 +353,15 @@ export class DefaultSchedulerStrategy implements SchedulerStrategy {
             this.tasks.set(taskId, { task: task.task, isRegistered: true });
         }
     }
+}
+
+/**
+ * `constructor.name` rather than `name` because a subclass which does not set `name`
+ * still inherits `'Error'` from `Error.prototype`.
+ */
+function errorLabel(error: unknown): string {
+    if (!(error instanceof Error)) {
+        return 'Unknown error';
+    }
+    return error.message || error.constructor.name;
 }

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/mysql-search-strategy.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/mysql-search-strategy.ts
@@ -17,6 +17,7 @@ import {
     createCollectionIdCountMap,
     createFacetIdCountMap,
     createPlaceholderFromId,
+    hasSortParameter,
     mapToSearchResult,
 } from './search-strategy-utils';
 
@@ -100,7 +101,7 @@ export class MysqlSearchStrategy implements SearchStrategy {
 
         this.applyTermAndFilters(ctx, qb, input);
 
-        if (sort) {
+        if (hasSortParameter(sort)) {
             if (sort.name) {
                 qb.addOrderBy('si_productName', sort.name);
             }

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/postgres-search-strategy.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/postgres-search-strategy.ts
@@ -17,6 +17,7 @@ import {
     createCollectionIdCountMap,
     createFacetIdCountMap,
     createPlaceholderFromId,
+    hasSortParameter,
     mapToSearchResult,
 } from './search-strategy-utils';
 
@@ -100,7 +101,7 @@ export class PostgresSearchStrategy implements SearchStrategy {
 
         this.applyTermAndFilters(ctx, qb, input);
 
-        if (sort) {
+        if (hasSortParameter(sort)) {
             if (sort.name) {
                 qb.addOrderBy('"si_productName"', sort.name);
             }

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/search-strategy-utils.spec.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/search-strategy-utils.spec.ts
@@ -1,0 +1,31 @@
+import { SearchResultSortParameter, SortOrder } from '@vendure/common/lib/generated-types';
+import { describe, expect, it } from 'vitest';
+
+import { hasSortParameter } from './search-strategy-utils';
+
+describe('hasSortParameter()', () => {
+    it('returns false when no sort parameter was given', () => {
+        expect(hasSortParameter(undefined)).toBe(false);
+        expect(hasSortParameter(null)).toBe(false);
+    });
+
+    it('returns false for an empty sort object', () => {
+        expect(hasSortParameter({})).toBe(false);
+    });
+
+    it('returns false when all sort fields are null or undefined', () => {
+        // GraphQL can deliver an explicit null at runtime, which the generated input type does not model
+        expect(
+            hasSortParameter({ name: null, price: undefined } as unknown as SearchResultSortParameter),
+        ).toBe(false);
+    });
+
+    it('returns true when at least one sort field is set', () => {
+        expect(hasSortParameter({ name: SortOrder.ASC })).toBe(true);
+        expect(hasSortParameter({ price: SortOrder.DESC })).toBe(true);
+        // GraphQL can deliver an explicit null at runtime, which the generated input type does not model
+        expect(
+            hasSortParameter({ name: null, price: SortOrder.ASC } as unknown as SearchResultSortParameter),
+        ).toBe(true);
+    });
+});

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/search-strategy-utils.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/search-strategy-utils.ts
@@ -5,6 +5,7 @@ import {
     PriceRange,
     SearchResult,
     SearchResultAsset,
+    SearchResultSortParameter,
     SinglePrice,
 } from '@vendure/common/lib/generated-types';
 import { ID } from '@vendure/common/lib/shared-types';
@@ -114,6 +115,18 @@ function parseFocalPoint(focalPoint: any): Coordinate | undefined {
 
 export function createPlaceholderFromId(id: ID): string {
     return '_' + id.toString().replace(/-/g, '_');
+}
+
+/**
+ * Returns true if the given sort parameter actually specifies a field to sort by.
+ *
+ * Clients built with GraphQL code generation commonly send `sort: {}` when the user has
+ * not selected any sort order. Since an empty object is truthy, it must not be treated as
+ * an explicit sort, otherwise no ordering would be applied at all and the relevance
+ * ordering which applies when searching by term would be silently suppressed.
+ */
+export function hasSortParameter(sort?: SearchResultSortParameter | null): sort is SearchResultSortParameter {
+    return sort != null && Object.values(sort).some(value => value != null);
 }
 
 /**

--- a/packages/core/src/plugin/default-search-plugin/search-strategy/sqlite-search-strategy.ts
+++ b/packages/core/src/plugin/default-search-plugin/search-strategy/sqlite-search-strategy.ts
@@ -16,6 +16,7 @@ import {
     createCollectionIdCountMap,
     createFacetIdCountMap,
     createPlaceholderFromId,
+    hasSortParameter,
     mapToSearchResult,
 } from './search-strategy-utils';
 
@@ -99,7 +100,7 @@ export class SqliteSearchStrategy implements SearchStrategy {
 
         this.applyTermAndFilters(ctx, qb, input);
 
-        if (sort) {
+        if (hasSortParameter(sort)) {
             if (sort.name) {
                 // TODO: v3 - set the collation on the SearchIndexItem entity
                 qb.addOrderBy('si.productName COLLATE NOCASE', sort.name);

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.spec.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.spec.ts
@@ -1517,6 +1517,197 @@ describe('OrderCalculator', () => {
                 expect(order.subTotal).toBe(1350);
             });
         });
+
+        describe('promotions which apply no discount', () => {
+            // Models the common "facet exclusions" setup: the conditions pass for the whole Order,
+            // but the action discounts only some of the items.
+            const discountExpensiveItemsAction = new PromotionItemAction({
+                code: 'discount_expensive_items_action',
+                description: [{ languageCode: LanguageCode.en, value: '' }],
+                args: {},
+                execute(ctx, orderLine) {
+                    return 1000 <= orderLine.unitPrice ? -100 : 0;
+                },
+            });
+
+            const neverDiscountAction = new PromotionItemAction({
+                code: 'never_discount_action',
+                description: [{ languageCode: LanguageCode.en, value: '' }],
+                args: {},
+                execute() {
+                    return 0;
+                },
+            });
+
+            const sideEffectAction = new PromotionItemAction({
+                code: 'side_effect_action',
+                description: [{ languageCode: LanguageCode.en, value: '' }],
+                args: {},
+                execute() {
+                    return 0;
+                },
+                // The benefit of this action is delivered by the side effect, not by a discount.
+                onActivate: () => undefined,
+            });
+
+            function createItemPromotion(action: PromotionItemAction, id = 1) {
+                return new Promotion({
+                    id,
+                    name: `Test promotion ${id}`,
+                    conditions: [{ code: alwaysTrueCondition.code, args: [] }],
+                    promotionConditions: [alwaysTrueCondition],
+                    actions: [{ code: action.code, args: [] }],
+                    promotionActions: [action],
+                });
+            }
+
+            it('is not added to the Order', async () => {
+                const ctx = createRequestContext({ pricesIncludeTax: false });
+                const order = createOrder({
+                    ctx,
+                    lines: [
+                        {
+                            listPrice: 100,
+                            taxCategory: taxCategoryStandard,
+                            quantity: 1,
+                        },
+                    ],
+                });
+
+                await orderCalculator.applyPriceAdjustments(ctx, order, [
+                    createItemPromotion(discountExpensiveItemsAction),
+                ]);
+
+                expect(order.discounts.length).toBe(0);
+                expect(order.promotions).toEqual([]);
+            });
+
+            it('is added to the Order when it discounts at least one line', async () => {
+                const ctx = createRequestContext({ pricesIncludeTax: false });
+                const order = createOrder({
+                    ctx,
+                    lines: [
+                        {
+                            listPrice: 100,
+                            taxCategory: taxCategoryStandard,
+                            quantity: 1,
+                        },
+                        {
+                            listPrice: 2000,
+                            taxCategory: taxCategoryStandard,
+                            quantity: 1,
+                        },
+                    ],
+                });
+
+                await orderCalculator.applyPriceAdjustments(ctx, order, [
+                    createItemPromotion(discountExpensiveItemsAction),
+                ]);
+
+                expect(order.discounts.length).toBe(1);
+                expect(order.promotions.map(p => p.id)).toEqual([1]);
+            });
+
+            it('is removed without removing the other Promotions on the Order', async () => {
+                const ctx = createRequestContext({ pricesIncludeTax: false });
+                const order = createOrder({
+                    ctx,
+                    lines: [
+                        {
+                            listPrice: 2000,
+                            taxCategory: taxCategoryStandard,
+                            quantity: 1,
+                        },
+                    ],
+                });
+
+                await orderCalculator.applyPriceAdjustments(ctx, order, [
+                    createItemPromotion(discountExpensiveItemsAction, 1),
+                    createItemPromotion(neverDiscountAction, 2),
+                ]);
+
+                expect(order.discounts.length).toBe(1);
+                expect(order.promotions.map(p => p.id)).toEqual([1]);
+            });
+
+            it('is removed from the Order once it no longer discounts anything', async () => {
+                const ctx = createRequestContext({ pricesIncludeTax: false });
+                const promotion = createItemPromotion(discountExpensiveItemsAction);
+                const order = createOrder({
+                    ctx,
+                    lines: [
+                        {
+                            listPrice: 2000,
+                            taxCategory: taxCategoryStandard,
+                            quantity: 1,
+                        },
+                    ],
+                });
+
+                await orderCalculator.applyPriceAdjustments(ctx, order, [promotion]);
+                expect(order.promotions.map(p => p.id)).toEqual([1]);
+
+                order.lines[0].listPrice = 100;
+                await orderCalculator.applyPriceAdjustments(ctx, order, [promotion]);
+
+                expect(order.discounts.length).toBe(0);
+                expect(order.promotions).toEqual([]);
+            });
+
+            it('is added to the Order when it only discounts shipping', async () => {
+                const ctx = createRequestContext({ pricesIncludeTax: false });
+                const promotion = new Promotion({
+                    id: 2,
+                    name: 'Free shipping',
+                    conditions: [{ code: alwaysTrueCondition.code, args: [] }],
+                    promotionConditions: [alwaysTrueCondition],
+                    actions: [{ code: freeShippingAction.code, args: [] }],
+                    promotionActions: [freeShippingAction],
+                });
+                const order = createOrder({
+                    ctx,
+                    lines: [
+                        {
+                            listPrice: 100,
+                            taxCategory: taxCategoryStandard,
+                            quantity: 1,
+                        },
+                    ],
+                });
+                order.shippingLines = [
+                    new ShippingLine({
+                        shippingMethodId: mockShippingMethodId,
+                        adjustments: [],
+                    }),
+                ];
+
+                await orderCalculator.applyPriceAdjustments(ctx, order, [promotion]);
+
+                expect(order.shipping).toBe(0);
+                expect(order.promotions.map(p => p.id)).toEqual([2]);
+            });
+
+            it('is added to the Order when its action has a side effect', async () => {
+                const ctx = createRequestContext({ pricesIncludeTax: false });
+                const order = createOrder({
+                    ctx,
+                    lines: [
+                        {
+                            listPrice: 100,
+                            taxCategory: taxCategoryStandard,
+                            quantity: 1,
+                        },
+                    ],
+                });
+
+                await orderCalculator.applyPriceAdjustments(ctx, order, [
+                    createItemPromotion(sideEffectAction),
+                ]);
+
+                expect(order.discounts.length).toBe(0);
+                expect(order.promotions.map(p => p.id)).toEqual([1]);
+            });
+        });
     });
 
     describe('surcharges', () => {

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.ts
@@ -113,6 +113,7 @@ export class OrderCalculator {
             await this.applyShippingPromotions(ctx, order, promotions);
         }
         this.calculateOrderTotals(order);
+        this.removeIneffectivePromotions(order);
         return order;
     }
 
@@ -386,5 +387,36 @@ export class OrderCalculator {
         if (order.promotions && !order.promotions.find(p => idsAreEqual(p.id, promotion.id))) {
             order.promotions.push(promotion);
         }
+    }
+
+    /**
+     * Promotions are added to the Order as soon as their conditions pass, since a Promotion which
+     * discounts nothing on one OrderLine may still discount a later line, the Order total or the
+     * shipping. Once everything has been applied, any Promotion which ended up adjusting nothing
+     * at all is removed again: `Order.promotions` is what the usage limits are counted from, so a
+     * Promotion the customer got no benefit from must not consume a usage.
+     *
+     * Promotions whose actions define side effects are kept regardless, as their benefit (a free
+     * gift, say) is not expressed as an adjustment amount - and on the first pass the side effect
+     * has not run yet, so there is nothing to discount.
+     */
+    private removeIneffectivePromotions(order: Order) {
+        if (!order.promotions?.length) {
+            return;
+        }
+        const adjustmentSources = new Set<string>();
+        for (const line of order.lines) {
+            for (const adjustment of line.adjustments ?? []) {
+                adjustmentSources.add(adjustment.adjustmentSource);
+            }
+        }
+        for (const shippingLine of order.shippingLines ?? []) {
+            for (const adjustment of shippingLine.adjustments ?? []) {
+                adjustmentSources.add(adjustment.adjustmentSource);
+            }
+        }
+        order.promotions = order.promotions.filter(
+            promotion => adjustmentSources.has(promotion.getSourceId()) || promotion.hasSideEffects,
+        );
     }
 }

--- a/packages/dashboard/e2e/tests/catalog/product-list.spec.ts
+++ b/packages/dashboard/e2e/tests/catalog/product-list.spec.ts
@@ -353,6 +353,47 @@ test.describe('Product List', () => {
             ).toBeVisible();
         });
 
+        // #5272 — verifies that product search and column filters combine with AND semantics
+        test('should keep column filters applied when a search term is entered', async ({ page }) => {
+            const lp = listPage(page);
+            await lp.goto();
+            await lp.expectLoaded();
+
+            const initialCount = await lp.getRows().count();
+
+            // Filter down to the 3 products with "Camera" in the name
+            await lp.openAddFilterMenu();
+            const dropdown = page.locator('[data-slot="dropdown-menu-content"]');
+            await dropdown.getByRole('menuitem', { name: /name/i }).click();
+
+            const dialog = page.locator('[role="dialog"]');
+            await dialog.getByPlaceholder('Enter filter value...').fill('Camera');
+            const filterResponse = page.waitForResponse(
+                resp => resp.url().includes('/admin-api') && resp.status() === 200,
+            );
+            await dialog.getByRole('button', { name: 'Apply filter' }).click();
+            await filterResponse;
+            await lp.expectRowCount(3);
+
+            // Searching within that filter must AND the two, not OR them
+            await lp.search('Lens');
+            await lp.expectRowCount(1);
+            await expect(lp.getRows().filter({ hasText: 'Camera Lens' })).toHaveCount(1);
+            await expect(lp.getRows().filter({ hasText: 'Instant Camera' })).toHaveCount(0);
+
+            // Clearing the search must restore the filtered set
+            await lp.clearSearch();
+            await lp.expectRowCount(3);
+
+            // Clearing the filter must restore the initial set
+            const clearResponse = page.waitForResponse(
+                resp => resp.url().includes('/admin-api') && resp.status() === 200,
+            );
+            await page.getByRole('button', { name: 'Clear all' }).click();
+            await clearResponse;
+            await lp.expectRowCount(initialCount);
+        });
+
         test('should clear an applied filter via the clear all button', async ({ page }) => {
             const lp = listPage(page);
             await lp.goto();

--- a/packages/dashboard/src/app/routes/_authenticated/_administrators/administrators.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_administrators/administrators.tsx
@@ -25,19 +25,13 @@ function AdministratorListPage() {
             onSearchTermChange={searchTerm => {
                 return searchTerm
                     ? {
-                          firstName: { contains: searchTerm },
-                          lastName: { contains: searchTerm },
-                          emailAddress: { contains: searchTerm },
+                          _or: [
+                              { firstName: { contains: searchTerm } },
+                              { lastName: { contains: searchTerm } },
+                              { emailAddress: { contains: searchTerm } },
+                          ],
                       }
                     : {};
-            }}
-            transformVariables={variables => {
-                return {
-                    options: {
-                        ...variables.options,
-                        filterOperator: 'OR',
-                    },
-                };
             }}
             additionalColumns={{
                 name: {

--- a/packages/dashboard/src/app/routes/_authenticated/_countries/countries.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_countries/countries.tsx
@@ -28,19 +28,9 @@ function CountryListPage() {
             onSearchTermChange={searchTerm => {
                 return searchTerm
                     ? {
-                          name: { contains: searchTerm },
-                          code: { contains: searchTerm },
+                          _or: [{ name: { contains: searchTerm } }, { code: { contains: searchTerm } }],
                       }
                     : {};
-            }}
-            transformVariables={variables => {
-                return {
-                    ...variables,
-                    options: {
-                        ...variables.options,
-                        filterOperator: 'OR',
-                    },
-                };
             }}
             customizeColumns={{
                 name: {

--- a/packages/dashboard/src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
@@ -93,12 +93,10 @@ export function CustomerGroupMembersTable({
                 }}
                 onSearchTermChange={searchTerm => {
                     return {
-                        lastName: {
-                            contains: searchTerm,
-                        },
-                        emailAddress: {
-                            contains: searchTerm,
-                        },
+                        _or: [
+                            { lastName: { contains: searchTerm } },
+                            { emailAddress: { contains: searchTerm } },
+                        ],
                     };
                 }}
                 additionalColumns={{

--- a/packages/dashboard/src/app/routes/_authenticated/_customers/customers.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_customers/customers.tsx
@@ -24,19 +24,13 @@ function CustomerListPage() {
             onSearchTermChange={searchTerm => {
                 return searchTerm
                     ? {
-                          lastName: { contains: searchTerm },
-                          emailAddress: { contains: searchTerm },
-                          phoneNumber: { contains: searchTerm },
+                          _or: [
+                              { lastName: { contains: searchTerm } },
+                              { emailAddress: { contains: searchTerm } },
+                              { phoneNumber: { contains: searchTerm } },
+                          ],
                       }
                     : {};
-            }}
-            transformVariables={variables => {
-                return {
-                    options: {
-                        ...variables.options,
-                        filterOperator: 'OR',
-                    },
-                };
             }}
             route={Route}
             customizeColumns={{

--- a/packages/dashboard/src/app/routes/_authenticated/_product-variants/product-variants.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_product-variants/product-variants.tsx
@@ -88,18 +88,9 @@ function ProductListPage() {
             onSearchTermChange={searchTerm => {
                 return searchTerm
                     ? {
-                          name: { contains: searchTerm },
-                          sku: { contains: searchTerm },
+                          _or: [{ name: { contains: searchTerm } }, { sku: { contains: searchTerm } }],
                       }
                     : {};
-            }}
-            transformVariables={variables => {
-                return {
-                    options: {
-                        ...variables.options,
-                        filterOperator: 'OR',
-                    },
-                };
             }}
             route={Route}
         ></ListPage>

--- a/packages/dashboard/src/app/routes/_authenticated/_products/products.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/products.tsx
@@ -56,9 +56,11 @@ function ProductListPage() {
             onSearchTermChange={searchTerm => {
                 return searchTerm
                     ? {
-                          name: { contains: searchTerm },
-                          slug: { contains: searchTerm },
-                          sku: { contains: searchTerm },
+                          _or: [
+                              { name: { contains: searchTerm } },
+                              { slug: { contains: searchTerm } },
+                              { sku: { contains: searchTerm } },
+                          ],
                       }
                     : {};
             }}
@@ -76,14 +78,6 @@ function ProductListPage() {
                     title: t`Facet values`,
                     component: FacetValueFacetedFilter,
                 },
-            }}
-            transformVariables={variables => {
-                return {
-                    options: {
-                        ...variables.options,
-                        filterOperator: 'OR',
-                    },
-                };
             }}
             defaultSort={[{ id: 'updatedAt', desc: true }]}
             defaultVisibility={{

--- a/packages/dashboard/src/app/routes/_authenticated/_promotions/promotions.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_promotions/promotions.tsx
@@ -38,18 +38,9 @@ function PromotionListPage() {
             onSearchTermChange={searchTerm => {
                 return searchTerm
                     ? {
-                          name: { contains: searchTerm },
-                          couponCode: { contains: searchTerm },
+                          _or: [{ name: { contains: searchTerm } }, { couponCode: { contains: searchTerm } }],
                       }
                     : {};
-            }}
-            transformVariables={variables => {
-                return {
-                    options: {
-                        ...variables.options,
-                        filterOperator: 'OR' as const,
-                    },
-                };
             }}
             customizeColumns={{
                 name: {

--- a/packages/dashboard/src/i18n/locales/ne.po
+++ b/packages/dashboard/src/i18n/locales/ne.po
@@ -4880,7 +4880,7 @@ msgstr ""
 #: src/app/routes/_authenticated/_orders/orders.tsx
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
-msgstr "राज्य"
+msgstr "अवस्था"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx

--- a/packages/dashboard/src/i18n/locales/nl.po
+++ b/packages/dashboard/src/i18n/locales/nl.po
@@ -4871,7 +4871,7 @@ msgstr ""
 #: src/app/routes/_authenticated/_orders/orders.tsx
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
-msgstr "Staat"
+msgstr "Status"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx

--- a/packages/dashboard/src/i18n/locales/ru.po
+++ b/packages/dashboard/src/i18n/locales/ru.po
@@ -4880,7 +4880,7 @@ msgstr ""
 #: src/app/routes/_authenticated/_orders/orders.tsx
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
-msgstr "Регион"
+msgstr "Состояние"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx

--- a/packages/dashboard/src/i18n/locales/sv.po
+++ b/packages/dashboard/src/i18n/locales/sv.po
@@ -4880,7 +4880,7 @@ msgstr ""
 #: src/app/routes/_authenticated/_orders/orders.tsx
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
-msgstr "Region"
+msgstr "Tillstånd"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx

--- a/packages/dashboard/src/i18n/locales/tr.po
+++ b/packages/dashboard/src/i18n/locales/tr.po
@@ -4880,7 +4880,7 @@ msgstr ""
 #: src/app/routes/_authenticated/_orders/orders.tsx
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
-msgstr "İl"
+msgstr "Durum"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx

--- a/packages/dashboard/src/i18n/locales/uk.po
+++ b/packages/dashboard/src/i18n/locales/uk.po
@@ -4880,7 +4880,7 @@ msgstr ""
 #: src/app/routes/_authenticated/_orders/orders.tsx
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
-msgstr "Регіон"
+msgstr "Стан"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx

--- a/packages/dashboard/src/i18n/locales/zh_Hans.po
+++ b/packages/dashboard/src/i18n/locales/zh_Hans.po
@@ -4880,7 +4880,7 @@ msgstr ""
 #: src/app/routes/_authenticated/_orders/orders.tsx
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
-msgstr "州/省"
+msgstr "状态"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx

--- a/packages/dashboard/src/i18n/locales/zh_Hant.po
+++ b/packages/dashboard/src/i18n/locales/zh_Hant.po
@@ -4880,7 +4880,7 @@ msgstr ""
 #: src/app/routes/_authenticated/_orders/orders.tsx
 #: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
-msgstr "州/省"
+msgstr "狀態"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx

--- a/packages/dashboard/src/lib/framework/page/list-page.stories.tsx
+++ b/packages/dashboard/src/lib/framework/page/list-page.stories.tsx
@@ -148,21 +148,7 @@ export const WithSearch: Story = {
         },
         onSearchTermChange: (searchTerm: string) => {
             return {
-                name: {
-                    contains: searchTerm,
-                },
-                code: {
-                    contains: searchTerm,
-                },
-            };
-        },
-        transformVariables: (variables: any) => {
-            return {
-                ...variables,
-                options: {
-                    ...variables.options,
-                    filterOperator: 'OR',
-                },
+                _or: [{ name: { contains: searchTerm } }, { code: { contains: searchTerm } }],
             };
         },
         customizeColumns: {
@@ -222,21 +208,7 @@ export const Complete: Story = {
         },
         onSearchTermChange: (searchTerm: string) => {
             return {
-                name: {
-                    contains: searchTerm,
-                },
-                code: {
-                    contains: searchTerm,
-                },
-            };
-        },
-        transformVariables: (variables: any) => {
-            return {
-                ...variables,
-                options: {
-                    ...variables.options,
-                    filterOperator: 'OR',
-                },
+                _or: [{ name: { contains: searchTerm } }, { code: { contains: searchTerm } }],
             };
         },
         customizeColumns: {

--- a/packages/dashboard/src/lib/framework/page/list-page.tsx
+++ b/packages/dashboard/src/lib/framework/page/list-page.tsx
@@ -140,6 +140,11 @@ export interface ListPageProps<
      * Allows you to customize how the search term is used in the list query options.
      * For instance, when you want the term to filter on specific fields.
      *
+     * The returned filter is merged with the column & faceted filters, so when the term should
+     * match any of several fields, group those fields in an `_or` block. Setting a page-level
+     * `filterOperator: 'OR'` would instead OR together _every_ top-level condition, including
+     * the column filters.
+     *
      * @example
      * ```tsx
      *  <ListPage
@@ -148,9 +153,11 @@ export interface ListPageProps<
      *    listQuery={administratorListDocument}
      *    onSearchTermChange={searchTerm => {
      *      return {
-     *        firstName: { contains: searchTerm },
-     *        lastName: { contains: searchTerm },
-     *        emailAddress: { contains: searchTerm },
+     *        _or: [
+     *          { firstName: { contains: searchTerm } },
+     *          { lastName: { contains: searchTerm } },
+     *          { emailAddress: { contains: searchTerm } },
+     *        ],
      *      };
      *    }}
      *  />


### PR DESCRIPTION
# Description

In the dashboard i18n catalogs, `msgid "State"` (used in payment details, order lists, and job queue) was mistranslated in several languages as a geographic or administrative division (such as region, province, or US state) rather than a lifecycle condition or status.

This PR updates the translation to mean condition/status in the following locales:
- **ne** (Nepali): `"राज्य"` (province/realm) -> `"अवस्था"` (state/condition)
- **ru** (Russian): `"Регион"` (region) -> `"Состояние"` (state/condition)
- **sv** (Swedish): `"Region"` (region) -> `"Tillstånd"` (state/condition)
- **tr** (Turkish): `"İl"` (province) -> `"Durum"` (state/condition)
- **uk** (Ukrainian): `"Регіон"` (region) -> `"Стан"` (state/condition)
- **zh_Hans** (Simplified Chinese): `"州/省"` (state/province) -> `"状态"` (state/condition)
- **zh_Hant** (Traditional Chinese): `"州/省"` (state/province) -> `"狀態"` (state/condition)

# Breaking changes

None.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791382274&installation_model_id=20193&pr_number=5302&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5302&signature=339f3a912b8efb3e5a52f90a7758405cbf213bb852ab33fba6fd931e3d175bf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->