### PR TITLE
feat(cli): let plugins run after a Console project link

### DIFF
--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -793,11 +793,12 @@ export default defineCliPlugin({
 });
 ```
 
-The hook receives the resolved `projectRoot`, the `manifest` as written and its
-`manifestPath`, the Console `endpoints` the link was made against, the
-`AbortSignal` the command runs under, the command's `reporter`, a `confirm`
-function for yes/no questions, `isNonInteractive`, and whether `--force` was
-given.
+The hook receives the resolved `projectRoot`, the `manifest` and its
+`manifestPath`, the Console `endpoints` the link was made against, whether this
+run linked or repaired (`outcome`), the `AbortSignal` the command runs under,
+the command's `reporter`, a `confirm` function for yes/no questions,
+`isNonInteractive`, and whether `--force` was given. Each hook gets its own
+context, so one hook cannot change what a later one reads.
 
 Do not replace the `console` command to do this. Linking stays one
 implementation, so every project links the same way whether or not a plugin is
@@ -812,16 +813,36 @@ it.
   command says so rather than reporting that nothing changed.
 - Hooks run in `vendure.cli.plugins` order, and the first to throw stops the
   rest.
-- Running `vendure console link` again creates a **new** Project Link rather than
-  repairing the existing one. Work that has to be repeatable, such as replacing
-  a credential a developer has lost, belongs in a command of the plugin's own
-  that reads the existing manifest. Do not send people back to `console link`
-  for it.
+- It has to be repeatable, because `vendure console link` repairs a link as well
+  as making one (see below).
 
 Throwing is for work that failed, not for work that cannot be done here. A hook
-that needs an answer it cannot get, such as a sign-in with no terminal attached,
-should say what is missing through `reporter` and return. The command still
-exits 0, because linking is what it was asked to do and it did it.
+that needs something it cannot get in this run should say what is missing
+through `reporter` and return. The command still exits 0, because linking is
+what it was asked to do and it did it.
+
+`context.confirm` asks a yes/no question and rejects when `isNonInteractive` is
+`true`, since there is nobody to answer. Check `isNonInteractive` first.
+Multi-choice questions belong in the plugin's own command, where it owns the
+whole screen.
+
+#### Repeating a link repairs it
+
+Run `vendure console link` in a project that is already linked and it reuses the
+manifest on disk and runs the hooks again, with `context.outcome` set to
+`'repaired'`. It does not create a second Project Link, which would abandon the
+first in Console over a problem that is local to the checkout.
+
+That makes `vendure console link` the command a developer runs to put back
+something the project needs and no longer has, such as a credential a hook
+writes. A plugin does not need a repair command of its own, and should send
+people here instead.
+
+`--force` is how a checkout is linked to a **different** Console Project: it
+skips the reuse, creates a new Project Link, and the hooks run with an `outcome`
+of `'linked'`. A hook that rotates a remote credential should treat `'repaired'`
+as the case that needs confirming, because the credential it is replacing may
+still be live for someone else.
 
 `context.endpoints.areDefault` is `false` when the link was made against
 endpoints set by `VENDURE_CONSOLE_LINK_URL` and `VENDURE_CONSOLE_LINK_API_URL`

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -367,6 +367,16 @@ npx vendure console unlink --force
 
 `--force` does not bypass ambiguous project selection or a manifest that belongs to another project root.
 
+Running `vendure console link` in a project that is already linked repairs it rather than replacing it: the manifest
+is reused and any plugin setup runs again. Where a plugin is registered, that is confirmed first, because the manifest
+may have arrived with a clone. Use `--yes` to answer that confirmation in advance:
+
+```bash
+npx vendure console link --yes
+```
+
+`--force` is different: it links this checkout to a **different** Console Project, which creates a new Project Link.
+
 ### Manifest and source control
 
 The v1 manifest contains identity metadata only:
@@ -857,13 +867,13 @@ The pair is matched as a pair, so a production app origin with a staging API is
 not official. A loopback pair is not official either; it is a development and
 test convenience.
 
-It says where this run will talk, not where the manifest came from. The manifest
-records no origin, so on a repair the Console that issued its project and
-account identifiers is unknown, and a `'production'` answer does not vouch for
-them. A hook that acts on the identifiers, rather than only on the origin,
+`official` says where this run will talk, not where the manifest came from. The
+manifest records no origin, so on a repair the Console that issued its project
+and account identifiers is unknown, and a `'production'` answer does not vouch
+for them. A hook that acts on the identifiers, rather than only on the origin,
 should treat a repair as unverified provenance.
 
-It is a fact, not a permission. Approving a custom endpoint approves it for
+`official` is a fact, not a permission. Approving a custom endpoint approves it for
 creating a Project Link, not for receiving anything secret. A hook that holds
 credentials checks `official` before it reads a credential file or sends a
 request, and refuses when it is `undefined`. Do not draw the same conclusion

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -790,7 +790,7 @@ an `afterConsoleLink` hook:
 import { defineCliPlugin } from '@vendure/cli';
 
 export default defineCliPlugin({
-    id: '@example/platform-cli-plugin',
+    id: '@example/setup-cli-plugin',
     commands: [],
     afterConsoleLink: async context => {
         // Everything the command already worked out, so the hook never

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -830,6 +830,26 @@ permission: approving a custom endpoint approves it for creating a Project Link,
 not for receiving anything secret. A hook that holds credentials keeps its own
 list of the hosts it will talk to and refuses when the origins do not match it.
 
+### Checking what the installed CLI supports
+
+`defineCliPlugin` ignores keys it does not know. A plugin written against a newer
+CLI than the one it resolves therefore loads cleanly and then quietly decorates
+nothing and runs no hook, which is harder to spot than a refusal. Read
+`CLI_PLUGIN_EXTENSION_POINTS` to fail loudly instead:
+
+```ts
+import * as cli from '@vendure/cli';
+
+// Builds older than this constant export nothing, so `undefined` is the answer.
+const supported: readonly string[] = cli.CLI_PLUGIN_EXTENSION_POINTS ?? [];
+if (!supported.includes('afterConsoleLink')) {
+    throw new Error('This @vendure/cli is too old to run afterConsoleLink hooks.');
+}
+```
+
+Entries are only added, never removed or renamed, so a check written against one
+release keeps working.
+
 ### Shared options
 
 Options that apply to more than one command are declared once, at the scope

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -844,12 +844,18 @@ of `'linked'`. A hook that rotates a remote credential should treat `'repaired'`
 as the case that needs confirming, because the credential it is replacing may
 still be live for someone else.
 
-`context.endpoints.areDefault` is `false` when the link was made against
-endpoints set by `VENDURE_CONSOLE_LINK_URL` and `VENDURE_CONSOLE_LINK_API_URL`
-rather than Vendure's own. It is a fact about where the manifest came from, not a
-permission: approving a custom endpoint approves it for creating a Project Link,
-not for receiving anything secret. A hook that holds credentials keeps its own
-list of the hosts it will talk to and refuses when the origins do not match it.
+`context.endpoints.official` names which official Vendure Console the link was
+made against, `'production'` or `'staging'`, and is `undefined` for anything
+else. The pair is matched as a pair, so a production app origin with a staging
+API is not official. A loopback pair is not official either; it is a development
+and test convenience.
+
+It is a fact about where the manifest came from, not a permission. Approving a
+custom endpoint approves it for creating a Project Link, not for receiving
+anything secret. A hook that holds credentials checks `official` before it reads
+a credential file or sends a request, and refuses when it is `undefined`. Do not
+draw the same conclusion from the absence of a custom-endpoint prompt: that
+permits loopback, and this does not.
 
 ### Checking what the installed CLI supports
 

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -833,10 +833,16 @@ manifest on disk and runs the hooks again, with `context.outcome` set to
 `'repaired'`. It does not create a second Project Link, which would abandon the
 first in Console over a problem that is local to the checkout.
 
-That makes `vendure console link` the command a developer runs to put back
-something the project needs and no longer has, such as a credential a hook
-writes. A plugin does not need a repair command of its own, and should send
-people here instead.
+That makes `vendure console link` the command a developer runs to have the
+setup after a link done again. It repairs the setup, not a sign-in: it asks
+Console nothing and opens no browser, so a hook that needs a session it does
+not have still cannot obtain one here. A plugin does not need a repair command
+of its own, and should send people here instead.
+
+Because the manifest may have arrived with a clone, a repair that would run
+hooks names the project and account and asks first. With no hooks registered
+there is nothing to approve and nothing is asked. Non-interactive runs proceed,
+so the backfill works in CI.
 
 `--force` is how a checkout is linked to a **different** Console Project: it
 skips the reuse, creates a new Project Link, and the hooks run with an `outcome`
@@ -844,9 +850,8 @@ of `'linked'`. A hook that rotates a remote credential should treat `'repaired'`
 as the case that needs confirming, because the credential it is replacing may
 still be live for someone else.
 
-`context.endpoints.official` names which official Vendure Console the link was
-made against, `'production'` or `'staging'`, and is `undefined` for anything
-else. The pair is matched as a pair, so a production app origin with a staging
+`context.endpoints.official` names which official Vendure Console this run will
+talk to, `'production'` or `'staging'`, and is `undefined` for anything else. The pair is matched as a pair, so a production app origin with a staging
 API is not official. A loopback pair is not official either; it is a development
 and test convenience.
 
@@ -856,6 +861,12 @@ anything secret. A hook that holds credentials checks `official` before it reads
 a credential file or sends a request, and refuses when it is `undefined`. Do not
 draw the same conclusion from the absence of a custom-endpoint prompt: that
 permits loopback, and this does not.
+
+It describes where this run will talk, not where the manifest came from. The
+manifest records no origin, so on a repair the Console that issued its project
+and account identifiers is unknown, and a `'production'` answer does not vouch
+for them. A hook that acts on the identifiers, rather than only on the origin,
+should treat a repair as unverified provenance.
 
 ### Checking what the installed CLI supports
 

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -769,6 +769,67 @@ different subcommands to one group is not supported: the second registration of
 the group name is a collision, and `replaces: true` is refused once the group has
 been extended. A group and all its subcommands must come from one plugin.
 
+### Running after a project link
+
+`vendure console link` links a checkout to a Vendure Console Project and writes
+the Project Link Manifest. A plugin that has its own setup to do once a project
+is linked, such as obtaining the credentials that project then needs, registers
+an `afterConsoleLink` hook:
+
+```ts
+import { defineCliPlugin } from '@vendure/cli';
+
+export default defineCliPlugin({
+    id: '@example/platform-cli-plugin',
+    commands: [],
+    afterConsoleLink: async context => {
+        // Everything the command already worked out, so the hook never
+        // re-derives it and reaches a different answer.
+        context.reporter.info(`Setting up ${context.manifest.project.name}`);
+        await setUpProject(context.projectRoot, context.manifest.project.id, {
+            signal: context.signal,
+        });
+    },
+});
+```
+
+The hook receives the resolved `projectRoot`, the `manifest` as written and its
+`manifestPath`, the Console `endpoints` the link was made against, the
+`AbortSignal` the command runs under, the command's `reporter`, a `confirm`
+function for yes/no questions, `isNonInteractive`, and whether `--force` was
+given.
+
+Do not replace the `console` command to do this. Linking stays one
+implementation, so every project links the same way whether or not a plugin is
+installed; a second `console` command forks the protocol instead of adding to
+it.
+
+#### What a hook can rely on, and what it cannot
+
+- It never runs before the manifest is on disk, so the link is always recorded
+  by the time it starts.
+- It cannot undo the link. The manifest survives a hook that fails, and the
+  command says so rather than reporting that nothing changed.
+- Hooks run in `vendure.cli.plugins` order, and the first to throw stops the
+  rest.
+- Running `vendure console link` again creates a **new** Project Link rather than
+  repairing the existing one. Work that has to be repeatable, such as replacing
+  a credential a developer has lost, belongs in a command of the plugin's own
+  that reads the existing manifest. Do not send people back to `console link`
+  for it.
+
+Throwing is for work that failed, not for work that cannot be done here. A hook
+that needs an answer it cannot get, such as a sign-in with no terminal attached,
+should say what is missing through `reporter` and return. The command still
+exits 0, because linking is what it was asked to do and it did it.
+
+`context.endpoints.areDefault` is `false` when the link was made against
+endpoints set by `VENDURE_CONSOLE_LINK_URL` and `VENDURE_CONSOLE_LINK_API_URL`
+rather than Vendure's own. It is a fact about where the manifest came from, not a
+permission: approving a custom endpoint approves it for creating a Project Link,
+not for receiving anything secret. A hook that holds credentials keeps its own
+list of the hosts it will talk to and refuses when the origins do not match it.
+
 ### Shared options
 
 Options that apply to more than one command are declared once, at the scope

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -677,8 +677,8 @@ error: unknown command 'plann'
 
 ### Extending an existing command
 
-More than one plugin may need the same command. Vendure Platform adds a
-credential to `vendure dev`, and a Cloud package may need to add to it as well.
+More than one plugin may need the same command. One plugin might add a
+credential to `vendure dev`, and another might need to add to it as well.
 `extendCommands` lets each of them contribute without discarding the others:
 their options are merged onto one command and their decorators are composed.
 
@@ -686,7 +686,7 @@ their options are merged onto one command and their decorators are composed.
 import { defineCliPlugin, readCommandContext, readCommandOptions } from '@vendure/cli';
 
 export default defineCliPlugin({
-    id: '@example/platform-cli-plugin',
+    id: '@example/credentials-cli-plugin',
     commands: [],
     extendCommands: [
         {
@@ -743,16 +743,16 @@ plugin is the outermost wrapper and its decorator runs first**. With:
 {
     "vendure": {
         "cli": {
-            "plugins": ["@example/platform-cli-plugin", "@example/cloud-cli-plugin"]
+            "plugins": ["@example/credentials-cli-plugin", "@example/telemetry-cli-plugin"]
         }
     }
 }
 ```
 
-running `vendure dev` calls the Cloud wrapper, which calls the Platform wrapper,
-which calls the built-in. Each wrapper runs once per invocation. The Cloud
-plugin, being applied last, also sees the option the Platform plugin added in
-its `command` argument; reverse the list and the roles swap.
+running `vendure dev` calls the telemetry wrapper, which calls the credentials
+wrapper, which calls the built-in. Each wrapper runs once per invocation. The
+telemetry plugin, being applied last, also sees the option the credentials
+plugin added in its `command` argument; reverse the list and the roles swap.
 
 #### Adding to a command
 

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -842,7 +842,8 @@ of its own, and should send people here instead.
 Because the manifest may have arrived with a clone, a repair that would run
 hooks names the project and account and asks first. With no hooks registered
 there is nothing to approve and nothing is asked. Non-interactive runs proceed,
-so the backfill works in CI.
+so the backfill works in CI, and `--yes` answers the question in advance for a
+project whose manifest the developer already trusts.
 
 `--force` is how a checkout is linked to a **different** Console Project: it
 skips the reuse, creates a new Project Link, and the hooks run with an `outcome`
@@ -851,22 +852,30 @@ as the case that needs confirming, because the credential it is replacing may
 still be live for someone else.
 
 `context.endpoints.official` names which official Vendure Console this run will
-talk to, `'production'` or `'staging'`, and is `undefined` for anything else. The pair is matched as a pair, so a production app origin with a staging
-API is not official. A loopback pair is not official either; it is a development
-and test convenience.
+talk to, `'production'` or `'staging'`, and is `undefined` for anything else.
+The pair is matched as a pair, so a production app origin with a staging API is
+not official. A loopback pair is not official either; it is a development and
+test convenience.
 
-It is a fact about where the manifest came from, not a permission. Approving a
-custom endpoint approves it for creating a Project Link, not for receiving
-anything secret. A hook that holds credentials checks `official` before it reads
-a credential file or sends a request, and refuses when it is `undefined`. Do not
-draw the same conclusion from the absence of a custom-endpoint prompt: that
-permits loopback, and this does not.
-
-It describes where this run will talk, not where the manifest came from. The
-manifest records no origin, so on a repair the Console that issued its project
-and account identifiers is unknown, and a `'production'` answer does not vouch
-for them. A hook that acts on the identifiers, rather than only on the origin,
+It says where this run will talk, not where the manifest came from. The manifest
+records no origin, so on a repair the Console that issued its project and
+account identifiers is unknown, and a `'production'` answer does not vouch for
+them. A hook that acts on the identifiers, rather than only on the origin,
 should treat a repair as unverified provenance.
+
+It is a fact, not a permission. Approving a custom endpoint approves it for
+creating a Project Link, not for receiving anything secret. A hook that holds
+credentials checks `official` before it reads a credential file or sends a
+request, and refuses when it is `undefined`. Do not draw the same conclusion
+from the absence of a custom-endpoint prompt: that permits loopback, and this
+does not.
+
+Staging is reached by pointing `VENDURE_CONSOLE_LINK_URL` and
+`VENDURE_CONSOLE_LINK_API_URL` at its pair, and that is deliberately not
+prompted for, so anything able to set two environment variables can send a hook
+to staging rather than production with nobody confirming it. Both are Vendure's,
+which is why this is a choice and not a hole, but a hook that must not touch
+staging should compare against `'production'` rather than against `undefined`.
 
 ### Checking what the installed CLI supports
 
@@ -879,7 +888,7 @@ nothing and runs no hook, which is harder to spot than a refusal. Read
 import * as cli from '@vendure/cli';
 
 // Builds older than this constant export nothing, so `undefined` is the answer.
-const supported: readonly string[] = cli.CLI_PLUGIN_EXTENSION_POINTS ?? [];
+const supported = cli.CLI_PLUGIN_EXTENSION_POINTS ?? [];
 if (!supported.includes('afterConsoleLink')) {
     throw new Error('This @vendure/cli is too old to run afterConsoleLink hooks.');
 }

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -986,6 +986,9 @@ argument is mandatory.
 A plugin that would take over or discard something it does not own is not
 registered at all, and the reason is written to stderr. This applies to:
 
+- a plugin `id` that a plugin already applied uses, whatever either of them
+  registers, because the id is what a conflict names and what a hook is
+  recorded against;
 - a top-level command that a built-in or another plugin already provides, unless
   the definition sets `replaces: true`;
 - a replacement of a command that another plugin has extended;

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -357,25 +357,29 @@ Vendure project under `packages`, `apps`, `libs`, `services`, or `modules`. If m
 npx vendure console status --project ./apps/server
 ```
 
-Replacing or removing a manifest requires confirmation. In non-interactive environments, use `--force` to confirm the
-specific action:
+Use `--force` to create a different Project Link for an already-linked project, or to remove its current link without
+confirmation:
 
 ```bash
 npx vendure console link --force
 npx vendure console unlink --force
 ```
 
-`--force` does not bypass ambiguous project selection or a manifest that belongs to another project root.
+`--force` also permits replacement of an invalid manifest. It does not bypass ambiguous project selection or a manifest
+that belongs to another project root.
 
 Running `vendure console link` in a project that is already linked repairs it rather than replacing it: the manifest
 is reused and any plugin setup runs again. Where a plugin is registered, that is confirmed first, because the manifest
-may have arrived with a clone. Use `--yes` to answer that confirmation in advance:
+may have arrived with a clone.
+
+Use `--yes` to answer every confirmation owned by the CLI. This includes manifest changes, custom Console endpoints,
+and plugin setup on a repair. It does not answer questions asked by a plugin hook:
 
 ```bash
 npx vendure console link --yes
 ```
 
-`--force` is different: it links this checkout to a **different** Console Project, which creates a new Project Link.
+On an already-linked project, `--yes` keeps the repair behavior. Only `--force` creates a different Project Link.
 
 ### Manifest and source control
 
@@ -428,8 +432,8 @@ The variables apply only to the unauthenticated Project Link exchange. They do n
 Environment Credentials, Registry access, package downloads, or Vendure Cloud operations.
 
 The CLI rejects partial endpoint configuration and URLs that contain credentials, paths, queries, or fragments. It
-requires HTTPS except for `localhost`, `127.0.0.1`, and `::1`. The production Console and API origins must be used
-together.
+requires HTTPS except for `localhost`, `127.0.0.1`, and `::1`. An official Console app or API origin is accepted only
+with the matching official origin from the same environment.
 
 Before it contacts a custom remote environment, the CLI displays both origins and asks for confirmation. In a
 non-interactive environment, pass `--allow-custom-console` to confirm them explicitly:
@@ -781,10 +785,8 @@ been extended. A group and all its subcommands must come from one plugin.
 
 ### Running after a project link
 
-`vendure console link` links a checkout to a Vendure Console Project and writes
-the Project Link Manifest. A plugin that has its own setup to do once a project
-is linked, such as obtaining the credentials that project then needs, registers
-an `afterConsoleLink` hook:
+Register an `afterConsoleLink` hook when a plugin must run setup after
+`vendure console link` writes or reuses the Project Link Manifest:
 
 ```ts
 import { defineCliPlugin } from '@vendure/cli';
