### PR TITLE
fix(dashboard): show field name instead of form path as custom field label

### DIFF
--- a/packages/dashboard/src/lib/components/shared/custom-fields-form.tsx
+++ b/packages/dashboard/src/lib/components/shared/custom-fields-form.tsx
@@ -249,7 +249,7 @@ function CustomFieldItem({ fieldDef, control, fieldName, disabled }: Readonly<Cu
                             <CustomFieldFormItem
                                 fieldDef={fieldDef}
                                 getTranslation={getTranslation}
-                                fieldName={field.name}
+                                fieldName={fieldDef.name}
                                 fieldState={fieldState}
                             >
                                 {localeFallbackPlaceholder
@@ -275,7 +275,7 @@ function CustomFieldItem({ fieldDef, control, fieldName, disabled }: Readonly<Cu
                         <CustomFieldFormItem
                             fieldDef={fieldDef}
                             getTranslation={getTranslation}
-                            fieldName={field.name}
+                            fieldName={fieldDef.name}
                             fieldState={fieldState}
                         >
                             <CustomFormComponent fieldDef={fieldDef} {...field} />


### PR DESCRIPTION
## Description

Fixes localized custom fields (`localeString`/`localeText`) in the Dashboard showing an internal form path (e.g. `translations.0.customFields.tagline`) as their label instead of the field name, when no matching `label` translation exists for the operator's display language.

`CustomFieldItem` in `custom-fields-form.tsx` renders labels via `getTranslation(fieldDef.label) ?? fieldName`. Three of five field-rendering branches already passed `fieldDef.name` (e.g. `tagline`) as the fallback; the localized-field branch and the custom-form-component branch passed `field.name` from the RHF controller instead, which is the full path into the form value (and includes the translation row index, so it also changed when switching content language).

## Fix

Pass `fieldDef.name` consistently in all branches, matching the existing plain-field branches.

## Test plan

- [x] Declared a `localeString` custom field with no `label` on Product
- [x] Opened the entity in the Dashboard — label reads the field name (`tagline`), not the form path, on both the create form and the persisted entity's edit form
- [x] Verified via DOM inspection that the label's `for` attribute is `field-tagline`, not the RHF path

Fixes #5246

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791439993&installation_model_id=20193&pr_number=5312&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5312&signature=83bc4bd48031bd61af82f478c393152911d2c51ff4bb317868765546452f6ee6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->