@@ -793,8 +795,6 @@ export default defineCliPlugin({
     id: '@example/setup-cli-plugin',
     commands: [],
     afterConsoleLink: async context => {
-        // Everything the command already worked out, so the hook never
-        // re-derives it and reaches a different answer.
         context.reporter.info(`Setting up ${context.manifest.project.name}`);
         await setUpProject(context.projectRoot, context.manifest.project.id, {
             signal: context.signal,
@@ -803,89 +803,48 @@ export default defineCliPlugin({
 });
 ```
 
-The hook receives the resolved `projectRoot`, the `manifest` and its
-`manifestPath`, the Console `endpoints` the link was made against, whether this
-run linked or repaired (`outcome`), the `AbortSignal` the command runs under,
-the command's `reporter`, a `confirm` function for yes/no questions,
-`isNonInteractive`, and whether `--force` was given. Each hook gets its own
-context, so one hook cannot change what a later one reads.
+The context contains `projectRoot`, `manifest`, `manifestPath`, `endpoints`,
+`outcome`, `signal`, `reporter`, `confirm`, `isNonInteractive`, and `force`.
+Each hook gets its own manifest and endpoint objects.
 
-Do not replace the `console` command to do this. Linking stays one
-implementation, so every project links the same way whether or not a plugin is
-installed; a second `console` command forks the protocol instead of adding to
-it.
+Do not replace the `console` command for post-link setup. Register the hook.
 
-#### What a hook can rely on, and what it cannot
+#### Hook behavior
 
-- It never runs before the manifest is on disk, so the link is always recorded
-  by the time it starts.
-- It cannot undo the link. The manifest survives a hook that fails, and the
-  command says so rather than reporting that nothing changed.
-- Hooks run in `vendure.cli.plugins` order, and the first to throw stops the
-  rest.
-- It has to be repeatable, because `vendure console link` repairs a link as well
-  as making one (see below).
+- Hooks run after the manifest is on disk.
+- Hooks run in `vendure.cli.plugins` order. The first thrown error stops the rest.
+- A hook failure does not remove the manifest.
+- Hooks must be repeatable because a repair runs them again.
 
-Throwing is for work that failed, not for work that cannot be done here. A hook
-that needs something it cannot get in this run should say what is missing
-through `reporter` and return. The command still exits 0, because linking is
-what it was asked to do and it did it.
+Throw when setup fails. If the hook cannot run in the current environment,
+report what the user must do and return.
 
-`context.confirm` asks a yes/no question and rejects when `isNonInteractive` is
-`true`, since there is nobody to answer. Check `isNonInteractive` first.
-Multi-choice questions belong in the plugin's own command, where it owns the
-whole screen.
+Check `context.isNonInteractive` before calling `context.confirm`. The confirm
+function rejects in a non-interactive run. Put multi-choice setup in a plugin
+command.
 
 #### Repeating a link repairs it
 
-Run `vendure console link` in a project that is already linked and it reuses the
-manifest on disk and runs the hooks again, with `context.outcome` set to
-`'repaired'`. It does not create a second Project Link, which would abandon the
-first in Console over a problem that is local to the checkout.
+In an already-linked project, `vendure console link` reuses the manifest and
+runs hooks with `context.outcome` set to `'repaired'`. The repair makes no
+Console request and does not open a browser.
 
-That makes `vendure console link` the command a developer runs to have the
-setup after a link done again. It repairs the setup, not a sign-in: it asks
-Console nothing and opens no browser, so a hook that needs a session it does
-not have still cannot obtain one here. A plugin does not need a repair command
-of its own, and should send people here instead.
+An interactive repair names the project and account before it runs hooks. Pass
+`--yes` to answer this CLI confirmation in advance. The CLI asks nothing when
+no hooks are registered or when the run is non-interactive.
 
-Because the manifest may have arrived with a clone, a repair that would run
-hooks names the project and account and asks first. With no hooks registered
-there is nothing to approve and nothing is asked. Non-interactive runs proceed,
-so the backfill works in CI, and `--yes` answers the question in advance for a
-project whose manifest the developer already trusts.
-
-`--force` is how a checkout is linked to a **different** Console Project: it
+`--force` links a checkout to a **different** Console Project. It
 skips the reuse, creates a new Project Link, and the hooks run with an `outcome`
-of `'linked'`. A hook that rotates a remote credential should treat `'repaired'`
-as the case that needs confirming, because the credential it is replacing may
-still be live for someone else.
+of `'linked'`.
 
-`context.endpoints.official` names which official Vendure Console this run will
-talk to, `'production'` or `'staging'`, and is `undefined` for anything else.
-The pair is matched as a pair, so a production app origin with a staging API is
-not official. A loopback pair is not official either; it is a development and
-test convenience.
+If a hook must run only against production, require
+`context.endpoints.official === 'production'`. The value is `'staging'` for the
+official staging pair and `undefined` for custom or loopback origins. A custom
+endpoint confirmation does not authorize a hook to send credentials there.
 
-`official` says where this run will talk, not where the manifest came from. The
-manifest records no origin, so on a repair the Console that issued its project
-and account identifiers is unknown, and a `'production'` answer does not vouch
-for them. A hook that acts on the identifiers, rather than only on the origin,
-should treat a repair as unverified provenance.
-
-`official` is a fact, not a permission. Approving a custom endpoint approves it for
-creating a Project Link, not for receiving anything secret. A hook that holds
-credentials checks `official` before it reads a credential file or sends a
-request, and refuses when it is `undefined`. Do not draw the same conclusion
-from the absence of a custom-endpoint prompt: that permits loopback, and this
-does not.
-
-Staging is reached by pointing `VENDURE_CONSOLE_LINK_URL` and
-`VENDURE_CONSOLE_LINK_API_URL` at its pair, and that is deliberately not
-prompted for, so anything able to set two environment variables can send a hook
-to staging rather than production with nobody confirming it. Both are Vendure's,
-which is why this is a choice and not a hole, but a hook that must not touch
-staging should compare against `'production'` rather than against `undefined`.
+The value describes the origins for the current run. The manifest does not
+record its source origin, so a repair cannot verify where its identifiers came
+from.
 
 ### Checking what the installed CLI supports
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,7 +4,6 @@ import { Command } from 'commander';
 import pc from 'picocolors';
 
 import { builtinCommandDefs } from './commands/builtins';
-import { setConsoleLinkHooks } from './commands/console/console-link-hook';
 import { registerCommands } from './shared/command-registry';
 import { CommandRegistry } from './shared/command-registry-store';
 import {
@@ -62,11 +61,9 @@ Y88  88P 88888888 888  888 888  888 888  888 888    88888888
         }
     }
 
-    // The `console` command is a static definition, so the hooks reach it from
-    // here rather than it reaching into the registry.
-    setConsoleLinkHooks(registry.getConsoleLinkHooks());
-
-    registerCommands(program, registry.toArray(), registry.getRootOptions());
+    registerCommands(program, registry.toArray(), registry.getRootOptions(), extensionPoint =>
+        registry.getPluginExtensions(extensionPoint),
+    );
 
     program.on('command:*', operands => {
         const unknown = operands[0] ?? '';

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 import pc from 'picocolors';
 
 import { builtinCommandDefs } from './commands/builtins';
+import { setConsoleLinkHooks } from './commands/console/console-link-hook';
 import { registerCommands } from './shared/command-registry';
 import { CommandRegistry } from './shared/command-registry-store';
 import {
@@ -60,6 +61,10 @@ Y88  88P 88888888 888  888 888  888 888  888 888    88888888
             writePluginSkipped(packageName, 'Failed to register CLI plugin', reason);
         }
     }
+
+    // The `console` command is a static definition, so the hooks reach it from
+    // here rather than it reaching into the registry.
+    setConsoleLinkHooks(registry.getConsoleLinkHooks());
 
     registerCommands(program, registry.toArray(), registry.getRootOptions());
 

--- a/packages/cli/src/commands/console/command.spec.ts
+++ b/packages/cli/src/commands/console/command.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { consoleCommandDef } from './command';
+
+describe('console command definition', () => {
+    // Every other test calls `consoleCommand` directly, so the flags the person
+    // actually types were reachable only through this file.
+    it.each(['--allow-custom-console', '--project <path>', '--force', '--yes'])('registers %s', flag => {
+        expect(consoleCommandDef.options?.map(option => option.long)).toContain(flag);
+    });
+
+    it('takes the action as an optional argument', () => {
+        expect(consoleCommandDef.arguments?.[0]).toMatchObject({ name: 'action', required: false });
+    });
+});

--- a/packages/cli/src/commands/console/command.spec.ts
+++ b/packages/cli/src/commands/console/command.spec.ts
@@ -12,4 +12,16 @@ describe('console command definition', () => {
     it('takes the action as an optional argument', () => {
         expect(consoleCommandDef.arguments?.[0]).toMatchObject({ name: 'action', required: false });
     });
+
+    it('describes --force as creating a different link or removing the current one', () => {
+        expect(consoleCommandDef.options?.find(option => option.long === '--force')?.description).toBe(
+            'Create a different Project Link or remove the current link without confirmation',
+        );
+    });
+
+    it('describes --yes as answering every CLI confirmation', () => {
+        expect(consoleCommandDef.options?.find(option => option.long === '--yes')?.description).toBe(
+            'Answer every CLI confirmation. Plugin hooks can still ask their own questions.',
+        );
+    });
 });

--- a/packages/cli/src/commands/console/command.ts
+++ b/packages/cli/src/commands/console/command.ts
@@ -1,5 +1,7 @@
-import { CliCommandDefinition } from '../../shared/cli-command-definition';
+import { CliCommandContext, CliCommandDefinition } from '../../shared/cli-command-definition';
 import { runCliCommand } from '../../shared/cli-command-exit';
+
+import { ConsoleLinkHook } from './console-link-hook';
 
 export const consoleCommandDef: CliCommandDefinition = {
     name: 'console',
@@ -24,21 +26,22 @@ export const consoleCommandDef: CliCommandDefinition = {
         },
         {
             long: '--force',
-            description: 'Confirm replacement or unlink without an interactive prompt',
+            description: 'Create a different Project Link or remove the current link without confirmation',
             required: false,
         },
         {
             long: '--yes',
-            description:
-                "Answer the CLI's own confirmation before it runs plugin setup for an " +
-                'already-linked project. A plugin still asks its own questions.',
+            description: 'Answer every CLI confirmation. Plugin hooks can still ask their own questions.',
             required: false,
         },
     ],
-    action: async (action, options) => {
+    action: async (action, options, _command, context: CliCommandContext) => {
         return runCliCommand(async () => {
             const { consoleCommand } = await import('./console');
-            return consoleCommand(action, options);
+            const hooks = context
+                .getPluginExtensions<ConsoleLinkHook>('afterConsoleLink')
+                .map(({ pluginId, extension: hook }) => ({ pluginId, hook }));
+            return consoleCommand(action, options, { hooks });
         });
     },
 };

--- a/packages/cli/src/commands/console/command.ts
+++ b/packages/cli/src/commands/console/command.ts
@@ -27,6 +27,11 @@ export const consoleCommandDef: CliCommandDefinition = {
             description: 'Confirm replacement or unlink without an interactive prompt',
             required: false,
         },
+        {
+            long: '--yes',
+            description: 'Run plugin setup for an already-linked project without an interactive prompt',
+            required: false,
+        },
     ],
     action: async (action, options) => {
         return runCliCommand(async () => {

--- a/packages/cli/src/commands/console/command.ts
+++ b/packages/cli/src/commands/console/command.ts
@@ -29,7 +29,9 @@ export const consoleCommandDef: CliCommandDefinition = {
         },
         {
             long: '--yes',
-            description: 'Run plugin setup for an already-linked project without an interactive prompt',
+            description:
+                "Answer the CLI's own confirmation before it runs plugin setup for an " +
+                'already-linked project. A plugin still asks its own questions.',
             required: false,
         },
     ],

--- a/packages/cli/src/commands/console/console-link-hook.spec.ts
+++ b/packages/cli/src/commands/console/console-link-hook.spec.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { CliCommandExit } from '../../shared/cli-command-exit';
 import { CLI_PLUGIN_EXTENSION_POINTS, defineCliPlugin } from '../../shared/cli-plugin';
 import { CommandRegistry } from '../../shared/command-registry-store';
 import { builtinCommandDefs } from '../builtins';
@@ -55,6 +56,7 @@ describe('console link hooks', () => {
         expect(context.manifestPath).toBe(getProjectLinkManifestPath(root));
         expect(context.manifest).toEqual(manifest);
         expect(context.force).toBe(false);
+        expect(context.outcome).toBe('linked');
         expect(context.isNonInteractive).toBe(true);
         expect(context.signal.aborted).toBe(false);
         // A loopback Console is not the production pair, so a hook holding
@@ -225,6 +227,114 @@ describe('console link hooks', () => {
         expect(CLI_PLUGIN_EXTENSION_POINTS).toContain('afterConsoleLink');
         expect(CLI_PLUGIN_EXTENSION_POINTS).toContain('extendCommands');
         expect(Object.isFrozen(CLI_PLUGIN_EXTENSION_POINTS)).toBe(true);
+    });
+
+    it('runs the hooks again for a project that is already linked, without a second Project Link', async () => {
+        const contexts: ConsoleLinkContext[] = [];
+        const registry = registryWith(
+            plugin(PLATFORM_ID, async received => {
+                contexts.push(received);
+            }),
+        );
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const fetchMock = vi.fn() as unknown as typeof fetch;
+
+        const exitCode = await consoleCommand(
+            'link',
+            {},
+            { ...offlineDependencies(root), fetch: fetchMock, hooks: registry.getConsoleLinkHooks() },
+        );
+
+        expect(exitCode).toBe(0);
+        // Repair is local. Nothing is asked of Console, so no second Project
+        // Link is minted and the first is not abandoned.
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+        expect(contexts).toHaveLength(1);
+        expect(contexts[0].outcome).toBe('repaired');
+        expect(contexts[0].manifest).toEqual(manifest);
+        expect(contexts[0].manifestPath).toBe(getProjectLinkManifestPath(root));
+    });
+
+    it('reports a repair that did not finish without claiming the link changed', async () => {
+        const registry = registryWith(
+            plugin(PLATFORM_ID, async () => {
+                throw new Error('Console rejected the credential request.');
+            }),
+        );
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const messages: string[] = [];
+
+        const exitCode = await consoleCommand(
+            'link',
+            {},
+            { ...offlineDependencies(root, messages), hooks: registry.getConsoleLinkHooks() },
+        );
+
+        expect(exitCode).toBe(1);
+        const output = messages.join('\n');
+        expect(output).toContain('was not changed');
+        expect(output).not.toContain('The link succeeded');
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+    });
+
+    it('gives each hook its own context, so one cannot decide what the next reads', async () => {
+        const seen: Array<{ areDefault: boolean; projectName: string }> = [];
+        const registry = registryWith(
+            plugin(PLATFORM_ID, async context => {
+                // `areDefault` is the fact a hook holding a credential checks
+                // before it sends anything, so the plugin listed first must not
+                // be able to answer it for the plugin listed second.
+                context.endpoints.areDefault = true;
+                context.manifest.project.name = 'Tampered';
+            }),
+            plugin(CLOUD_ID, async context => {
+                seen.push({
+                    areDefault: context.endpoints.areDefault,
+                    projectName: context.manifest.project.name,
+                });
+            }),
+        );
+        const root = vendureProject();
+        const test = await runLink(root, registry);
+
+        expect(test.exitCode).toBe(0);
+        expect(seen).toEqual([{ areDefault: false, projectName: manifest.project.name }]);
+    });
+
+    it('refuses a hook confirmation when there is nobody to answer it', async () => {
+        let refusal: string | undefined;
+        const registry = registryWith(
+            plugin(PLATFORM_ID, async context => {
+                // The hook ignored `isNonInteractive`. Prompting here would
+                // write a question into a pipe and then wait for an answer.
+                await context.confirm('Replace the stored credential?').catch((error: Error) => {
+                    refusal = error.message;
+                    throw error;
+                });
+            }),
+        );
+        const root = vendureProject();
+        const test = await runLink(root, registry);
+
+        expect(test.exitCode).toBe(1);
+        expect(refusal).toContain('non-interactive');
+        expect(test.messages.join('\n')).toContain('context.isNonInteractive');
+    });
+
+    it('lets the CLI host own an exit a hook asked for', async () => {
+        const registry = registryWith(
+            plugin(PLATFORM_ID, async () => {
+                throw new CliCommandExit(2);
+            }),
+        );
+        const root = vendureProject();
+
+        await expect(runLink(root, registry)).rejects.toBeInstanceOf(CliCommandExit);
     });
 
     it('rejects a plugin whose afterConsoleLink is not a function', () => {

--- a/packages/cli/src/commands/console/console-link-hook.spec.ts
+++ b/packages/cli/src/commands/console/console-link-hook.spec.ts
@@ -59,9 +59,9 @@ describe('console link hooks', () => {
         expect(context.outcome).toBe('linked');
         expect(context.isNonInteractive).toBe(true);
         expect(context.signal.aborted).toBe(false);
-        // A loopback Console is not the production pair, so a hook holding
+        // A loopback Console is not an official origin, so a hook holding
         // credentials is told plainly that it is not talking to Vendure.
-        expect(context.endpoints.areDefault).toBe(false);
+        expect(context.endpoints.official).toBeUndefined();
         expect(context.endpoints.apiUrl).toBe(test.apiUrl);
     });
 
@@ -283,18 +283,18 @@ describe('console link hooks', () => {
     });
 
     it('gives each hook its own context, so one cannot decide what the next reads', async () => {
-        const seen: Array<{ areDefault: boolean; projectName: string }> = [];
+        const seen: Array<{ official: string | undefined; projectName: string }> = [];
         const registry = registryWith(
             plugin(PLATFORM_ID, async context => {
-                // `areDefault` is the fact a hook holding a credential checks
+                // `official` is the fact a hook holding a credential checks
                 // before it sends anything, so the plugin listed first must not
                 // be able to answer it for the plugin listed second.
-                context.endpoints.areDefault = true;
+                context.endpoints.official = 'production';
                 context.manifest.project.name = 'Tampered';
             }),
             plugin(CLOUD_ID, async context => {
                 seen.push({
-                    areDefault: context.endpoints.areDefault,
+                    official: context.endpoints.official,
                     projectName: context.manifest.project.name,
                 });
             }),
@@ -303,7 +303,7 @@ describe('console link hooks', () => {
         const test = await runLink(root, registry);
 
         expect(test.exitCode).toBe(0);
-        expect(seen).toEqual([{ areDefault: false, projectName: manifest.project.name }]);
+        expect(seen).toEqual([{ official: undefined, projectName: manifest.project.name }]);
     });
 
     it('refuses a hook confirmation when there is nobody to answer it', async () => {

--- a/packages/cli/src/commands/console/console-link-hook.spec.ts
+++ b/packages/cli/src/commands/console/console-link-hook.spec.ts
@@ -1,0 +1,340 @@
+import fs from 'fs-extra';
+import { IncomingMessage, Server, ServerResponse, createServer } from 'node:http';
+import { AddressInfo } from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { defineCliPlugin } from '../../shared/cli-plugin';
+import { CommandRegistry } from '../../shared/command-registry-store';
+import { builtinCommandDefs } from '../builtins';
+
+import { ConsoleCommandDependencies, ConsoleReporter, consoleCommand } from './console';
+import { ConsoleLinkContext, ConsoleLinkHook } from './console-link-hook';
+import { LINK_ID, POLLING_SECRET, manifest } from './console.fixtures';
+import { getProjectLinkManifestPath } from './project-link-manifest';
+
+const PLATFORM_ID = '@vendure-platform/cli';
+const CLOUD_ID = '@vendure/cloud';
+
+const temporaryDirectories: string[] = [];
+let server: Server | undefined;
+
+afterEach(async () => {
+    vi.restoreAllMocks();
+    if (server) {
+        await new Promise<void>((resolve, reject) =>
+            server?.close(error => (error ? reject(error) : resolve())),
+        );
+        server = undefined;
+    }
+    for (const directory of temporaryDirectories.splice(0)) {
+        fs.removeSync(directory);
+    }
+});
+
+describe('console link hooks', () => {
+    it('runs a plugin hook once after a link, with what the command already resolved', async () => {
+        const contexts: ConsoleLinkContext[] = [];
+        const registry = registryWith(
+            plugin(PLATFORM_ID, async received => {
+                contexts.push(received);
+            }),
+        );
+        const root = vendureProject();
+        const test = await runLink(root, registry);
+
+        expect(test.exitCode).toBe(0);
+        // The OSS protocol ran exactly once: one create, one poll.
+        expect(test.requestPaths).toEqual(['/v1/project-links', `/v1/project-links/${LINK_ID}/poll`]);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+
+        expect(contexts).toHaveLength(1);
+        const context = contexts[0];
+        expect(context.projectRoot).toBe(root);
+        expect(context.manifestPath).toBe(getProjectLinkManifestPath(root));
+        expect(context.manifest).toEqual(manifest);
+        expect(context.force).toBe(false);
+        expect(context.isNonInteractive).toBe(true);
+        expect(context.signal.aborted).toBe(false);
+        // A loopback Console is not the production pair, so a hook holding
+        // credentials is told plainly that it is not talking to Vendure.
+        expect(context.endpoints.areDefault).toBe(false);
+        expect(context.endpoints.apiUrl).toBe(test.apiUrl);
+    });
+
+    it('links the same way when no plugin registers a hook', async () => {
+        const root = vendureProject();
+        const test = await runLink(root, registryWith());
+
+        expect(test.exitCode).toBe(0);
+        expect(test.requestPaths).toEqual(['/v1/project-links', `/v1/project-links/${LINK_ID}/poll`]);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+    });
+
+    it('runs hooks in plugin order and stops at the first failure', async () => {
+        const trace: string[] = [];
+        const registry = registryWith(
+            plugin(PLATFORM_ID, async () => {
+                trace.push(PLATFORM_ID);
+                throw new Error('Console rejected the credential request.');
+            }),
+            plugin(CLOUD_ID, async () => {
+                trace.push(CLOUD_ID);
+            }),
+        );
+        const root = vendureProject();
+        const test = await runLink(root, registry);
+
+        expect(trace).toEqual([PLATFORM_ID]);
+        expect(test.exitCode).toBe(1);
+        // The link is not rolled back, and the report says so rather than
+        // leaving the reader to guess what survived.
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+        const output = test.messages.join('\n');
+        expect(output).toContain(`The ${PLATFORM_ID} plugin failed after linking`);
+        expect(output).toContain('Console rejected the credential request.');
+        expect(output).toContain('The link succeeded');
+        // Repairing a credential store must not be sold as another link, which
+        // would mint a second Project Link in Console.
+        expect(output).not.toContain('vendure console link again');
+    });
+
+    it('keeps the exit code at 0 when a hook reports that it could not finish', async () => {
+        const registry = registryWith(
+            plugin(PLATFORM_ID, async context => {
+                context.reporter.warn('No Console session on this machine. Run "vendure platform repair".');
+            }),
+        );
+        const root = vendureProject();
+        const test = await runLink(root, registry);
+
+        // Linking is what the command was asked to do, and it did it.
+        expect(test.exitCode).toBe(0);
+        expect(test.messages.join('\n')).toContain('vendure platform repair');
+    });
+
+    it('does not claim nothing changed when interrupted after the manifest is written', async () => {
+        const abort = new AbortController();
+        const registry = registryWith(
+            plugin(PLATFORM_ID, async () => {
+                abort.abort();
+                throw new Error('aborted while issuing a credential');
+            }),
+        );
+        const root = vendureProject();
+        const test = await runLink(root, registry, { signal: abort.signal });
+
+        expect(test.exitCode).toBe(130);
+        expect(fs.existsSync(getProjectLinkManifestPath(root))).toBe(true);
+        const output = test.messages.join('\n');
+        expect(output).toContain('The link succeeded');
+        expect(output).not.toContain('No Project Link Manifest was changed');
+    });
+
+    it('does not run hooks for status, unlink or an unknown action', async () => {
+        const hook = vi.fn<ConsoleLinkHook>(async () => undefined);
+        const registry = registryWith(plugin(PLATFORM_ID, hook));
+        const root = vendureProject();
+        const hooks = registry.getConsoleLinkHooks();
+
+        for (const action of ['status', 'unlink', 'nonsense']) {
+            await consoleCommand(action, {}, { ...offlineDependencies(root), hooks });
+        }
+
+        expect(hook).not.toHaveBeenCalled();
+    });
+
+    it('does not run hooks when a link is refused before any request', async () => {
+        const hook = vi.fn<ConsoleLinkHook>(async () => undefined);
+        const registry = registryWith(plugin(PLATFORM_ID, hook));
+        const fetchMock = vi.fn() as unknown as typeof fetch;
+        const root = vendureProject();
+
+        const exitCode = await consoleCommand(
+            'link',
+            {},
+            {
+                ...offlineDependencies(root),
+                // A custom remote Console with no approval, so the command
+                // stops before it creates anything.
+                env: {
+                    VENDURE_CLI_NON_INTERACTIVE: 'true',
+                    VENDURE_CONSOLE_LINK_URL: 'https://console.staging.example.com',
+                    VENDURE_CONSOLE_LINK_API_URL: 'https://api.staging.example.com',
+                },
+                fetch: fetchMock,
+                hooks: registry.getConsoleLinkHooks(),
+            },
+        );
+
+        expect(exitCode).toBe(1);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(hook).not.toHaveBeenCalled();
+    });
+
+    it('registers no hook for a plugin the registry rejected', () => {
+        const registry = registryWith();
+        const rejected = defineCliPlugin({
+            id: PLATFORM_ID,
+            // `console` is already a built-in and this does not set
+            // `replaces`, so the whole plugin is refused.
+            commands: [{ name: 'console', description: 'Shadowed console', action: async () => 0 }],
+            afterConsoleLink: async () => undefined,
+        });
+
+        expect(() => registry.applyPlugin(rejected)).toThrow();
+        expect(registry.getConsoleLinkHooks()).toEqual([]);
+    });
+
+    it('lets one plugin both extend the console command and register a hook', async () => {
+        const trace: string[] = [];
+        const registry = registryWith();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: PLATFORM_ID,
+                commands: [],
+                extendCommands: [
+                    {
+                        command: 'console',
+                        decorate:
+                            ({ next }) =>
+                            async (...args) => {
+                                trace.push('decorator');
+                                return next(...args);
+                            },
+                    },
+                ],
+                afterConsoleLink: async () => {
+                    trace.push('hook');
+                },
+            }),
+        );
+
+        expect(registry.getConsoleLinkHooks().map(entry => entry.pluginId)).toEqual([PLATFORM_ID]);
+        const root = vendureProject();
+        const test = await runLink(root, registry);
+
+        expect(test.exitCode).toBe(0);
+        expect(trace).toEqual(['hook']);
+    });
+
+    it('rejects a plugin whose afterConsoleLink is not a function', () => {
+        expect(() =>
+            defineCliPlugin({
+                id: PLATFORM_ID,
+                commands: [],
+                afterConsoleLink: 'not a function' as unknown as ConsoleLinkHook,
+            }),
+        ).toThrow('afterConsoleLink must be a function');
+    });
+});
+
+function plugin(id: string, afterConsoleLink: ConsoleLinkHook) {
+    return defineCliPlugin({ id, commands: [], afterConsoleLink });
+}
+
+/**
+ * A registry holding the real built-in commands, so `console` is registered the
+ * way the host registers it and a plugin meets the same collision rules.
+ */
+function registryWith(...plugins: Array<ReturnType<typeof plugin>>): CommandRegistry {
+    const registry = new CommandRegistry();
+    registry.registerAll(builtinCommandDefs);
+    for (const entry of plugins) {
+        registry.applyPlugin(entry);
+    }
+    return registry;
+}
+
+/**
+ * Runs `vendure console link` against a local Console that completes the
+ * protocol, with the hooks the registry collected.
+ */
+async function runLink(
+    root: string,
+    registry: CommandRegistry,
+    overrides: Partial<ConsoleCommandDependencies> = {},
+): Promise<{ exitCode: number; messages: string[]; requestPaths: string[]; apiUrl: string }> {
+    const requestPaths: string[] = [];
+    server = createServer((request, response) => {
+        requestPaths.push(request.url ?? '');
+        respondAsConsole(request, response);
+    });
+    await new Promise<void>(resolve => server?.listen(0, '127.0.0.1', resolve));
+    const apiUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+
+    const messages: string[] = [];
+    const exitCode = await consoleCommand(
+        'link',
+        {},
+        {
+            ...offlineDependencies(root, messages),
+            env: {
+                VENDURE_CLI_NON_INTERACTIVE: 'true',
+                VENDURE_CONSOLE_LINK_URL: 'http://localhost:3000',
+                VENDURE_CONSOLE_LINK_API_URL: apiUrl,
+            },
+            fetch: globalThis.fetch,
+            hooks: registry.getConsoleLinkHooks(),
+            ...overrides,
+        },
+    );
+
+    return { exitCode, messages, requestPaths, apiUrl };
+}
+
+function offlineDependencies(root: string, messages: string[] = []): Partial<ConsoleCommandDependencies> {
+    const reporter: ConsoleReporter = {
+        error: message => messages.push(message),
+        info: message => messages.push(message),
+        success: message => messages.push(message),
+        warn: message => messages.push(message),
+        url: value => messages.push(value),
+    };
+    return {
+        cwd: root,
+        env: { VENDURE_CLI_NON_INTERACTIVE: 'true' },
+        fetch: vi.fn() as unknown as typeof fetch,
+        hooks: [],
+        isNonInteractive: () => true,
+        openUrl: () => Promise.resolve(),
+        prompt: () => Promise.resolve(true),
+        reporter,
+        sleep: () => Promise.resolve(),
+    };
+}
+
+function respondAsConsole(request: IncomingMessage, response: ServerResponse): void {
+    request.resume();
+    response.setHeader('Content-Type', 'application/json');
+    if (request.url === '/v1/project-links') {
+        response.end(
+            JSON.stringify({
+                id: LINK_ID,
+                state: 'pending',
+                protocolVersion: 1,
+                expiresAt: new Date(Date.now() + 60_000).toISOString(),
+                pollingSecret: POLLING_SECRET,
+                verificationPath: `/?link=${LINK_ID}`,
+            }),
+        );
+        return;
+    }
+    response.end(
+        JSON.stringify({
+            state: 'approved',
+            expiresAt: new Date(Date.now() + 60_000).toISOString(),
+            manifest,
+        }),
+    );
+}
+
+function vendureProject(): string {
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'vendure-console-hook-')));
+    temporaryDirectories.push(root);
+    fs.writeJsonSync(path.join(root, 'package.json'), {
+        dependencies: { '@vendure/core': '3.7.2' },
+    });
+    return root;
+}

--- a/packages/cli/src/commands/console/console-link-hook.spec.ts
+++ b/packages/cli/src/commands/console/console-link-hook.spec.ts
@@ -10,8 +10,9 @@ import { CLI_PLUGIN_EXTENSION_POINTS, defineCliPlugin } from '../../shared/cli-p
 import { CommandRegistry } from '../../shared/command-registry-store';
 import { builtinCommandDefs } from '../builtins';
 
-import { ConsoleCommandDependencies, ConsoleReporter, consoleCommand } from './console';
+import { ConsoleCommandDependencies, consoleCommand } from './console';
 import { ConsoleLinkContext, ConsoleLinkHook } from './console-link-hook';
+import { ConsoleReporter } from './console-reporter';
 import { LINK_ID, POLLING_SECRET, manifest } from './console.fixtures';
 import { getProjectLinkManifestPath } from './project-link-manifest';
 
@@ -59,7 +60,6 @@ describe('console link hooks', () => {
         expect(context.force).toBe(false);
         expect(context.outcome).toBe('linked');
         expect(context.isNonInteractive).toBe(true);
-        expect(context.signal.aborted).toBe(false);
         // A loopback Console is not an official origin, so a hook holding
         // credentials is told plainly that it is not talking to Vendure.
         expect(context.endpoints.official).toBeUndefined();
@@ -99,7 +99,7 @@ describe('console link hooks', () => {
         expect(output).toContain('Console rejected the credential request.');
         expect(output).toContain('The link succeeded');
         // Repairing a credential store must not be sold as another link, which
-        // would mint a second Project Link in Console.
+        // would create a second Project Link in Console.
         expect(output).not.toContain('vendure console link again');
     });
 
@@ -138,15 +138,12 @@ describe('console link hooks', () => {
         expect(output).not.toContain('No Project Link Manifest was changed');
     });
 
-    it('does not run hooks for status, unlink or an unknown action', async () => {
+    it.each(['status', 'unlink', 'nonsense'])('does not run hooks for %s', async action => {
         const hook = vi.fn<ConsoleLinkHook>(async () => undefined);
         const registry = registryWith(plugin(FIRST_PLUGIN, hook));
         const root = vendureProject();
-        const hooks = registry.getConsoleLinkHooks();
 
-        for (const action of ['status', 'unlink', 'nonsense']) {
-            await consoleCommand(action, {}, { ...offlineDependencies(root), hooks });
-        }
+        await consoleCommand(action, {}, { ...offlineDependencies(root), hooks: consoleLinkHooks(registry) });
 
         expect(hook).not.toHaveBeenCalled();
     });
@@ -170,7 +167,7 @@ describe('console link hooks', () => {
                     VENDURE_CONSOLE_LINK_API_URL: 'https://api.staging.example.com',
                 },
                 fetch: fetchMock,
-                hooks: registry.getConsoleLinkHooks(),
+                hooks: consoleLinkHooks(registry),
             },
         );
 
@@ -190,7 +187,7 @@ describe('console link hooks', () => {
         });
 
         expect(() => registry.applyPlugin(rejected)).toThrow();
-        expect(registry.getConsoleLinkHooks()).toEqual([]);
+        expect(registry.getPluginExtensions('afterConsoleLink')).toEqual([]);
     });
 
     it('lets one plugin both extend the console command and register a hook', async () => {
@@ -217,7 +214,9 @@ describe('console link hooks', () => {
             }),
         );
 
-        expect(registry.getConsoleLinkHooks().map(entry => entry.pluginId)).toEqual([FIRST_PLUGIN]);
+        expect(registry.getPluginExtensions('afterConsoleLink').map(entry => entry.pluginId)).toEqual([
+            FIRST_PLUGIN,
+        ]);
         const root = vendureProject();
         const test = await runLink(root, registry);
 
@@ -228,8 +227,13 @@ describe('console link hooks', () => {
     it('names afterConsoleLink as a supported extension point at runtime', () => {
         // A plugin resolving an older CLI gets `undefined` here, which is how
         // it tells that its hook would be accepted and then never run.
-        expect(CLI_PLUGIN_EXTENSION_POINTS).toContain('afterConsoleLink');
-        expect(CLI_PLUGIN_EXTENSION_POINTS).toContain('extendCommands');
+        expect(CLI_PLUGIN_EXTENSION_POINTS).toEqual([
+            'commands',
+            'rootOptions',
+            'subcommands',
+            'extendCommands',
+            'afterConsoleLink',
+        ]);
         expect(Object.isFrozen(CLI_PLUGIN_EXTENSION_POINTS)).toBe(true);
     });
 
@@ -248,12 +252,12 @@ describe('console link hooks', () => {
         const exitCode = await consoleCommand(
             'link',
             {},
-            { ...offlineDependencies(root), fetch: fetchMock, hooks: registry.getConsoleLinkHooks() },
+            { ...offlineDependencies(root), fetch: fetchMock, hooks: consoleLinkHooks(registry) },
         );
 
         expect(exitCode).toBe(0);
         // Repair is local. Nothing is asked of Console, so no second Project
-        // Link is minted and the first is not abandoned.
+        // Link is created and the first is not abandoned.
         expect(fetchMock).not.toHaveBeenCalled();
         expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
         expect(contexts).toHaveLength(1);
@@ -276,7 +280,7 @@ describe('console link hooks', () => {
         const exitCode = await consoleCommand(
             'link',
             {},
-            { ...offlineDependencies(root, messages), hooks: registry.getConsoleLinkHooks() },
+            { ...offlineDependencies(root, messages), hooks: consoleLinkHooks(registry) },
         );
 
         expect(exitCode).toBe(1);
@@ -333,9 +337,13 @@ describe('console link hooks', () => {
     // Zero as well as non-zero: `exitCliCommand(0)` is how every built-in
     // prompt reports a cancellation, so a hook driving one unwinds through here
     // with a code that means "stopped", not "nothing happened".
-    it.each([0, 2])('says what survived when a hook exits with code %i', async exitCode => {
+    it.each([
+        { exitCode: 0, level: 'warn' as const },
+        { exitCode: 2, level: 'error' as const },
+    ])('preserves exit code $exitCode and reports at $level level', async ({ exitCode, level }) => {
         const trace: string[] = [];
         const messages: string[] = [];
+        const reports: Array<{ level: keyof ConsoleReporter; message: string }> = [];
         const registry = registryWith(
             plugin(FIRST_PLUGIN, async () => {
                 trace.push(FIRST_PLUGIN);
@@ -348,15 +356,34 @@ describe('console link hooks', () => {
         const root = vendureProject();
 
         await expect(
-            runLink(root, registry, { reporter: recordingReporter(messages) }),
-        ).rejects.toBeInstanceOf(CliCommandExit);
+            runLink(root, registry, { reporter: recordingReporter(messages, reports) }),
+        ).rejects.toMatchObject({ exitCode });
         // The hooks after it did not run, and the reader is told so rather than
         // being left with an exit code and a success message.
         expect(trace).toEqual([FIRST_PLUGIN]);
         const output = messages.join('\n');
         expect(output).toContain(`The ${FIRST_PLUGIN} plugin stopped the run after linking`);
+        expect(reports).toContainEqual({
+            level,
+            message: `The ${FIRST_PLUGIN} plugin stopped the run after linking.`,
+        });
         expect(output).toContain('The link succeeded');
         expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+    });
+
+    it('snapshots non-interactive mode once for a hook context and its confirm function', async () => {
+        const isNonInteractive = vi.fn().mockReturnValueOnce(true).mockReturnValue(false);
+        const registry = registryWith(
+            plugin(FIRST_PLUGIN, async context => {
+                expect(context.isNonInteractive).toBe(true);
+                await expect(context.confirm('Continue?')).rejects.toThrow('non-interactive');
+            }),
+        );
+
+        const test = await runLink(vendureProject(), registry, { isNonInteractive });
+
+        expect(test.exitCode).toBe(0);
+        expect(isNonInteractive).toHaveBeenCalledTimes(1);
     });
 
     it('rejects a plugin whose afterConsoleLink is not a function', () => {
@@ -416,7 +443,7 @@ async function runLink(
                 VENDURE_CONSOLE_LINK_API_URL: apiUrl,
             },
             fetch: globalThis.fetch,
-            hooks: registry.getConsoleLinkHooks(),
+            hooks: consoleLinkHooks(registry),
             ...overrides,
         },
     );
@@ -424,14 +451,28 @@ async function runLink(
     return { exitCode, messages, requestPaths, apiUrl };
 }
 
-function recordingReporter(messages: string[]): ConsoleReporter {
+function recordingReporter(
+    messages: string[],
+    reports?: Array<{ level: keyof ConsoleReporter; message: string }>,
+): ConsoleReporter {
     return {
-        error: message => messages.push(message),
-        info: message => messages.push(message),
-        success: message => messages.push(message),
-        warn: message => messages.push(message),
-        url: value => messages.push(value),
+        error: message => record('error', message),
+        info: message => record('info', message),
+        success: message => record('success', message),
+        warn: message => record('warn', message),
+        url: value => record('url', value),
     };
+
+    function record(level: keyof ConsoleReporter, message: string): void {
+        messages.push(message);
+        reports?.push({ level, message });
+    }
+}
+
+function consoleLinkHooks(registry: CommandRegistry) {
+    return registry
+        .getPluginExtensions<ConsoleLinkHook>('afterConsoleLink')
+        .map(({ pluginId, extension: hook }) => ({ pluginId, hook }));
 }
 
 function offlineDependencies(root: string, messages: string[] = []): Partial<ConsoleCommandDependencies> {

--- a/packages/cli/src/commands/console/console-link-hook.spec.ts
+++ b/packages/cli/src/commands/console/console-link-hook.spec.ts
@@ -15,8 +15,9 @@ import { ConsoleLinkContext, ConsoleLinkHook } from './console-link-hook';
 import { LINK_ID, POLLING_SECRET, manifest } from './console.fixtures';
 import { getProjectLinkManifestPath } from './project-link-manifest';
 
-const PLATFORM_ID = '@vendure-platform/cli';
-const CLOUD_ID = '@vendure/cloud';
+// Two plugins, so the tests that care about order can name which is which.
+const FIRST_PLUGIN = '@example/first-cli-plugin';
+const SECOND_PLUGIN = '@example/second-cli-plugin';
 
 const temporaryDirectories: string[] = [];
 let server: Server | undefined;
@@ -38,7 +39,7 @@ describe('console link hooks', () => {
     it('runs a plugin hook once after a link, with what the command already resolved', async () => {
         const contexts: ConsoleLinkContext[] = [];
         const registry = registryWith(
-            plugin(PLATFORM_ID, async received => {
+            plugin(FIRST_PLUGIN, async received => {
                 contexts.push(received);
             }),
         );
@@ -77,24 +78,24 @@ describe('console link hooks', () => {
     it('runs hooks in plugin order and stops at the first failure', async () => {
         const trace: string[] = [];
         const registry = registryWith(
-            plugin(PLATFORM_ID, async () => {
-                trace.push(PLATFORM_ID);
+            plugin(FIRST_PLUGIN, async () => {
+                trace.push(FIRST_PLUGIN);
                 throw new Error('Console rejected the credential request.');
             }),
-            plugin(CLOUD_ID, async () => {
-                trace.push(CLOUD_ID);
+            plugin(SECOND_PLUGIN, async () => {
+                trace.push(SECOND_PLUGIN);
             }),
         );
         const root = vendureProject();
         const test = await runLink(root, registry);
 
-        expect(trace).toEqual([PLATFORM_ID]);
+        expect(trace).toEqual([FIRST_PLUGIN]);
         expect(test.exitCode).toBe(1);
         // The link is not rolled back, and the report says so rather than
         // leaving the reader to guess what survived.
         expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
         const output = test.messages.join('\n');
-        expect(output).toContain(`The ${PLATFORM_ID} plugin failed after linking`);
+        expect(output).toContain(`The ${FIRST_PLUGIN} plugin failed after linking`);
         expect(output).toContain('Console rejected the credential request.');
         expect(output).toContain('The link succeeded');
         // Repairing a credential store must not be sold as another link, which
@@ -104,8 +105,11 @@ describe('console link hooks', () => {
 
     it('keeps the exit code at 0 when a hook reports that it could not finish', async () => {
         const registry = registryWith(
-            plugin(PLATFORM_ID, async context => {
-                context.reporter.warn('No Console session on this machine. Run "vendure platform repair".');
+            plugin(FIRST_PLUGIN, async context => {
+                // A hook that cannot finish says so through the reporter and
+                // returns, rather than throwing. Naming what to run next is the
+                // plugin's own business, so this is the plugin's own command.
+                context.reporter.warn('Nothing to set up from here yet. Run "example-setup init".');
             }),
         );
         const root = vendureProject();
@@ -113,13 +117,13 @@ describe('console link hooks', () => {
 
         // Linking is what the command was asked to do, and it did it.
         expect(test.exitCode).toBe(0);
-        expect(test.messages.join('\n')).toContain('vendure platform repair');
+        expect(test.messages.join('\n')).toContain('example-setup init');
     });
 
     it('does not claim nothing changed when interrupted after the manifest is written', async () => {
         const abort = new AbortController();
         const registry = registryWith(
-            plugin(PLATFORM_ID, async () => {
+            plugin(FIRST_PLUGIN, async () => {
                 abort.abort();
                 throw new Error('aborted while issuing a credential');
             }),
@@ -136,7 +140,7 @@ describe('console link hooks', () => {
 
     it('does not run hooks for status, unlink or an unknown action', async () => {
         const hook = vi.fn<ConsoleLinkHook>(async () => undefined);
-        const registry = registryWith(plugin(PLATFORM_ID, hook));
+        const registry = registryWith(plugin(FIRST_PLUGIN, hook));
         const root = vendureProject();
         const hooks = registry.getConsoleLinkHooks();
 
@@ -149,7 +153,7 @@ describe('console link hooks', () => {
 
     it('does not run hooks when a link is refused before any request', async () => {
         const hook = vi.fn<ConsoleLinkHook>(async () => undefined);
-        const registry = registryWith(plugin(PLATFORM_ID, hook));
+        const registry = registryWith(plugin(FIRST_PLUGIN, hook));
         const fetchMock = vi.fn() as unknown as typeof fetch;
         const root = vendureProject();
 
@@ -178,7 +182,7 @@ describe('console link hooks', () => {
     it('registers no hook for a plugin the registry rejected', () => {
         const registry = registryWith();
         const rejected = defineCliPlugin({
-            id: PLATFORM_ID,
+            id: FIRST_PLUGIN,
             // `console` is already a built-in and this does not set
             // `replaces`, so the whole plugin is refused.
             commands: [{ name: 'console', description: 'Shadowed console', action: async () => 0 }],
@@ -194,7 +198,7 @@ describe('console link hooks', () => {
         const registry = registryWith();
         registry.applyPlugin(
             defineCliPlugin({
-                id: PLATFORM_ID,
+                id: FIRST_PLUGIN,
                 commands: [],
                 extendCommands: [
                     {
@@ -213,7 +217,7 @@ describe('console link hooks', () => {
             }),
         );
 
-        expect(registry.getConsoleLinkHooks().map(entry => entry.pluginId)).toEqual([PLATFORM_ID]);
+        expect(registry.getConsoleLinkHooks().map(entry => entry.pluginId)).toEqual([FIRST_PLUGIN]);
         const root = vendureProject();
         const test = await runLink(root, registry);
 
@@ -232,7 +236,7 @@ describe('console link hooks', () => {
     it('runs the hooks again for a project that is already linked, without a second Project Link', async () => {
         const contexts: ConsoleLinkContext[] = [];
         const registry = registryWith(
-            plugin(PLATFORM_ID, async received => {
+            plugin(FIRST_PLUGIN, async received => {
                 contexts.push(received);
             }),
         );
@@ -260,7 +264,7 @@ describe('console link hooks', () => {
 
     it('reports a repair that did not finish without claiming the link changed', async () => {
         const registry = registryWith(
-            plugin(PLATFORM_ID, async () => {
+            plugin(FIRST_PLUGIN, async () => {
                 throw new Error('Console rejected the credential request.');
             }),
         );
@@ -285,14 +289,14 @@ describe('console link hooks', () => {
     it('gives each hook its own context, so one cannot decide what the next reads', async () => {
         const seen: Array<{ official: string | undefined; projectName: string }> = [];
         const registry = registryWith(
-            plugin(PLATFORM_ID, async context => {
+            plugin(FIRST_PLUGIN, async context => {
                 // `official` is the fact a hook holding a credential checks
                 // before it sends anything, so the plugin listed first must not
                 // be able to answer it for the plugin listed second.
                 context.endpoints.official = 'production';
                 context.manifest.project.name = 'Tampered';
             }),
-            plugin(CLOUD_ID, async context => {
+            plugin(SECOND_PLUGIN, async context => {
                 seen.push({
                     official: context.endpoints.official,
                     projectName: context.manifest.project.name,
@@ -309,7 +313,7 @@ describe('console link hooks', () => {
     it('refuses a hook confirmation when there is nobody to answer it', async () => {
         let refusal: string | undefined;
         const registry = registryWith(
-            plugin(PLATFORM_ID, async context => {
+            plugin(FIRST_PLUGIN, async context => {
                 // The hook ignored `isNonInteractive`. Prompting here would
                 // write a question into a pipe and then wait for an answer.
                 await context.confirm('Replace the stored credential?').catch((error: Error) => {
@@ -333,12 +337,12 @@ describe('console link hooks', () => {
         const trace: string[] = [];
         const messages: string[] = [];
         const registry = registryWith(
-            plugin(PLATFORM_ID, async () => {
-                trace.push(PLATFORM_ID);
+            plugin(FIRST_PLUGIN, async () => {
+                trace.push(FIRST_PLUGIN);
                 throw new CliCommandExit(exitCode);
             }),
-            plugin(CLOUD_ID, async () => {
-                trace.push(CLOUD_ID);
+            plugin(SECOND_PLUGIN, async () => {
+                trace.push(SECOND_PLUGIN);
             }),
         );
         const root = vendureProject();
@@ -348,9 +352,9 @@ describe('console link hooks', () => {
         ).rejects.toBeInstanceOf(CliCommandExit);
         // The hooks after it did not run, and the reader is told so rather than
         // being left with an exit code and a success message.
-        expect(trace).toEqual([PLATFORM_ID]);
+        expect(trace).toEqual([FIRST_PLUGIN]);
         const output = messages.join('\n');
-        expect(output).toContain(`The ${PLATFORM_ID} plugin stopped the run after linking`);
+        expect(output).toContain(`The ${FIRST_PLUGIN} plugin stopped the run after linking`);
         expect(output).toContain('The link succeeded');
         expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
     });
@@ -358,7 +362,7 @@ describe('console link hooks', () => {
     it('rejects a plugin whose afterConsoleLink is not a function', () => {
         expect(() =>
             defineCliPlugin({
-                id: PLATFORM_ID,
+                id: FIRST_PLUGIN,
                 commands: [],
                 afterConsoleLink: 'not a function' as unknown as ConsoleLinkHook,
             }),

--- a/packages/cli/src/commands/console/console-link-hook.spec.ts
+++ b/packages/cli/src/commands/console/console-link-hook.spec.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { defineCliPlugin } from '../../shared/cli-plugin';
+import { CLI_PLUGIN_EXTENSION_POINTS, defineCliPlugin } from '../../shared/cli-plugin';
 import { CommandRegistry } from '../../shared/command-registry-store';
 import { builtinCommandDefs } from '../builtins';
 
@@ -217,6 +217,14 @@ describe('console link hooks', () => {
 
         expect(test.exitCode).toBe(0);
         expect(trace).toEqual(['hook']);
+    });
+
+    it('names afterConsoleLink as a supported extension point at runtime', () => {
+        // A plugin resolving an older CLI gets `undefined` here, which is how
+        // it tells that its hook would be accepted and then never run.
+        expect(CLI_PLUGIN_EXTENSION_POINTS).toContain('afterConsoleLink');
+        expect(CLI_PLUGIN_EXTENSION_POINTS).toContain('extendCommands');
+        expect(Object.isFrozen(CLI_PLUGIN_EXTENSION_POINTS)).toBe(true);
     });
 
     it('rejects a plugin whose afterConsoleLink is not a function', () => {

--- a/packages/cli/src/commands/console/console-link-hook.spec.ts
+++ b/packages/cli/src/commands/console/console-link-hook.spec.ts
@@ -326,15 +326,33 @@ describe('console link hooks', () => {
         expect(test.messages.join('\n')).toContain('context.isNonInteractive');
     });
 
-    it('lets the CLI host own an exit a hook asked for', async () => {
+    // Zero as well as non-zero: `exitCliCommand(0)` is how every built-in
+    // prompt reports a cancellation, so a hook driving one unwinds through here
+    // with a code that means "stopped", not "nothing happened".
+    it.each([0, 2])('says what survived when a hook exits with code %i', async exitCode => {
+        const trace: string[] = [];
+        const messages: string[] = [];
         const registry = registryWith(
             plugin(PLATFORM_ID, async () => {
-                throw new CliCommandExit(2);
+                trace.push(PLATFORM_ID);
+                throw new CliCommandExit(exitCode);
+            }),
+            plugin(CLOUD_ID, async () => {
+                trace.push(CLOUD_ID);
             }),
         );
         const root = vendureProject();
 
-        await expect(runLink(root, registry)).rejects.toBeInstanceOf(CliCommandExit);
+        await expect(
+            runLink(root, registry, { reporter: recordingReporter(messages) }),
+        ).rejects.toBeInstanceOf(CliCommandExit);
+        // The hooks after it did not run, and the reader is told so rather than
+        // being left with an exit code and a success message.
+        expect(trace).toEqual([PLATFORM_ID]);
+        const output = messages.join('\n');
+        expect(output).toContain(`The ${PLATFORM_ID} plugin stopped the run after linking`);
+        expect(output).toContain('The link succeeded');
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
     });
 
     it('rejects a plugin whose afterConsoleLink is not a function', () => {
@@ -402,14 +420,18 @@ async function runLink(
     return { exitCode, messages, requestPaths, apiUrl };
 }
 
-function offlineDependencies(root: string, messages: string[] = []): Partial<ConsoleCommandDependencies> {
-    const reporter: ConsoleReporter = {
+function recordingReporter(messages: string[]): ConsoleReporter {
+    return {
         error: message => messages.push(message),
         info: message => messages.push(message),
         success: message => messages.push(message),
         warn: message => messages.push(message),
         url: value => messages.push(value),
     };
+}
+
+function offlineDependencies(root: string, messages: string[] = []): Partial<ConsoleCommandDependencies> {
+    const reporter = recordingReporter(messages);
     return {
         cwd: root,
         env: { VENDURE_CLI_NON_INTERACTIVE: 'true' },

--- a/packages/cli/src/commands/console/console-link-hook.ts
+++ b/packages/cli/src/commands/console/console-link-hook.ts
@@ -33,39 +33,21 @@ export interface ConsoleLinkEndpoints {
      * Which official Vendure Console this pair is, or `undefined` when it is
      * not an official one.
      *
-     * Both official deployments are named, production and staging, because
-     * refusing staging is as wrong as accepting an unknown host. Staging is
-     * reached by setting `VENDURE_CONSOLE_LINK_URL` and
-     * `VENDURE_CONSOLE_LINK_API_URL` to its pair, and that is deliberately not
-     * prompted for, so anything able to set two environment variables can send
-     * a hook to staging rather than production without anyone confirming it.
-     * Both are Vendure's, which is why this is a choice rather than a hole, but
-     * a hook that must not touch staging should compare against `'production'`
-     * rather than against `undefined`. The pair is
-     * matched as a pair: a production app origin with a staging API is not
-     * official, it points at two deployments at once. `undefined` also covers
-     * a loopback pair, which is a development and test convenience and never
-     * an official origin.
+     * Both deployments are named, production and staging, because refusing
+     * staging is as wrong as accepting an unknown host. The pair is matched as
+     * a pair: a production app origin with a staging API is not official.
+     * `undefined` also covers a loopback pair, which is a development and test
+     * convenience.
      *
-     * This is a fact, not a permission. A person answering the custom-endpoint
-     * prompt, or passing `--allow-custom-console`, approved those origins for
-     * creating a Project Link and writing identity metadata into this
-     * repository. They did not approve sending anything secret there, and
-     * Console itself does not treat a custom Project Link endpoint as one that
-     * may configure an authenticated client.
+     * This is a fact, not a permission. A hook that holds credentials checks it
+     * before it reads a credential file or sends a request, and refuses when
+     * the answer is `undefined`.
      *
-     * So a hook that holds credentials checks this before it reads a
-     * credential file or sends a request, and refuses when the answer is
-     * `undefined`. Do not derive the same conclusion from the absence of a
-     * custom-endpoint prompt: that permits loopback, and it is not this.
-     *
-     * It describes where this run will talk, not where the manifest came from.
-     * The manifest records no origin, so when
-     * {@link ConsoleLinkContext.outcome} is `'repaired'` the Console that
-     * issued these project and account identifiers is unknown, and a
-     * `'production'` answer here does not vouch for them. A hook that acts on
-     * the identifiers rather than only on the origin should treat a repair as
-     * unverified provenance.
+     * It says where this run will talk, not where the manifest came from, so a
+     * `'production'` answer does not vouch for the identifiers in a manifest
+     * this run did not write. The reasoning, and what a hook should do about
+     * staging and about a repair, is in the CLI guide under "Running after a
+     * project link".
      */
     official: ConsoleOriginEnvironment | undefined;
 }

--- a/packages/cli/src/commands/console/console-link-hook.ts
+++ b/packages/cli/src/commands/console/console-link-hook.ts
@@ -1,0 +1,150 @@
+import { ProjectLinkManifest } from './project-link-manifest';
+
+/**
+ * How the `console` command reports progress. Handed to a
+ * {@link ConsoleLinkHook} so a plugin's output goes to the same streams, in the
+ * same style, as the rest of the command.
+ *
+ * @since 3.8.0
+ */
+export interface ConsoleReporter {
+    error(message: string): void;
+    info(message: string): void;
+    success(message: string): void;
+    warn(message: string): void;
+    url(value: string): void;
+}
+
+/**
+ * The Console origins the link was made against.
+ *
+ * @since 3.8.0
+ */
+export interface ConsoleLinkEndpoints {
+    consoleUrl: string;
+    apiUrl: string;
+    /**
+     * Whether these are the built-in production origins, rather than the pair
+     * given by `VENDURE_CONSOLE_LINK_URL` and `VENDURE_CONSOLE_LINK_API_URL`.
+     *
+     * This is a fact about where the manifest came from, not a permission. A
+     * person answering the custom-endpoint prompt, or passing
+     * `--allow-custom-console`, approved those origins for creating a Project
+     * Link and writing identity metadata into this repository. They did not
+     * approve sending anything secret there, and Console itself does not treat
+     * a custom Project Link endpoint as one that may configure an authenticated
+     * client.
+     *
+     * So a hook that holds credentials keeps its own list of the hosts it will
+     * talk to, checks these origins against it before it reads a credential
+     * file or sends a request, and refuses when they do not match. `false` here
+     * means the link was made against a Console that such a hook should decline
+     * to use, not one it should follow.
+     */
+    areDefault: boolean;
+}
+
+/**
+ * What `vendure console link` hands a {@link ConsoleLinkHook}.
+ *
+ * Everything the command already resolved is passed in so that a hook never
+ * repeats the work and reaches a different answer. `projectRoot` in particular:
+ * re-deriving it from the working directory is how a plugin ends up writing
+ * beside the manifest it thinks it wrote.
+ *
+ * @since 3.8.0
+ */
+export interface ConsoleLinkContext {
+    /**
+     * The absolute project directory the command resolved, after `--project`
+     * and the search for the nearest `@vendure/core` dependency.
+     */
+    projectRoot: string;
+    /** The Project Link Manifest as it was written. */
+    manifest: ProjectLinkManifest;
+    /** Absolute path of the manifest file. */
+    manifestPath: string;
+    endpoints: ConsoleLinkEndpoints;
+    /**
+     * Aborts on SIGINT and SIGTERM, the same signal the link itself ran under.
+     * Anything a hook does remotely should be passed this, so that Ctrl-C does
+     * not leave half-finished work behind.
+     */
+    signal: AbortSignal;
+    reporter: ConsoleReporter;
+    /**
+     * Asks a yes/no question. Resolves `undefined` when the person cancelled,
+     * which a hook should treat as "stop", not as "no".
+     *
+     * Only callable when {@link isNonInteractive} is `false`.
+     *
+     * Yes/no is all there is, deliberately. It covers confirming something
+     * destructive, which is the decision that has to be taken here because it
+     * is about what this link just did. A question with several answers, such
+     * as which of a set of things to set up, is a conversation of its own and
+     * belongs in the plugin's own command, where it owns the whole screen.
+     */
+    confirm(message: string): Promise<boolean | undefined>;
+    /**
+     * No terminal is attached, so {@link confirm} can never be answered. A hook
+     * that needs a decision here should fail with a message naming the flag
+     * that supplies it, rather than printing a question into a pipe.
+     */
+    isNonInteractive: boolean;
+    /** Whether `--force` was given. */
+    force: boolean;
+}
+
+/**
+ * Runs after `vendure console link` has written the Project Link Manifest.
+ *
+ * The CLI owns linking: resolving the endpoints, approving custom ones, opening
+ * the browser, polling for approval, validating the manifest and writing it
+ * with the `.gitignore` rules. A hook adds what happens next for one plugin,
+ * such as obtaining the credentials that project then needs.
+ *
+ * A hook never runs before the manifest is on disk, so it can rely on the link
+ * being recorded. It equally cannot undo it: the manifest survives a hook that
+ * fails, and the command says so rather than claiming nothing changed. Work
+ * that has to be repeatable belongs in a command of its own, because running
+ * `vendure console link` again creates a new Project Link rather than repairing
+ * the existing one.
+ *
+ * Hooks run in `vendure.cli.plugins` order, one after another, and the first
+ * one to throw stops the rest.
+ *
+ * Throwing is for work that failed, not for work that cannot be done here. A
+ * hook that needs an answer it cannot get — no terminal, so no sign-in, so no
+ * credential — should say what is missing through {@link ConsoleLinkContext.reporter}
+ * and return. The command still exits 0, because linking is what it was asked
+ * to do and it did it. Naming the command that finishes the job is the hook's
+ * to do: the CLI does not suggest one, and never suggests linking again.
+ *
+ * @since 3.8.0
+ */
+export type ConsoleLinkHook = (context: ConsoleLinkContext) => Promise<void>;
+
+/**
+ * A hook together with the plugin that registered it, so a failure can name it.
+ */
+export interface RegisteredConsoleLinkHook {
+    pluginId: string;
+    hook: ConsoleLinkHook;
+}
+
+/**
+ * Hooks contributed by the plugins the host loaded.
+ *
+ * The `console` command is a static definition, so the host hands the hooks
+ * over here once plugins have been applied, rather than the command reaching
+ * into the registry. Tests pass them straight to `consoleCommand` instead.
+ */
+let registeredHooks: readonly RegisteredConsoleLinkHook[] = [];
+
+export function setConsoleLinkHooks(hooks: readonly RegisteredConsoleLinkHook[]): void {
+    registeredHooks = hooks;
+}
+
+export function getConsoleLinkHooks(): readonly RegisteredConsoleLinkHook[] {
+    return registeredHooks;
+}

--- a/packages/cli/src/commands/console/console-link-hook.ts
+++ b/packages/cli/src/commands/console/console-link-hook.ts
@@ -1,54 +1,12 @@
 import { ConsoleOriginEnvironment } from './console-origins';
+import { ConsoleReporter } from './console-reporter';
 import { ProjectLinkManifest } from './project-link-manifest';
 
-/**
- * How the `console` command reports progress. Handed to a
- * {@link ConsoleLinkHook} so a plugin's output goes to the same streams, in the
- * same style, as the rest of the command.
- *
- * @since 3.8.0
- */
-export interface ConsoleReporter {
-    error(message: string): void;
-    info(message: string): void;
-    success(message: string): void;
-    warn(message: string): void;
-    url(value: string): void;
-}
-
-/**
- * The Console origins this run resolved, and will use.
- *
- * Not necessarily the origins the link was made against. The Project Link
- * Manifest records no origin, so on a repair these come from the environment
- * of the repairing run, not from whoever minted the manifest. See
- * {@link ConsoleLinkEndpoints.official}.
- *
- * @since 3.8.0
- */
+/** The Console origins resolved for this run. @since 3.8.0 */
 export interface ConsoleLinkEndpoints {
     consoleUrl: string;
     apiUrl: string;
-    /**
-     * Which official Vendure Console this pair is, or `undefined` when it is
-     * not an official one.
-     *
-     * Both deployments are named, production and staging, because refusing
-     * staging is as wrong as accepting an unknown host. The pair is matched as
-     * a pair: a production app origin with a staging API is not official.
-     * `undefined` also covers a loopback pair, which is a development and test
-     * convenience.
-     *
-     * This is a fact, not a permission. A hook that holds credentials checks it
-     * before it reads a credential file or sends a request, and refuses when
-     * the answer is `undefined`.
-     *
-     * It says where this run will talk, not where the manifest came from, so a
-     * `'production'` answer does not vouch for the identifiers in a manifest
-     * this run did not write. The reasoning, and what a hook should do about
-     * staging and about a repair, is in the CLI guide under "Running after a
-     * project link".
-     */
+    /** The matching official environment, or `undefined` for custom and loopback origins. */
     official: ConsoleOriginEnvironment | undefined;
 }
 
@@ -60,106 +18,31 @@ export interface ConsoleLinkEndpoints {
  */
 export type ConsoleLinkOutcome = 'linked' | 'repaired';
 
-/**
- * What `vendure console link` hands a {@link ConsoleLinkHook}.
- *
- * Everything the command already resolved is passed in so that a hook never
- * repeats the work and reaches a different answer. `projectRoot` in particular:
- * re-deriving it from the working directory is how a plugin ends up writing
- * beside the manifest it thinks it wrote.
- *
- * @since 3.8.0
- */
+/** Values supplied to an {@link ConsoleLinkHook}. @since 3.8.0 */
 export interface ConsoleLinkContext {
-    /**
-     * The absolute project directory the command resolved, after `--project`
-     * and the search for the nearest `@vendure/core` dependency.
-     */
+    /** The absolute Vendure project directory. */
     projectRoot: string;
-    /**
-     * The Project Link Manifest, as this run wrote it or as it already stood on
-     * disk. Each hook gets its own copy, so one hook cannot change what the
-     * next one reads.
-     */
+    /** A copy of the Project Link Manifest for this hook. */
     manifest: ProjectLinkManifest;
     /** Absolute path of the manifest file. */
     manifestPath: string;
     endpoints: ConsoleLinkEndpoints;
-    /**
-     * Which of the two things `vendure console link` does brought the hook here.
-     *
-     * `'linked'` means this run created the Project Link and wrote the manifest
-     * above. `'repaired'` means the project was already linked and the manifest
-     * on disk was reused unchanged, so the hook is being asked to redo its own
-     * setup for a link that has not moved.
-     *
-     * A hook that only writes files can ignore this. A hook that rotates a
-     * remote credential cannot: repairing is the case where a credential the
-     * developer no longer holds locally may still be live, and replacing it
-     * takes the old one away. Confirm that before doing it.
-     *
-     * A repair also runs against a manifest this command did not write, which
-     * may have arrived with a clone. Its identifiers are unverified.
-     */
+    /** Whether this run created the link or reused the manifest on disk. */
     outcome: ConsoleLinkOutcome;
-    /**
-     * Aborts on SIGINT and SIGTERM, the same signal the link itself ran under.
-     * Anything a hook does remotely should be passed this, so that Ctrl-C does
-     * not leave half-finished work behind.
-     */
+    /** Aborts on SIGINT or SIGTERM. */
     signal: AbortSignal;
     reporter: ConsoleReporter;
-    /**
-     * Asks a yes/no question. Resolves `undefined` when the person cancelled,
-     * which a hook should treat as "stop", not as "no".
-     *
-     * Only callable when {@link isNonInteractive} is `false`.
-     *
-     * Yes/no is all there is, deliberately. It covers confirming something
-     * destructive, which is the decision that has to be taken here because it
-     * is about what this link just did. A question with several answers, such
-     * as which of a set of things to set up, is a conversation of its own and
-     * belongs in the plugin's own command, where it owns the whole screen.
-     */
+    /** Asks a yes/no question. Use only when {@link isNonInteractive} is `false`. */
     confirm(message: string): Promise<boolean | undefined>;
-    /**
-     * No terminal is attached, so {@link confirm} can never be answered. A hook
-     * that needs a decision here should fail with a message naming the flag
-     * that supplies it, rather than printing a question into a pipe.
-     */
+    /** Whether no terminal is available for {@link confirm}. */
     isNonInteractive: boolean;
     /** Whether `--force` was given. */
     force: boolean;
 }
 
 /**
- * Runs after `vendure console link` has written the Project Link Manifest.
- *
- * The CLI owns linking: resolving the endpoints, approving custom ones, opening
- * the browser, polling for approval, validating the manifest and writing it
- * with the `.gitignore` rules. A hook adds what happens next for one plugin,
- * such as obtaining the credentials that project then needs.
- *
- * A hook never runs before the manifest is on disk, so it can rely on the link
- * being recorded. It equally cannot undo it: the manifest survives a hook that
- * fails, and the command says so rather than claiming nothing changed.
- *
- * A hook has to be repeatable, because `vendure console link` is the command
- * that repairs a link as well as the one that makes it. Run in a project that
- * is already linked, it reuses the manifest on disk and calls the hooks again
- * with an {@link ConsoleLinkContext.outcome} of `'repaired'`, rather than
- * minting a second Project Link in Console and leaving the first behind.
- * `--force` is the way to link a checkout to a different Project.
- *
- * Hooks run in `vendure.cli.plugins` order, one after another, and the first
- * one to throw stops the rest. Each is given its own context, so a hook cannot
- * change what a later one reads.
- *
- * Throwing is for work that failed, not for work that cannot be done here. A
- * hook that needs something it cannot get in this run should say what is
- * missing through {@link ConsoleLinkContext.reporter} and return. The command
- * still exits 0, because linking is what it was asked to do and it did it, and
- * `vendure console link` is what the developer runs again to finish the job.
+ * Runs after `vendure console link` writes or reuses the Project Link Manifest.
+ * See the CLI guide for hook behavior and endpoint checks.
  *
  * @since 3.8.0
  */
@@ -171,21 +54,4 @@ export type ConsoleLinkHook = (context: ConsoleLinkContext) => Promise<void>;
 export interface RegisteredConsoleLinkHook {
     pluginId: string;
     hook: ConsoleLinkHook;
-}
-
-/**
- * Hooks contributed by the plugins the host loaded.
- *
- * The `console` command is a static definition, so the host hands the hooks
- * over here once plugins have been applied, rather than the command reaching
- * into the registry. Tests pass them straight to `consoleCommand` instead.
- */
-let registeredHooks: readonly RegisteredConsoleLinkHook[] = [];
-
-export function setConsoleLinkHooks(hooks: readonly RegisteredConsoleLinkHook[]): void {
-    registeredHooks = hooks;
-}
-
-export function getConsoleLinkHooks(): readonly RegisteredConsoleLinkHook[] {
-    return registeredHooks;
 }

--- a/packages/cli/src/commands/console/console-link-hook.ts
+++ b/packages/cli/src/commands/console/console-link-hook.ts
@@ -34,27 +34,33 @@ export interface ConsoleLinkEndpoints {
      * not an official one.
      *
      * Both official deployments are named, production and staging, because
-     * refusing staging is as wrong as accepting an unknown host. The pair is
+     * refusing staging is as wrong as accepting an unknown host. Staging is
+     * reached by setting `VENDURE_CONSOLE_LINK_URL` and
+     * `VENDURE_CONSOLE_LINK_API_URL` to its pair, and that is deliberately not
+     * prompted for, so anything able to set two environment variables can send
+     * a hook to staging rather than production without anyone confirming it.
+     * Both are Vendure's, which is why this is a choice rather than a hole, but
+     * a hook that must not touch staging should compare against `'production'`
+     * rather than against `undefined`. The pair is
      * matched as a pair: a production app origin with a staging API is not
      * official, it points at two deployments at once. `undefined` also covers
      * a loopback pair, which is a development and test convenience and never
      * an official origin.
      *
-     * This is a fact about where the manifest came from, not a permission. A
-     * person answering the custom-endpoint prompt, or passing
-     * `--allow-custom-console`, approved those origins for creating a Project
-     * Link and writing identity metadata into this repository. They did not
-     * approve sending anything secret there, and Console itself does not treat
-     * a custom Project Link endpoint as one that may configure an
-     * authenticated client.
+     * This is a fact, not a permission. A person answering the custom-endpoint
+     * prompt, or passing `--allow-custom-console`, approved those origins for
+     * creating a Project Link and writing identity metadata into this
+     * repository. They did not approve sending anything secret there, and
+     * Console itself does not treat a custom Project Link endpoint as one that
+     * may configure an authenticated client.
      *
      * So a hook that holds credentials checks this before it reads a
      * credential file or sends a request, and refuses when the answer is
      * `undefined`. Do not derive the same conclusion from the absence of a
      * custom-endpoint prompt: that permits loopback, and it is not this.
      *
-     * This describes where this run will talk, not where the manifest came
-     * from. The manifest records no origin, so when
+     * It describes where this run will talk, not where the manifest came from.
+     * The manifest records no origin, so when
      * {@link ConsoleLinkContext.outcome} is `'repaired'` the Console that
      * issued these project and account identifiers is unknown, and a
      * `'production'` answer here does not vouch for them. A hook that acts on
@@ -64,7 +70,12 @@ export interface ConsoleLinkEndpoints {
     official: ConsoleOriginEnvironment | undefined;
 }
 
-/** @since 3.8.0 */
+/**
+ * `'linked'` when the run created the Project Link, `'repaired'` when it reused
+ * one already on disk.
+ *
+ * @since 3.8.0
+ */
 export type ConsoleLinkOutcome = 'linked' | 'repaired';
 
 /**

--- a/packages/cli/src/commands/console/console-link-hook.ts
+++ b/packages/cli/src/commands/console/console-link-hook.ts
@@ -17,7 +17,12 @@ export interface ConsoleReporter {
 }
 
 /**
- * The Console origins the link was made against.
+ * The Console origins this run resolved, and will use.
+ *
+ * Not necessarily the origins the link was made against. The Project Link
+ * Manifest records no origin, so on a repair these come from the environment
+ * of the repairing run, not from whoever minted the manifest. See
+ * {@link ConsoleLinkEndpoints.official}.
  *
  * @since 3.8.0
  */
@@ -47,16 +52,19 @@ export interface ConsoleLinkEndpoints {
      * credential file or sends a request, and refuses when the answer is
      * `undefined`. Do not derive the same conclusion from the absence of a
      * custom-endpoint prompt: that permits loopback, and it is not this.
+     *
+     * This describes where this run will talk, not where the manifest came
+     * from. The manifest records no origin, so when
+     * {@link ConsoleLinkContext.outcome} is `'repaired'` the Console that
+     * issued these project and account identifiers is unknown, and a
+     * `'production'` answer here does not vouch for them. A hook that acts on
+     * the identifiers rather than only on the origin should treat a repair as
+     * unverified provenance.
      */
     official: ConsoleOriginEnvironment | undefined;
 }
 
-/**
- * Whether the run that called the hook established the link or repaired one
- * that already existed.
- *
- * @since 3.8.0
- */
+/** @since 3.8.0 */
 export type ConsoleLinkOutcome = 'linked' | 'repaired';
 
 /**
@@ -96,6 +104,9 @@ export interface ConsoleLinkContext {
      * remote credential cannot: repairing is the case where a credential the
      * developer no longer holds locally may still be live, and replacing it
      * takes the old one away. Confirm that before doing it.
+     *
+     * A repair also runs against a manifest this command did not write, which
+     * may have arrived with a clone. Its identifiers are unverified.
      */
     outcome: ConsoleLinkOutcome;
     /**

--- a/packages/cli/src/commands/console/console-link-hook.ts
+++ b/packages/cli/src/commands/console/console-link-hook.ts
@@ -45,6 +45,14 @@ export interface ConsoleLinkEndpoints {
 }
 
 /**
+ * Whether the run that called the hook established the link or repaired one
+ * that already existed.
+ *
+ * @since 3.8.0
+ */
+export type ConsoleLinkOutcome = 'linked' | 'repaired';
+
+/**
  * What `vendure console link` hands a {@link ConsoleLinkHook}.
  *
  * Everything the command already resolved is passed in so that a hook never
@@ -60,11 +68,29 @@ export interface ConsoleLinkContext {
      * and the search for the nearest `@vendure/core` dependency.
      */
     projectRoot: string;
-    /** The Project Link Manifest as it was written. */
+    /**
+     * The Project Link Manifest, as this run wrote it or as it already stood on
+     * disk. Each hook gets its own copy, so one hook cannot change what the
+     * next one reads.
+     */
     manifest: ProjectLinkManifest;
     /** Absolute path of the manifest file. */
     manifestPath: string;
     endpoints: ConsoleLinkEndpoints;
+    /**
+     * Which of the two things `vendure console link` does brought the hook here.
+     *
+     * `'linked'` means this run created the Project Link and wrote the manifest
+     * above. `'repaired'` means the project was already linked and the manifest
+     * on disk was reused unchanged, so the hook is being asked to redo its own
+     * setup for a link that has not moved.
+     *
+     * A hook that only writes files can ignore this. A hook that rotates a
+     * remote credential cannot: repairing is the case where a credential the
+     * developer no longer holds locally may still be live, and replacing it
+     * takes the old one away. Confirm that before doing it.
+     */
+    outcome: ConsoleLinkOutcome;
     /**
      * Aborts on SIGINT and SIGTERM, the same signal the link itself ran under.
      * Anything a hook does remotely should be passed this, so that Ctrl-C does
@@ -105,20 +131,24 @@ export interface ConsoleLinkContext {
  *
  * A hook never runs before the manifest is on disk, so it can rely on the link
  * being recorded. It equally cannot undo it: the manifest survives a hook that
- * fails, and the command says so rather than claiming nothing changed. Work
- * that has to be repeatable belongs in a command of its own, because running
- * `vendure console link` again creates a new Project Link rather than repairing
- * the existing one.
+ * fails, and the command says so rather than claiming nothing changed.
+ *
+ * A hook has to be repeatable, because `vendure console link` is the command
+ * that repairs a link as well as the one that makes it. Run in a project that
+ * is already linked, it reuses the manifest on disk and calls the hooks again
+ * with an {@link ConsoleLinkContext.outcome} of `'repaired'`, rather than
+ * minting a second Project Link in Console and leaving the first behind.
+ * `--force` is the way to link a checkout to a different Project.
  *
  * Hooks run in `vendure.cli.plugins` order, one after another, and the first
- * one to throw stops the rest.
+ * one to throw stops the rest. Each is given its own context, so a hook cannot
+ * change what a later one reads.
  *
  * Throwing is for work that failed, not for work that cannot be done here. A
- * hook that needs an answer it cannot get — no terminal, so no sign-in, so no
- * credential — should say what is missing through {@link ConsoleLinkContext.reporter}
- * and return. The command still exits 0, because linking is what it was asked
- * to do and it did it. Naming the command that finishes the job is the hook's
- * to do: the CLI does not suggest one, and never suggests linking again.
+ * hook that needs something it cannot get in this run should say what is
+ * missing through {@link ConsoleLinkContext.reporter} and return. The command
+ * still exits 0, because linking is what it was asked to do and it did it, and
+ * `vendure console link` is what the developer runs again to finish the job.
  *
  * @since 3.8.0
  */

--- a/packages/cli/src/commands/console/console-link-hook.ts
+++ b/packages/cli/src/commands/console/console-link-hook.ts
@@ -1,3 +1,4 @@
+import { ConsoleOriginEnvironment } from './console-origins';
 import { ProjectLinkManifest } from './project-link-manifest';
 
 /**
@@ -24,24 +25,30 @@ export interface ConsoleLinkEndpoints {
     consoleUrl: string;
     apiUrl: string;
     /**
-     * Whether these are the built-in production origins, rather than the pair
-     * given by `VENDURE_CONSOLE_LINK_URL` and `VENDURE_CONSOLE_LINK_API_URL`.
+     * Which official Vendure Console this pair is, or `undefined` when it is
+     * not an official one.
+     *
+     * Both official deployments are named, production and staging, because
+     * refusing staging is as wrong as accepting an unknown host. The pair is
+     * matched as a pair: a production app origin with a staging API is not
+     * official, it points at two deployments at once. `undefined` also covers
+     * a loopback pair, which is a development and test convenience and never
+     * an official origin.
      *
      * This is a fact about where the manifest came from, not a permission. A
      * person answering the custom-endpoint prompt, or passing
      * `--allow-custom-console`, approved those origins for creating a Project
      * Link and writing identity metadata into this repository. They did not
      * approve sending anything secret there, and Console itself does not treat
-     * a custom Project Link endpoint as one that may configure an authenticated
-     * client.
+     * a custom Project Link endpoint as one that may configure an
+     * authenticated client.
      *
-     * So a hook that holds credentials keeps its own list of the hosts it will
-     * talk to, checks these origins against it before it reads a credential
-     * file or sends a request, and refuses when they do not match. `false` here
-     * means the link was made against a Console that such a hook should decline
-     * to use, not one it should follow.
+     * So a hook that holds credentials checks this before it reads a
+     * credential file or sends a request, and refuses when the answer is
+     * `undefined`. Do not derive the same conclusion from the absence of a
+     * custom-endpoint prompt: that permits loopback, and it is not this.
      */
-    areDefault: boolean;
+    official: ConsoleOriginEnvironment | undefined;
 }
 
 /**

--- a/packages/cli/src/commands/console/console-origins.spec.ts
+++ b/packages/cli/src/commands/console/console-origins.spec.ts
@@ -10,8 +10,12 @@ import {
  * The literals the Platform sign-in validator uses
  * (`libs/console-auth/src/origins.ts`). They are repeated here rather than
  * imported, because that package is not public and `@vendure/cli` may not
- * depend on it. Repeating them is only safe if a change on either side fails a
- * test, which is what this file is for.
+ * depend on it.
+ *
+ * This is a second hand-maintained copy, not a guarantee. It catches a change
+ * made to `console-origins.ts` alone. It cannot see a change made to the
+ * Platform source, which is not in this repository. Adding an official origin
+ * means editing both repositories, and knowing to.
  */
 const PLATFORM_ORIGINS = {
     productionApp: 'https://console.vendure.io',
@@ -21,7 +25,7 @@ const PLATFORM_ORIGINS = {
 };
 
 describe('officialConsoleEnvironment()', () => {
-    it('uses the same literals as the Platform validator', () => {
+    it('matches the literals copied from the Platform validator', () => {
         expect(DEFAULT_CONSOLE_URL).toBe(PLATFORM_ORIGINS.productionApp);
         expect(DEFAULT_CONSOLE_API_URL).toBe(PLATFORM_ORIGINS.productionApi);
         expect(

--- a/packages/cli/src/commands/console/console-origins.spec.ts
+++ b/packages/cli/src/commands/console/console-origins.spec.ts
@@ -3,17 +3,14 @@ import { describe, expect, it } from 'vitest';
 import { DEFAULT_CONSOLE_API_URL, DEFAULT_CONSOLE_URL, officialConsoleEnvironment } from './console-origins';
 
 /**
- * The literals the Platform sign-in validator uses
- * (`libs/console-auth/src/origins.ts`). They are repeated here rather than
- * imported, because that package is not public and `@vendure/cli` may not
- * depend on it.
+ * The official Console origins, written out again so that changing one in
+ * `console-origins.ts` fails a test rather than passing quietly.
  *
- * This is a second hand-maintained copy, not a guarantee. It catches a change
- * made to `console-origins.ts` alone. It cannot see a change made to the
- * Platform source, which is not in this repository. Adding an official origin
- * means editing both repositories, and knowing to.
+ * That is the whole of what this catches. Both copies live in this repository,
+ * so neither can tell you that Console has added a deployment; only that
+ * somebody edited one of the two places and not the other.
  */
-const PLATFORM_ORIGINS = {
+const OFFICIAL_ORIGINS = {
     productionApp: 'https://console.vendure.io',
     productionApi: 'https://api.vendure.io',
     stagingApp: 'https://staging.console.vendure.io',
@@ -21,13 +18,13 @@ const PLATFORM_ORIGINS = {
 };
 
 describe('officialConsoleEnvironment()', () => {
-    it('matches the literals copied from the Platform validator', () => {
-        expect(DEFAULT_CONSOLE_URL).toBe(PLATFORM_ORIGINS.productionApp);
-        expect(DEFAULT_CONSOLE_API_URL).toBe(PLATFORM_ORIGINS.productionApi);
+    it('recognises the official production and staging pairs', () => {
+        expect(DEFAULT_CONSOLE_URL).toBe(OFFICIAL_ORIGINS.productionApp);
+        expect(DEFAULT_CONSOLE_API_URL).toBe(OFFICIAL_ORIGINS.productionApi);
         expect(
             officialConsoleEnvironment({
-                consoleUrl: PLATFORM_ORIGINS.stagingApp,
-                apiUrl: PLATFORM_ORIGINS.stagingApi,
+                consoleUrl: OFFICIAL_ORIGINS.stagingApp,
+                apiUrl: OFFICIAL_ORIGINS.stagingApi,
             }),
         ).toBe('staging');
     });
@@ -35,15 +32,15 @@ describe('officialConsoleEnvironment()', () => {
     it('names both official deployments', () => {
         expect(
             officialConsoleEnvironment({
-                consoleUrl: PLATFORM_ORIGINS.productionApp,
-                apiUrl: PLATFORM_ORIGINS.productionApi,
+                consoleUrl: OFFICIAL_ORIGINS.productionApp,
+                apiUrl: OFFICIAL_ORIGINS.productionApi,
             }),
         ).toBe('production');
         // Refusing staging is as wrong as accepting an unknown host.
         expect(
             officialConsoleEnvironment({
-                consoleUrl: PLATFORM_ORIGINS.stagingApp,
-                apiUrl: PLATFORM_ORIGINS.stagingApi,
+                consoleUrl: OFFICIAL_ORIGINS.stagingApp,
+                apiUrl: OFFICIAL_ORIGINS.stagingApi,
             }),
         ).toBe('staging');
     });
@@ -51,8 +48,8 @@ describe('officialConsoleEnvironment()', () => {
     it('accepts a trailing slash, which names the same origin', () => {
         expect(
             officialConsoleEnvironment({
-                consoleUrl: `${PLATFORM_ORIGINS.productionApp}/`,
-                apiUrl: `${PLATFORM_ORIGINS.productionApi}/`,
+                consoleUrl: `${OFFICIAL_ORIGINS.productionApp}/`,
+                apiUrl: `${OFFICIAL_ORIGINS.productionApi}/`,
             }),
         ).toBe('production');
     });
@@ -60,8 +57,8 @@ describe('officialConsoleEnvironment()', () => {
     // The pair is matched as a pair. Either half from another environment
     // points the run at two deployments at once.
     it.each([
-        ['production app with staging API', PLATFORM_ORIGINS.productionApp, PLATFORM_ORIGINS.stagingApi],
-        ['staging app with production API', PLATFORM_ORIGINS.stagingApp, PLATFORM_ORIGINS.productionApi],
+        ['production app with staging API', OFFICIAL_ORIGINS.productionApp, OFFICIAL_ORIGINS.stagingApi],
+        ['staging app with production API', OFFICIAL_ORIGINS.stagingApp, OFFICIAL_ORIGINS.productionApi],
     ])('refuses a %s', (_label, consoleUrl, apiUrl) => {
         expect(officialConsoleEnvironment({ consoleUrl, apiUrl })).toBeUndefined();
     });
@@ -70,13 +67,13 @@ describe('officialConsoleEnvironment()', () => {
     // else while the hostname still reads correctly.
     it.each([
         ['plain http', 'http://console.vendure.io', 'http://api.vendure.io'],
-        ['embedded credentials', 'https://user:pw@console.vendure.io', PLATFORM_ORIGINS.productionApi],
-        ['a path', 'https://console.vendure.io/link', PLATFORM_ORIGINS.productionApi],
-        ['a query', 'https://console.vendure.io/?next=x', PLATFORM_ORIGINS.productionApi],
-        ['a fragment', 'https://console.vendure.io/#x', PLATFORM_ORIGINS.productionApi],
-        ['a lookalike host', 'https://console.vendure.io.evil.test', PLATFORM_ORIGINS.productionApi],
-        ['a subdomain of an official host', 'https://a.console.vendure.io', PLATFORM_ORIGINS.productionApi],
-        ['an unparseable URL', 'not a url', PLATFORM_ORIGINS.productionApi],
+        ['embedded credentials', 'https://user:pw@console.vendure.io', OFFICIAL_ORIGINS.productionApi],
+        ['a path', 'https://console.vendure.io/link', OFFICIAL_ORIGINS.productionApi],
+        ['a query', 'https://console.vendure.io/?next=x', OFFICIAL_ORIGINS.productionApi],
+        ['a fragment', 'https://console.vendure.io/#x', OFFICIAL_ORIGINS.productionApi],
+        ['a lookalike host', 'https://console.vendure.io.evil.test', OFFICIAL_ORIGINS.productionApi],
+        ['a subdomain of an official host', 'https://a.console.vendure.io', OFFICIAL_ORIGINS.productionApi],
+        ['an unparseable URL', 'not a url', OFFICIAL_ORIGINS.productionApi],
     ])('refuses %s', (_label, consoleUrl, apiUrl) => {
         expect(officialConsoleEnvironment({ consoleUrl, apiUrl })).toBeUndefined();
     });

--- a/packages/cli/src/commands/console/console-origins.spec.ts
+++ b/packages/cli/src/commands/console/console-origins.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    DEFAULT_CONSOLE_API_URL,
+    DEFAULT_CONSOLE_URL,
+    officialConsoleEnvironment,
+} from './console-origins';
+
+/**
+ * The literals the Platform sign-in validator uses
+ * (`libs/console-auth/src/origins.ts`). They are repeated here rather than
+ * imported, because that package is not public and `@vendure/cli` may not
+ * depend on it. Repeating them is only safe if a change on either side fails a
+ * test, which is what this file is for.
+ */
+const PLATFORM_ORIGINS = {
+    productionApp: 'https://console.vendure.io',
+    productionApi: 'https://api.vendure.io',
+    stagingApp: 'https://staging.console.vendure.io',
+    stagingApi: 'https://staging.api.vendure.io',
+};
+
+describe('officialConsoleEnvironment()', () => {
+    it('uses the same literals as the Platform validator', () => {
+        expect(DEFAULT_CONSOLE_URL).toBe(PLATFORM_ORIGINS.productionApp);
+        expect(DEFAULT_CONSOLE_API_URL).toBe(PLATFORM_ORIGINS.productionApi);
+        expect(
+            officialConsoleEnvironment({
+                consoleUrl: PLATFORM_ORIGINS.stagingApp,
+                apiUrl: PLATFORM_ORIGINS.stagingApi,
+            }),
+        ).toBe('staging');
+    });
+
+    it('names both official deployments', () => {
+        expect(
+            officialConsoleEnvironment({
+                consoleUrl: PLATFORM_ORIGINS.productionApp,
+                apiUrl: PLATFORM_ORIGINS.productionApi,
+            }),
+        ).toBe('production');
+        // Refusing staging is as wrong as accepting an unknown host.
+        expect(
+            officialConsoleEnvironment({
+                consoleUrl: PLATFORM_ORIGINS.stagingApp,
+                apiUrl: PLATFORM_ORIGINS.stagingApi,
+            }),
+        ).toBe('staging');
+    });
+
+    it('accepts a trailing slash, which names the same origin', () => {
+        expect(
+            officialConsoleEnvironment({
+                consoleUrl: `${PLATFORM_ORIGINS.productionApp}/`,
+                apiUrl: `${PLATFORM_ORIGINS.productionApi}/`,
+            }),
+        ).toBe('production');
+    });
+
+    // The pair is matched as a pair. Either half from another environment
+    // points the run at two deployments at once.
+    it.each([
+        ['production app with staging API', PLATFORM_ORIGINS.productionApp, PLATFORM_ORIGINS.stagingApi],
+        ['staging app with production API', PLATFORM_ORIGINS.stagingApp, PLATFORM_ORIGINS.productionApi],
+    ])('refuses a %s', (_label, consoleUrl, apiUrl) => {
+        expect(officialConsoleEnvironment({ consoleUrl, apiUrl })).toBeUndefined();
+    });
+
+    // Everything past the host list. Each of these points a request somewhere
+    // else while the hostname still reads correctly.
+    it.each([
+        ['plain http', 'http://console.vendure.io', 'http://api.vendure.io'],
+        ['embedded credentials', 'https://user:pw@console.vendure.io', PLATFORM_ORIGINS.productionApi],
+        ['a path', 'https://console.vendure.io/link', PLATFORM_ORIGINS.productionApi],
+        ['a query', 'https://console.vendure.io/?next=x', PLATFORM_ORIGINS.productionApi],
+        ['a fragment', 'https://console.vendure.io/#x', PLATFORM_ORIGINS.productionApi],
+        ['a lookalike host', 'https://console.vendure.io.evil.test', PLATFORM_ORIGINS.productionApi],
+        ['a subdomain of an official host', 'https://a.console.vendure.io', PLATFORM_ORIGINS.productionApi],
+        ['an unparseable URL', 'not a url', PLATFORM_ORIGINS.productionApi],
+    ])('refuses %s', (_label, consoleUrl, apiUrl) => {
+        expect(officialConsoleEnvironment({ consoleUrl, apiUrl })).toBeUndefined();
+    });
+
+    // Loopback is a development and test convenience. It is not an official
+    // origin, and nothing deciding whether to release a credential may read it
+    // as one. This is the difference between this check and the absence of a
+    // custom-endpoint prompt, which does permit loopback.
+    it.each([
+        ['IPv4 loopback', 'http://127.0.0.1:3000', 'http://127.0.0.1:3001'],
+        ['IPv6 loopback', 'http://[::1]:3000', 'http://[::1]:3001'],
+        ['localhost', 'http://localhost:3000', 'http://localhost:3001'],
+    ])('does not treat %s as official', (_label, consoleUrl, apiUrl) => {
+        expect(officialConsoleEnvironment({ consoleUrl, apiUrl })).toBeUndefined();
+    });
+});

--- a/packages/cli/src/commands/console/console-origins.spec.ts
+++ b/packages/cli/src/commands/console/console-origins.spec.ts
@@ -18,40 +18,21 @@ const OFFICIAL_ORIGINS = {
 };
 
 describe('officialConsoleEnvironment()', () => {
-    it('recognises the official production and staging pairs', () => {
+    it('pins and recognises the official production and staging pairs', () => {
         expect(DEFAULT_CONSOLE_URL).toBe(OFFICIAL_ORIGINS.productionApp);
         expect(DEFAULT_CONSOLE_API_URL).toBe(OFFICIAL_ORIGINS.productionApi);
-        expect(
-            officialConsoleEnvironment({
-                consoleUrl: OFFICIAL_ORIGINS.stagingApp,
-                apiUrl: OFFICIAL_ORIGINS.stagingApi,
-            }),
-        ).toBe('staging');
-    });
-
-    it('names both official deployments', () => {
         expect(
             officialConsoleEnvironment({
                 consoleUrl: OFFICIAL_ORIGINS.productionApp,
                 apiUrl: OFFICIAL_ORIGINS.productionApi,
             }),
         ).toBe('production');
-        // Refusing staging is as wrong as accepting an unknown host.
         expect(
             officialConsoleEnvironment({
                 consoleUrl: OFFICIAL_ORIGINS.stagingApp,
                 apiUrl: OFFICIAL_ORIGINS.stagingApi,
             }),
         ).toBe('staging');
-    });
-
-    it('accepts a trailing slash, which names the same origin', () => {
-        expect(
-            officialConsoleEnvironment({
-                consoleUrl: `${OFFICIAL_ORIGINS.productionApp}/`,
-                apiUrl: `${OFFICIAL_ORIGINS.productionApi}/`,
-            }),
-        ).toBe('production');
     });
 
     // The pair is matched as a pair. Either half from another environment

--- a/packages/cli/src/commands/console/console-origins.spec.ts
+++ b/packages/cli/src/commands/console/console-origins.spec.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-    DEFAULT_CONSOLE_API_URL,
-    DEFAULT_CONSOLE_URL,
-    officialConsoleEnvironment,
-} from './console-origins';
+import { DEFAULT_CONSOLE_API_URL, DEFAULT_CONSOLE_URL, officialConsoleEnvironment } from './console-origins';
 
 /**
  * The literals the Platform sign-in validator uses

--- a/packages/cli/src/commands/console/console-origins.ts
+++ b/packages/cli/src/commands/console/console-origins.ts
@@ -4,7 +4,11 @@
  * These literals and the rules below mirror the Platform sign-in validator
  * (`libs/console-auth/src/origins.ts`). They are copied rather than imported,
  * because that package is not public and `@vendure/cli` may not depend on it.
- * `console-origins.spec.ts` pins every rule so the two cannot drift quietly.
+ *
+ * The copies are maintained by hand. Nothing here can detect a change made on
+ * the other side, because that source is not in this repository and the tests
+ * compare these literals against a second copy of the same literals. Adding an
+ * official origin means editing both, and knowing to.
  *
  * The checks past the host list matter as much as the list. A URL carrying a
  * path, a query, a fragment or credentials is a URL built to be appended to,

--- a/packages/cli/src/commands/console/console-origins.ts
+++ b/packages/cli/src/commands/console/console-origins.ts
@@ -53,6 +53,20 @@ export function officialConsoleEnvironment(endpoints: {
     )?.environment;
 }
 
+export function assertOfficialConsoleOriginPair(endpoints: { consoleUrl: string; apiUrl: string }): void {
+    if (officialConsoleEnvironment(endpoints) !== undefined) {
+        return;
+    }
+    const includesOfficialOrigin = OFFICIAL_CONSOLE_ORIGINS.some(
+        pair =>
+            isOfficialOrigin(endpoints.consoleUrl, pair.consoleUrl) ||
+            isOfficialOrigin(endpoints.apiUrl, pair.apiUrl),
+    );
+    if (includesOfficialOrigin) {
+        throw new Error('Official Console app and API origins must be used as a matching pair.');
+    }
+}
+
 function isOfficialOrigin(value: string, official: string): boolean {
     let url: URL;
     try {

--- a/packages/cli/src/commands/console/console-origins.ts
+++ b/packages/cli/src/commands/console/console-origins.ts
@@ -1,14 +1,10 @@
 /**
  * The official Vendure Console origins, and the check that recognises them.
  *
- * These literals and the rules below mirror the Platform sign-in validator
- * (`libs/console-auth/src/origins.ts`). They are copied rather than imported,
- * because that package is not public and `@vendure/cli` may not depend on it.
- *
- * The copies are maintained by hand. Nothing here can detect a change made on
- * the other side, because that source is not in this repository and the tests
- * compare these literals against a second copy of the same literals. Adding an
- * official origin means editing both, and knowing to.
+ * These are part of the Console contract, so they are written here as literals
+ * rather than discovered. A check on whether an origin is Vendure's cannot ask
+ * that origin, and it has to give the same answer before any request is made.
+ * Adding a Console deployment means adding it here.
  *
  * The checks past the host list matter as much as the list. A URL carrying a
  * path, a query, a fragment or credentials is a URL built to be appended to,

--- a/packages/cli/src/commands/console/console-origins.ts
+++ b/packages/cli/src/commands/console/console-origins.ts
@@ -1,0 +1,72 @@
+/**
+ * The official Vendure Console origins, and the check that recognises them.
+ *
+ * These literals and the rules below mirror the Platform sign-in validator
+ * (`libs/console-auth/src/origins.ts`). They are copied rather than imported,
+ * because that package is not public and `@vendure/cli` may not depend on it.
+ * `console-origins.spec.ts` pins every rule so the two cannot drift quietly.
+ *
+ * The checks past the host list matter as much as the list. A URL carrying a
+ * path, a query, a fragment or credentials is a URL built to be appended to,
+ * and each of those points a request somewhere else while the hostname still
+ * reads correctly.
+ */
+
+/** An official Console deployment. Anything else is not official. */
+export type ConsoleOriginEnvironment = 'production' | 'staging';
+
+export const DEFAULT_CONSOLE_URL = 'https://console.vendure.io';
+export const DEFAULT_CONSOLE_API_URL = 'https://api.vendure.io';
+
+const STAGING_CONSOLE_URL = 'https://staging.console.vendure.io';
+const STAGING_CONSOLE_API_URL = 'https://staging.api.vendure.io';
+
+/**
+ * Paired on purpose. A Console app origin from one environment with an API
+ * origin from another is not an official pair, it is a request pointed at two
+ * deployments at once.
+ */
+const OFFICIAL_CONSOLE_ORIGINS: ReadonlyArray<{
+    environment: ConsoleOriginEnvironment;
+    consoleUrl: string;
+    apiUrl: string;
+}> = [
+    { environment: 'production', consoleUrl: DEFAULT_CONSOLE_URL, apiUrl: DEFAULT_CONSOLE_API_URL },
+    { environment: 'staging', consoleUrl: STAGING_CONSOLE_URL, apiUrl: STAGING_CONSOLE_API_URL },
+];
+
+/**
+ * Which official Console the given pair is, or `undefined` when it is not one.
+ *
+ * `undefined` covers a loopback pair as well as an unknown host. Loopback is a
+ * development and test convenience, not an official origin, and nothing that
+ * decides whether to release a credential may treat it as one.
+ */
+export function officialConsoleEnvironment(endpoints: {
+    consoleUrl: string;
+    apiUrl: string;
+}): ConsoleOriginEnvironment | undefined {
+    return OFFICIAL_CONSOLE_ORIGINS.find(
+        pair =>
+            isOfficialOrigin(endpoints.consoleUrl, pair.consoleUrl) &&
+            isOfficialOrigin(endpoints.apiUrl, pair.apiUrl),
+    )?.environment;
+}
+
+function isOfficialOrigin(value: string, official: string): boolean {
+    let url: URL;
+    try {
+        url = new URL(value);
+    } catch {
+        return false;
+    }
+    return (
+        url.protocol === 'https:' &&
+        url.username === '' &&
+        url.password === '' &&
+        url.pathname === '/' &&
+        url.search === '' &&
+        url.hash === '' &&
+        url.origin === official
+    );
+}

--- a/packages/cli/src/commands/console/console-reporter.ts
+++ b/packages/cli/src/commands/console/console-reporter.ts
@@ -1,0 +1,12 @@
+/**
+ * Reports progress from the `console` command and its plugin hooks.
+ *
+ * @since 3.8.0
+ */
+export interface ConsoleReporter {
+    error(message: string): void;
+    info(message: string): void;
+    success(message: string): void;
+    warn(message: string): void;
+    url(value: string): void;
+}

--- a/packages/cli/src/commands/console/console.integration.spec.ts
+++ b/packages/cli/src/commands/console/console.integration.spec.ts
@@ -5,7 +5,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { ConsoleCommandDependencies, ConsoleReporter, consoleCommand } from './console';
+import { ConsoleCommandDependencies, consoleCommand } from './console';
+import { ConsoleReporter } from './console-reporter';
 import { LINK_ID, POLLING_SECRET, manifest } from './console.fixtures';
 import { getProjectLinkManifestPath } from './project-link-manifest';
 

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -518,10 +518,7 @@ describe('console command', () => {
         fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
         fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
         const fetchMock = vi.fn() as unknown as typeof fetch;
-        const test = testDependencies(root, fetchMock, {
-            isNonInteractive: () => false,
-            prompt: () => Promise.resolve(false),
-        });
+        const test = testDependencies(root, fetchMock);
 
         expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
         expect(fetchMock).not.toHaveBeenCalled();
@@ -529,6 +526,63 @@ describe('console command', () => {
         const output = test.messages.join('\n');
         expect(output).toContain('Already linked to');
         expect(output).toContain('vendure console link --force');
+    });
+
+    // A manifest is meant to be committed, so an already-linked project may be
+    // one the developer has just cloned.
+    it('names the project before running plugin setup against a manifest it did not write', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const hook = vi.fn(async () => undefined);
+        const prompt = vi.fn(() => Promise.resolve(false));
+        const test = testDependencies(root, vi.fn() as unknown as typeof fetch, {
+            hooks: [{ pluginId: '@example/p', hook }],
+            isNonInteractive: () => false,
+            prompt,
+        });
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(prompt).toHaveBeenCalledWith(expect.stringContaining(manifest.project.name));
+        expect(prompt).toHaveBeenCalledWith(expect.stringContaining(manifest.account.name));
+        expect(hook).not.toHaveBeenCalled();
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+    });
+
+    it('does not ask before a repair that would run no plugin setup', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const prompt = vi.fn(() => Promise.resolve(true));
+        const test = testDependencies(root, vi.fn() as unknown as typeof fetch, {
+            isNonInteractive: () => false,
+            prompt,
+        });
+
+        // With no hooks registered there is nothing to approve.
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(prompt).not.toHaveBeenCalled();
+    });
+
+    // Calling the official staging Console "custom" and then reporting it to a
+    // hook as official said two different things about one pair.
+    it('does not treat the official staging Console as a custom endpoint', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const prompt = vi.fn(() => Promise.resolve(true));
+        const test = testDependencies(root, vi.fn() as unknown as typeof fetch, {
+            env: {
+                VENDURE_CONSOLE_LINK_URL: 'https://staging.console.vendure.io',
+                VENDURE_CONSOLE_LINK_API_URL: 'https://staging.api.vendure.io',
+            },
+            isNonInteractive: () => false,
+            prompt,
+        });
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(prompt).not.toHaveBeenCalled();
+        expect(test.messages.join('\n')).not.toContain('custom Console');
     });
 
     it('repairs rather than failing closed when a linked project repeats a link non-interactively', async () => {

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -571,18 +571,91 @@ describe('console command', () => {
         fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
         fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
         const prompt = vi.fn(() => Promise.resolve(true));
+        const seen: Array<string | undefined> = [];
         const test = testDependencies(root, vi.fn() as unknown as typeof fetch, {
             env: {
                 VENDURE_CONSOLE_LINK_URL: 'https://staging.console.vendure.io',
                 VENDURE_CONSOLE_LINK_API_URL: 'https://staging.api.vendure.io',
             },
+            hooks: [
+                {
+                    pluginId: '@example/p',
+                    hook: async context => {
+                        seen.push(context.endpoints.official);
+                    },
+                },
+            ],
+            isNonInteractive: () => false,
+            prompt,
+        });
+
+        // `--yes` answers the repair question, leaving only the custom-endpoint
+        // prompt this test is about, which must not be asked.
+        expect(await consoleCommand('link', { yes: true }, test.dependencies)).toBe(0);
+        expect(prompt).not.toHaveBeenCalled();
+        expect(seen).toEqual(['staging']);
+    });
+
+    it('runs plugin setup on a repair once the prompt is accepted', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const outcomes: string[] = [];
+        const prompt = vi.fn(() => Promise.resolve(true));
+        const test = testDependencies(root, vi.fn() as unknown as typeof fetch, {
+            hooks: [
+                {
+                    pluginId: '@example/p',
+                    hook: async context => {
+                        outcomes.push(context.outcome);
+                    },
+                },
+            ],
             isNonInteractive: () => false,
             prompt,
         });
 
         expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(prompt).toHaveBeenCalledTimes(1);
+        expect(outcomes).toEqual(['repaired']);
+    });
+
+    it('skips the repair prompt for --yes without linking to a different Project', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const hook = vi.fn(async () => undefined);
+        const prompt = vi.fn(() => Promise.resolve(true));
+        const fetchMock = vi.fn() as unknown as typeof fetch;
+        const test = testDependencies(root, fetchMock, {
+            hooks: [{ pluginId: '@example/p', hook }],
+            isNonInteractive: () => false,
+            prompt,
+        });
+
+        expect(await consoleCommand('link', { yes: true }, test.dependencies)).toBe(0);
         expect(prompt).not.toHaveBeenCalled();
-        expect(test.messages.join('\n')).not.toContain('custom Console');
+        expect(hook).toHaveBeenCalledTimes(1);
+        // `--yes` answers the question. It does not mint a second Project Link.
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+    });
+
+    it('applies the gitignore rules on a repair whose plugin setup is declined', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const hook = vi.fn(async () => undefined);
+        const test = testDependencies(root, vi.fn() as unknown as typeof fetch, {
+            hooks: [{ pluginId: '@example/p', hook }],
+            isNonInteractive: () => false,
+            prompt: () => Promise.resolve(false),
+        });
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(hook).not.toHaveBeenCalled();
+        // Declining plugin setup does not decline the rules this path writes.
+        expect(fs.existsSync(path.join(root, '.gitignore'))).toBe(true);
     });
 
     it('repairs rather than failing closed when a linked project repeats a link non-interactively', async () => {

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -443,13 +443,15 @@ describe('console command', () => {
     it('fails closed for replacement in non-interactive mode and allows --force', async () => {
         const root = vendureProject();
         fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
-        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        // An invalid manifest is the case that still has to be replaced: there
+        // is no link in it to repair, so the command needs a decision.
+        fs.writeFileSync(getProjectLinkManifestPath(root), '{invalid');
         const blockedFetch = vi.fn() as unknown as typeof fetch;
         const blocked = testDependencies(root, blockedFetch);
 
         expect(await consoleCommand('link', {}, blocked.dependencies)).toBe(1);
         expect(blockedFetch).not.toHaveBeenCalled();
-        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+        expect(fs.readFileSync(getProjectLinkManifestPath(root), 'utf-8')).toBe('{invalid');
 
         const replacement = { ...manifest, project: { ...manifest.project, name: 'Replacement' } };
         const allowed = testDependencies(
@@ -483,7 +485,7 @@ describe('console command', () => {
     it('rethrows CliCommandExit from the prompt so the CLI host owns the exit', async () => {
         const root = vendureProject();
         fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
-        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        fs.writeFileSync(getProjectLinkManifestPath(root), '{invalid');
         const test = testDependencies(root, vi.fn() as unknown as typeof fetch, {
             isNonInteractive: () => false,
             prompt: () => Promise.reject(new CliCommandExit(1)),
@@ -491,10 +493,27 @@ describe('console command', () => {
 
         await expect(consoleCommand('link', {}, test.dependencies)).rejects.toBeInstanceOf(CliCommandExit);
         expect(test.messages.join('\n')).not.toContain('requested exit code');
-        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+        expect(fs.readFileSync(getProjectLinkManifestPath(root), 'utf-8')).toBe('{invalid');
     });
 
-    it('leaves an existing manifest unchanged when interactive replacement is cancelled', async () => {
+    it('leaves an invalid manifest unchanged when interactive replacement is cancelled', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeFileSync(getProjectLinkManifestPath(root), '{invalid');
+        const fetchMock = vi.fn() as unknown as typeof fetch;
+        const test = testDependencies(root, fetchMock, {
+            isNonInteractive: () => false,
+            prompt: () => Promise.resolve(false),
+        });
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(fs.readFileSync(getProjectLinkManifestPath(root), 'utf-8')).toBe('{invalid');
+    });
+
+    // Repeating a link is how a project that is already linked gets its setup
+    // run again. Minting a second Project Link would abandon the first.
+    it('repeats a link without asking Console for another one, and names --force', async () => {
         const root = vendureProject();
         fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
         fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
@@ -507,6 +526,41 @@ describe('console command', () => {
         expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
         expect(fetchMock).not.toHaveBeenCalled();
         expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+        const output = test.messages.join('\n');
+        expect(output).toContain('Already linked to');
+        expect(output).toContain('vendure console link --force');
+    });
+
+    it('repairs rather than failing closed when a linked project repeats a link non-interactively', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const fetchMock = vi.fn() as unknown as typeof fetch;
+        const test = testDependencies(root, fetchMock);
+
+        // The backfill path a linked project needs has to work in CI, where
+        // there is nobody to confirm anything and nothing to confirm.
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+    });
+
+    it('still applies the custom endpoint policy when a link is repeated', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const fetchMock = vi.fn() as unknown as typeof fetch;
+        const test = testDependencies(root, fetchMock, {
+            env: {
+                VENDURE_CLI_NON_INTERACTIVE: 'true',
+                VENDURE_CONSOLE_LINK_URL: 'https://console.staging.example.com',
+                VENDURE_CONSOLE_LINK_API_URL: 'https://api.staging.example.com',
+            },
+        });
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(1);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(test.messages.join('\n')).toContain('without explicit approval');
     });
 
     it('returns an interrupt exit code when the confirmation prompt is cancelled', async () => {

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -5,16 +5,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { CliCommandExit } from '../../shared/cli-command-exit';
 
-import {
-    ConsoleCommandDependencies,
-    ConsoleReporter,
-    consoleCommand,
-    resolveConsoleEndpoints,
-} from './console';
+import { ConsoleCommandDependencies, consoleCommand, resolveConsoleEndpoints } from './console';
+import { ConsoleReporter } from './console-reporter';
 import {
     ACCOUNT_ID,
     LINK_ID,
     NOW,
+    OTHER_LINK_ID,
     POLLING_SECRET,
     createResponse,
     expiry,
@@ -90,7 +87,19 @@ describe('console command', () => {
                 VENDURE_CONSOLE_LINK_URL: 'https://console.example.com',
                 VENDURE_CONSOLE_LINK_API_URL: 'https://api.vendure.io',
             }),
-        ).toThrow('production Console and API origins must be used together');
+        ).toThrow('Official Console app and API origins must be used as a matching pair');
+        expect(() =>
+            resolveConsoleEndpoints({
+                VENDURE_CONSOLE_LINK_URL: 'https://staging.console.vendure.io',
+                VENDURE_CONSOLE_LINK_API_URL: 'https://api.example.com',
+            }),
+        ).toThrow('Official Console app and API origins must be used as a matching pair');
+        expect(() =>
+            resolveConsoleEndpoints({
+                VENDURE_CONSOLE_LINK_URL: 'https://console.vendure.io',
+                VENDURE_CONSOLE_LINK_API_URL: 'https://staging.api.vendure.io',
+            }),
+        ).toThrow('Official Console app and API origins must be used as a matching pair');
     });
 
     it('requires explicit approval for custom remote Console endpoints in non-interactive mode', async () => {
@@ -114,6 +123,31 @@ describe('console command', () => {
 
         expect(await consoleCommand('link', { allowCustomConsole: true }, allowed.dependencies)).toBe(0);
         expect(allowedFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports the official production environment to a link hook', async () => {
+        const seen: Array<string | undefined> = [];
+        const test = testDependencies(
+            vendureProject(),
+            sequenceFetch(
+                jsonResponse(createResponse()),
+                jsonResponse({ state: 'approved', expiresAt: expiry(), manifest }),
+            ),
+            {
+                env: {},
+                hooks: [
+                    {
+                        pluginId: '@example/p',
+                        hook: async context => {
+                            seen.push(context.endpoints.official);
+                        },
+                    },
+                ],
+            },
+        );
+
+        expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
+        expect(seen).toEqual(['production']);
     });
 
     it('shows custom remote Console origins before an interactive request', async () => {
@@ -464,6 +498,92 @@ describe('console command', () => {
         expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(replacement);
     });
 
+    it('uses --force to replace a valid manifest with a new Project Link', async () => {
+        const root = vendureProject();
+        const previous = {
+            ...manifest,
+            project: { ...manifest.project, name: 'Previous' },
+            link: { ...manifest.link, id: OTHER_LINK_ID },
+        };
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), previous);
+        const contexts: Array<{ force: boolean; outcome: string }> = [];
+        const fetchMock = sequenceFetch(
+            jsonResponse(createResponse()),
+            jsonResponse({ state: 'approved', expiresAt: expiry(), manifest }),
+        );
+        const test = testDependencies(root, fetchMock, {
+            hooks: [
+                {
+                    pluginId: '@example/p',
+                    hook: async context => {
+                        contexts.push({ force: context.force, outcome: context.outcome });
+                    },
+                },
+            ],
+        });
+
+        expect(await consoleCommand('link', { force: true }, test.dependencies)).toBe(0);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+        expect(contexts).toEqual([{ force: true, outcome: 'linked' }]);
+    });
+
+    it('uses --yes for every CLI confirmation without forcing a new link', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const hook = vi.fn(async () => undefined);
+        const prompt = vi.fn(() => Promise.resolve(false));
+        const fetchMock = vi.fn() as unknown as typeof fetch;
+        const test = testDependencies(root, fetchMock, {
+            env: {
+                VENDURE_CONSOLE_LINK_URL: 'https://console.example.com',
+                VENDURE_CONSOLE_LINK_API_URL: 'https://api.example.com',
+            },
+            hooks: [{ pluginId: '@example/p', hook }],
+            isNonInteractive: () => false,
+            prompt,
+        });
+
+        expect(await consoleCommand('link', { yes: true }, test.dependencies)).toBe(0);
+        expect(prompt).not.toHaveBeenCalled();
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(hook).toHaveBeenCalledOnce();
+    });
+
+    it('uses --yes to approve manifest replacement and removal', async () => {
+        const replacementRoot = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(replacementRoot)));
+        fs.writeFileSync(getProjectLinkManifestPath(replacementRoot), '{invalid');
+        const replacementPrompt = vi.fn(() => Promise.resolve(false));
+        const replacement = testDependencies(
+            replacementRoot,
+            sequenceFetch(
+                jsonResponse(createResponse()),
+                jsonResponse({ state: 'approved', expiresAt: expiry(), manifest }),
+            ),
+            { isNonInteractive: () => false, prompt: replacementPrompt },
+        );
+
+        expect(await consoleCommand('link', { yes: true }, replacement.dependencies)).toBe(0);
+        expect(replacementPrompt).not.toHaveBeenCalled();
+        expect(fs.readJsonSync(getProjectLinkManifestPath(replacementRoot))).toEqual(manifest);
+
+        const unlinkRoot = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(unlinkRoot)));
+        fs.writeJsonSync(getProjectLinkManifestPath(unlinkRoot), manifest);
+        const unlinkPrompt = vi.fn(() => Promise.resolve(false));
+        const unlink = testDependencies(unlinkRoot, vi.fn() as unknown as typeof fetch, {
+            isNonInteractive: () => false,
+            prompt: unlinkPrompt,
+        });
+
+        expect(await consoleCommand('unlink', { yes: true }, unlink.dependencies)).toBe(0);
+        expect(unlinkPrompt).not.toHaveBeenCalled();
+        expect(fs.existsSync(getProjectLinkManifestPath(unlinkRoot))).toBe(false);
+    });
+
     it('validates Console endpoints before prompting to replace a manifest', async () => {
         const root = vendureProject();
         fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
@@ -563,8 +683,6 @@ describe('console command', () => {
         expect(prompt).not.toHaveBeenCalled();
     });
 
-    // Calling the official staging Console "custom" and then reporting it to a
-    // hook as official said two different things about one pair.
     it('does not treat the official staging Console as a custom endpoint', async () => {
         const root = vendureProject();
         fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
@@ -635,7 +753,7 @@ describe('console command', () => {
         expect(await consoleCommand('link', { yes: true }, test.dependencies)).toBe(0);
         expect(prompt).not.toHaveBeenCalled();
         expect(hook).toHaveBeenCalledTimes(1);
-        // `--yes` answers the question. It does not mint a second Project Link.
+        // `--yes` answers the question. It does not create a second Project Link.
         expect(fetchMock).not.toHaveBeenCalled();
         expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
     });

--- a/packages/cli/src/commands/console/console.spec.ts
+++ b/packages/cli/src/commands/console/console.spec.ts
@@ -20,6 +20,7 @@ import {
     expiry,
     manifest,
 } from './console.fixtures';
+import { PROJECT_LINK_KEEP_MANIFEST } from './project-link-gitignore';
 import { ProjectLinkManifest, getProjectLinkManifestPath } from './project-link-manifest';
 
 const UUID_V7_LINK_ID = '33333333-3333-7333-8333-333333333333';
@@ -149,9 +150,7 @@ describe('console command', () => {
         expect(fs.readFileSync(path.join(root, '.gitignore'), 'utf8')).toContain('!.vendure/project.json');
         expect(fetchMock).toHaveBeenCalledTimes(3);
         expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:3001/v1/project-links');
-        expect(fetchMock.mock.calls[1][0]).toBe(
-            `http://localhost:3001/v1/project-links/${LINK_ID}/poll`,
-        );
+        expect(fetchMock.mock.calls[1][0]).toBe(`http://localhost:3001/v1/project-links/${LINK_ID}/poll`);
         expect(fetchMock.mock.calls[0][1]?.redirect).toBe('error');
         expect(fetchMock.mock.calls[1][1]?.redirect).toBe('error');
         expect(fetchMock.mock.calls[1][1]?.body).toBe(JSON.stringify({ pollingSecret: POLLING_SECRET }));
@@ -655,7 +654,9 @@ describe('console command', () => {
         expect(await consoleCommand('link', {}, test.dependencies)).toBe(0);
         expect(hook).not.toHaveBeenCalled();
         // Declining plugin setup does not decline the rules this path writes.
-        expect(fs.existsSync(path.join(root, '.gitignore'))).toBe(true);
+        expect(fs.readFileSync(path.join(root, '.gitignore'), 'utf-8')).toContain(PROJECT_LINK_KEEP_MANIFEST);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(root))).toEqual(manifest);
+        expect(test.messages.join('\n')).toContain('No plugin setup was run');
     });
 
     it('repairs rather than failing closed when a linked project repeats a link non-interactively', async () => {

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -4,14 +4,14 @@ import { ChildProcess, spawn } from 'node:child_process';
 import { CliCommandExit } from '../../shared/cli-command-exit';
 import { isNonInteractiveEnvironment, withInteractiveTimeout } from '../../utilities/utils';
 
+import { ConsoleLinkContext, ConsoleLinkOutcome, RegisteredConsoleLinkHook } from './console-link-hook';
 import {
-    ConsoleLinkContext,
-    ConsoleLinkOutcome,
-    ConsoleReporter,
-    RegisteredConsoleLinkHook,
-    getConsoleLinkHooks,
-} from './console-link-hook';
-import { DEFAULT_CONSOLE_API_URL, DEFAULT_CONSOLE_URL, officialConsoleEnvironment } from './console-origins';
+    DEFAULT_CONSOLE_API_URL,
+    DEFAULT_CONSOLE_URL,
+    assertOfficialConsoleOriginPair,
+    officialConsoleEnvironment,
+} from './console-origins';
+import { ConsoleReporter } from './console-reporter';
 import { ensureProjectLinkGitignore } from './project-link-gitignore';
 import {
     ManifestReadResult,
@@ -35,11 +35,9 @@ export interface ConsoleCommandOptions {
     allowCustomConsole?: boolean;
     project?: string;
     force?: boolean;
-    /** Answers the repair confirmation in advance. See {@link confirmRepair}. */
+    /** Answers every confirmation owned by the CLI. */
     yes?: boolean;
 }
-
-export type { ConsoleReporter };
 
 export interface ConsoleCommandDependencies {
     cwd: string;
@@ -107,7 +105,7 @@ function createDefaultDependencies(): ConsoleCommandDependencies {
         cwd: process.cwd(),
         env: process.env,
         fetch: globalThis.fetch,
-        hooks: getConsoleLinkHooks(),
+        hooks: [],
         isNonInteractive: () => isNonInteractiveEnvironment(),
         now: () => Date.now(),
         openUrl: openUrlInBrowser,
@@ -230,9 +228,7 @@ export function resolveConsoleEndpoints(env: NodeJS.ProcessEnv): ConsoleEndpoint
     }
     const consoleUrl = baseUrl(consoleOverride ?? DEFAULT_CONSOLE_URL, 'VENDURE_CONSOLE_LINK_URL');
     const apiUrl = baseUrl(apiOverride ?? DEFAULT_CONSOLE_API_URL, 'VENDURE_CONSOLE_LINK_API_URL');
-    if ((consoleUrl === DEFAULT_CONSOLE_URL) !== (apiUrl === DEFAULT_CONSOLE_API_URL)) {
-        throw new Error('The production Console and API origins must be used together.');
-    }
+    assertOfficialConsoleOriginPair({ consoleUrl, apiUrl });
     return { consoleUrl, apiUrl };
 }
 
@@ -246,13 +242,7 @@ async function link(
     const endpoints = resolveConsoleEndpoints(dependencies.env);
     const existing = readProjectLinkManifest(projectRoot);
     if (existing.kind === 'valid' && !options.force) {
-        // `vendure console link` establishes a link and repairs one, rather
-        // than establishing one and leaving repair to somewhere else. A repeat
-        // in a project that is already linked runs the setup again against the
-        // manifest on disk. Minting a second Project Link would abandon the
-        // first in Console for a problem that is local, and it would put the
-        // choice of Project back in front of someone who only wanted their
-        // credentials back.
+        // A repeated link reuses the manifest and reruns plugin setup.
         return repair(
             projectRoot,
             existing.manifest,
@@ -301,25 +291,7 @@ async function link(
     );
 }
 
-/**
- * Runs the setup that follows a link for a project that is already linked,
- * against the manifest already on disk.
- *
- * Nothing is asked of Console and the manifest is not rewritten: the Project
- * Link it names is still the one in force. The `.gitignore` rules are applied
- * as they are after a link, so a checkout that never had them gets them. That
- * is the one write this path makes, and it happens whether or not the plugin
- * setup below is approved.
- *
- * The custom-endpoint gate runs all the same, because a hook is given these
- * origins and may talk to them.
- *
- * A manifest is meant to be committed, so an already-linked project may be one
- * the developer has just cloned, naming an account and a project they have
- * never seen. Running hooks against it without asking would hand a plugin
- * somebody else's identifiers. So when there are hooks to run and a terminal
- * to ask, the project and account are named and confirmed first.
- */
+/** Reuses the manifest, reapplies its `.gitignore` rules, and reruns plugin setup. */
 async function repair(
     projectRoot: string,
     manifest: ProjectLinkManifest,
@@ -396,17 +368,7 @@ interface ConsoleLinkHookInputs {
     outcome: ConsoleLinkOutcome;
 }
 
-/**
- * Runs the plugin hooks, in the order the plugins were listed.
- *
- * The manifest is on disk by this point and is not removed by a hook that
- * fails, so a failure is reported as what it is: the link is in place and the
- * work after it did not finish. Rolling the manifest back would be worse,
- * because the Project Link exists in Console either way.
- *
- * The first failure stops the rest. A later hook would be setting up a project
- * whose earlier setup is known to be incomplete.
- */
+/** Runs plugin hooks in registration order and stops after the first failure. */
 async function runConsoleLinkHooks(
     inputs: ConsoleLinkHookInputs,
     options: ConsoleCommandOptions,
@@ -447,22 +409,14 @@ async function runConsoleLinkHooks(
     return 0;
 }
 
-/**
- * Builds a context for one hook.
- *
- * A fresh one each time, rather than one shared by all of them. Hooks run in a
- * configured order, and `endpoints.official` is the fact a hook holding a
- * credential checks before it sends anything. A shared object would let the
- * plugin listed first decide what the plugin listed second sees.
- *
- * `reporter` and `signal` are deliberately the same objects in every context.
- */
+/** Builds an isolated context for one hook. */
 function createConsoleLinkContext(
     inputs: ConsoleLinkHookInputs,
     options: ConsoleCommandOptions,
     dependencies: ConsoleCommandDependencies,
     signal: AbortSignal,
 ): ConsoleLinkContext {
+    const isNonInteractive = dependencies.isNonInteractive();
     return {
         projectRoot: inputs.projectRoot,
         manifest: structuredClone(inputs.manifest),
@@ -475,8 +429,8 @@ function createConsoleLinkContext(
         outcome: inputs.outcome,
         signal,
         reporter: dependencies.reporter,
-        confirm: message => confirmForHook(message, dependencies),
-        isNonInteractive: dependencies.isNonInteractive(),
+        confirm: message => confirmForHook(message, isNonInteractive, dependencies.prompt),
+        isNonInteractive,
         force: options.force === true,
     };
 }
@@ -490,9 +444,10 @@ function createConsoleLinkContext(
  */
 function confirmForHook(
     message: string,
-    dependencies: ConsoleCommandDependencies,
+    isNonInteractive: boolean,
+    prompt: ConsoleCommandDependencies['prompt'],
 ): Promise<boolean | undefined> {
-    if (dependencies.isNonInteractive()) {
+    if (isNonInteractive) {
         return Promise.reject(
             new Error(
                 'Cannot ask for confirmation in a non-interactive environment. ' +
@@ -500,7 +455,7 @@ function confirmForHook(
             ),
         );
     }
-    return dependencies.prompt(message);
+    return prompt(message);
 }
 
 function linkUnfinished(outcome: ConsoleLinkOutcome, manifestPath: string): string {
@@ -516,7 +471,7 @@ async function confirmCustomConsoleEndpoints(
     options: ConsoleCommandOptions,
     dependencies: ConsoleCommandDependencies,
 ): Promise<'confirmed' | 'cancelled' | 'required'> {
-    if (!usesCustomRemoteEndpoints(endpoints) || options.allowCustomConsole) {
+    if (!usesCustomRemoteEndpoints(endpoints) || options.allowCustomConsole || options.yes) {
         return 'confirmed';
     }
     if (dependencies.isNonInteractive()) {
@@ -621,7 +576,7 @@ async function confirmManifestChange(
     options: ConsoleCommandOptions,
     dependencies: ConsoleCommandDependencies,
 ): Promise<'confirmed' | 'cancelled' | 'required'> {
-    if (options.force) {
+    if (options.force || options.yes) {
         return 'confirmed';
     }
     if (dependencies.isNonInteractive()) {
@@ -823,8 +778,8 @@ async function requestJson(
     }
 }
 
-function isTransientHttpStatus(status: number): boolean {
-    return status >= 500 || status === 408 || status === 429;
+function isTransientHttpStatus(statusCode: number): boolean {
+    return statusCode >= 500 || statusCode === 408 || statusCode === 429;
 }
 
 async function readJsonBody(response: Response, signal: AbortSignal): Promise<unknown> {
@@ -922,14 +877,7 @@ function isLoopbackHostname(hostname: string): boolean {
     return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
 }
 
-/**
- * Whether these origins are a remote Console that is not Vendure's.
- *
- * Both official deployments pass, not only production. Calling the official
- * staging Console "custom" and then reporting it to a hook as official said
- * two different things about one pair, and the prompt was the one that was
- * wrong. A loopback pair still passes, for development and tests.
- */
+/** Whether these origins are a remote Console that Vendure does not operate. */
 function usesCustomRemoteEndpoints(endpoints: ConsoleEndpoints): boolean {
     if (officialConsoleEnvironment(endpoints) !== undefined) {
         return false;

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -307,10 +307,19 @@ async function link(
  * Runs the setup that follows a link for a project that is already linked,
  * against the manifest already on disk.
  *
- * Nothing is written and nothing is asked of Console: the Project Link this
- * manifest names is still the one in force. The custom-endpoint gate runs all
- * the same, because a hook is given these origins and may talk to them, and
- * approving them is the decision this command exists to take.
+ * Nothing is asked of Console and the manifest is not rewritten: the Project
+ * Link it names is still the one in force. The `.gitignore` rules are still
+ * applied, as they are after a link, so a checkout that never had them gets
+ * them. That is the one write this path makes.
+ *
+ * The custom-endpoint gate runs all the same, because a hook is given these
+ * origins and may talk to them.
+ *
+ * A manifest is meant to be committed, so an already-linked project may be one
+ * the developer has just cloned, naming an account and a project they have
+ * never seen. Running hooks against it without asking would hand a plugin
+ * somebody else's identifiers. So when there are hooks to run and a terminal
+ * to ask, the project and account are named and confirmed first.
  */
 async function repair(
     projectRoot: string,
@@ -326,6 +335,10 @@ async function repair(
     if (endpointApproval !== 'confirmed') {
         return endpointApproval === 'cancelled' ? 0 : 1;
     }
+    const confirmed = await confirmRepair(manifest, options, dependencies);
+    if (confirmed !== 'confirmed') {
+        return confirmed === 'cancelled' ? 0 : 1;
+    }
     state.outcome = 'repaired';
     state.manifestPath = manifestPath;
     dependencies.reporter.success(`Already linked to ${manifest.project.name} in ${manifest.account.name}.`);
@@ -340,6 +353,36 @@ async function repair(
         dependencies,
         signal,
     );
+}
+
+/**
+ * Confirms running plugin setup against a manifest this run did not write.
+ *
+ * Only asked when a plugin would actually do something, because with no hooks
+ * registered a repair reports the link and changes nothing, and there is
+ * nothing to approve. Non-interactive runs proceed: the backfill this command
+ * exists to provide has to work in CI, where the manifest is part of the
+ * checked-out source the operator chose to run and there is nobody to ask.
+ */
+async function confirmRepair(
+    manifest: ProjectLinkManifest,
+    options: ConsoleCommandOptions,
+    dependencies: ConsoleCommandDependencies,
+): Promise<'confirmed' | 'cancelled'> {
+    if (options.force || dependencies.hooks.length === 0 || dependencies.isNonInteractive()) {
+        return 'confirmed';
+    }
+    const result = await dependencies.prompt(
+        `Run plugin setup for ${manifest.project.name} in ${manifest.account.name}?`,
+    );
+    if (result === undefined) {
+        throw new CommandInterruptedError();
+    }
+    if (result !== true) {
+        dependencies.reporter.info('No plugin setup was run. The Project Link Manifest is unchanged.');
+        return 'cancelled';
+    }
+    return 'confirmed';
 }
 
 /** What the command resolved, before it is shaped into a per-hook context. */
@@ -378,7 +421,9 @@ async function runConsoleLinkHooks(
                 throw new CommandInterruptedError();
             }
             // The host owns this one, and it carries the exit code with it.
+            // Still say what survived, or the exit code is all the reader gets.
             if (error instanceof CliCommandExit) {
+                dependencies.reporter.warn(linkUnfinished(inputs.outcome, inputs.manifestPath));
                 throw error;
             }
             const detail = error instanceof Error ? error.message : String(error);
@@ -394,9 +439,12 @@ async function runConsoleLinkHooks(
  * Builds a context for one hook.
  *
  * A fresh one each time, rather than one shared by all of them. Hooks run in a
- * configured order, and `endpoints.areDefault` is the fact a hook holding a
+ * configured order, and `endpoints.official` is the fact a hook holding a
  * credential checks before it sends anything. A shared object would let the
  * plugin listed first decide what the plugin listed second sees.
+ *
+ * `reporter` and `signal` are deliberately the same objects in every context.
+ * One output stream and one abort signal are the point of them.
  */
 function createConsoleLinkContext(
     inputs: ConsoleLinkHookInputs,
@@ -863,8 +911,16 @@ function isLoopbackHostname(hostname: string): boolean {
     return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
 }
 
+/**
+ * Whether these origins are a remote Console that is not Vendure's.
+ *
+ * Both official deployments pass, not only production. Calling the official
+ * staging Console "custom" and then reporting it to a hook as official said
+ * two different things about one pair, and the prompt was the one that was
+ * wrong. A loopback pair still passes, for development and tests.
+ */
 function usesCustomRemoteEndpoints(endpoints: ConsoleEndpoints): boolean {
-    if (endpoints.consoleUrl === DEFAULT_CONSOLE_URL && endpoints.apiUrl === DEFAULT_CONSOLE_API_URL) {
+    if (officialConsoleEnvironment(endpoints) !== undefined) {
         return false;
     }
     return ![endpoints.consoleUrl, endpoints.apiUrl].every(value =>

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -11,11 +11,7 @@ import {
     RegisteredConsoleLinkHook,
     getConsoleLinkHooks,
 } from './console-link-hook';
-import {
-    DEFAULT_CONSOLE_API_URL,
-    DEFAULT_CONSOLE_URL,
-    officialConsoleEnvironment,
-} from './console-origins';
+import { DEFAULT_CONSOLE_API_URL, DEFAULT_CONSOLE_URL, officialConsoleEnvironment } from './console-origins';
 import { ensureProjectLinkGitignore } from './project-link-gitignore';
 import {
     ManifestReadResult,
@@ -310,9 +306,10 @@ async function link(
  * against the manifest already on disk.
  *
  * Nothing is asked of Console and the manifest is not rewritten: the Project
- * Link it names is still the one in force. The `.gitignore` rules are still
- * applied, as they are after a link, so a checkout that never had them gets
- * them. That is the one write this path makes.
+ * Link it names is still the one in force. The `.gitignore` rules are applied
+ * as they are after a link, so a checkout that never had them gets them. That
+ * is the one write this path makes, and it happens whether or not the plugin
+ * setup below is approved.
  *
  * The custom-endpoint gate runs all the same, because a hook is given these
  * origins and may talk to them.
@@ -341,8 +338,6 @@ async function repair(
     dependencies.reporter.info(
         `Kept ${manifestPath}. Run vendure console link --force to link this project to a different Console Project.`,
     );
-    // Before the question, because the rules are this path's own write and have
-    // nothing to do with whether a plugin runs.
     reportProjectLinkGitignore(projectRoot, dependencies.reporter);
     if (!(await confirmRepair(manifest, options, dependencies))) {
         return 0;
@@ -428,11 +423,12 @@ async function runConsoleLinkHooks(
                 throw new CommandInterruptedError();
             }
             // The host owns this one, and it carries the exit code with it.
+            // Reported whatever the code, because a hook that stops the run at
+            // zero still stops every hook after it, and the exit code alone
+            // does not tell the reader that some setup never ran.
             if (error instanceof CliCommandExit) {
-                if (error.exitCode !== 0) {
-                    dependencies.reporter.error(`The ${pluginId} plugin stopped after linking.`);
-                    dependencies.reporter.warn(linkUnfinished(inputs.outcome, inputs.manifestPath));
-                }
+                dependencies.reporter.error(`The ${pluginId} plugin stopped the run after linking.`);
+                dependencies.reporter.warn(linkUnfinished(inputs.outcome, inputs.manifestPath));
                 throw error;
             }
             const detail = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -39,6 +39,8 @@ export interface ConsoleCommandOptions {
     allowCustomConsole?: boolean;
     project?: string;
     force?: boolean;
+    /** Answers the repair confirmation in advance. See {@link confirmRepair}. */
+    yes?: boolean;
 }
 
 export type { ConsoleReporter };
@@ -335,17 +337,18 @@ async function repair(
     if (endpointApproval !== 'confirmed') {
         return endpointApproval === 'cancelled' ? 0 : 1;
     }
-    const confirmed = await confirmRepair(manifest, options, dependencies);
-    if (confirmed !== 'confirmed') {
-        return confirmed === 'cancelled' ? 0 : 1;
-    }
-    state.outcome = 'repaired';
-    state.manifestPath = manifestPath;
     dependencies.reporter.success(`Already linked to ${manifest.project.name} in ${manifest.account.name}.`);
     dependencies.reporter.info(
         `Kept ${manifestPath}. Run vendure console link --force to link this project to a different Console Project.`,
     );
+    // Before the question, because the rules are this path's own write and have
+    // nothing to do with whether a plugin runs.
     reportProjectLinkGitignore(projectRoot, dependencies.reporter);
+    if (!(await confirmRepair(manifest, options, dependencies))) {
+        return 0;
+    }
+    state.outcome = 'repaired';
+    state.manifestPath = manifestPath;
 
     return runConsoleLinkHooks(
         { projectRoot, manifest, manifestPath, endpoints, outcome: 'repaired' },
@@ -356,21 +359,25 @@ async function repair(
 }
 
 /**
- * Confirms running plugin setup against a manifest this run did not write.
+ * Whether to run plugin setup against a manifest this run did not write.
  *
  * Only asked when a plugin would actually do something, because with no hooks
- * registered a repair reports the link and changes nothing, and there is
- * nothing to approve. Non-interactive runs proceed: the backfill this command
- * exists to provide has to work in CI, where the manifest is part of the
- * checked-out source the operator chose to run and there is nobody to ask.
+ * registered a repair reports the link and changes nothing. Non-interactive
+ * runs proceed: the backfill this command exists to provide has to work in CI,
+ * where the manifest is part of the checked-out source the operator chose to
+ * run and there is nobody to ask. `--yes` is the answer given in advance, for
+ * repeating a repair in a project whose manifest the developer already trusts.
+ *
+ * `--force` is not that answer. It links to a different Project, so it never
+ * reaches here.
  */
 async function confirmRepair(
     manifest: ProjectLinkManifest,
     options: ConsoleCommandOptions,
     dependencies: ConsoleCommandDependencies,
-): Promise<'confirmed' | 'cancelled'> {
-    if (options.force || dependencies.hooks.length === 0 || dependencies.isNonInteractive()) {
-        return 'confirmed';
+): Promise<boolean> {
+    if (options.yes || dependencies.hooks.length === 0 || dependencies.isNonInteractive()) {
+        return true;
     }
     const result = await dependencies.prompt(
         `Run plugin setup for ${manifest.project.name} in ${manifest.account.name}?`,
@@ -380,9 +387,9 @@ async function confirmRepair(
     }
     if (result !== true) {
         dependencies.reporter.info('No plugin setup was run. The Project Link Manifest is unchanged.');
-        return 'cancelled';
+        return false;
     }
-    return 'confirmed';
+    return true;
 }
 
 /** What the command resolved, before it is shaped into a per-hook context. */
@@ -421,9 +428,11 @@ async function runConsoleLinkHooks(
                 throw new CommandInterruptedError();
             }
             // The host owns this one, and it carries the exit code with it.
-            // Still say what survived, or the exit code is all the reader gets.
             if (error instanceof CliCommandExit) {
-                dependencies.reporter.warn(linkUnfinished(inputs.outcome, inputs.manifestPath));
+                if (error.exitCode !== 0) {
+                    dependencies.reporter.error(`The ${pluginId} plugin stopped after linking.`);
+                    dependencies.reporter.warn(linkUnfinished(inputs.outcome, inputs.manifestPath));
+                }
                 throw error;
             }
             const detail = error instanceof Error ? error.message : String(error);
@@ -444,7 +453,6 @@ async function runConsoleLinkHooks(
  * plugin listed first decide what the plugin listed second sees.
  *
  * `reporter` and `signal` are deliberately the same objects in every context.
- * One output stream and one abort signal are the point of them.
  */
 function createConsoleLinkContext(
     inputs: ConsoleLinkHookInputs,

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -4,6 +4,12 @@ import { ChildProcess, spawn } from 'node:child_process';
 import { CliCommandExit } from '../../shared/cli-command-exit';
 import { isNonInteractiveEnvironment, withInteractiveTimeout } from '../../utilities/utils';
 
+import {
+    ConsoleLinkContext,
+    ConsoleReporter,
+    RegisteredConsoleLinkHook,
+    getConsoleLinkHooks,
+} from './console-link-hook';
 import { ensureProjectLinkGitignore } from './project-link-gitignore';
 import {
     ManifestReadResult,
@@ -31,18 +37,17 @@ export interface ConsoleCommandOptions {
     force?: boolean;
 }
 
-export interface ConsoleReporter {
-    error(message: string): void;
-    info(message: string): void;
-    success(message: string): void;
-    warn(message: string): void;
-    url(value: string): void;
-}
+export type { ConsoleReporter };
 
 export interface ConsoleCommandDependencies {
     cwd: string;
     env: NodeJS.ProcessEnv;
     fetch: typeof globalThis.fetch;
+    /**
+     * Plugin hooks to run once a link has been written. Defaults to the ones
+     * the host collected from the loaded plugins.
+     */
+    hooks: readonly RegisteredConsoleLinkHook[];
     isNonInteractive: () => boolean;
     now: () => number;
     openUrl: (url: string) => Promise<void>;
@@ -100,6 +105,7 @@ function createDefaultDependencies(): ConsoleCommandDependencies {
         cwd: process.cwd(),
         env: process.env,
         fetch: globalThis.fetch,
+        hooks: getConsoleLinkHooks(),
         isNonInteractive: () => isNonInteractiveEnvironment(),
         now: () => Date.now(),
         openUrl: openUrlInBrowser,
@@ -145,14 +151,20 @@ export async function consoleCommand(
         externalSignal?.addEventListener('abort', onExternalAbort, { once: true });
     }
 
+    const state: ConsoleCommandState = {};
     try {
-        return await runConsoleCommand(action, options, resolvedDependencies, abortController.signal);
+        return await runConsoleCommand(action, options, resolvedDependencies, abortController.signal, state);
     } catch (error) {
         if (interruptedExitCode !== undefined || error instanceof CommandInterruptedError) {
             // A process signal wins so SIGTERM retains exit code 143. Prompt cancellation and external aborts use 130.
             const exitCode = interruptedExitCode ?? 130;
             resolvedDependencies.reporter.warn(
-                'Console command interrupted. No Project Link Manifest was changed.',
+                // Once the manifest is written the link is done and cannot be
+                // taken back, so saying nothing changed would be untrue. An
+                // interrupt after that point stopped a hook, not the link.
+                state.manifestPath
+                    ? `Console command interrupted. ${linkedButUnfinished(state.manifestPath)}`
+                    : 'Console command interrupted. No Project Link Manifest was changed.',
             );
             return exitCode;
         }
@@ -168,11 +180,21 @@ export async function consoleCommand(
     }
 }
 
+/**
+ * What the run has already done, for messages that would otherwise overstate
+ * how much an interrupt took back.
+ */
+interface ConsoleCommandState {
+    /** Set once the Project Link Manifest is on disk. */
+    manifestPath?: string;
+}
+
 async function runConsoleCommand(
     action: string | undefined,
     options: ConsoleCommandOptions,
     dependencies: ConsoleCommandDependencies,
     signal: AbortSignal,
+    state: ConsoleCommandState,
 ): Promise<number> {
     const normalizedAction = action?.trim().toLowerCase();
     if (!normalizedAction || !['link', 'status', 'unlink'].includes(normalizedAction)) {
@@ -192,7 +214,7 @@ async function runConsoleCommand(
     if (normalizedAction === 'unlink') {
         return unlink(projectRoot, options, dependencies);
     }
-    return link(projectRoot, options, dependencies, signal);
+    return link(projectRoot, options, dependencies, signal, state);
 }
 
 export function resolveConsoleEndpoints(env: NodeJS.ProcessEnv): ConsoleEndpoints {
@@ -216,6 +238,7 @@ async function link(
     options: ConsoleCommandOptions,
     dependencies: ConsoleCommandDependencies,
     signal: AbortSignal,
+    state: ConsoleCommandState,
 ): Promise<number> {
     const endpoints = resolveConsoleEndpoints(dependencies.env);
     const existing = readProjectLinkManifest(projectRoot);
@@ -242,10 +265,65 @@ async function link(
     const manifest = await waitForApproval(request, endpoints, dependencies, signal);
     throwIfAborted(signal);
     const manifestPath = await writeProjectLinkManifestAtomic(projectRoot, manifest);
+    state.manifestPath = manifestPath;
     dependencies.reporter.success(`Linked ${manifest.project.name} to ${manifest.account.name}.`);
     dependencies.reporter.info(`Wrote ${manifestPath}`);
     reportProjectLinkGitignore(projectRoot, dependencies.reporter);
+
+    return runConsoleLinkHooks(
+        {
+            projectRoot,
+            manifest,
+            manifestPath,
+            endpoints: { ...endpoints, areDefault: usesDefaultEndpoints(endpoints) },
+            signal,
+            reporter: dependencies.reporter,
+            confirm: message => dependencies.prompt(message),
+            isNonInteractive: dependencies.isNonInteractive(),
+            force: options.force === true,
+        },
+        dependencies,
+        signal,
+    );
+}
+
+/**
+ * Runs the plugin hooks, in the order the plugins were listed.
+ *
+ * The link is already written by this point and is not undone by a hook that
+ * fails, so a failure is reported as what it is: the link succeeded and the
+ * work after it did not. Rolling the manifest back would be worse, because the
+ * Project Link exists in Console either way and a second `vendure console link`
+ * creates another one rather than repairing this one.
+ *
+ * The first failure stops the rest. A later hook would be setting up a project
+ * whose earlier setup is known to be incomplete.
+ */
+async function runConsoleLinkHooks(
+    context: ConsoleLinkContext,
+    dependencies: ConsoleCommandDependencies,
+    signal: AbortSignal,
+): Promise<number> {
+    for (const { pluginId, hook } of dependencies.hooks) {
+        try {
+            await hook(context);
+        } catch (error) {
+            // Ctrl-C during a hook is an interrupt whatever the hook threw, so
+            // it is reported by the one handler that knows the exit code.
+            if (signal.aborted || error instanceof CommandInterruptedError) {
+                throw new CommandInterruptedError();
+            }
+            const detail = error instanceof Error ? error.message : String(error);
+            dependencies.reporter.error(`The ${pluginId} plugin failed after linking: ${detail}`);
+            dependencies.reporter.warn(linkedButUnfinished(context.manifestPath));
+            return 1;
+        }
+    }
     return 0;
+}
+
+function linkedButUnfinished(manifestPath: string): string {
+    return `The link succeeded and ${manifestPath} is in place. The setup that runs after linking did not finish.`;
 }
 
 async function confirmCustomConsoleEndpoints(
@@ -657,6 +735,16 @@ function baseUrl(value: string, label: string): string {
 
 function isLoopbackHostname(hostname: string): boolean {
     return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+}
+
+/**
+ * Whether the built-in production origins were used. Narrower than the negation
+ * of {@link usesCustomRemoteEndpoints}, which also passes a loopback pair: a
+ * hook holding credentials has no more reason to trust a local Console than a
+ * remote one it does not recognise.
+ */
+function usesDefaultEndpoints(endpoints: ConsoleEndpoints): boolean {
+    return endpoints.consoleUrl === DEFAULT_CONSOLE_URL && endpoints.apiUrl === DEFAULT_CONSOLE_API_URL;
 }
 
 function usesCustomRemoteEndpoints(endpoints: ConsoleEndpoints): boolean {

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -11,6 +11,11 @@ import {
     RegisteredConsoleLinkHook,
     getConsoleLinkHooks,
 } from './console-link-hook';
+import {
+    DEFAULT_CONSOLE_API_URL,
+    DEFAULT_CONSOLE_URL,
+    officialConsoleEnvironment,
+} from './console-origins';
 import { ensureProjectLinkGitignore } from './project-link-gitignore';
 import {
     ManifestReadResult,
@@ -24,8 +29,6 @@ import {
 } from './project-link-manifest';
 import { nonEmptyString, objectValue, uuid } from './project-link-validation';
 
-const DEFAULT_CONSOLE_URL = 'https://console.vendure.io';
-const DEFAULT_CONSOLE_API_URL = 'https://api.vendure.io';
 const PROJECT_LINKS_PATH = '/v1/project-links';
 const POLL_INTERVAL_MS = 2_000;
 const REQUEST_TIMEOUT_MS = 10_000;
@@ -408,7 +411,7 @@ function createConsoleLinkContext(
         endpoints: {
             consoleUrl: inputs.endpoints.consoleUrl,
             apiUrl: inputs.endpoints.apiUrl,
-            areDefault: usesDefaultEndpoints(inputs.endpoints),
+            official: officialConsoleEnvironment(inputs.endpoints),
         },
         outcome: inputs.outcome,
         signal,
@@ -858,16 +861,6 @@ function baseUrl(value: string, label: string): string {
 
 function isLoopbackHostname(hostname: string): boolean {
     return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
-}
-
-/**
- * Whether the built-in production origins were used. Narrower than the negation
- * of {@link usesCustomRemoteEndpoints}, which also passes a loopback pair: a
- * hook holding credentials has no more reason to trust a local Console than a
- * remote one it does not recognise.
- */
-function usesDefaultEndpoints(endpoints: ConsoleEndpoints): boolean {
-    return endpoints.consoleUrl === DEFAULT_CONSOLE_URL && endpoints.apiUrl === DEFAULT_CONSOLE_API_URL;
 }
 
 function usesCustomRemoteEndpoints(endpoints: ConsoleEndpoints): boolean {

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -6,6 +6,7 @@ import { isNonInteractiveEnvironment, withInteractiveTimeout } from '../../utili
 
 import {
     ConsoleLinkContext,
+    ConsoleLinkOutcome,
     ConsoleReporter,
     RegisteredConsoleLinkHook,
     getConsoleLinkHooks,
@@ -162,8 +163,8 @@ export async function consoleCommand(
                 // Once the manifest is written the link is done and cannot be
                 // taken back, so saying nothing changed would be untrue. An
                 // interrupt after that point stopped a hook, not the link.
-                state.manifestPath
-                    ? `Console command interrupted. ${linkedButUnfinished(state.manifestPath)}`
+                state.manifestPath && state.outcome
+                    ? `Console command interrupted. ${linkUnfinished(state.outcome, state.manifestPath)}`
                     : 'Console command interrupted. No Project Link Manifest was changed.',
             );
             return exitCode;
@@ -185,8 +186,9 @@ export async function consoleCommand(
  * how much an interrupt took back.
  */
 interface ConsoleCommandState {
-    /** Set once the Project Link Manifest is on disk. */
+    /** Set once the Project Link Manifest is on disk, written or reused. */
     manifestPath?: string;
+    outcome?: ConsoleLinkOutcome;
 }
 
 async function runConsoleCommand(
@@ -242,6 +244,25 @@ async function link(
 ): Promise<number> {
     const endpoints = resolveConsoleEndpoints(dependencies.env);
     const existing = readProjectLinkManifest(projectRoot);
+    if (existing.kind === 'valid' && !options.force) {
+        // `vendure console link` establishes a link and repairs one, rather
+        // than establishing one and leaving repair to somewhere else. A repeat
+        // in a project that is already linked runs the setup again against the
+        // manifest on disk. Minting a second Project Link would abandon the
+        // first in Console for a problem that is local, and it would put the
+        // choice of Project back in front of someone who only wanted their
+        // credentials back.
+        return repair(
+            projectRoot,
+            existing.manifest,
+            existing.path,
+            endpoints,
+            options,
+            dependencies,
+            signal,
+            state,
+        );
+    }
     if (existing.kind !== 'missing') {
         const confirmed = await confirmManifestChange('replace', existing, options, dependencies);
         if (confirmed !== 'confirmed') {
@@ -265,65 +286,167 @@ async function link(
     const manifest = await waitForApproval(request, endpoints, dependencies, signal);
     throwIfAborted(signal);
     const manifestPath = await writeProjectLinkManifestAtomic(projectRoot, manifest);
+    state.outcome = 'linked';
     state.manifestPath = manifestPath;
     dependencies.reporter.success(`Linked ${manifest.project.name} to ${manifest.account.name}.`);
     dependencies.reporter.info(`Wrote ${manifestPath}`);
     reportProjectLinkGitignore(projectRoot, dependencies.reporter);
 
     return runConsoleLinkHooks(
-        {
-            projectRoot,
-            manifest,
-            manifestPath,
-            endpoints: { ...endpoints, areDefault: usesDefaultEndpoints(endpoints) },
-            signal,
-            reporter: dependencies.reporter,
-            confirm: message => dependencies.prompt(message),
-            isNonInteractive: dependencies.isNonInteractive(),
-            force: options.force === true,
-        },
+        { projectRoot, manifest, manifestPath, endpoints, outcome: 'linked' },
+        options,
         dependencies,
         signal,
     );
 }
 
 /**
+ * Runs the setup that follows a link for a project that is already linked,
+ * against the manifest already on disk.
+ *
+ * Nothing is written and nothing is asked of Console: the Project Link this
+ * manifest names is still the one in force. The custom-endpoint gate runs all
+ * the same, because a hook is given these origins and may talk to them, and
+ * approving them is the decision this command exists to take.
+ */
+async function repair(
+    projectRoot: string,
+    manifest: ProjectLinkManifest,
+    manifestPath: string,
+    endpoints: ConsoleEndpoints,
+    options: ConsoleCommandOptions,
+    dependencies: ConsoleCommandDependencies,
+    signal: AbortSignal,
+    state: ConsoleCommandState,
+): Promise<number> {
+    const endpointApproval = await confirmCustomConsoleEndpoints(endpoints, options, dependencies);
+    if (endpointApproval !== 'confirmed') {
+        return endpointApproval === 'cancelled' ? 0 : 1;
+    }
+    state.outcome = 'repaired';
+    state.manifestPath = manifestPath;
+    dependencies.reporter.success(`Already linked to ${manifest.project.name} in ${manifest.account.name}.`);
+    dependencies.reporter.info(
+        `Kept ${manifestPath}. Run vendure console link --force to link this project to a different Console Project.`,
+    );
+    reportProjectLinkGitignore(projectRoot, dependencies.reporter);
+
+    return runConsoleLinkHooks(
+        { projectRoot, manifest, manifestPath, endpoints, outcome: 'repaired' },
+        options,
+        dependencies,
+        signal,
+    );
+}
+
+/** What the command resolved, before it is shaped into a per-hook context. */
+interface ConsoleLinkHookInputs {
+    projectRoot: string;
+    manifest: ProjectLinkManifest;
+    manifestPath: string;
+    endpoints: ConsoleEndpoints;
+    outcome: ConsoleLinkOutcome;
+}
+
+/**
  * Runs the plugin hooks, in the order the plugins were listed.
  *
- * The link is already written by this point and is not undone by a hook that
- * fails, so a failure is reported as what it is: the link succeeded and the
- * work after it did not. Rolling the manifest back would be worse, because the
- * Project Link exists in Console either way and a second `vendure console link`
- * creates another one rather than repairing this one.
+ * The manifest is on disk by this point and is not removed by a hook that
+ * fails, so a failure is reported as what it is: the link is in place and the
+ * work after it did not finish. Rolling the manifest back would be worse,
+ * because the Project Link exists in Console either way.
  *
  * The first failure stops the rest. A later hook would be setting up a project
  * whose earlier setup is known to be incomplete.
  */
 async function runConsoleLinkHooks(
-    context: ConsoleLinkContext,
+    inputs: ConsoleLinkHookInputs,
+    options: ConsoleCommandOptions,
     dependencies: ConsoleCommandDependencies,
     signal: AbortSignal,
 ): Promise<number> {
     for (const { pluginId, hook } of dependencies.hooks) {
         try {
-            await hook(context);
+            await hook(createConsoleLinkContext(inputs, options, dependencies, signal));
         } catch (error) {
             // Ctrl-C during a hook is an interrupt whatever the hook threw, so
             // it is reported by the one handler that knows the exit code.
             if (signal.aborted || error instanceof CommandInterruptedError) {
                 throw new CommandInterruptedError();
             }
+            // The host owns this one, and it carries the exit code with it.
+            if (error instanceof CliCommandExit) {
+                throw error;
+            }
             const detail = error instanceof Error ? error.message : String(error);
             dependencies.reporter.error(`The ${pluginId} plugin failed after linking: ${detail}`);
-            dependencies.reporter.warn(linkedButUnfinished(context.manifestPath));
+            dependencies.reporter.warn(linkUnfinished(inputs.outcome, inputs.manifestPath));
             return 1;
         }
     }
     return 0;
 }
 
-function linkedButUnfinished(manifestPath: string): string {
-    return `The link succeeded and ${manifestPath} is in place. The setup that runs after linking did not finish.`;
+/**
+ * Builds a context for one hook.
+ *
+ * A fresh one each time, rather than one shared by all of them. Hooks run in a
+ * configured order, and `endpoints.areDefault` is the fact a hook holding a
+ * credential checks before it sends anything. A shared object would let the
+ * plugin listed first decide what the plugin listed second sees.
+ */
+function createConsoleLinkContext(
+    inputs: ConsoleLinkHookInputs,
+    options: ConsoleCommandOptions,
+    dependencies: ConsoleCommandDependencies,
+    signal: AbortSignal,
+): ConsoleLinkContext {
+    return {
+        projectRoot: inputs.projectRoot,
+        manifest: structuredClone(inputs.manifest),
+        manifestPath: inputs.manifestPath,
+        endpoints: {
+            consoleUrl: inputs.endpoints.consoleUrl,
+            apiUrl: inputs.endpoints.apiUrl,
+            areDefault: usesDefaultEndpoints(inputs.endpoints),
+        },
+        outcome: inputs.outcome,
+        signal,
+        reporter: dependencies.reporter,
+        confirm: message => confirmForHook(message, dependencies),
+        isNonInteractive: dependencies.isNonInteractive(),
+        force: options.force === true,
+    };
+}
+
+/**
+ * Asks the hook's yes/no question, or refuses when there is nobody to answer.
+ *
+ * Without this the question goes into a pipe and the command waits for a reply
+ * that cannot come. `isNonInteractive` is on the context so that a hook takes
+ * the other path before it reaches here; this is what happens when one does not.
+ */
+function confirmForHook(
+    message: string,
+    dependencies: ConsoleCommandDependencies,
+): Promise<boolean | undefined> {
+    if (dependencies.isNonInteractive()) {
+        return Promise.reject(
+            new Error(
+                'Cannot ask for confirmation in a non-interactive environment. ' +
+                    'Check context.isNonInteractive before calling context.confirm.',
+            ),
+        );
+    }
+    return dependencies.prompt(message);
+}
+
+function linkUnfinished(outcome: ConsoleLinkOutcome, manifestPath: string): string {
+    const survived =
+        outcome === 'linked'
+            ? `The link succeeded and ${manifestPath} is in place.`
+            : `The existing link at ${manifestPath} was not changed.`;
+    return `${survived} The setup that runs after linking did not finish.`;
 }
 
 async function confirmCustomConsoleEndpoints(

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -427,7 +427,14 @@ async function runConsoleLinkHooks(
             // zero still stops every hook after it, and the exit code alone
             // does not tell the reader that some setup never ran.
             if (error instanceof CliCommandExit) {
-                dependencies.reporter.error(`The ${pluginId} plugin stopped the run after linking.`);
+                const stopped = `The ${pluginId} plugin stopped the run after linking.`;
+                // The level follows the code the process will actually exit
+                // with, so a log that reads as a failure matches one.
+                if (error.exitCode === 0) {
+                    dependencies.reporter.warn(stopped);
+                } else {
+                    dependencies.reporter.error(stopped);
+                }
                 dependencies.reporter.warn(linkUnfinished(inputs.outcome, inputs.manifestPath));
                 throw error;
             }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -51,6 +51,7 @@ export type {
     ConsoleLinkOutcome,
     ConsoleReporter,
 } from './commands/console/console-link-hook';
+export type { ConsoleOriginEnvironment } from './commands/console/console-origins';
 export type { ProjectLinkManifest } from './commands/console/project-link-manifest';
 export { readCommandContext, readCommandOptions } from './shared/cli-command-definition';
 export type {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,9 +49,9 @@ export type {
     ConsoleLinkEndpoints,
     ConsoleLinkHook,
     ConsoleLinkOutcome,
-    ConsoleReporter,
 } from './commands/console/console-link-hook';
 export type { ConsoleOriginEnvironment } from './commands/console/console-origins';
+export type { ConsoleReporter } from './commands/console/console-reporter';
 export type { ProjectLinkManifest } from './commands/console/project-link-manifest';
 export { readCommandContext, readCommandOptions } from './shared/cli-command-definition';
 export type {
@@ -69,3 +69,4 @@ export type {
 } from './shared/cli-command-definition';
 export { CLI_PLUGIN_EXTENSION_POINTS, defineCliPlugin } from './shared/cli-plugin';
 export type { CliPlugin } from './shared/cli-plugin';
+export type { CliPluginExtensionAccessor, RegisteredCliPluginExtension } from './shared/cli-plugin-extension';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,10 +36,21 @@
  *       },
  *     },
  *   ],
+ *   // Runs once `vendure console link` has written the Project Link Manifest.
+ *   afterConsoleLink: async ({ projectRoot, manifest, reporter }) => {
+ *     reporter.info(`Set up ${manifest.project.name} in ${projectRoot}`);
+ *   },
  * });
  * ```
  */
 export { builtinCommands } from './commands/builtins';
+export type {
+    ConsoleLinkContext,
+    ConsoleLinkEndpoints,
+    ConsoleLinkHook,
+    ConsoleReporter,
+} from './commands/console/console-link-hook';
+export type { ProjectLinkManifest } from './commands/console/project-link-manifest';
 export { readCommandContext, readCommandOptions } from './shared/cli-command-definition';
 export type {
     CliCommandAction,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -65,5 +65,5 @@ export type {
     CliCommandOption,
     ProjectCliPluginConfig,
 } from './shared/cli-command-definition';
-export { defineCliPlugin } from './shared/cli-plugin';
+export { CLI_PLUGIN_EXTENSION_POINTS, defineCliPlugin } from './shared/cli-plugin';
 export type { CliPlugin } from './shared/cli-plugin';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,6 +48,7 @@ export type {
     ConsoleLinkContext,
     ConsoleLinkEndpoints,
     ConsoleLinkHook,
+    ConsoleLinkOutcome,
     ConsoleReporter,
 } from './commands/console/console-link-hook';
 export type { ProjectLinkManifest } from './commands/console/project-link-manifest';

--- a/packages/cli/src/shared/__tests__/fixtures/example-cli-plugin.ts
+++ b/packages/cli/src/shared/__tests__/fixtures/example-cli-plugin.ts
@@ -76,6 +76,12 @@ export default defineCliPlugin({
                 },
         },
     ],
+    // Runs after `vendure console link` has written the Project Link Manifest.
+    // Adds to linking rather than replacing the console command, so every
+    // project still links the same way.
+    afterConsoleLink: async ({ projectRoot, manifest, reporter }) => {
+        reporter.info(`Setting up ${manifest.project.name} in ${projectRoot}`);
+    },
 });
 
 /**

--- a/packages/cli/src/shared/__tests__/run-cli.ts
+++ b/packages/cli/src/shared/__tests__/run-cli.ts
@@ -2,6 +2,7 @@ import { Command, CommanderError } from 'commander';
 import { vi } from 'vitest';
 
 import { CliCommandNode, CliCommandOption } from '../cli-command-definition';
+import { CliPluginExtensionAccessor } from '../cli-plugin-extension';
 import { registerCommands } from '../command-registry';
 
 /**
@@ -39,6 +40,7 @@ export async function runCli(
     commands: CliCommandNode[],
     sharedOptions: CliCommandOption[],
     argv: string[],
+    getPluginExtensions?: CliPluginExtensionAccessor,
 ): Promise<CliRun> {
     let stdout = '';
     let commanderStderr = '';
@@ -56,7 +58,7 @@ export async function runCli(
             commanderStderr += str;
         },
     });
-    registerCommands(program, commands, sharedOptions);
+    registerCommands(program, commands, sharedOptions, getPluginExtensions);
 
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
         throw new ExitSignal(code ?? 0);

--- a/packages/cli/src/shared/cli-command-definition.spec.ts
+++ b/packages/cli/src/shared/cli-command-definition.spec.ts
@@ -7,7 +7,11 @@ import { CliCommandContext, readCommandContext, readCommandOptions } from './cli
  * parsed options, then the Command, then the context the host appends.
  */
 function actionArgs(positionals: unknown[], options: Record<string, any>): unknown[] {
-    const context: CliCommandContext = { inheritedOptions: { token: 'tok' }, commandPath: ['a', 'b'] };
+    const context: CliCommandContext = {
+        inheritedOptions: { token: 'tok' },
+        commandPath: ['a', 'b'],
+        getPluginExtensions: () => [],
+    };
     return [...positionals, options, { name: () => 'b' }, context];
 }
 

--- a/packages/cli/src/shared/cli-command-definition.ts
+++ b/packages/cli/src/shared/cli-command-definition.ts
@@ -1,3 +1,5 @@
+import { CliPluginExtensionAccessor } from './cli-plugin-extension';
+
 /**
  * An option on a CLI command.
  *
@@ -57,6 +59,8 @@ export interface CliCommandContext<TInheritedOptions extends Record<string, any>
      * `['config', 'server', 'set']` for `vendure config server set`.
      */
     commandPath: string[];
+    /** Reads plugin contributions registered for a named extension point. */
+    getPluginExtensions: CliPluginExtensionAccessor;
 }
 
 /**

--- a/packages/cli/src/shared/cli-plugin-extension.ts
+++ b/packages/cli/src/shared/cli-plugin-extension.ts
@@ -1,0 +1,8 @@
+export interface RegisteredCliPluginExtension<T = unknown> {
+    pluginId: string;
+    extension: T;
+}
+
+export type CliPluginExtensionAccessor = <T = unknown>(
+    extensionPoint: string,
+) => ReadonlyArray<RegisteredCliPluginExtension<T>>;

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -69,7 +69,11 @@ export interface CliPlugin {
 }
 
 /**
- * The plugin extension points this build of the CLI understands.
+ * The plugin capabilities this build of the CLI understands.
+ *
+ * Entries name capabilities, not only keys of {@link CliPlugin}. `subcommands`
+ * is the ability to nest commands, which a plugin declares inside `commands`
+ * rather than through a key of its own.
  *
  * A plugin that resolves an older `@vendure/cli` than it was written against is
  * not told so. {@link assertCliPlugin} ignores keys it does not know, so a
@@ -82,7 +86,7 @@ export interface CliPlugin {
  * import * as cli from '@vendure/cli';
  *
  * // Older builds export no such constant, so `undefined` is itself the answer.
- * const supported: readonly string[] = cli.CLI_PLUGIN_EXTENSION_POINTS ?? [];
+ * const supported = cli.CLI_PLUGIN_EXTENSION_POINTS ?? [];
  * if (!supported.includes('afterConsoleLink')) {
  *     throw new Error(
  *         'This @vendure/cli is too old to run afterConsoleLink hooks. Upgrade it, ' +
@@ -96,12 +100,13 @@ export interface CliPlugin {
  *
  * @since 3.8.0
  */
-export const CLI_PLUGIN_EXTENSION_POINTS = Object.freeze([
+export const CLI_PLUGIN_EXTENSION_POINTS: readonly string[] = Object.freeze([
+    'commands',
     'rootOptions',
     'subcommands',
     'extendCommands',
     'afterConsoleLink',
-] as const);
+]);
 
 export function assertCliPlugin(value: unknown): asserts value is CliPlugin {
     if (!value || typeof value !== 'object') {

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -1,3 +1,5 @@
+import type { ConsoleLinkHook } from '../commands/console/console-link-hook';
+
 import {
     CliCommandDefinition,
     CliCommandExtension,
@@ -52,6 +54,18 @@ export interface CliPlugin {
      * @since 3.8.0
      */
     extendCommands?: CliCommandExtension[];
+    /**
+     * Runs after `vendure console link` has written the Project Link Manifest,
+     * for a plugin that has its own setup to do once a project is linked.
+     *
+     * This is not a way to take the command over. `vendure console link` stays
+     * the one implementation of linking, so every project links the same way
+     * whether or not a plugin is installed. Replacing the `console` command
+     * instead would fork the protocol.
+     *
+     * @since 3.8.0
+     */
+    afterConsoleLink?: ConsoleLinkHook;
 }
 
 export function assertCliPlugin(value: unknown): asserts value is CliPlugin {
@@ -77,6 +91,10 @@ export function assertCliPlugin(value: unknown): asserts value is CliPlugin {
         throw new TypeError(`CLI plugin "${plugin.id}" extendCommands must be an array`);
     }
     assertExtensions(plugin.id, extensions, rootOptions);
+
+    if (plugin.afterConsoleLink !== undefined && typeof plugin.afterConsoleLink !== 'function') {
+        throw new TypeError(`CLI plugin "${plugin.id}" afterConsoleLink must be a function`);
+    }
 }
 
 /**

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -68,6 +68,17 @@ export interface CliPlugin {
     afterConsoleLink?: ConsoleLinkHook;
 }
 
+interface CliPluginExtensionEntry {
+    extensionPoint: string;
+    extension: unknown;
+}
+
+export function getCliPluginExtensionEntries(plugin: CliPlugin): CliPluginExtensionEntry[] {
+    return plugin.afterConsoleLink
+        ? [{ extensionPoint: 'afterConsoleLink', extension: plugin.afterConsoleLink }]
+        : [];
+}
+
 /**
  * The plugin capabilities this build of the CLI understands.
  *

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -68,6 +68,41 @@ export interface CliPlugin {
     afterConsoleLink?: ConsoleLinkHook;
 }
 
+/**
+ * The plugin extension points this build of the CLI understands.
+ *
+ * A plugin that resolves an older `@vendure/cli` than it was written against is
+ * not told so. {@link assertCliPlugin} ignores keys it does not know, so a
+ * plugin declaring `extendCommands` or `afterConsoleLink` loads cleanly on a
+ * build that has neither, and then quietly decorates nothing and runs no hook.
+ * A silent no-op is worse than a refusal, and this is how a plugin refuses:
+ *
+ * @example
+ * ```ts
+ * import * as cli from '@vendure/cli';
+ *
+ * // Older builds export no such constant, so `undefined` is itself the answer.
+ * const supported: readonly string[] = cli.CLI_PLUGIN_EXTENSION_POINTS ?? [];
+ * if (!supported.includes('afterConsoleLink')) {
+ *     throw new Error(
+ *         'This @vendure/cli is too old to run afterConsoleLink hooks. Upgrade it, ' +
+ *             'or the credentials this plugin sets up after linking are never written.',
+ *     );
+ * }
+ * ```
+ *
+ * Entries are only ever added, never removed or renamed, so a check written
+ * against one release keeps working.
+ *
+ * @since 3.8.0
+ */
+export const CLI_PLUGIN_EXTENSION_POINTS = Object.freeze([
+    'rootOptions',
+    'subcommands',
+    'extendCommands',
+    'afterConsoleLink',
+] as const);
+
 export function assertCliPlugin(value: unknown): asserts value is CliPlugin {
     if (!value || typeof value !== 'object') {
         throw new Error('CLI plugin must be an object');

--- a/packages/cli/src/shared/command-extensions.spec.ts
+++ b/packages/cli/src/shared/command-extensions.spec.ts
@@ -21,8 +21,8 @@ beforeEach(() => {
     trace.length = 0;
 });
 
-const PLATFORM_ID = '@vendure-platform/cli';
-const CLOUD_ID = '@vendure/cloud';
+const CREDENTIALS_ID = '@example/credentials-cli-plugin';
+const TELEMETRY_ID = '@example/telemetry-cli-plugin';
 
 /**
  * Stands in for the built-in `dev` command.
@@ -55,25 +55,24 @@ function registryWithCore(): CommandRegistry {
 }
 
 /**
- * Mirrors what `@vendure-platform/cli` does today: add an option to `dev` and
- * wrap its action, calling the action it was handed rather than importing the
- * built-in one.
+ * A plugin that adds an option to `dev` and wraps its action, calling the
+ * action it was handed rather than importing the built-in one.
  */
-function platformPlugin() {
+function credentialsPlugin() {
     return defineCliPlugin({
-        id: PLATFORM_ID,
+        id: CREDENTIALS_ID,
         commands: [],
         extendCommands: [
             {
                 command: 'dev',
-                description: 'Run Vendure in development mode with linked Platform credentials',
+                description: 'Run Vendure in development mode with linked credentials',
                 options: [{ long: '--rotate-credential', description: 'Replace the active credential' }],
                 decorate:
                     ({ next }) =>
                     async (...args: any[]) => {
-                        trace.push('platform:before');
+                        trace.push('credentials:before');
                         const code = await next(...args);
-                        trace.push('platform:after');
+                        trace.push('credentials:after');
                         return code;
                     },
             },
@@ -81,9 +80,9 @@ function platformPlugin() {
     });
 }
 
-function cloudPlugin() {
+function telemetryPlugin() {
     return defineCliPlugin({
-        id: CLOUD_ID,
+        id: TELEMETRY_ID,
         commands: [],
         extendCommands: [
             {
@@ -92,9 +91,9 @@ function cloudPlugin() {
                 decorate:
                     ({ next }) =>
                     async (...args: any[]) => {
-                        trace.push('cloud:before');
+                        trace.push('telemetry:before');
                         const code = await next(...args);
-                        trace.push('cloud:after');
+                        trace.push('telemetry:after');
                         return code;
                     },
             },
@@ -109,48 +108,48 @@ function devCommand(registry: CommandRegistry): CliCommandDefinition {
 describe('Command extensions: composition', () => {
     it('runs every wrapper exactly once, outermost first', async () => {
         const registry = registryWithCore();
-        registry.applyPlugin(platformPlugin());
-        registry.applyPlugin(cloudPlugin());
+        registry.applyPlugin(credentialsPlugin());
+        registry.applyPlugin(telemetryPlugin());
 
         await devCommand(registry).action('server');
 
         expect(trace).toEqual([
-            'cloud:before',
-            'platform:before',
+            'telemetry:before',
+            'credentials:before',
             'core:server',
-            'platform:after',
-            'cloud:after',
+            'credentials:after',
+            'telemetry:after',
         ]);
     });
 
     it('follows vendure.cli.plugins order, so the last listed plugin is outermost', async () => {
         const registry = registryWithCore();
-        registry.applyPlugin(cloudPlugin());
-        registry.applyPlugin(platformPlugin());
+        registry.applyPlugin(telemetryPlugin());
+        registry.applyPlugin(credentialsPlugin());
 
         await devCommand(registry).action('server');
 
         expect(trace).toEqual([
-            'platform:before',
-            'cloud:before',
+            'credentials:before',
+            'telemetry:before',
             'core:server',
-            'cloud:after',
-            'platform:after',
+            'telemetry:after',
+            'credentials:after',
         ]);
     });
 
     it('records which plugins extended the command, in application order', () => {
         const registry = registryWithCore();
-        registry.applyPlugin(platformPlugin());
-        registry.applyPlugin(cloudPlugin());
+        registry.applyPlugin(credentialsPlugin());
+        registry.applyPlugin(telemetryPlugin());
 
-        expect(registry.getExtendedBy('dev')).toEqual([PLATFORM_ID, CLOUD_ID]);
+        expect(registry.getExtendedBy('dev')).toEqual([CREDENTIALS_ID, TELEMETRY_ID]);
     });
 
     it('keeps the options contributed by every plugin', () => {
         const registry = registryWithCore();
-        registry.applyPlugin(platformPlugin());
-        registry.applyPlugin(cloudPlugin());
+        registry.applyPlugin(credentialsPlugin());
+        registry.applyPlugin(telemetryPlugin());
 
         expect(devCommand(registry).options?.map(option => option.long)).toEqual([
             '--no-reload',
@@ -189,7 +188,7 @@ describe('Command extensions: composition', () => {
         const originalAction = original.action;
         const registry = new CommandRegistry();
         registry.registerAll([original]);
-        registry.applyPlugin(platformPlugin());
+        registry.applyPlugin(credentialsPlugin());
 
         expect(original.options?.map(option => option.long)).toEqual(['--no-reload']);
         expect(original.action).toBe(originalAction);
@@ -202,10 +201,10 @@ describe('Command extensions: composition', () => {
     it('takes the description from the last plugin that sets one, with a notice', () => {
         const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
         const registry = registryWithCore();
-        registry.applyPlugin(platformPlugin());
+        registry.applyPlugin(credentialsPlugin());
         registry.applyPlugin(
             defineCliPlugin({
-                id: CLOUD_ID,
+                id: TELEMETRY_ID,
                 commands: [],
                 extendCommands: [{ command: 'dev', description: 'Run against Vendure Cloud' }],
             }),
@@ -213,8 +212,8 @@ describe('Command extensions: composition', () => {
 
         expect(devCommand(registry).description).toBe('Run against Vendure Cloud');
         const written = writeSpy.mock.calls.map(call => String(call[0])).join('');
-        expect(written).toContain(`Description of "vendure dev" set by ${CLOUD_ID}`);
-        expect(written).toContain(PLATFORM_ID);
+        expect(written).toContain(`Description of "vendure dev" set by ${TELEMETRY_ID}`);
+        expect(written).toContain(CREDENTIALS_ID);
         writeSpy.mockRestore();
     });
 
@@ -271,14 +270,14 @@ describe('Command extensions: composition', () => {
 describe('Command extensions: registration through Commander', () => {
     it('exposes every plugin option and runs the whole chain', async () => {
         const registry = registryWithCore();
-        registry.applyPlugin(platformPlugin());
-        registry.applyPlugin(cloudPlugin());
+        registry.applyPlugin(credentialsPlugin());
+        registry.applyPlugin(telemetryPlugin());
 
         const help = await runCli(registry.toArray(), registry.getRootOptions(), ['dev', '--help']);
         expect(help.stdout).toContain('--rotate-credential');
         expect(help.stdout).toContain('--cloud-env');
         expect(help.stdout).toContain('--no-reload');
-        expect(help.stdout).toContain('Run Vendure in development mode with linked Platform credentials');
+        expect(help.stdout).toContain('Run Vendure in development mode with linked credentials');
 
         const run = await runCli(registry.toArray(), registry.getRootOptions(), [
             'dev',
@@ -289,23 +288,23 @@ describe('Command extensions: registration through Commander', () => {
         ]);
         expect(run.exitCode).toBe(0);
         expect(trace).toEqual([
-            'cloud:before',
-            'platform:before',
+            'telemetry:before',
+            'credentials:before',
             'core:server',
-            'platform:after',
-            'cloud:after',
+            'credentials:after',
+            'telemetry:after',
         ]);
     });
 
     it('keeps the exit code of the innermost command', async () => {
         const registry = new CommandRegistry();
         registry.registerAll([{ name: 'dev', description: 'Dev', action: async () => 7 }]);
-        registry.applyPlugin(platformPlugin());
+        registry.applyPlugin(credentialsPlugin());
 
         const run = await runCli(registry.toArray(), [], ['dev']);
 
         expect(run.exitCode).toBe(7);
-        expect(trace).toEqual(['platform:before', 'platform:after']);
+        expect(trace).toEqual(['credentials:before', 'credentials:after']);
     });
 });
 
@@ -364,7 +363,7 @@ describe('Command extensions: collisions', () => {
 
     it('rejects an option that the target already declares', () => {
         const registry = registryWithCore();
-        registry.applyPlugin(platformPlugin());
+        registry.applyPlugin(credentialsPlugin());
 
         const rival = defineCliPlugin({
             id: '@example/rival',
@@ -377,7 +376,7 @@ describe('Command extensions: collisions', () => {
         expect(() => registry.applyPlugin(rival)).toThrow(
             /Option "--rotate-credential" is already declared on "vendure dev"/,
         );
-        expect(registry.getExtendedBy('dev')).toEqual([PLATFORM_ID]);
+        expect(registry.getExtendedBy('dev')).toEqual([CREDENTIALS_ID]);
     });
 
     it('rejects an added option that uses a flag reserved by the CLI', () => {
@@ -416,15 +415,15 @@ describe('Command extensions: collisions', () => {
 
     it('rejects replacing a command that another plugin has extended', () => {
         const registry = registryWithCore();
-        registry.applyPlugin(platformPlugin());
+        registry.applyPlugin(credentialsPlugin());
 
         const replacer = defineCliPlugin({
             id: '@example/replacer',
             commands: [{ name: 'dev', description: 'My dev', replaces: true, action: async () => 0 }],
         });
 
-        expect(() => registry.applyPlugin(replacer)).toThrow(/has been extended by @vendure-platform\/cli/);
-        expect(devCommand(registry).description).toContain('Platform credentials');
+        expect(() => registry.applyPlugin(replacer)).toThrow(/has been extended by @example\/credentials-cli-plugin/);
+        expect(devCommand(registry).description).toContain('linked credentials');
     });
 
     it('extends a replacement when the replacing plugin is listed first', async () => {
@@ -445,11 +444,11 @@ describe('Command extensions: collisions', () => {
                 ],
             }),
         );
-        registry.applyPlugin(platformPlugin());
+        registry.applyPlugin(credentialsPlugin());
 
         await devCommand(registry).action();
 
-        expect(trace).toEqual(['platform:before', 'replacement', 'platform:after']);
+        expect(trace).toEqual(['credentials:before', 'replacement', 'credentials:after']);
     });
 
     it('reports a decorator that throws while being applied, and applies nothing', () => {
@@ -486,7 +485,7 @@ describe('Command extensions: collisions', () => {
 
     it('keeps earlier plugins intact when a later one is rejected', async () => {
         const registry = registryWithCore();
-        registry.applyPlugin(platformPlugin());
+        registry.applyPlugin(credentialsPlugin());
         const broken = defineCliPlugin({
             id: '@example/broken',
             commands: [],
@@ -496,7 +495,7 @@ describe('Command extensions: collisions', () => {
         expect(() => registry.applyPlugin(broken)).toThrow(CliPluginRegistrationError);
 
         await devCommand(registry).action('server');
-        expect(trace).toEqual(['platform:before', 'core:server', 'platform:after']);
+        expect(trace).toEqual(['credentials:before', 'core:server', 'credentials:after']);
     });
 });
 
@@ -1487,7 +1486,7 @@ describe('Command extensions: runnable parent commands', () => {
      */
     function cloudDeployPlugin() {
         return defineCliPlugin({
-            id: CLOUD_ID,
+            id: TELEMETRY_ID,
             commands: [
                 {
                     name: 'deploy',
@@ -1522,7 +1521,7 @@ describe('Command extensions: runnable parent commands', () => {
         const registry = registryWithDeploy();
         registry.applyPlugin(
             defineCliPlugin({
-                id: PLATFORM_ID,
+                id: CREDENTIALS_ID,
                 commands: [],
                 extendCommands: [
                     {
@@ -1530,7 +1529,7 @@ describe('Command extensions: runnable parent commands', () => {
                         decorate:
                             ({ next }) =>
                             async (...args: any[]) => {
-                                trace.push('platform:before');
+                                trace.push('credentials:before');
                                 return next(...args);
                             },
                     },
@@ -1540,14 +1539,14 @@ describe('Command extensions: runnable parent commands', () => {
 
         await runCli(registry.toArray(), registry.getRootOptions(), ['deploy']);
 
-        expect(trace).toEqual(['platform:before', 'core:deploy']);
+        expect(trace).toEqual(['credentials:before', 'core:deploy']);
     });
 
     it('leaves the subcommands of a decorated command in place', async () => {
         const registry = registryWithDeploy();
         registry.applyPlugin(
             defineCliPlugin({
-                id: PLATFORM_ID,
+                id: CREDENTIALS_ID,
                 commands: [],
                 extendCommands: [
                     {
@@ -1555,7 +1554,7 @@ describe('Command extensions: runnable parent commands', () => {
                         decorate:
                             ({ next }) =>
                             async (...args: any[]) => {
-                                trace.push('platform:before');
+                                trace.push('credentials:before');
                                 return next(...args);
                             },
                     },
@@ -1576,7 +1575,7 @@ describe('Command extensions: runnable parent commands', () => {
         let leafSeen: unknown = 'unset';
         registry.applyPlugin(
             defineCliPlugin({
-                id: PLATFORM_ID,
+                id: CREDENTIALS_ID,
                 commands: [],
                 extendCommands: [
                     {
@@ -1607,7 +1606,7 @@ describe('Command extensions: runnable parent commands', () => {
         let received: Readonly<CliCommandDefinition> | undefined;
         registry.applyPlugin(
             defineCliPlugin({
-                id: PLATFORM_ID,
+                id: CREDENTIALS_ID,
                 commands: [],
                 extendCommands: [
                     {
@@ -1692,7 +1691,7 @@ describe('Command extensions: runnable parent commands', () => {
         const registry = registryWithDeploy();
         registry.applyPlugin(
             defineCliPlugin({
-                id: PLATFORM_ID,
+                id: CREDENTIALS_ID,
                 commands: [],
                 extendCommands: [
                     {
@@ -1701,7 +1700,7 @@ describe('Command extensions: runnable parent commands', () => {
                         decorate:
                             ({ next }) =>
                             async (...args: any[]) => {
-                                trace.push('platform:plan');
+                                trace.push('credentials:plan');
                                 return next(...args);
                             },
                     },
@@ -1711,7 +1710,7 @@ describe('Command extensions: runnable parent commands', () => {
 
         await runCli(registry.toArray(), registry.getRootOptions(), ['deploy', 'plan']);
 
-        expect(trace).toEqual(['platform:plan', 'core:plan']);
+        expect(trace).toEqual(['credentials:plan', 'core:plan']);
     });
 
     it('shares an option added to a runnable parent with its subcommands', async () => {
@@ -1719,7 +1718,7 @@ describe('Command extensions: runnable parent commands', () => {
         let inherited: Record<string, any> | undefined;
         registry.applyPlugin(
             defineCliPlugin({
-                id: PLATFORM_ID,
+                id: CREDENTIALS_ID,
                 commands: [],
                 extendCommands: [
                     {

--- a/packages/cli/src/shared/command-registry-store.spec.ts
+++ b/packages/cli/src/shared/command-registry-store.spec.ts
@@ -761,6 +761,41 @@ describe('resolveCliPlugins()', () => {
         expect(discovered.every(plugin => plugin.status === 'not-enabled')).toBe(true);
     });
 
+    // A plugin applied twice contributes its afterConsoleLink hook twice, and a
+    // plugin with no commands has nothing to collide with on the second pass.
+    it('loads a plugin listed twice only once', () => {
+        const fixture = makeTempProject({
+            project: {
+                name: 'demo',
+                dependencies: { '@example/a': '1.0.0' },
+                vendure: { cli: { plugins: ['@example/a', '@example/a'] } },
+            },
+            plugins: [
+                {
+                    name: '@example/a',
+                    packageJson: {
+                        name: '@example/a',
+                        vendure: { cliPlugin: './cli-plugin.js' },
+                    },
+                    entrySource: `
+                        module.exports = { id: '@example/a', commands: [] };
+                    `,
+                },
+            ],
+        });
+
+        const { loaded, failures } = resolveCliPlugins({
+            cwd: fixture.root,
+            projectPackageJson: fs.readJsonSync(
+                path.join(fixture.root, 'package.json'),
+            ) as PackageJsonLike,
+            resolvePackage: fixture.resolvePackage,
+        });
+
+        expect(failures).toEqual([]);
+        expect(loaded.map(plugin => plugin.packageName)).toEqual(['@example/a']);
+    });
+
     it('loads allowlisted plugins in declared order', () => {
         const fixture = makeTempProject({
             project: {

--- a/packages/cli/src/shared/command-registry-store.spec.ts
+++ b/packages/cli/src/shared/command-registry-store.spec.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { builtinCommands } from '../commands/builtins';
+
 import {
     CliCommandDefinition,
     CliCommandGroupDefinition,
@@ -801,7 +802,7 @@ describe('resolveCliPlugins()', () => {
         for (const entry of loaded) {
             registry.applyPlugin(entry.plugin);
         }
-        expect(registry.getConsoleLinkHooks()).toHaveLength(1);
+        expect(registry.getPluginExtensions('afterConsoleLink')).toHaveLength(1);
     });
 
     // The allowlist is not the only way an id reaches the registry twice, and
@@ -827,7 +828,7 @@ describe('resolveCliPlugins()', () => {
         ).toThrow(/already registered under the id/);
         // Rejected whole, like every other collision: no second hook, and the
         // command it would have added is not half-applied.
-        expect(registry.getConsoleLinkHooks()).toHaveLength(1);
+        expect(registry.getPluginExtensions('afterConsoleLink')).toHaveLength(1);
         expect(registry.has('second')).toBe(false);
         expect(registry.has('first')).toBe(true);
     });

--- a/packages/cli/src/shared/command-registry-store.spec.ts
+++ b/packages/cli/src/shared/command-registry-store.spec.ts
@@ -806,8 +806,9 @@ describe('resolveCliPlugins()', () => {
         expect(registry.getConsoleLinkHooks()).toHaveLength(1);
     });
 
-    // The allowlist is not the only way the same plugin reaches the registry.
-    it('registers one console link hook per plugin id however often it is applied', () => {
+    // The allowlist is not the only way an id reaches the registry twice, and
+    // `id` is author-chosen, so two packages can collide on it.
+    it('refuses a second plugin under an id that already registered a hook', () => {
         const registry = new CommandRegistry();
         const plugin = defineCliPlugin({
             id: '@example/a',
@@ -816,8 +817,9 @@ describe('resolveCliPlugins()', () => {
         });
 
         registry.applyPlugin(plugin);
-        registry.applyPlugin(plugin);
-
+        expect(() => registry.applyPlugin(plugin)).toThrow(/must be unique/);
+        // Rejected whole, like every other collision: one hook, and the second
+        // plugin's commands are not half-applied.
         expect(registry.getConsoleLinkHooks()).toHaveLength(1);
     });
 

--- a/packages/cli/src/shared/command-registry-store.spec.ts
+++ b/packages/cli/src/shared/command-registry-store.spec.ts
@@ -778,7 +778,11 @@ describe('resolveCliPlugins()', () => {
                         vendure: { cliPlugin: './cli-plugin.js' },
                     },
                     entrySource: `
-                        module.exports = { id: '@example/a', commands: [] };
+                        module.exports = {
+                            id: '@example/a',
+                            commands: [],
+                            afterConsoleLink: async () => undefined,
+                        };
                     `,
                 },
             ],
@@ -794,6 +798,27 @@ describe('resolveCliPlugins()', () => {
 
         expect(failures).toEqual([]);
         expect(loaded.map(plugin => plugin.packageName)).toEqual(['@example/a']);
+
+        const registry = new CommandRegistry();
+        for (const entry of loaded) {
+            registry.applyPlugin(entry.plugin);
+        }
+        expect(registry.getConsoleLinkHooks()).toHaveLength(1);
+    });
+
+    // The allowlist is not the only way the same plugin reaches the registry.
+    it('registers one console link hook per plugin id however often it is applied', () => {
+        const registry = new CommandRegistry();
+        const plugin = defineCliPlugin({
+            id: '@example/a',
+            commands: [],
+            afterConsoleLink: async () => undefined,
+        });
+
+        registry.applyPlugin(plugin);
+        registry.applyPlugin(plugin);
+
+        expect(registry.getConsoleLinkHooks()).toHaveLength(1);
     });
 
     it('loads allowlisted plugins in declared order', () => {

--- a/packages/cli/src/shared/command-registry-store.spec.ts
+++ b/packages/cli/src/shared/command-registry-store.spec.ts
@@ -790,9 +790,7 @@ describe('resolveCliPlugins()', () => {
 
         const { loaded, failures } = resolveCliPlugins({
             cwd: fixture.root,
-            projectPackageJson: fs.readJsonSync(
-                path.join(fixture.root, 'package.json'),
-            ) as PackageJsonLike,
+            projectPackageJson: fs.readJsonSync(path.join(fixture.root, 'package.json')) as PackageJsonLike,
             resolvePackage: fixture.resolvePackage,
         });
 
@@ -808,19 +806,52 @@ describe('resolveCliPlugins()', () => {
 
     // The allowlist is not the only way an id reaches the registry twice, and
     // `id` is author-chosen, so two packages can collide on it.
-    it('refuses a second plugin under an id that already registered a hook', () => {
+    it('refuses a second plugin under an id that is already registered', () => {
         const registry = new CommandRegistry();
-        const plugin = defineCliPlugin({
-            id: '@example/a',
-            commands: [],
-            afterConsoleLink: async () => undefined,
-        });
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@example/a',
+                commands: [{ name: 'first', description: 'First', action: async () => 0 }],
+                afterConsoleLink: async () => undefined,
+            }),
+        );
 
-        registry.applyPlugin(plugin);
-        expect(() => registry.applyPlugin(plugin)).toThrow(/must be unique/);
-        // Rejected whole, like every other collision: one hook, and the second
-        // plugin's commands are not half-applied.
+        expect(() =>
+            registry.applyPlugin(
+                defineCliPlugin({
+                    id: '@example/a',
+                    commands: [{ name: 'second', description: 'Second', action: async () => 0 }],
+                    afterConsoleLink: async () => undefined,
+                }),
+            ),
+        ).toThrow(/already registered under the id/);
+        // Rejected whole, like every other collision: no second hook, and the
+        // command it would have added is not half-applied.
         expect(registry.getConsoleLinkHooks()).toHaveLength(1);
+        expect(registry.has('second')).toBe(false);
+        expect(registry.has('first')).toBe(true);
+    });
+
+    // The id rule is about the id, not about hooks. It held in one combination
+    // of four when it only fired alongside a hook.
+    it('refuses a duplicate id even when neither plugin registers a hook', () => {
+        const registry = new CommandRegistry();
+        registry.applyPlugin(
+            defineCliPlugin({
+                id: '@example/a',
+                commands: [{ name: 'first', description: 'First', action: async () => 0 }],
+            }),
+        );
+
+        expect(() =>
+            registry.applyPlugin(
+                defineCliPlugin({
+                    id: '@example/a',
+                    commands: [{ name: 'second', description: 'Second', action: async () => 0 }],
+                }),
+            ),
+        ).toThrow(/already registered under the id/);
+        expect(registry.has('second')).toBe(false);
     });
 
     it('loads allowlisted plugins in declared order', () => {

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -1,5 +1,5 @@
-import type { RegisteredConsoleLinkHook } from '../commands/console/console-link-hook';
 import pc from 'picocolors';
+import type { RegisteredConsoleLinkHook } from '../commands/console/console-link-hook';
 
 import {
     CliCommandArgument,
@@ -74,6 +74,8 @@ interface RegisteredOption {
 interface RegistryState {
     commands: Map<string, RegisteredCommand>;
     rootOptions: Map<string, RegisteredOption>;
+    /** Ids of the plugins applied so far. One plugin, one id. */
+    pluginIds: Set<string>;
     /** Console link hooks, in the order the plugins providing them were applied. */
     consoleLinkHooks: RegisteredConsoleLinkHook[];
 }
@@ -98,7 +100,12 @@ export class CliPluginRegistrationError extends Error {
  * activation order.
  */
 export class CommandRegistry {
-    private state: RegistryState = { commands: new Map(), rootOptions: new Map(), consoleLinkHooks: [] };
+    private state: RegistryState = {
+        commands: new Map(),
+        rootOptions: new Map(),
+        pluginIds: new Set(),
+        consoleLinkHooks: [],
+    };
 
     /**
      * Registers the built-in commands. Plugins go through {@link applyPlugin},
@@ -127,10 +134,19 @@ export class CommandRegistry {
         const draft: RegistryState = {
             commands: new Map(this.state.commands),
             rootOptions: new Map(this.state.rootOptions),
+            pluginIds: new Set(this.state.pluginIds),
             consoleLinkHooks: [...this.state.consoleLinkHooks],
         };
         const conflicts: string[] = [];
         const notices: string[] = [];
+
+        // Checked for every plugin, not only one contributing a hook. The id is
+        // what a conflict message names and what a hook is recorded against, so
+        // two plugins sharing one is ambiguous everywhere, not just here.
+        if (draft.pluginIds.has(plugin.id)) {
+            conflicts.push(`Another CLI plugin is already registered under the id "${plugin.id}".`);
+        }
+        draft.pluginIds.add(plugin.id);
 
         for (const option of plugin.rootOptions ?? []) {
             this.draftRootOption(draft, option, plugin.id, conflicts, false);
@@ -147,19 +163,7 @@ export class CommandRegistry {
         if (plugin.afterConsoleLink) {
             // Added to the draft like everything else, so a plugin rejected for
             // a command or option conflict contributes no hook either.
-            //
-            // A second plugin under an id that already registered a hook is a
-            // conflict rather than a notice. `id` is author-chosen, so two
-            // packages can collide on it, and half-applying one of them would
-            // register its commands while dropping the setup they rely on.
-            if (draft.consoleLinkHooks.some(entry => entry.pluginId === plugin.id)) {
-                conflicts.push(
-                    `CLI plugin id "${plugin.id}" is already registered by a plugin with an ` +
-                        `afterConsoleLink hook. Plugin ids must be unique.`,
-                );
-            } else {
-                draft.consoleLinkHooks.push({ pluginId: plugin.id, hook: plugin.afterConsoleLink });
-            }
+            draft.consoleLinkHooks.push({ pluginId: plugin.id, hook: plugin.afterConsoleLink });
         }
 
         if (conflicts.length > 0) {

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -1,5 +1,4 @@
 import pc from 'picocolors';
-import type { RegisteredConsoleLinkHook } from '../commands/console/console-link-hook';
 
 import {
     CliCommandArgument,
@@ -13,7 +12,8 @@ import {
     isRunnableCliCommand,
 } from './cli-command-definition';
 import { describeOption, ParsedCliOption, parseOptionFlags, withSubOptions } from './cli-command-options';
-import { CliPlugin, normalizeCommandPath } from './cli-plugin';
+import { CliPlugin, getCliPluginExtensionEntries, normalizeCommandPath } from './cli-plugin';
+import { RegisteredCliPluginExtension } from './cli-plugin-extension';
 
 /**
  * Why a flag cannot be shared by a command that has subcommands and by
@@ -76,8 +76,7 @@ interface RegistryState {
     rootOptions: Map<string, RegisteredOption>;
     /** Ids of the plugins applied so far. One plugin, one id. */
     pluginIds: Set<string>;
-    /** Console link hooks, in the order the plugins providing them were applied. */
-    consoleLinkHooks: RegisteredConsoleLinkHook[];
+    pluginExtensions: Map<string, RegisteredCliPluginExtension[]>;
 }
 
 /**
@@ -104,7 +103,7 @@ export class CommandRegistry {
         commands: new Map(),
         rootOptions: new Map(),
         pluginIds: new Set(),
-        consoleLinkHooks: [],
+        pluginExtensions: new Map(),
     };
 
     /**
@@ -135,7 +134,12 @@ export class CommandRegistry {
             commands: new Map(this.state.commands),
             rootOptions: new Map(this.state.rootOptions),
             pluginIds: new Set(this.state.pluginIds),
-            consoleLinkHooks: [...this.state.consoleLinkHooks],
+            pluginExtensions: new Map(
+                Array.from(this.state.pluginExtensions, ([extensionPoint, entries]) => [
+                    extensionPoint,
+                    [...entries],
+                ]),
+            ),
         };
         const conflicts: string[] = [];
         const notices: string[] = [];
@@ -160,10 +164,10 @@ export class CommandRegistry {
         for (const extension of plugin.extendCommands ?? []) {
             draftExtension(draft, extension, plugin.id, conflicts, notices);
         }
-        if (plugin.afterConsoleLink) {
-            // Added to the draft like everything else, so a plugin rejected for
-            // a command or option conflict contributes no hook either.
-            draft.consoleLinkHooks.push({ pluginId: plugin.id, hook: plugin.afterConsoleLink });
+        for (const { extensionPoint, extension } of getCliPluginExtensionEntries(plugin)) {
+            const entries = draft.pluginExtensions.get(extensionPoint) ?? [];
+            entries.push({ pluginId: plugin.id, extension });
+            draft.pluginExtensions.set(extensionPoint, entries);
         }
 
         if (conflicts.length > 0) {
@@ -211,12 +215,10 @@ export class CommandRegistry {
         return [...(this.state.commands.get(name)?.extendedBy ?? [])];
     }
 
-    /**
-     * Hooks to run after `vendure console link` writes a manifest, in the order
-     * the plugins providing them were applied.
-     */
-    getConsoleLinkHooks(): readonly RegisteredConsoleLinkHook[] {
-        return [...this.state.consoleLinkHooks];
+    getPluginExtensions<T = unknown>(extensionPoint: string): ReadonlyArray<RegisteredCliPluginExtension<T>> {
+        return [...(this.state.pluginExtensions.get(extensionPoint) ?? [])] as Array<
+            RegisteredCliPluginExtension<T>
+        >;
     }
 
     private draftRootOption(

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -147,7 +147,16 @@ export class CommandRegistry {
         if (plugin.afterConsoleLink) {
             // Added to the draft like everything else, so a plugin rejected for
             // a command or option conflict contributes no hook either.
-            draft.consoleLinkHooks.push({ pluginId: plugin.id, hook: plugin.afterConsoleLink });
+            //
+            // One hook per plugin id. A plugin that registers no command has no
+            // name to collide with, so nothing else stops the same id being
+            // applied twice and running its setup twice for one link.
+            if (draft.consoleLinkHooks.some(entry => entry.pluginId === plugin.id)) {
+                // The write loop colours these; do not colour it twice.
+                notices.push(`Ignored a second afterConsoleLink hook from CLI plugin "${plugin.id}".\n`);
+            } else {
+                draft.consoleLinkHooks.push({ pluginId: plugin.id, hook: plugin.afterConsoleLink });
+            }
         }
 
         if (conflicts.length > 0) {

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -1,3 +1,4 @@
+import type { RegisteredConsoleLinkHook } from '../commands/console/console-link-hook';
 import pc from 'picocolors';
 
 import {
@@ -73,6 +74,8 @@ interface RegisteredOption {
 interface RegistryState {
     commands: Map<string, RegisteredCommand>;
     rootOptions: Map<string, RegisteredOption>;
+    /** Console link hooks, in the order the plugins providing them were applied. */
+    consoleLinkHooks: RegisteredConsoleLinkHook[];
 }
 
 /**
@@ -95,7 +98,7 @@ export class CliPluginRegistrationError extends Error {
  * activation order.
  */
 export class CommandRegistry {
-    private state: RegistryState = { commands: new Map(), rootOptions: new Map() };
+    private state: RegistryState = { commands: new Map(), rootOptions: new Map(), consoleLinkHooks: [] };
 
     /**
      * Registers the built-in commands. Plugins go through {@link applyPlugin},
@@ -124,6 +127,7 @@ export class CommandRegistry {
         const draft: RegistryState = {
             commands: new Map(this.state.commands),
             rootOptions: new Map(this.state.rootOptions),
+            consoleLinkHooks: [...this.state.consoleLinkHooks],
         };
         const conflicts: string[] = [];
         const notices: string[] = [];
@@ -139,6 +143,11 @@ export class CommandRegistry {
         }
         for (const extension of plugin.extendCommands ?? []) {
             draftExtension(draft, extension, plugin.id, conflicts, notices);
+        }
+        if (plugin.afterConsoleLink) {
+            // Added to the draft like everything else, so a plugin rejected for
+            // a command or option conflict contributes no hook either.
+            draft.consoleLinkHooks.push({ pluginId: plugin.id, hook: plugin.afterConsoleLink });
         }
 
         if (conflicts.length > 0) {
@@ -184,6 +193,14 @@ export class CommandRegistry {
      */
     getExtendedBy(name: string): string[] {
         return [...(this.state.commands.get(name)?.extendedBy ?? [])];
+    }
+
+    /**
+     * Hooks to run after `vendure console link` writes a manifest, in the order
+     * the plugins providing them were applied.
+     */
+    getConsoleLinkHooks(): readonly RegisteredConsoleLinkHook[] {
+        return [...this.state.consoleLinkHooks];
     }
 
     private draftRootOption(

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -148,12 +148,15 @@ export class CommandRegistry {
             // Added to the draft like everything else, so a plugin rejected for
             // a command or option conflict contributes no hook either.
             //
-            // One hook per plugin id. A plugin that registers no command has no
-            // name to collide with, so nothing else stops the same id being
-            // applied twice and running its setup twice for one link.
+            // A second plugin under an id that already registered a hook is a
+            // conflict rather than a notice. `id` is author-chosen, so two
+            // packages can collide on it, and half-applying one of them would
+            // register its commands while dropping the setup they rely on.
             if (draft.consoleLinkHooks.some(entry => entry.pluginId === plugin.id)) {
-                // The write loop colours these; do not colour it twice.
-                notices.push(`Ignored a second afterConsoleLink hook from CLI plugin "${plugin.id}".\n`);
+                conflicts.push(
+                    `CLI plugin id "${plugin.id}" is already registered by a plugin with an ` +
+                        `afterConsoleLink hook. Plugin ids must be unique.`,
+                );
             } else {
                 draft.consoleLinkHooks.push({ pluginId: plugin.id, hook: plugin.afterConsoleLink });
             }

--- a/packages/cli/src/shared/command-registry.spec.ts
+++ b/packages/cli/src/shared/command-registry.spec.ts
@@ -108,6 +108,26 @@ function cloudCommands(): CliCommandNode[] {
 }
 
 describe('registerCommands() with nested commands', () => {
+    it('passes opaque plugin extension values to command actions', async () => {
+        const extension = { requiresSession: true };
+        let received: unknown;
+        const command: CliCommandDefinition = {
+            name: 'inspect',
+            description: 'Inspect extensions',
+            action: async (...args: any[]) => {
+                received = readCommandContext(args).getPluginExtensions('example')[0];
+                return 0;
+            },
+        };
+
+        await runCli([command], [], ['inspect'], name =>
+            name === 'example' ? [{ pluginId: '@example/plugin', extension }] : [],
+        );
+
+        expect(received).toEqual({ pluginId: '@example/plugin', extension });
+        expect((received as { extension: unknown }).extension).toBe(extension);
+    });
+
     it('executes a two-level command', async () => {
         const result = await runCli(cloudCommands(), rootOptions, ['project', 'list']);
 

--- a/packages/cli/src/shared/command-registry.ts
+++ b/packages/cli/src/shared/command-registry.ts
@@ -10,6 +10,7 @@ import {
 } from './cli-command-definition';
 import { CliCommandExit } from './cli-command-exit';
 import { buildOptionFlags, parseOptionFlags } from './cli-command-options';
+import { CliPluginExtensionAccessor } from './cli-plugin-extension';
 
 /**
  * An option declared on an ancestor of a command. Commander stores the parsed
@@ -25,10 +26,11 @@ export function registerCommands(
     program: Command,
     commands: CliCommandNode[],
     rootOptions: CliCommandOption[] = [],
+    getPluginExtensions: CliPluginExtensionAccessor = () => [],
 ): void {
     const sharedOptions = declareOptions(program, rootOptions);
     for (const node of commands) {
-        registerNode(program, node, [], sharedOptions);
+        registerNode(program, node, [], sharedOptions, getPluginExtensions);
     }
 }
 
@@ -37,6 +39,7 @@ function registerNode(
     node: CliCommandNode,
     path: string[],
     sharedOptions: SharedOption[],
+    getPluginExtensions: CliPluginExtensionAccessor,
 ): void {
     const command = parent.command(node.name).description(node.description);
     const commandPath = [...path, node.name];
@@ -53,7 +56,7 @@ function registerNode(
         // it; hasCliSubcommands explains why.
         const inheritedOptions = [...sharedOptions, ...ownOptions];
         for (const subcommand of subcommands) {
-            registerNode(command, subcommand, commandPath, inheritedOptions);
+            registerNode(command, subcommand, commandPath, inheritedOptions, getPluginExtensions);
         }
         if (runnable) {
             // A command with subcommands takes no positional arguments, so any
@@ -91,6 +94,7 @@ function registerNode(
         const context: CliCommandContext = {
             inheritedOptions: readSharedValues(sharedOptions),
             commandPath,
+            getPluginExtensions,
         };
         // Exit is owned by the host so plugins can wrap built-in actions.
         process.exit(await runAction(runnable.action, args, context));

--- a/packages/cli/src/shared/resolve-cli-plugins.ts
+++ b/packages/cli/src/shared/resolve-cli-plugins.ts
@@ -312,8 +312,13 @@ function getProjectPluginContext(options: ResolveCliPluginsOptions): ProjectPlug
 
     // Explicit activation: only packages listed in plugins are loaded.
     // An empty or missing list means load nothing.
+    //
+    // Deduplicated because a package listed twice is applied twice, and a
+    // plugin that contributes no command has nothing to collide with the
+    // second time. Its `afterConsoleLink` hook would then run twice per link,
+    // repeating whatever setup that hook does.
     const allowlist = projectPackageJson.vendure?.cli?.plugins
-        ? [...projectPackageJson.vendure.cli.plugins]
+        ? [...new Set(projectPackageJson.vendure.cli.plugins)]
         : undefined;
 
     const resolvePackage =


### PR DESCRIPTION
`vendure console link` owns linking: it resolves the Console endpoints, approves custom ones, opens the browser, polls for approval, validates the Project Link Manifest, writes it atomically, and updates `.gitignore`. A plugin that needs its own setup after linking can now extend that flow without replacing the `console` command.

## What this adds

**`CliPlugin.afterConsoleLink`** runs after the manifest is written. It receives the resolved project root, manifest and path, Console endpoints, link outcome, abort signal, reporter, confirmation function, terminal mode, and `--force` state.

Each hook gets its own context, manifest, and endpoint objects. Hooks run in plugin order, and the first failure stops the remaining hooks without removing the manifest.

**Repeating a link repairs it.** In an already-linked project, the command reuses the manifest and runs hooks with `outcome: 'repaired'`. It creates no second Project Link. `--force` creates a different Project Link and runs hooks with `outcome: 'linked'`. `--yes` answers every confirmation owned by the CLI without changing repair into relink behavior.

**Official Console origins are one paired rule.** Production and staging app/API origins must be used as matching pairs. `endpoints.official` is `'production'`, `'staging'`, or `undefined` for custom and loopback origins. Public API and documentation remain specific to the Console integration.

**The shared registry stores extension values generically.** `CliCommandContext.getPluginExtensions()` returns registered values by extension-point name. It preserves each extension value opaquely, while the `console` command maps `afterConsoleLink` values into its local hook dependency. This removes the mutable global hook accessor and leaves future extension metadata intact.

**`CLI_PLUGIN_EXTENSION_POINTS`** lets a plugin refuse to load when the installed CLI does not support its extension. The full marker list is pinned by a test.

The registry also rejects every duplicate plugin ID and deduplicates repeated package entries, including plugins that contribute no command.

## Checks

Environment: Darwin arm64, Bun 1.4.0, Node v24.16.0.

- Built `@vendure/common` and `@vendure/core` so the doctor suites could collect.
- `bun run build` in `packages/cli`: passed.
- Focused Console/shared suite: 8 files passed, 177 tests passed.
- Full serialized CLI Vitest suite: 36 files passed, 553 tests passed, 1 skipped.
- PR-file ESLint: 6 errors and 128 warnings. All 6 errors are in `shared/resolve-cli-plugins.ts` at code already present on `minor`; that file is unchanged from the reviewed head. The seventh error previously reported was a `status` name shadow in `console.ts`, which this update removes.

Relates to EE-308
