### PR TITLE
feat(cli): settle a Console session with the Project Link approval

### DIFF
--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -804,8 +804,36 @@ export default defineCliPlugin({
 ```
 
 The context contains `projectRoot`, `manifest`, `manifestPath`, `endpoints`,
-`outcome`, `signal`, `reporter`, `confirm`, `isNonInteractive`, and `force`.
-Each hook gets its own manifest and endpoint objects.
+`outcome`, the optional `session`, `signal`, `reporter`, `confirm`,
+`isNonInteractive`, and `force`. Each hook gets its own manifest and endpoint
+objects. A session is also copied when the hook requested one and the login
+succeeded.
+
+A hook does not receive a Console session unless it requests one. Wrap a hook
+with `requiresSession: true` when it needs the session from the same browser
+approval:
+
+```ts
+export default defineCliPlugin({
+    id: '@example/credential-cli-plugin',
+    commands: [],
+    afterConsoleLink: {
+        requiresSession: true,
+        hook: async context => {
+            if (!context.session) {
+                context.reporter.warn('No Console session was obtained.');
+                return;
+            }
+            await storeCredential(context.session);
+        },
+    },
+});
+```
+
+The session is user-scoped and can authorize access across the user's Console
+projects. The CLI does not store it. If a plugin stores the session, use an OS
+credential store or a user-specific configuration directory outside the
+Vendure project. Never write it to the project directory or commit it.
 
 Do not replace the `console` command for post-link setup. Register the hook.
 

--- a/packages/cli/src/commands/console/cli-auth.spec.ts
+++ b/packages/cli/src/commands/console/cli-auth.spec.ts
@@ -178,24 +178,46 @@ describe('parseConsoleSession()', () => {
 
     it('accepts a response with no refresh token', () => {
         expect(
-            parseConsoleSession(
-                { access_token: 'vcli_access', token_type: 'Bearer', expires_in: 60 },
-                now,
-            ).refreshToken,
+            parseConsoleSession({ access_token: 'vcli_access', token_type: 'Bearer', expires_in: 60 }, now)
+                .refreshToken,
         ).toBeUndefined();
     });
 
     it.each([
         ['no access token', { token_type: 'Bearer', expires_in: 60 }, /invalid access token/],
-        ['an empty access token', { access_token: '', token_type: 'Bearer', expires_in: 60 }, /invalid access token/],
-        ['an unsupported token type', { access_token: 'a', token_type: 'Basic', expires_in: 60 }, /token type/],
+        [
+            'an empty access token',
+            { access_token: '', token_type: 'Bearer', expires_in: 60 },
+            /invalid access token/,
+        ],
+        [
+            'an unsupported token type',
+            { access_token: 'a', token_type: 'Basic', expires_in: 60 },
+            /token type/,
+        ],
         ['no lifetime', { access_token: 'a', token_type: 'Bearer' }, /token lifetime/],
-        ['a non-numeric lifetime', { access_token: 'a', token_type: 'Bearer', expires_in: '60' }, /token lifetime/],
+        [
+            'a non-numeric lifetime',
+            { access_token: 'a', token_type: 'Bearer', expires_in: '60' },
+            /token lifetime/,
+        ],
         // A lifetime at or before now is a dead token described as a live one.
         ['a zero lifetime', { access_token: 'a', token_type: 'Bearer', expires_in: 0 }, /token lifetime/],
-        ['a negative lifetime', { access_token: 'a', token_type: 'Bearer', expires_in: -3600 }, /token lifetime/],
-        ['an absurd lifetime', { access_token: 'a', token_type: 'Bearer', expires_in: 1e15 }, /token lifetime/],
-        ['a fractional lifetime', { access_token: 'a', token_type: 'Bearer', expires_in: 1.5 }, /token lifetime/],
+        [
+            'a negative lifetime',
+            { access_token: 'a', token_type: 'Bearer', expires_in: -3600 },
+            /token lifetime/,
+        ],
+        [
+            'an absurd lifetime',
+            { access_token: 'a', token_type: 'Bearer', expires_in: 1e15 },
+            /token lifetime/,
+        ],
+        [
+            'a fractional lifetime',
+            { access_token: 'a', token_type: 'Bearer', expires_in: 1.5 },
+            /token lifetime/,
+        ],
         ['a response that is not an object', 'nope', /malformed token response/],
     ])('refuses a response with %s', (_label, value, message) => {
         expect(() => parseConsoleSession(value, now)).toThrow(message);

--- a/packages/cli/src/commands/console/cli-auth.spec.ts
+++ b/packages/cli/src/commands/console/cli-auth.spec.ts
@@ -219,6 +219,16 @@ describe('parseConsoleSession()', () => {
             /token lifetime/,
         ],
         ['a response that is not an object', 'nope', /malformed token response/],
+        [
+            'an empty refresh token',
+            { access_token: 'a', token_type: 'Bearer', expires_in: 60, refresh_token: '' },
+            /invalid refresh token/,
+        ],
+        [
+            'a non-string refresh token',
+            { access_token: 'a', token_type: 'Bearer', expires_in: 60, refresh_token: 123 },
+            /invalid refresh token/,
+        ],
     ])('refuses a response with %s', (_label, value, message) => {
         expect(() => parseConsoleSession(value, now)).toThrow(message);
     });

--- a/packages/cli/src/commands/console/cli-auth.spec.ts
+++ b/packages/cli/src/commands/console/cli-auth.spec.ts
@@ -1,0 +1,170 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import {
+    authorizationCodeGrant,
+    cliAuthSearchParams,
+    createLoginState,
+    createPkceChallenge,
+    parseConsoleSession,
+    startLoopbackCallback,
+} from './cli-auth';
+
+describe('createPkceChallenge()', () => {
+    it('derives the challenge from the verifier with S256', () => {
+        const { verifier, challenge } = createPkceChallenge();
+        expect(challenge).toBe(createHash('sha256').update(verifier).digest('base64url'));
+    });
+
+    it('does not repeat a verifier', () => {
+        expect(createPkceChallenge().verifier).not.toBe(createPkceChallenge().verifier);
+        expect(createLoginState()).not.toBe(createLoginState());
+    });
+});
+
+describe('cliAuthSearchParams()', () => {
+    // Console reads these five names and refuses a partial set, so the spelling
+    // is the contract rather than a detail.
+    it('names the five parameters Console reads', () => {
+        expect(
+            cliAuthSearchParams({
+                redirectUri: 'http://127.0.0.1:1234/auth/callback',
+                state: 'state-value',
+                challenge: 'challenge-value',
+            }),
+        ).toEqual({
+            client: 'cli',
+            redirect_uri: 'http://127.0.0.1:1234/auth/callback',
+            state: 'state-value',
+            code_challenge: 'challenge-value',
+            code_challenge_method: 'S256',
+        });
+    });
+});
+
+describe('authorizationCodeGrant()', () => {
+    it('uses the field names the existing token route takes', () => {
+        expect(
+            authorizationCodeGrant({
+                code: 'the-code',
+                verifier: 'the-verifier',
+                redirectUri: 'http://127.0.0.1:1234/auth/callback',
+            }),
+        ).toEqual({
+            grant_type: 'authorization_code',
+            code: 'the-code',
+            code_verifier: 'the-verifier',
+            redirect_uri: 'http://127.0.0.1:1234/auth/callback',
+        });
+    });
+});
+
+describe('startLoopbackCallback()', () => {
+    it('binds the dotted quad and the path Console accepts', async () => {
+        const callback = await startLoopbackCallback('state-value');
+        try {
+            const url = new URL(callback.redirectUri);
+            expect(url.protocol).toBe('http:');
+            expect(url.hostname).toBe('127.0.0.1');
+            expect(url.pathname).toBe('/auth/callback');
+            // Console refuses a callback without an explicit port.
+            expect(Number(url.port)).toBeGreaterThan(0);
+        } finally {
+            callback.close();
+        }
+    });
+
+    it('returns the code the browser arrives with', async () => {
+        const callback = await startLoopbackCallback('state-value');
+        try {
+            const response = await fetch(`${callback.redirectUri}?code=the-code&state=state-value`);
+            expect(response.status).toBe(200);
+            await expect(callback.code()).resolves.toBe('the-code');
+        } finally {
+            callback.close();
+        }
+    });
+
+    it('resolves undefined for a refusal, which the poll reports instead', async () => {
+        const callback = await startLoopbackCallback('state-value');
+        try {
+            await fetch(`${callback.redirectUri}?error=access_denied&state=state-value`);
+            await expect(callback.code()).resolves.toBeUndefined();
+        } finally {
+            callback.close();
+        }
+    });
+
+    it('ignores a callback that does not carry the state this run generated', async () => {
+        const callback = await startLoopbackCallback('state-value');
+        try {
+            const wrong = await fetch(`${callback.redirectUri}?code=injected&state=someone-else`);
+            expect(wrong.status).toBe(400);
+            const missing = await fetch(`${callback.redirectUri}?code=injected`);
+            expect(missing.status).toBe(400);
+            // Still waiting for the real one, and it still wins.
+            await fetch(`${callback.redirectUri}?code=the-code&state=state-value`);
+            await expect(callback.code()).resolves.toBe('the-code');
+        } finally {
+            callback.close();
+        }
+    });
+
+    it('answers anything off the callback path with 404', async () => {
+        const callback = await startLoopbackCallback('state-value');
+        try {
+            const response = await fetch(`${new URL(callback.redirectUri).origin}/elsewhere`);
+            expect(response.status).toBe(404);
+        } finally {
+            callback.close();
+        }
+    });
+
+    it('unblocks a waiter when it is closed, so closing never hangs a caller', async () => {
+        const callback = await startLoopbackCallback('state-value');
+        const pending = callback.code();
+        callback.close();
+        await expect(pending).resolves.toBeUndefined();
+    });
+});
+
+describe('parseConsoleSession()', () => {
+    const now = 1_000_000;
+
+    it('reads the token response and turns the lifetime into an expiry', () => {
+        expect(
+            parseConsoleSession(
+                {
+                    access_token: 'vcli_access',
+                    token_type: 'Bearer',
+                    expires_in: 3600,
+                    refresh_token: 'vclr_refresh',
+                },
+                now,
+            ),
+        ).toEqual({
+            accessToken: 'vcli_access',
+            refreshToken: 'vclr_refresh',
+            expiresAt: now + 3_600_000,
+        });
+    });
+
+    it('accepts a response with no refresh token', () => {
+        expect(
+            parseConsoleSession(
+                { access_token: 'vcli_access', token_type: 'Bearer', expires_in: 60 },
+                now,
+            ).refreshToken,
+        ).toBeUndefined();
+    });
+
+    it.each([
+        ['no access token', { token_type: 'Bearer', expires_in: 60 }],
+        ['an empty access token', { access_token: '', token_type: 'Bearer', expires_in: 60 }],
+        ['an unsupported token type', { access_token: 'a', token_type: 'Basic', expires_in: 60 }],
+        ['no lifetime', { access_token: 'a', token_type: 'Bearer' }],
+        ['a non-numeric lifetime', { access_token: 'a', token_type: 'Bearer', expires_in: '60' }],
+    ])('refuses a response with %s', (_label, value) => {
+        expect(() => parseConsoleSession(value, now)).toThrow();
+    });
+});

--- a/packages/cli/src/commands/console/cli-auth.spec.ts
+++ b/packages/cli/src/commands/console/cli-auth.spec.ts
@@ -126,6 +126,33 @@ describe('startLoopbackCallback()', () => {
         callback.close();
         await expect(pending).resolves.toBeUndefined();
     });
+
+    it('can be closed twice, because every path that ends a link closes it', async () => {
+        const callback = await startLoopbackCallback('state-value');
+        callback.close();
+        expect(() => callback.close()).not.toThrow();
+    });
+
+    it('keeps the first code when a second callback arrives', async () => {
+        const callback = await startLoopbackCallback('state-value');
+        try {
+            await fetch(`${callback.redirectUri}?code=first&state=state-value`);
+            await fetch(`${callback.redirectUri}?code=second&state=state-value`);
+            await expect(callback.code()).resolves.toBe('first');
+        } finally {
+            callback.close();
+        }
+    });
+
+    it('does not let the answer be stored anywhere the code outlives the tab', async () => {
+        const callback = await startLoopbackCallback('state-value');
+        try {
+            const response = await fetch(`${callback.redirectUri}?code=the-code&state=state-value`);
+            expect(response.headers.get('cache-control')).toBe('no-store');
+        } finally {
+            callback.close();
+        }
+    });
 });
 
 describe('parseConsoleSession()', () => {
@@ -159,12 +186,18 @@ describe('parseConsoleSession()', () => {
     });
 
     it.each([
-        ['no access token', { token_type: 'Bearer', expires_in: 60 }],
-        ['an empty access token', { access_token: '', token_type: 'Bearer', expires_in: 60 }],
-        ['an unsupported token type', { access_token: 'a', token_type: 'Basic', expires_in: 60 }],
-        ['no lifetime', { access_token: 'a', token_type: 'Bearer' }],
-        ['a non-numeric lifetime', { access_token: 'a', token_type: 'Bearer', expires_in: '60' }],
-    ])('refuses a response with %s', (_label, value) => {
-        expect(() => parseConsoleSession(value, now)).toThrow();
+        ['no access token', { token_type: 'Bearer', expires_in: 60 }, /invalid access token/],
+        ['an empty access token', { access_token: '', token_type: 'Bearer', expires_in: 60 }, /invalid access token/],
+        ['an unsupported token type', { access_token: 'a', token_type: 'Basic', expires_in: 60 }, /token type/],
+        ['no lifetime', { access_token: 'a', token_type: 'Bearer' }, /token lifetime/],
+        ['a non-numeric lifetime', { access_token: 'a', token_type: 'Bearer', expires_in: '60' }, /token lifetime/],
+        // A lifetime at or before now is a dead token described as a live one.
+        ['a zero lifetime', { access_token: 'a', token_type: 'Bearer', expires_in: 0 }, /token lifetime/],
+        ['a negative lifetime', { access_token: 'a', token_type: 'Bearer', expires_in: -3600 }, /token lifetime/],
+        ['an absurd lifetime', { access_token: 'a', token_type: 'Bearer', expires_in: 1e15 }, /token lifetime/],
+        ['a fractional lifetime', { access_token: 'a', token_type: 'Bearer', expires_in: 1.5 }, /token lifetime/],
+        ['a response that is not an object', 'nope', /malformed token response/],
+    ])('refuses a response with %s', (_label, value, message) => {
+        expect(() => parseConsoleSession(value, now)).toThrow(message);
     });
 });

--- a/packages/cli/src/commands/console/cli-auth.ts
+++ b/packages/cli/src/commands/console/cli-auth.ts
@@ -5,20 +5,6 @@ import { AddressInfo } from 'node:net';
 import { nonEmptyString, objectValue } from './project-link-validation';
 
 /**
- * The capability a Console advertises when a Project Link approval can also
- * settle a command line login. A Console that does not name it approves the
- * link only, and this CLI then asks for no login at all.
- */
-export const CLI_AUTH_CAPABILITY = 'cli-auth';
-
-/**
- * The tools Console names on the approval page, as Console defines them. This
- * CLI is always `cli`; `create` is the other value Console accepts, and is
- * spelled out here so one conformance test can drive both.
- */
-export type CliAuthClient = 'cli' | 'create';
-
-/**
  * Console's CLI session token route, where an authorization code is exchanged.
  *
  * The route, the grant types and the field names are Console's, so every
@@ -39,11 +25,7 @@ const CALLBACK_PATH = '/auth/callback';
  */
 const NO_STORE = { 'Cache-Control': 'no-store', 'Content-Type': 'text/plain' };
 
-/**
- * A lifetime past this is not a token this CLI will describe as valid. Console
- * issues an hour; anything near a year is a malformed response rather than a
- * generous one.
- */
+/** Console issues one-hour sessions. Refuse implausibly long token lifetimes. */
 const MAX_TOKEN_LIFETIME_SECONDS = 365 * 24 * 60 * 60;
 
 /**
@@ -51,6 +33,8 @@ const MAX_TOKEN_LIFETIME_SECONDS = 365 * 24 * 60 * 60;
  *
  * The CLI does not write this anywhere. It is handed to the plugin hook that
  * asked for it, and storing it is that plugin's to do, under its own rules.
+ *
+ * @since 3.8.0
  */
 export interface ConsoleSession {
     accessToken: string;
@@ -84,10 +68,9 @@ export function cliAuthSearchParams(input: {
     redirectUri: string;
     state: string;
     challenge: string;
-    client?: CliAuthClient;
 }): Record<string, string> {
     return {
-        client: input.client ?? 'cli',
+        client: 'cli',
         redirect_uri: input.redirectUri,
         state: input.state,
         code_challenge: input.challenge,
@@ -117,9 +100,9 @@ export interface LoopbackCallback {
  * request is already listening when Console redirects to it.
  */
 export async function startLoopbackCallback(expectedState: string): Promise<LoopbackCallback> {
-    let settle: ((code: string | undefined) => void) | undefined;
+    let resolveCode: ((code: string | undefined) => void) | undefined;
     const received = new Promise<string | undefined>(resolve => {
-        settle = resolve;
+        resolveCode = resolve;
     });
 
     const server: Server = createServer((request, response) => {
@@ -142,18 +125,16 @@ export async function startLoopbackCallback(expectedState: string): Promise<Loop
                     ? 'Signed in. You can close this tab and return to your terminal.\n'
                     : 'The command line login was refused. You can close this tab.\n',
             );
-        settle?.(code);
+        resolveCode?.(code);
     });
 
     await new Promise<void>((resolve, reject) => {
         server.once('error', reject);
         server.listen(0, '127.0.0.1', () => {
-            // The listen handler rejects a promise that is about to settle, so
-            // it cannot stay: a later error would be swallowed, and the one
-            // after that would have no listener at all and take the process
-            // down mid-link.
+            // Keep a listener after binding so a later server error does not
+            // terminate the process.
             server.removeListener('error', reject);
-            server.on('error', () => settle?.(undefined));
+            server.on('error', () => resolveCode?.(undefined));
             resolve();
         });
     });
@@ -168,9 +149,7 @@ export async function startLoopbackCallback(expectedState: string): Promise<Loop
                 return;
             }
             closed = true;
-            // Unblock anything waiting before the socket goes, so closing is
-            // never the reason a caller hangs.
-            settle?.(undefined);
+            resolveCode?.(undefined);
             server.closeAllConnections();
             server.close();
         },
@@ -220,8 +199,8 @@ export function parseConsoleSession(value: unknown, now: number): ConsoleSession
         throw new Error('Console returned an invalid token lifetime.');
     }
     const refreshToken =
-        typeof object.refresh_token === 'string' && object.refresh_token.length > 0
-            ? object.refresh_token
-            : undefined;
+        object.refresh_token === undefined
+            ? undefined
+            : nonEmptyString(object.refresh_token, 'Console returned an invalid refresh token.');
     return { accessToken, refreshToken, expiresAt: now + object.expires_in * 1000 };
 }

--- a/packages/cli/src/commands/console/cli-auth.ts
+++ b/packages/cli/src/commands/console/cli-auth.ts
@@ -177,9 +177,9 @@ export async function startLoopbackCallback(expectedState: string): Promise<Loop
 }
 
 /**
- * The state is this flow's CSRF nonce and a page in the browser can time
- * requests to the port, so it is compared without leaking its length or the
- * position of the first difference.
+ * The state is this flow's CSRF nonce, so the comparison does not leak where
+ * two values first differ. It does return early on a length mismatch, which is
+ * harmless here because the expected value is a fixed-length local nonce.
  */
 function matchesState(received: string | null, expected: string): boolean {
     if (received === null) {

--- a/packages/cli/src/commands/console/cli-auth.ts
+++ b/packages/cli/src/commands/console/cli-auth.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from 'node:crypto';
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 import { Server, createServer } from 'node:http';
 import { AddressInfo } from 'node:net';
 
@@ -12,9 +12,9 @@ import { nonEmptyString, objectValue } from './project-link-validation';
 export const CLI_AUTH_CAPABILITY = 'cli-auth';
 
 /**
- * The tools Console names on the approval page. This CLI is always `cli`;
- * `create` is the same exchange driven by `@vendure-platform/create`, and is
- * named here so one conformance fixture can cover both halves of the contract.
+ * The tools Console names on the approval page. This CLI is always `cli`.
+ * `create` is the same exchange driven from elsewhere, and is accepted here so
+ * a cross-repository conformance test can drive both without a second client.
  */
 export type CliAuthClient = 'cli' | 'create';
 
@@ -31,6 +31,19 @@ export const CLI_TOKEN_PATH = '/v1/auth/cli/token';
  * but what Console appends.
  */
 const CALLBACK_PATH = '/auth/callback';
+
+/**
+ * The callback URL carries a live authorization code, so the answer to it must
+ * not be stored anywhere a later reader can find it.
+ */
+const NO_STORE = { 'Cache-Control': 'no-store', 'Content-Type': 'text/plain' };
+
+/**
+ * A lifetime past this is not a token this CLI will describe as valid. Console
+ * issues an hour; anything near a year is a malformed response rather than a
+ * generous one.
+ */
+const MAX_TOKEN_LIFETIME_SECONDS = 365 * 24 * 60 * 60;
 
 /**
  * A Console CLI Session, as the token route issued it.
@@ -97,11 +110,10 @@ export interface LoopbackCallback {
 /**
  * Binds a one-shot callback on this machine.
  *
- * `127.0.0.1` rather than `localhost`, because that is what Console's redirect
- * check is given today and a name that resolves elsewhere is not a loopback.
- * Port 0, so the operating system picks one that is free, and it is bound
- * before the browser opens so the address in the approval request is already
- * listening.
+ * The address is `127.0.0.1` rather than `localhost`, because a name can be
+ * made to resolve elsewhere. Port 0 lets the operating system pick a free one.
+ * The bind happens before the browser opens, so the address in the approval
+ * request is already listening when Console redirects to it.
  */
 export async function startLoopbackCallback(expectedState: string): Promise<LoopbackCallback> {
     let settle: ((code: string | undefined) => void) | undefined;
@@ -112,34 +124,49 @@ export async function startLoopbackCallback(expectedState: string): Promise<Loop
     const server: Server = createServer((request, response) => {
         const url = new URL(request.url ?? '/', 'http://127.0.0.1');
         if (url.pathname !== CALLBACK_PATH) {
-            response.writeHead(404).end();
+            response.writeHead(404, NO_STORE).end();
             return;
         }
         // Anything on this port that does not carry the state this run
         // generated is not the browser we sent. Answer it and keep waiting.
-        if (url.searchParams.get('state') !== expectedState) {
-            response.writeHead(400, { 'Content-Type': 'text/plain' }).end('Unexpected login callback.\n');
+        if (!matchesState(url.searchParams.get('state'), expectedState)) {
+            response.writeHead(400, NO_STORE).end('Unexpected login callback.\n');
             return;
         }
         const code = url.searchParams.get('code') ?? undefined;
-        response.writeHead(200, { 'Content-Type': 'text/plain' }).end(
-            code
-                ? 'Signed in. You can close this tab and return to your terminal.\n'
-                : 'The command line login was refused. You can close this tab.\n',
-        );
+        response
+            .writeHead(200, NO_STORE)
+            .end(
+                code
+                    ? 'Signed in. You can close this tab and return to your terminal.\n'
+                    : 'The command line login was refused. You can close this tab.\n',
+            );
         settle?.(code);
     });
 
     await new Promise<void>((resolve, reject) => {
         server.once('error', reject);
-        server.listen(0, '127.0.0.1', resolve);
+        server.listen(0, '127.0.0.1', () => {
+            // The listen handler rejects a promise that is about to settle, so
+            // it cannot stay: a later error would be swallowed, and the one
+            // after that would have no listener at all and take the process
+            // down mid-link.
+            server.removeListener('error', reject);
+            server.on('error', () => settle?.(undefined));
+            resolve();
+        });
     });
     const { port } = server.address() as AddressInfo;
 
+    let closed = false;
     return {
         redirectUri: `http://127.0.0.1:${port}${CALLBACK_PATH}`,
         code: () => received,
         close: () => {
+            if (closed) {
+                return;
+            }
+            closed = true;
             // Unblock anything waiting before the socket goes, so closing is
             // never the reason a caller hangs.
             settle?.(undefined);
@@ -147,6 +174,20 @@ export async function startLoopbackCallback(expectedState: string): Promise<Loop
             server.close();
         },
     };
+}
+
+/**
+ * The state is this flow's CSRF nonce and a page in the browser can time
+ * requests to the port, so it is compared without leaking its length or the
+ * position of the first difference.
+ */
+function matchesState(received: string | null, expected: string): boolean {
+    if (received === null) {
+        return false;
+    }
+    const a = Buffer.from(received);
+    const b = Buffer.from(expected);
+    return a.length === b.length && timingSafeEqual(a, b);
 }
 
 /** The body the token route takes for an authorization code. */
@@ -169,7 +210,12 @@ export function parseConsoleSession(value: unknown, now: number): ConsoleSession
     if (object.token_type !== 'Bearer') {
         throw new Error('Console returned an unsupported token type.');
     }
-    if (typeof object.expires_in !== 'number' || !Number.isFinite(object.expires_in)) {
+    if (
+        typeof object.expires_in !== 'number' ||
+        !Number.isInteger(object.expires_in) ||
+        object.expires_in <= 0 ||
+        object.expires_in > MAX_TOKEN_LIFETIME_SECONDS
+    ) {
         throw new Error('Console returned an invalid token lifetime.');
     }
     const refreshToken =

--- a/packages/cli/src/commands/console/cli-auth.ts
+++ b/packages/cli/src/commands/console/cli-auth.ts
@@ -1,0 +1,180 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { Server, createServer } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import { nonEmptyString, objectValue } from './project-link-validation';
+
+/**
+ * The capability a Console advertises when a Project Link approval can also
+ * settle a command line login. A Console that does not name it approves the
+ * link only, and this CLI then asks for no login at all.
+ */
+export const CLI_AUTH_CAPABILITY = 'cli-auth';
+
+/**
+ * The tools Console names on the approval page. This CLI is always `cli`;
+ * `create` is the same exchange driven by `@vendure-platform/create`, and is
+ * named here so one conformance fixture can cover both halves of the contract.
+ */
+export type CliAuthClient = 'cli' | 'create';
+
+/**
+ * Where the exchange happens. The same route `@vendure-platform/create`
+ * already uses, with the same grants and the same field names: one exchange
+ * with one spelling, rather than a second dialect against one Console.
+ */
+export const CLI_TOKEN_PATH = '/v1/auth/cli/token';
+
+/**
+ * The path the loopback listener answers on. Console refuses a callback
+ * carrying a query or a fragment and permits a path, so this carries nothing
+ * but what Console appends.
+ */
+const CALLBACK_PATH = '/auth/callback';
+
+/**
+ * A Console CLI Session, as the token route issued it.
+ *
+ * The CLI does not write this anywhere. It is handed to the plugin hook that
+ * asked for it, and storing it is that plugin's to do, under its own rules.
+ */
+export interface ConsoleSession {
+    accessToken: string;
+    refreshToken?: string;
+    /** Epoch milliseconds. */
+    expiresAt: number;
+}
+
+export interface PkceChallenge {
+    verifier: string;
+    challenge: string;
+}
+
+export function createPkceChallenge(): PkceChallenge {
+    const verifier = randomBytes(32).toString('base64url');
+    return { verifier, challenge: createHash('sha256').update(verifier).digest('base64url') };
+}
+
+export function createLoginState(): string {
+    return randomBytes(16).toString('base64url');
+}
+
+/**
+ * The query Console reads on the approval page.
+ *
+ * All five or none. Console shows an error and offers no approval for a
+ * partial set, which is what stops a malformed request approving the link and
+ * leaving this listener waiting for a callback nobody will make.
+ */
+export function cliAuthSearchParams(input: {
+    redirectUri: string;
+    state: string;
+    challenge: string;
+    client?: CliAuthClient;
+}): Record<string, string> {
+    return {
+        client: input.client ?? 'cli',
+        redirect_uri: input.redirectUri,
+        state: input.state,
+        code_challenge: input.challenge,
+        code_challenge_method: 'S256',
+    };
+}
+
+export interface LoopbackCallback {
+    /** The address Console sends the browser to. Bound before the browser opens. */
+    redirectUri: string;
+    /**
+     * The authorization code.
+     *
+     * Resolves `undefined` when the login was refused, or when {@link close} is
+     * called first because the browser is never going to arrive.
+     */
+    code(): Promise<string | undefined>;
+    close(): void;
+}
+
+/**
+ * Binds a one-shot callback on this machine.
+ *
+ * `127.0.0.1` rather than `localhost`, because that is what Console's redirect
+ * check is given today and a name that resolves elsewhere is not a loopback.
+ * Port 0, so the operating system picks one that is free, and it is bound
+ * before the browser opens so the address in the approval request is already
+ * listening.
+ */
+export async function startLoopbackCallback(expectedState: string): Promise<LoopbackCallback> {
+    let settle: ((code: string | undefined) => void) | undefined;
+    const received = new Promise<string | undefined>(resolve => {
+        settle = resolve;
+    });
+
+    const server: Server = createServer((request, response) => {
+        const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+        if (url.pathname !== CALLBACK_PATH) {
+            response.writeHead(404).end();
+            return;
+        }
+        // Anything on this port that does not carry the state this run
+        // generated is not the browser we sent. Answer it and keep waiting.
+        if (url.searchParams.get('state') !== expectedState) {
+            response.writeHead(400, { 'Content-Type': 'text/plain' }).end('Unexpected login callback.\n');
+            return;
+        }
+        const code = url.searchParams.get('code') ?? undefined;
+        response.writeHead(200, { 'Content-Type': 'text/plain' }).end(
+            code
+                ? 'Signed in. You can close this tab and return to your terminal.\n'
+                : 'The command line login was refused. You can close this tab.\n',
+        );
+        settle?.(code);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', resolve);
+    });
+    const { port } = server.address() as AddressInfo;
+
+    return {
+        redirectUri: `http://127.0.0.1:${port}${CALLBACK_PATH}`,
+        code: () => received,
+        close: () => {
+            // Unblock anything waiting before the socket goes, so closing is
+            // never the reason a caller hangs.
+            settle?.(undefined);
+            server.closeAllConnections();
+            server.close();
+        },
+    };
+}
+
+/** The body the token route takes for an authorization code. */
+export function authorizationCodeGrant(input: {
+    code: string;
+    verifier: string;
+    redirectUri: string;
+}): Record<string, string> {
+    return {
+        grant_type: 'authorization_code',
+        code: input.code,
+        code_verifier: input.verifier,
+        redirect_uri: input.redirectUri,
+    };
+}
+
+export function parseConsoleSession(value: unknown, now: number): ConsoleSession {
+    const object = objectValue(value, 'Console returned a malformed token response.');
+    const accessToken = nonEmptyString(object.access_token, 'Console returned an invalid access token.');
+    if (object.token_type !== 'Bearer') {
+        throw new Error('Console returned an unsupported token type.');
+    }
+    if (typeof object.expires_in !== 'number' || !Number.isFinite(object.expires_in)) {
+        throw new Error('Console returned an invalid token lifetime.');
+    }
+    const refreshToken =
+        typeof object.refresh_token === 'string' && object.refresh_token.length > 0
+            ? object.refresh_token
+            : undefined;
+    return { accessToken, refreshToken, expiresAt: now + object.expires_in * 1000 };
+}

--- a/packages/cli/src/commands/console/cli-auth.ts
+++ b/packages/cli/src/commands/console/cli-auth.ts
@@ -12,16 +12,17 @@ import { nonEmptyString, objectValue } from './project-link-validation';
 export const CLI_AUTH_CAPABILITY = 'cli-auth';
 
 /**
- * The tools Console names on the approval page. This CLI is always `cli`.
- * `create` is the same exchange driven from elsewhere, and is accepted here so
- * a cross-repository conformance test can drive both without a second client.
+ * The tools Console names on the approval page, as Console defines them. This
+ * CLI is always `cli`; `create` is the other value Console accepts, and is
+ * spelled out here so one conformance test can drive both.
  */
 export type CliAuthClient = 'cli' | 'create';
 
 /**
- * Where the exchange happens. The same route `@vendure-platform/create`
- * already uses, with the same grants and the same field names: one exchange
- * with one spelling, rather than a second dialect against one Console.
+ * Console's CLI session token route, where an authorization code is exchanged.
+ *
+ * The route, the grant types and the field names are Console's, so every
+ * client of it speaks the same exchange rather than a dialect of its own.
  */
 export const CLI_TOKEN_PATH = '/v1/auth/cli/token';
 

--- a/packages/cli/src/commands/console/command.ts
+++ b/packages/cli/src/commands/console/command.ts
@@ -1,7 +1,7 @@
 import { CliCommandContext, CliCommandDefinition } from '../../shared/cli-command-definition';
 import { runCliCommand } from '../../shared/cli-command-exit';
 
-import { ConsoleLinkHook } from './console-link-hook';
+import { ConsoleLinkHookRegistration } from './console-link-hook';
 
 export const consoleCommandDef: CliCommandDefinition = {
     name: 'console',
@@ -39,8 +39,12 @@ export const consoleCommandDef: CliCommandDefinition = {
         return runCliCommand(async () => {
             const { consoleCommand } = await import('./console');
             const hooks = context
-                .getPluginExtensions<ConsoleLinkHook>('afterConsoleLink')
-                .map(({ pluginId, extension: hook }) => ({ pluginId, hook }));
+                .getPluginExtensions<ConsoleLinkHookRegistration>('afterConsoleLink')
+                .map(({ pluginId, extension }) =>
+                    typeof extension === 'function'
+                        ? { pluginId, hook: extension, requiresSession: false }
+                        : { pluginId, hook: extension.hook, requiresSession: true },
+                );
             return consoleCommand(action, options, { hooks });
         });
     },

--- a/packages/cli/src/commands/console/console-link-hook.spec.ts
+++ b/packages/cli/src/commands/console/console-link-hook.spec.ts
@@ -11,7 +11,7 @@ import { CommandRegistry } from '../../shared/command-registry-store';
 import { builtinCommandDefs } from '../builtins';
 
 import { ConsoleCommandDependencies, consoleCommand } from './console';
-import { ConsoleLinkContext, ConsoleLinkHook } from './console-link-hook';
+import { ConsoleLinkContext, ConsoleLinkHook, ConsoleLinkHookRegistration } from './console-link-hook';
 import { ConsoleReporter } from './console-reporter';
 import { LINK_ID, POLLING_SECRET, manifest } from './console.fixtures';
 import { getProjectLinkManifestPath } from './project-link-manifest';
@@ -386,18 +386,29 @@ describe('console link hooks', () => {
         expect(isNonInteractive).toHaveBeenCalledTimes(1);
     });
 
-    it('rejects a plugin whose afterConsoleLink is not a function', () => {
+    it('preserves an explicit session request through registration', () => {
+        const hook = vi.fn<ConsoleLinkHook>(async () => undefined);
+        const registration = { hook, requiresSession: true } as const;
+        const registry = registryWith(plugin(FIRST_PLUGIN, registration));
+
+        expect(registry.getPluginExtensions('afterConsoleLink')).toEqual([
+            { pluginId: FIRST_PLUGIN, extension: registration },
+        ]);
+        expect(consoleLinkHooks(registry)).toEqual([{ pluginId: FIRST_PLUGIN, hook, requiresSession: true }]);
+    });
+
+    it('rejects an invalid afterConsoleLink registration', () => {
         expect(() =>
             defineCliPlugin({
                 id: FIRST_PLUGIN,
                 commands: [],
-                afterConsoleLink: 'not a function' as unknown as ConsoleLinkHook,
+                afterConsoleLink: { requiresSession: true } as unknown as ConsoleLinkHookRegistration,
             }),
-        ).toThrow('afterConsoleLink must be a function');
+        ).toThrow('afterConsoleLink must be a function or a session-requesting hook');
     });
 });
 
-function plugin(id: string, afterConsoleLink: ConsoleLinkHook) {
+function plugin(id: string, afterConsoleLink: ConsoleLinkHookRegistration) {
     return defineCliPlugin({ id, commands: [], afterConsoleLink });
 }
 
@@ -471,8 +482,12 @@ function recordingReporter(
 
 function consoleLinkHooks(registry: CommandRegistry) {
     return registry
-        .getPluginExtensions<ConsoleLinkHook>('afterConsoleLink')
-        .map(({ pluginId, extension: hook }) => ({ pluginId, hook }));
+        .getPluginExtensions<ConsoleLinkHookRegistration>('afterConsoleLink')
+        .map(({ pluginId, extension }) =>
+            typeof extension === 'function'
+                ? { pluginId, hook: extension, requiresSession: false }
+                : { pluginId, hook: extension.hook, requiresSession: true },
+        );
 }
 
 function offlineDependencies(root: string, messages: string[] = []): Partial<ConsoleCommandDependencies> {

--- a/packages/cli/src/commands/console/console-link-hook.ts
+++ b/packages/cli/src/commands/console/console-link-hook.ts
@@ -1,3 +1,4 @@
+import { ConsoleSession } from './cli-auth';
 import { ConsoleOriginEnvironment } from './console-origins';
 import { ProjectLinkManifest } from './project-link-manifest';
 
@@ -102,6 +103,22 @@ export interface ConsoleLinkContext {
      * may have arrived with a clone. Its identifiers are unverified.
      */
     outcome: ConsoleLinkOutcome;
+    /**
+     * The Console CLI Session this run obtained, when it obtained one.
+     *
+     * Present only when the same browser approval that settled the link also
+     * settled a command line login. That needs an official Console that says
+     * it supports one, a browser on this machine, and an approval rather than
+     * a refusal, so a hook must handle its absence rather than depend on it.
+     * `outcome: 'repaired'` never carries one: a repair asks Console nothing
+     * and opens no browser.
+     *
+     * The CLI does not write this anywhere. A plugin that stores it owns that,
+     * and owns keeping it out of the project directory: this is user-scoped and
+     * worth as much as the person's Console password across every project they
+     * own.
+     */
+    session?: ConsoleSession;
     /**
      * Aborts on SIGINT and SIGTERM, the same signal the link itself ran under.
      * Anything a hook does remotely should be passed this, so that Ctrl-C does

--- a/packages/cli/src/commands/console/console-link-hook.ts
+++ b/packages/cli/src/commands/console/console-link-hook.ts
@@ -51,10 +51,20 @@ export interface ConsoleLinkContext {
  */
 export type ConsoleLinkHook = (context: ConsoleLinkContext) => Promise<void>;
 
+/** A hook that explicitly requests a Console session. @since 3.8.0 */
+export interface ConsoleLinkHookWithSession {
+    hook: ConsoleLinkHook;
+    requiresSession: true;
+}
+
+/** A hook registration, optionally with an explicit session request. @since 3.8.0 */
+export type ConsoleLinkHookRegistration = ConsoleLinkHook | ConsoleLinkHookWithSession;
+
 /**
  * A hook together with the plugin that registered it, so a failure can name it.
  */
 export interface RegisteredConsoleLinkHook {
     pluginId: string;
     hook: ConsoleLinkHook;
+    requiresSession?: boolean;
 }

--- a/packages/cli/src/commands/console/console-login.spec.ts
+++ b/packages/cli/src/commands/console/console-login.spec.ts
@@ -1,0 +1,321 @@
+import fs from 'fs-extra';
+import { createHash } from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ConsoleSession } from './cli-auth';
+import { ConsoleCommandDependencies, ConsoleReporter, consoleCommand } from './console';
+import { ConsoleLinkContext } from './console-link-hook';
+import { LINK_ID, POLLING_SECRET, manifest } from './console.fixtures';
+import { getProjectLinkManifestPath } from './project-link-manifest';
+
+/**
+ * The official production pair, so the origin gate opens. Nothing reaches the
+ * network: every request goes through the injected `fetch`, and the only real
+ * socket is the loopback listener the client binds on this machine.
+ */
+const OFFICIAL_ENV = {
+    VENDURE_CLI_NON_INTERACTIVE: 'true',
+    VENDURE_CONSOLE_LINK_URL: 'https://console.vendure.io',
+    VENDURE_CONSOLE_LINK_API_URL: 'https://api.vendure.io',
+};
+
+const ACCESS_TOKEN = 'vcli_access-token';
+const REFRESH_TOKEN = 'vclr_refresh-token';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    for (const directory of temporaryDirectories.splice(0)) {
+        fs.removeSync(directory);
+    }
+});
+
+describe('console link command line login', () => {
+    it('settles the link and the session from one browser approval', async () => {
+        const test = await runLink();
+
+        expect(test.exitCode).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
+        // One approval. The browser was opened once and never sent to the
+        // standalone sign-in page.
+        expect(test.openedUrls).toHaveLength(1);
+        expect(new URL(test.openedUrls[0]).pathname).not.toBe('/cli-auth');
+
+        // All five parameters, on the verification URL Console already returned.
+        const opened = new URL(test.openedUrls[0]);
+        expect(opened.searchParams.get('client')).toBe('cli');
+        expect(opened.searchParams.get('code_challenge_method')).toBe('S256');
+        expect(opened.searchParams.get('state')).toBeTruthy();
+        const redirectUri = opened.searchParams.get('redirect_uri') ?? '';
+        expect(new URL(redirectUri).hostname).toBe('127.0.0.1');
+        expect(new URL(redirectUri).pathname).toBe('/auth/callback');
+
+        // The exchange proved possession of the verifier behind the challenge.
+        expect(createHash('sha256').update(test.grant.code_verifier).digest('base64url')).toBe(
+            opened.searchParams.get('code_challenge'),
+        );
+        expect(test.grant.grant_type).toBe('authorization_code');
+        expect(test.grant.redirect_uri).toBe(redirectUri);
+
+        expect(test.sessions).toEqual([
+            { accessToken: ACCESS_TOKEN, refreshToken: REFRESH_TOKEN, expiresAt: expect.any(Number) },
+        ]);
+    });
+
+    it('links without a session when the Console does not settle a login, and says so', async () => {
+        const test = await runLink({ supports: [] });
+
+        expect(test.exitCode).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
+        // No login was requested, so the verification URL is the plain one.
+        expect(new URL(test.openedUrls[0]).searchParams.get('client')).toBeNull();
+        expect(test.sessions).toEqual([undefined]);
+        expect(test.messages.join('\n')).toContain('does not settle a command line login');
+    });
+
+    it('asks for the link alone when no browser can be opened here', async () => {
+        const test = await runLink({ openUrl: () => Promise.reject(new Error('no browser')) });
+
+        expect(test.exitCode).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
+        // The URL offered for another machine carries no callback address,
+        // because that address is only reachable from this one.
+        const printed = test.messages.find(message => message.startsWith('https://'));
+        expect(printed).toBeDefined();
+        expect(new URL(printed ?? '').searchParams.get('redirect_uri')).toBeNull();
+        expect(test.sessions).toEqual([undefined]);
+        // Said before the person approves, not after.
+        expect(test.messages.join('\n')).toContain('will not obtain a Console session');
+    });
+
+    it('keeps the link when the browser approved somewhere the callback cannot reach', async () => {
+        // The approval happens, so the poll completes, but nothing ever calls
+        // the listener on this machine.
+        const test = await runLink({ openUrl: () => Promise.resolve() });
+
+        expect(test.exitCode).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
+        expect(test.sessions).toEqual([undefined]);
+        expect(test.messages.join('\n')).toContain('no Console session was obtained');
+    });
+
+    it('keeps the link when the token exchange is refused', async () => {
+        const test = await runLink({ tokenStatus: 400 });
+
+        expect(test.exitCode).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
+        expect(test.sessions).toEqual([undefined]);
+        expect(test.messages.join('\n')).toContain('could not be obtained');
+    });
+
+    it('never carries a session into a repair, which asks Console nothing', async () => {
+        const root = vendureProject();
+        fs.ensureDirSync(path.dirname(getProjectLinkManifestPath(root)));
+        fs.writeJsonSync(getProjectLinkManifestPath(root), manifest);
+        const contexts: ConsoleLinkContext[] = [];
+        const fetchMock = vi.fn() as unknown as typeof fetch;
+
+        const exitCode = await consoleCommand(
+            'link',
+            {},
+            {
+                ...baseDependencies(root),
+                env: OFFICIAL_ENV,
+                fetch: fetchMock,
+                hooks: [
+                    {
+                        pluginId: '@example/p',
+                        hook: async context => {
+                            contexts.push(context);
+                        },
+                    },
+                ],
+            },
+        );
+
+        expect(exitCode).toBe(0);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(contexts[0].outcome).toBe('repaired');
+        expect(contexts[0].session).toBeUndefined();
+    });
+
+    it('does not offer a login to a Console that is not an official one', async () => {
+        const root = vendureProject();
+        const contexts: ConsoleLinkContext[] = [];
+        const openedUrls: string[] = [];
+        const messages: string[] = [];
+
+        const exitCode = await consoleCommand(
+            'link',
+            {},
+            {
+                ...baseDependencies(root, messages),
+                env: {
+                    VENDURE_CLI_NON_INTERACTIVE: 'true',
+                    VENDURE_CONSOLE_LINK_URL: 'http://localhost:3000',
+                    VENDURE_CONSOLE_LINK_API_URL: 'http://localhost:3001',
+                },
+                fetch: consoleFetch({}) as unknown as typeof fetch,
+                hooks: [
+                    {
+                        pluginId: '@example/p',
+                        hook: async context => {
+                            contexts.push(context);
+                        },
+                    },
+                ],
+                openUrl: async url => {
+                    openedUrls.push(url);
+                },
+            },
+        );
+
+        expect(exitCode).toBe(0);
+        expect(contexts[0].endpoints.official).toBeUndefined();
+        expect(contexts[0].session).toBeUndefined();
+        // No callback address was ever advertised to a Console we do not know.
+        expect(new URL(openedUrls[0]).searchParams.get('redirect_uri')).toBeNull();
+        // And no capability complaint, because the origin decided it first.
+        expect(messages.join('\n')).not.toContain('does not settle a command line login');
+    });
+});
+
+interface RunOptions {
+    supports?: string[];
+    tokenStatus?: number;
+    openUrl?: (url: string) => Promise<void>;
+}
+
+/**
+ * Drives `vendure console link` against an in-memory Console.
+ *
+ * The default `openUrl` is the browser: it follows the approval by calling the
+ * loopback address the client advertised, which is what Console's `redirectTo`
+ * makes the real browser do.
+ */
+async function runLink(options: RunOptions = {}) {
+    const root = vendureProject();
+    const openedUrls: string[] = [];
+    const messages: string[] = [];
+    const sessions: Array<ConsoleSession | undefined> = [];
+    const grants: Array<Record<string, string>> = [];
+
+    const fetchMock = consoleFetch({
+        supports: options.supports ?? ['cli-auth'],
+        tokenStatus: options.tokenStatus ?? 200,
+        grants,
+    });
+
+    const exitCode = await consoleCommand(
+        'link',
+        {},
+        {
+            ...baseDependencies(root, messages),
+            env: OFFICIAL_ENV,
+            fetch: fetchMock as unknown as typeof fetch,
+            hooks: [
+                {
+                    pluginId: '@example/p',
+                    hook: async context => {
+                        sessions.push(context.session);
+                    },
+                },
+            ],
+            openUrl: async url => {
+                openedUrls.push(url);
+                if (options.openUrl) {
+                    await options.openUrl(url);
+                    return;
+                }
+                // The browser: follow the approval to the address the client
+                // advertised, which is what Console's `redirectTo` makes it do.
+                const search = new URL(url).searchParams;
+                const redirectUri = search.get('redirect_uri');
+                const state = search.get('state');
+                if (redirectUri && state) {
+                    await fetch(`${redirectUri}?code=the-code&state=${encodeURIComponent(state)}`);
+                }
+            },
+        },
+    );
+
+    return { exitCode, root, openedUrls, messages, sessions, grant: grants[0] ?? {}, grants };
+}
+
+function consoleFetch(options: {
+    supports?: string[];
+    tokenStatus?: number;
+    grants?: Array<Record<string, string>>;
+}) {
+    return vi.fn(async (input: string, init?: RequestInit) => {
+        const url = new URL(input);
+        if (url.pathname === '/v1/project-links') {
+            return jsonResponse({
+                id: LINK_ID,
+                state: 'pending',
+                protocolVersion: 1,
+                expiresAt: new Date(Date.now() + 600_000).toISOString(),
+                pollingSecret: POLLING_SECRET,
+                verificationPath: `/?link=${LINK_ID}`,
+                ...(options.supports ? { supports: options.supports } : {}),
+            });
+        }
+        if (url.pathname.endsWith('/poll')) {
+            return jsonResponse({
+                state: 'approved',
+                expiresAt: new Date(Date.now() + 600_000).toISOString(),
+                manifest,
+            });
+        }
+        if (url.pathname === '/v1/auth/cli/token') {
+            options.grants?.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, string>);
+            if ((options.tokenStatus ?? 200) !== 200) {
+                return new Response('{}', { status: options.tokenStatus });
+            }
+            return jsonResponse({
+                access_token: ACCESS_TOKEN,
+                token_type: 'Bearer',
+                expires_in: 3600,
+                refresh_token: REFRESH_TOKEN,
+            });
+        }
+        throw new Error(`Unexpected request to ${input}`);
+    });
+}
+
+function jsonResponse(value: unknown): Response {
+    return new Response(JSON.stringify(value), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+function baseDependencies(root: string, messages: string[] = []): Partial<ConsoleCommandDependencies> {
+    const reporter: ConsoleReporter = {
+        error: message => messages.push(message),
+        info: message => messages.push(message),
+        success: message => messages.push(message),
+        warn: message => messages.push(message),
+        url: value => messages.push(value),
+    };
+    return {
+        cwd: root,
+        hooks: [],
+        isNonInteractive: () => true,
+        now: () => Date.now(),
+        openUrl: () => Promise.resolve(),
+        prompt: () => Promise.resolve(true),
+        reporter,
+        sleep: () => Promise.resolve(),
+    };
+}
+
+function vendureProject(): string {
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'vendure-console-login-')));
+    temporaryDirectories.push(root);
+    fs.writeJsonSync(path.join(root, 'package.json'), { dependencies: { '@vendure/core': '3.7.2' } });
+    return root;
+}

--- a/packages/cli/src/commands/console/console-login.spec.ts
+++ b/packages/cli/src/commands/console/console-login.spec.ts
@@ -4,8 +4,9 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import * as cliAuth from './cli-auth';
 import { ConsoleSession } from './cli-auth';
-import { ConsoleCommandDependencies, ConsoleReporter, consoleCommand } from './console';
+import { CALLBACK_GRACE_MS, ConsoleCommandDependencies, ConsoleReporter, consoleCommand } from './console';
 import { ConsoleLinkContext } from './console-link-hook';
 import { LINK_ID, NOW, POLLING_SECRET, manifest } from './console.fixtures';
 import { getProjectLinkManifestPath } from './project-link-manifest';
@@ -86,13 +87,13 @@ describe('console link command line login', () => {
             },
             // The grace period is where the callback lands.
             sleep: async milliseconds => {
-                if (milliseconds === 2_000) {
+                if (milliseconds === CALLBACK_GRACE_MS) {
                     await arrived;
                 }
             },
         });
 
-        expect(test.delays).toContain(2_000);
+        expect(test.delays).toContain(CALLBACK_GRACE_MS);
         expect(test.sessions[0]?.accessToken).toBe(ACCESS_TOKEN);
     });
 
@@ -100,7 +101,7 @@ describe('console link command line login', () => {
         const test = await runLink({ openUrl: () => Promise.resolve() });
 
         // Waited, then stopped waiting. The link is what the command owed.
-        expect(test.delays).toContain(2_000);
+        expect(test.delays).toContain(CALLBACK_GRACE_MS);
         expect(test.sessions).toEqual([undefined]);
     });
 
@@ -122,7 +123,10 @@ describe('console link command line login', () => {
         // process that happens to hold that port on the other machine.
         expect(new URL(test.openedUrls[0]).searchParams.get('redirect_uri')).toBeNull();
         expect(test.sessions).toEqual([undefined]);
-        expect(test.messages.join('\n')).toContain('will not obtain a Console session');
+        const output = test.messages.join('\n');
+        expect(output).toContain('remote shell');
+        // Re-running hits the same gate, so it must not be offered as a cure.
+        expect(output).not.toContain('vendure console link again');
     });
 
     it('keeps the link when the token response is malformed', async () => {
@@ -182,6 +186,39 @@ describe('console link command line login', () => {
         expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
         expect(test.sessions).toEqual([undefined]);
         expect(test.messages.join('\n')).toContain('could not be obtained');
+    });
+
+    // The first and largest claim of the correction: an interrupt between the
+    // approval and the manifest write used to leave an approved Project Link
+    // with nothing on disk, which the next run can only replace.
+    it('has the manifest on disk before the login can be interrupted', async () => {
+        const abort = new AbortController();
+        const test = await runLink({
+            // Approved in the browser, then Ctrl-C while the code is being
+            // exchanged, which is the window the reorder is about.
+            onTokenRequest: () => abort.abort(),
+            signal: abort.signal,
+        });
+
+        expect(test.exitCode).toBe(130);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
+        const output = test.messages.join('\n');
+        expect(output).toContain('The link succeeded');
+        expect(output).not.toContain('No Project Link Manifest was changed');
+    });
+
+    it('links without a session when the callback port cannot be bound', async () => {
+        const failing = vi
+            .spyOn(cliAuth, 'startLoopbackCallback')
+            .mockRejectedValue(new Error('listen EACCES 127.0.0.1'));
+        const test = await runLink();
+        failing.mockRestore();
+
+        // A port this process cannot bind has nothing to do with the link.
+        expect(test.exitCode).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
+        expect(test.sessions).toEqual([undefined]);
+        expect(test.messages.join('\n')).toContain('EACCES');
     });
 
     it('never carries a session into a repair, which asks Console nothing', async () => {
@@ -263,6 +300,8 @@ interface RunOptions {
     hooks?: ConsoleCommandDependencies['hooks'];
     env?: NodeJS.ProcessEnv;
     openUrl?: (url: string) => Promise<void>;
+    signal?: AbortSignal;
+    onTokenRequest?: () => void;
     /** Called with each requested delay, so the grace period is observable. */
     sleep?: (milliseconds: number) => Promise<void>;
 }
@@ -286,6 +325,7 @@ async function runLink(options: RunOptions = {}) {
         supports: options.supports ?? ['cli-auth'],
         tokenStatus: options.tokenStatus ?? 200,
         tokenBody: options.tokenBody,
+        onTokenRequest: options.onTokenRequest,
         grants,
     });
 
@@ -297,6 +337,7 @@ async function runLink(options: RunOptions = {}) {
             ...baseDependencies(root, messages),
             env: options.env ?? OFFICIAL_ENV,
             fetch: fetchMock as unknown as typeof fetch,
+            signal: options.signal,
             now: () => NOW,
             sleep: async milliseconds => {
                 delays.push(milliseconds);
@@ -346,6 +387,7 @@ function consoleFetch(options: {
     supports?: string[];
     tokenStatus?: number;
     tokenBody?: unknown;
+    onTokenRequest?: () => void;
     grants?: Array<Record<string, string>>;
 }) {
     return vi.fn(async (input: string, init?: RequestInit) => {
@@ -369,6 +411,7 @@ function consoleFetch(options: {
             });
         }
         if (url.pathname === '/v1/auth/cli/token') {
+            options.onTokenRequest?.();
             options.grants?.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, string>);
             if ((options.tokenStatus ?? 200) !== 200) {
                 return new Response('{}', { status: options.tokenStatus });
@@ -405,7 +448,6 @@ function baseDependencies(root: string, messages: string[] = []): Partial<Consol
         cwd: root,
         hooks: [],
         isNonInteractive: () => true,
-        now: () => Date.now(),
         now: () => NOW,
         openUrl: () => Promise.resolve(),
         prompt: () => Promise.resolve(true),

--- a/packages/cli/src/commands/console/console-login.spec.ts
+++ b/packages/cli/src/commands/console/console-login.spec.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ConsoleSession } from './cli-auth';
 import { ConsoleCommandDependencies, ConsoleReporter, consoleCommand } from './console';
 import { ConsoleLinkContext } from './console-link-hook';
-import { LINK_ID, POLLING_SECRET, manifest } from './console.fixtures';
+import { LINK_ID, NOW, POLLING_SECRET, manifest } from './console.fixtures';
 import { getProjectLinkManifestPath } from './project-link-manifest';
 
 /**
@@ -48,7 +48,9 @@ describe('console link command line login', () => {
         const opened = new URL(test.openedUrls[0]);
         expect(opened.searchParams.get('client')).toBe('cli');
         expect(opened.searchParams.get('code_challenge_method')).toBe('S256');
-        expect(opened.searchParams.get('state')).toBeTruthy();
+        // The state on the URL is the one the listener accepted: the browser
+        // stub only reaches the code path by echoing it back.
+        expect(opened.searchParams.get('state')).toBe(test.callbackState);
         const redirectUri = opened.searchParams.get('redirect_uri') ?? '';
         expect(new URL(redirectUri).hostname).toBe('127.0.0.1');
         expect(new URL(redirectUri).pathname).toBe('/auth/callback');
@@ -61,8 +63,75 @@ describe('console link command line login', () => {
         expect(test.grant.redirect_uri).toBe(redirectUri);
 
         expect(test.sessions).toEqual([
-            { accessToken: ACCESS_TOKEN, refreshToken: REFRESH_TOKEN, expiresAt: expect.any(Number) },
+            { accessToken: ACCESS_TOKEN, refreshToken: REFRESH_TOKEN, expiresAt: NOW + 3_600_000 },
         ]);
+    });
+
+    it('waits briefly for a callback the poll beat, rather than closing on it', async () => {
+        let releaseCallback: (() => void) | undefined;
+        const arrived = new Promise<void>(resolve => {
+            releaseCallback = resolve;
+        });
+        const test = await runLink({
+            // The browser has not answered by the time the poll returns, which
+            // is the ordinary case: the poll runs on its own clock.
+            openUrl: async url => {
+                const search = new URL(url).searchParams;
+                const redirectUri = search.get('redirect_uri') ?? '';
+                const state = search.get('state') ?? '';
+                void (async () => {
+                    await fetch(`${redirectUri}?code=the-code&state=${encodeURIComponent(state)}`);
+                    releaseCallback?.();
+                })();
+            },
+            // The grace period is where the callback lands.
+            sleep: async milliseconds => {
+                if (milliseconds === 2_000) {
+                    await arrived;
+                }
+            },
+        });
+
+        expect(test.delays).toContain(2_000);
+        expect(test.sessions[0]?.accessToken).toBe(ACCESS_TOKEN);
+    });
+
+    it('gives up on the callback once the grace period is spent', async () => {
+        const test = await runLink({ openUrl: () => Promise.resolve() });
+
+        // Waited, then stopped waiting. The link is what the command owed.
+        expect(test.delays).toContain(2_000);
+        expect(test.sessions).toEqual([undefined]);
+    });
+
+    it('obtains no session when no plugin asked for one', async () => {
+        const test = await runLink({ hooks: [] });
+
+        expect(test.exitCode).toBe(0);
+        // A token nobody consumes is still a live token, so none is minted and
+        // no callback address is advertised.
+        expect(new URL(test.openedUrls[0]).searchParams.get('redirect_uri')).toBeNull();
+        expect(test.grants).toEqual([]);
+    });
+
+    it('does not advertise a callback address over an SSH session', async () => {
+        const test = await runLink({ env: { ...OFFICIAL_ENV, SSH_CONNECTION: '10.0.0.1 22 10.0.0.2 22' } });
+
+        expect(test.exitCode).toBe(0);
+        // The browser is somewhere else, so the callback could only reach a
+        // process that happens to hold that port on the other machine.
+        expect(new URL(test.openedUrls[0]).searchParams.get('redirect_uri')).toBeNull();
+        expect(test.sessions).toEqual([undefined]);
+        expect(test.messages.join('\n')).toContain('will not obtain a Console session');
+    });
+
+    it('keeps the link when the token response is malformed', async () => {
+        const test = await runLink({ tokenBody: { access_token: 'vcli_a', token_type: 'Bearer' } });
+
+        expect(test.exitCode).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
+        expect(test.sessions).toEqual([undefined]);
+        expect(test.messages.join('\n')).toContain('could not be obtained');
     });
 
     it('links without a session when the Console does not settle a login, and says so', async () => {
@@ -99,7 +168,11 @@ describe('console link command line login', () => {
         expect(test.exitCode).toBe(0);
         expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
         expect(test.sessions).toEqual([undefined]);
-        expect(test.messages.join('\n')).toContain('no Console session was obtained');
+        const output = test.messages.join('\n');
+        expect(output).toContain('The link is in place.');
+        // Re-running runs the plugin setup again, which is where a plugin that
+        // needs a session signs in. The command itself cannot mint one.
+        expect(output).toContain('vendure console link again');
     });
 
     it('keeps the link when the token exchange is refused', async () => {
@@ -186,7 +259,12 @@ describe('console link command line login', () => {
 interface RunOptions {
     supports?: string[];
     tokenStatus?: number;
+    tokenBody?: unknown;
+    hooks?: ConsoleCommandDependencies['hooks'];
+    env?: NodeJS.ProcessEnv;
     openUrl?: (url: string) => Promise<void>;
+    /** Called with each requested delay, so the grace period is observable. */
+    sleep?: (milliseconds: number) => Promise<void>;
 }
 
 /**
@@ -202,21 +280,29 @@ async function runLink(options: RunOptions = {}) {
     const messages: string[] = [];
     const sessions: Array<ConsoleSession | undefined> = [];
     const grants: Array<Record<string, string>> = [];
+    const callbackStates: string[] = [];
 
     const fetchMock = consoleFetch({
         supports: options.supports ?? ['cli-auth'],
         tokenStatus: options.tokenStatus ?? 200,
+        tokenBody: options.tokenBody,
         grants,
     });
 
+    const delays: number[] = [];
     const exitCode = await consoleCommand(
         'link',
         {},
         {
             ...baseDependencies(root, messages),
-            env: OFFICIAL_ENV,
+            env: options.env ?? OFFICIAL_ENV,
             fetch: fetchMock as unknown as typeof fetch,
-            hooks: [
+            now: () => NOW,
+            sleep: async milliseconds => {
+                delays.push(milliseconds);
+                await (options.sleep?.(milliseconds) ?? Promise.resolve());
+            },
+            hooks: options.hooks ?? [
                 {
                     pluginId: '@example/p',
                     hook: async context => {
@@ -236,18 +322,30 @@ async function runLink(options: RunOptions = {}) {
                 const redirectUri = search.get('redirect_uri');
                 const state = search.get('state');
                 if (redirectUri && state) {
+                    callbackStates.push(state);
                     await fetch(`${redirectUri}?code=the-code&state=${encodeURIComponent(state)}`);
                 }
             },
         },
     );
 
-    return { exitCode, root, openedUrls, messages, sessions, grant: grants[0] ?? {}, grants };
+    return {
+        exitCode,
+        root,
+        openedUrls,
+        messages,
+        sessions,
+        delays,
+        callbackState: callbackStates[0],
+        grant: grants[0] ?? {},
+        grants,
+    };
 }
 
 function consoleFetch(options: {
     supports?: string[];
     tokenStatus?: number;
+    tokenBody?: unknown;
     grants?: Array<Record<string, string>>;
 }) {
     return vi.fn(async (input: string, init?: RequestInit) => {
@@ -275,12 +373,14 @@ function consoleFetch(options: {
             if ((options.tokenStatus ?? 200) !== 200) {
                 return new Response('{}', { status: options.tokenStatus });
             }
-            return jsonResponse({
-                access_token: ACCESS_TOKEN,
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: REFRESH_TOKEN,
-            });
+            return jsonResponse(
+                options.tokenBody ?? {
+                    access_token: ACCESS_TOKEN,
+                    token_type: 'Bearer',
+                    expires_in: 3600,
+                    refresh_token: REFRESH_TOKEN,
+                },
+            );
         }
         throw new Error(`Unexpected request to ${input}`);
     });
@@ -306,6 +406,7 @@ function baseDependencies(root: string, messages: string[] = []): Partial<Consol
         hooks: [],
         isNonInteractive: () => true,
         now: () => Date.now(),
+        now: () => NOW,
         openUrl: () => Promise.resolve(),
         prompt: () => Promise.resolve(true),
         reporter,

--- a/packages/cli/src/commands/console/console-login.spec.ts
+++ b/packages/cli/src/commands/console/console-login.spec.ts
@@ -1,14 +1,20 @@
 import fs from 'fs-extra';
 import { createHash } from 'node:crypto';
-import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import * as cliAuth from './cli-auth';
-import { ConsoleSession } from './cli-auth';
+import { ConsoleSession, startLoopbackCallback } from './cli-auth';
 import { CALLBACK_GRACE_MS, ConsoleCommandDependencies, ConsoleReporter, consoleCommand } from './console';
 import { ConsoleLinkContext } from './console-link-hook';
-import { LINK_ID, NOW, POLLING_SECRET, manifest } from './console.fixtures';
+import {
+    ACCESS_TOKEN,
+    LINK_ID,
+    NOW,
+    REFRESH_TOKEN,
+    createConsoleFetch,
+    createVendureProject,
+    manifest,
+} from './console.fixtures';
 import { getProjectLinkManifestPath } from './project-link-manifest';
 
 /**
@@ -22,9 +28,6 @@ const OFFICIAL_ENV = {
     VENDURE_CONSOLE_LINK_API_URL: 'https://api.vendure.io',
 };
 
-const ACCESS_TOKEN = 'vcli_access-token';
-const REFRESH_TOKEN = 'vclr_refresh-token';
-
 const temporaryDirectories: string[] = [];
 
 afterEach(() => {
@@ -36,34 +39,34 @@ afterEach(() => {
 
 describe('console link command line login', () => {
     it('settles the link and the session from one browser approval', async () => {
-        const test = await runLink();
+        const run = await runLink();
 
-        expect(test.exitCode).toBe(0);
-        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
+        expect(run.exitCode).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(run.root))).toEqual(manifest);
         // One approval. The browser was opened once and never sent to the
         // standalone sign-in page.
-        expect(test.openedUrls).toHaveLength(1);
-        expect(new URL(test.openedUrls[0]).pathname).not.toBe('/cli-auth');
+        expect(run.openedUrls).toHaveLength(1);
+        expect(new URL(run.openedUrls[0]).pathname).not.toBe('/cli-auth');
 
         // All five parameters, on the verification URL Console already returned.
-        const opened = new URL(test.openedUrls[0]);
+        const opened = new URL(run.openedUrls[0]);
         expect(opened.searchParams.get('client')).toBe('cli');
         expect(opened.searchParams.get('code_challenge_method')).toBe('S256');
         // The state on the URL is the one the listener accepted: the browser
         // stub only reaches the code path by echoing it back.
-        expect(opened.searchParams.get('state')).toBe(test.callbackState);
+        expect(opened.searchParams.get('state')).toBe(run.callbackState);
         const redirectUri = opened.searchParams.get('redirect_uri') ?? '';
         expect(new URL(redirectUri).hostname).toBe('127.0.0.1');
         expect(new URL(redirectUri).pathname).toBe('/auth/callback');
 
         // The exchange proved possession of the verifier behind the challenge.
-        expect(createHash('sha256').update(test.grant.code_verifier).digest('base64url')).toBe(
+        expect(createHash('sha256').update(run.grant.code_verifier).digest('base64url')).toBe(
             opened.searchParams.get('code_challenge'),
         );
-        expect(test.grant.grant_type).toBe('authorization_code');
-        expect(test.grant.redirect_uri).toBe(redirectUri);
+        expect(run.grant.grant_type).toBe('authorization_code');
+        expect(run.grant.redirect_uri).toBe(redirectUri);
 
-        expect(test.sessions).toEqual([
+        expect(run.sessions).toEqual([
             { accessToken: ACCESS_TOKEN, refreshToken: REFRESH_TOKEN, expiresAt: NOW + 3_600_000 },
         ]);
     });
@@ -73,7 +76,7 @@ describe('console link command line login', () => {
         const arrived = new Promise<void>(resolve => {
             releaseCallback = resolve;
         });
-        const test = await runLink({
+        const run = await runLink({
             // The browser has not answered by the time the poll returns, which
             // is the ordinary case: the poll runs on its own clock.
             openUrl: async url => {
@@ -93,86 +96,153 @@ describe('console link command line login', () => {
             },
         });
 
-        expect(test.delays).toContain(CALLBACK_GRACE_MS);
-        expect(test.sessions[0]?.accessToken).toBe(ACCESS_TOKEN);
+        expect(run.delays).toEqual([CALLBACK_GRACE_MS]);
+        expect(run.sessions[0]?.accessToken).toBe(ACCESS_TOKEN);
     });
 
     it('gives up on the callback once the grace period is spent', async () => {
-        const test = await runLink({ openUrl: () => Promise.resolve() });
+        const run = await runLink({ openUrl: () => Promise.resolve() });
 
-        // Waited, then stopped waiting. The link is what the command owed.
-        expect(test.delays).toContain(CALLBACK_GRACE_MS);
-        expect(test.sessions).toEqual([undefined]);
+        expect(run.delays).toEqual([CALLBACK_GRACE_MS]);
+        expect(run.sessions).toEqual([undefined]);
+    });
+
+    it('cancels the losing grace delay when the callback wins', async () => {
+        let graceSignal: AbortSignal | undefined;
+        const run = await runLink({
+            sleep: (milliseconds, signal) => {
+                expect(milliseconds).toBe(CALLBACK_GRACE_MS);
+                graceSignal = signal;
+                return new Promise((_resolve, reject) => {
+                    signal.addEventListener('abort', () => reject(new Error('grace cancelled')), {
+                        once: true,
+                    });
+                });
+            },
+        });
+
+        expect(run.exitCode).toBe(0);
+        expect(run.delays).toEqual([CALLBACK_GRACE_MS]);
+        expect(graceSignal?.aborted).toBe(true);
     });
 
     it('obtains no session when no plugin asked for one', async () => {
-        const test = await runLink({ hooks: [] });
+        const run = await runLink({ hooks: [] });
 
-        expect(test.exitCode).toBe(0);
+        expect(run.exitCode).toBe(0);
         // A token nobody consumes is still a live token, so none is minted and
         // no callback address is advertised.
-        expect(new URL(test.openedUrls[0]).searchParams.get('redirect_uri')).toBeNull();
-        expect(test.grants).toEqual([]);
+        expect(new URL(run.openedUrls[0]).searchParams.get('redirect_uri')).toBeNull();
+        expect(run.grants).toEqual([]);
+    });
+
+    it('does not obtain or expose a session for a hook that did not request one', async () => {
+        const sessions: Array<ConsoleSession | undefined> = [];
+        const run = await runLink({
+            hooks: [
+                {
+                    pluginId: '@example/config-only',
+                    hook: async context => {
+                        sessions.push(context.session);
+                    },
+                },
+            ],
+        });
+
+        expect(run.exitCode).toBe(0);
+        expect(new URL(run.openedUrls[0]).searchParams.get('redirect_uri')).toBeNull();
+        expect(run.grants).toEqual([]);
+        expect(sessions).toEqual([undefined]);
+    });
+
+    it('gives each requesting hook its own session copy', async () => {
+        const sessions: Array<ConsoleSession | undefined> = [];
+        const run = await runLink({
+            hooks: [
+                {
+                    pluginId: '@example/first',
+                    requiresSession: true,
+                    hook: async context => {
+                        sessions.push(context.session);
+                        if (context.session) {
+                            context.session.accessToken = 'changed-by-first';
+                        }
+                    },
+                },
+                {
+                    pluginId: '@example/second',
+                    requiresSession: true,
+                    hook: async context => {
+                        sessions.push(context.session);
+                    },
+                },
+            ],
+        });
+
+        expect(run.exitCode).toBe(0);
+        expect(sessions).toHaveLength(2);
+        expect(sessions[0]).not.toBe(sessions[1]);
+        expect(sessions[1]?.accessToken).toBe(ACCESS_TOKEN);
     });
 
     it('does not advertise a callback address over an SSH session', async () => {
-        const test = await runLink({ env: { ...OFFICIAL_ENV, SSH_CONNECTION: '10.0.0.1 22 10.0.0.2 22' } });
+        const run = await runLink({ env: { ...OFFICIAL_ENV, SSH_CONNECTION: '10.0.0.1 22 10.0.0.2 22' } });
 
-        expect(test.exitCode).toBe(0);
+        expect(run.exitCode).toBe(0);
         // The browser is somewhere else, so the callback could only reach a
         // process that happens to hold that port on the other machine.
-        expect(new URL(test.openedUrls[0]).searchParams.get('redirect_uri')).toBeNull();
-        expect(test.sessions).toEqual([undefined]);
-        const output = test.messages.join('\n');
+        expect(new URL(run.openedUrls[0]).searchParams.get('redirect_uri')).toBeNull();
+        expect(run.sessions).toEqual([undefined]);
+        const output = run.messages.join('\n');
         expect(output).toContain('remote shell');
         // Re-running hits the same gate, so it must not be offered as a cure.
         expect(output).not.toContain('vendure console link again');
     });
 
     it('keeps the link when the token response is malformed', async () => {
-        const test = await runLink({ tokenBody: { access_token: 'vcli_a', token_type: 'Bearer' } });
+        const run = await runLink({ tokenBody: { access_token: 'vcli_a', token_type: 'Bearer' } });
 
-        expect(test.exitCode).toBe(0);
-        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
-        expect(test.sessions).toEqual([undefined]);
-        expect(test.messages.join('\n')).toContain('could not be obtained');
+        expect(run.exitCode).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(run.root))).toEqual(manifest);
+        expect(run.sessions).toEqual([undefined]);
+        expect(run.messages.join('\n')).toContain('could not be obtained');
     });
 
     it('links without a session when the Console does not settle a login, and says so', async () => {
-        const test = await runLink({ supports: [] });
+        const run = await runLink({ supports: [] });
 
-        expect(test.exitCode).toBe(0);
-        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
+        expect(run.exitCode).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(run.root))).toEqual(manifest);
         // No login was requested, so the verification URL is the plain one.
-        expect(new URL(test.openedUrls[0]).searchParams.get('client')).toBeNull();
-        expect(test.sessions).toEqual([undefined]);
-        expect(test.messages.join('\n')).toContain('does not settle a command line login');
+        expect(new URL(run.openedUrls[0]).searchParams.get('client')).toBeNull();
+        expect(run.sessions).toEqual([undefined]);
+        expect(run.messages.join('\n')).toContain('does not settle a command line login');
     });
 
     it('asks for the link alone when no browser can be opened here', async () => {
-        const test = await runLink({ openUrl: () => Promise.reject(new Error('no browser')) });
+        const run = await runLink({ openUrl: () => Promise.reject(new Error('no browser')) });
 
-        expect(test.exitCode).toBe(0);
-        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
+        expect(run.exitCode).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(run.root))).toEqual(manifest);
         // The URL offered for another machine carries no callback address,
         // because that address is only reachable from this one.
-        const printed = test.messages.find(message => message.startsWith('https://'));
+        const printed = run.messages.find(message => message.startsWith('https://'));
         expect(printed).toBeDefined();
         expect(new URL(printed ?? '').searchParams.get('redirect_uri')).toBeNull();
-        expect(test.sessions).toEqual([undefined]);
+        expect(run.sessions).toEqual([undefined]);
         // Said before the person approves, not after.
-        expect(test.messages.join('\n')).toContain('will not obtain a Console session');
+        expect(run.messages.join('\n')).toContain('will not obtain a Console session');
     });
 
     it('keeps the link when the browser approved somewhere the callback cannot reach', async () => {
         // The approval happens, so the poll completes, but nothing ever calls
         // the listener on this machine.
-        const test = await runLink({ openUrl: () => Promise.resolve() });
+        const run = await runLink({ openUrl: () => Promise.resolve() });
 
-        expect(test.exitCode).toBe(0);
-        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
-        expect(test.sessions).toEqual([undefined]);
-        const output = test.messages.join('\n');
+        expect(run.exitCode).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(run.root))).toEqual(manifest);
+        expect(run.sessions).toEqual([undefined]);
+        const output = run.messages.join('\n');
         expect(output).toContain('The link is in place.');
         // Re-running runs the plugin setup again, which is where a plugin that
         // needs a session signs in. The command itself cannot mint one.
@@ -180,45 +250,58 @@ describe('console link command line login', () => {
     });
 
     it('keeps the link when the token exchange is refused', async () => {
-        const test = await runLink({ tokenStatus: 400 });
+        const run = await runLink({ tokenStatus: 400 });
 
-        expect(test.exitCode).toBe(0);
-        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
-        expect(test.sessions).toEqual([undefined]);
-        expect(test.messages.join('\n')).toContain('could not be obtained');
+        expect(run.exitCode).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(run.root))).toEqual(manifest);
+        expect(run.sessions).toEqual([undefined]);
+        expect(run.messages.join('\n')).toContain('could not be obtained');
     });
 
-    // The first and largest claim of the correction: an interrupt between the
-    // approval and the manifest write used to leave an approved Project Link
-    // with nothing on disk, which the next run can only replace.
     it('has the manifest on disk before the login can be interrupted', async () => {
         const abort = new AbortController();
-        const test = await runLink({
+        const run = await runLink({
             // Approved in the browser, then Ctrl-C while the code is being
             // exchanged, which is the window the reorder is about.
             onTokenRequest: () => abort.abort(),
             signal: abort.signal,
         });
 
-        expect(test.exitCode).toBe(130);
-        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
-        const output = test.messages.join('\n');
+        expect(run.exitCode).toBe(130);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(run.root))).toEqual(manifest);
+        const output = run.messages.join('\n');
         expect(output).toContain('The link succeeded');
         expect(output).not.toContain('No Project Link Manifest was changed');
     });
 
     it('links without a session when the callback port cannot be bound', async () => {
-        const failing = vi
-            .spyOn(cliAuth, 'startLoopbackCallback')
-            .mockRejectedValue(new Error('listen EACCES 127.0.0.1'));
-        const test = await runLink();
-        failing.mockRestore();
+        const run = await runLink({
+            startLoopbackCallback: vi.fn().mockRejectedValue(new Error('listen EACCES 127.0.0.1')),
+        });
 
-        // A port this process cannot bind has nothing to do with the link.
-        expect(test.exitCode).toBe(0);
-        expect(fs.readJsonSync(getProjectLinkManifestPath(test.root))).toEqual(manifest);
-        expect(test.sessions).toEqual([undefined]);
-        expect(test.messages.join('\n')).toContain('EACCES');
+        expect(run.exitCode).toBe(0);
+        expect(fs.readJsonSync(getProjectLinkManifestPath(run.root))).toEqual(manifest);
+        expect(run.sessions).toEqual([undefined]);
+        expect(run.messages.join('\n')).toContain('EACCES');
+    });
+
+    it('releases the loopback port after link returns', async () => {
+        const run = await runLink();
+        const redirectUri = new URL(run.openedUrls[0]).searchParams.get('redirect_uri');
+
+        expect(redirectUri).not.toBeNull();
+        await expect(fetch(redirectUri ?? '')).rejects.toThrow();
+    });
+
+    it('does not overwrite reserved authentication query parameters', async () => {
+        const run = await runLink({ verificationPath: `/?link=${LINK_ID}&state=console-state` });
+
+        const opened = new URL(run.openedUrls[0]);
+        expect(opened.searchParams.get('state')).toBe('console-state');
+        expect(opened.searchParams.get('redirect_uri')).toBeNull();
+        expect(run.grants).toEqual([]);
+        expect(run.sessions).toEqual([undefined]);
+        expect(run.messages.join('\n')).toContain('reserved authentication parameter "state"');
     });
 
     it('never carries a session into a repair, which asks Console nothing', async () => {
@@ -238,6 +321,7 @@ describe('console link command line login', () => {
                 hooks: [
                     {
                         pluginId: '@example/p',
+                        requiresSession: true,
                         hook: async context => {
                             contexts.push(context);
                         },
@@ -268,10 +352,11 @@ describe('console link command line login', () => {
                     VENDURE_CONSOLE_LINK_URL: 'http://localhost:3000',
                     VENDURE_CONSOLE_LINK_API_URL: 'http://localhost:3001',
                 },
-                fetch: consoleFetch({}) as unknown as typeof fetch,
+                fetch: vi.fn(createConsoleFetch()) as unknown as typeof fetch,
                 hooks: [
                     {
                         pluginId: '@example/p',
+                        requiresSession: true,
                         hook: async context => {
                             contexts.push(context);
                         },
@@ -288,8 +373,9 @@ describe('console link command line login', () => {
         expect(contexts[0].session).toBeUndefined();
         // No callback address was ever advertised to a Console we do not know.
         expect(new URL(openedUrls[0]).searchParams.get('redirect_uri')).toBeNull();
-        // And no capability complaint, because the origin decided it first.
-        expect(messages.join('\n')).not.toContain('does not settle a command line login');
+        const output = messages.join('\n');
+        expect(output).toContain('not an official Vendure Console');
+        expect(output).not.toContain('does not settle a command line login');
     });
 });
 
@@ -302,8 +388,10 @@ interface RunOptions {
     openUrl?: (url: string) => Promise<void>;
     signal?: AbortSignal;
     onTokenRequest?: () => void;
+    startLoopbackCallback?: typeof startLoopbackCallback;
+    verificationPath?: string;
     /** Called with each requested delay, so the grace period is observable. */
-    sleep?: (milliseconds: number) => Promise<void>;
+    sleep?: (milliseconds: number, signal: AbortSignal) => Promise<void>;
 }
 
 /**
@@ -321,13 +409,16 @@ async function runLink(options: RunOptions = {}) {
     const grants: Array<Record<string, string>> = [];
     const callbackStates: string[] = [];
 
-    const fetchMock = consoleFetch({
-        supports: options.supports ?? ['cli-auth'],
-        tokenStatus: options.tokenStatus ?? 200,
-        tokenBody: options.tokenBody,
-        onTokenRequest: options.onTokenRequest,
-        grants,
-    });
+    const fetchMock = vi.fn(
+        createConsoleFetch({
+            supports: options.supports ?? ['cli-auth'],
+            tokenStatus: options.tokenStatus ?? 200,
+            tokenBody: options.tokenBody,
+            onTokenRequest: options.onTokenRequest,
+            grants,
+            verificationPath: options.verificationPath,
+        }),
+    );
 
     const delays: number[] = [];
     const exitCode = await consoleCommand(
@@ -339,13 +430,17 @@ async function runLink(options: RunOptions = {}) {
             fetch: fetchMock as unknown as typeof fetch,
             signal: options.signal,
             now: () => NOW,
-            sleep: async milliseconds => {
+            sleep: async (milliseconds, signal) => {
                 delays.push(milliseconds);
-                await (options.sleep?.(milliseconds) ?? Promise.resolve());
+                await (options.sleep?.(milliseconds, signal) ?? Promise.resolve());
             },
+            ...(options.startLoopbackCallback
+                ? { startLoopbackCallback: options.startLoopbackCallback }
+                : {}),
             hooks: options.hooks ?? [
                 {
                     pluginId: '@example/p',
+                    requiresSession: true,
                     hook: async context => {
                         sessions.push(context.session);
                     },
@@ -383,59 +478,6 @@ async function runLink(options: RunOptions = {}) {
     };
 }
 
-function consoleFetch(options: {
-    supports?: string[];
-    tokenStatus?: number;
-    tokenBody?: unknown;
-    onTokenRequest?: () => void;
-    grants?: Array<Record<string, string>>;
-}) {
-    return vi.fn(async (input: string, init?: RequestInit) => {
-        const url = new URL(input);
-        if (url.pathname === '/v1/project-links') {
-            return jsonResponse({
-                id: LINK_ID,
-                state: 'pending',
-                protocolVersion: 1,
-                expiresAt: new Date(Date.now() + 600_000).toISOString(),
-                pollingSecret: POLLING_SECRET,
-                verificationPath: `/?link=${LINK_ID}`,
-                ...(options.supports ? { supports: options.supports } : {}),
-            });
-        }
-        if (url.pathname.endsWith('/poll')) {
-            return jsonResponse({
-                state: 'approved',
-                expiresAt: new Date(Date.now() + 600_000).toISOString(),
-                manifest,
-            });
-        }
-        if (url.pathname === '/v1/auth/cli/token') {
-            options.onTokenRequest?.();
-            options.grants?.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, string>);
-            if ((options.tokenStatus ?? 200) !== 200) {
-                return new Response('{}', { status: options.tokenStatus });
-            }
-            return jsonResponse(
-                options.tokenBody ?? {
-                    access_token: ACCESS_TOKEN,
-                    token_type: 'Bearer',
-                    expires_in: 3600,
-                    refresh_token: REFRESH_TOKEN,
-                },
-            );
-        }
-        throw new Error(`Unexpected request to ${input}`);
-    });
-}
-
-function jsonResponse(value: unknown): Response {
-    return new Response(JSON.stringify(value), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-    });
-}
-
 function baseDependencies(root: string, messages: string[] = []): Partial<ConsoleCommandDependencies> {
     const reporter: ConsoleReporter = {
         error: message => messages.push(message),
@@ -457,8 +499,5 @@ function baseDependencies(root: string, messages: string[] = []): Partial<Consol
 }
 
 function vendureProject(): string {
-    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'vendure-console-login-')));
-    temporaryDirectories.push(root);
-    fs.writeJsonSync(path.join(root, 'package.json'), { dependencies: { '@vendure/core': '3.7.2' } });
-    return root;
+    return createVendureProject(temporaryDirectories, 'vendure-console-login-');
 }

--- a/packages/cli/src/commands/console/console.fixtures.ts
+++ b/packages/cli/src/commands/console/console.fixtures.ts
@@ -1,4 +1,8 @@
-import type { ProjectLinkManifest } from './project-link-manifest';
+import fs from 'fs-extra';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ProjectLinkManifest } from './project-link-manifest';
 
 export const NOW = Date.parse('2026-08-19T10:00:00.000Z');
 export const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
@@ -6,6 +10,8 @@ export const PROJECT_ID = '22222222-2222-4222-8222-222222222222';
 export const LINK_ID = '33333333-3333-4333-8333-333333333333';
 export const OTHER_LINK_ID = '44444444-4444-4444-8444-444444444444';
 export const POLLING_SECRET = 'one-time-polling-secret';
+export const ACCESS_TOKEN = 'vcli_access-token';
+export const REFRESH_TOKEN = 'vclr_refresh-token';
 
 export const manifest: ProjectLinkManifest = {
     schemaVersion: 1,
@@ -26,5 +32,62 @@ export function createResponse(expiresAt = expiry()) {
         expiresAt,
         pollingSecret: POLLING_SECRET,
         verificationPath: `/?link=${LINK_ID}`,
+    };
+}
+
+export function createVendureProject(temporaryDirectories: string[], prefix: string): string {
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+    temporaryDirectories.push(root);
+    fs.writeJsonSync(path.join(root, 'package.json'), {
+        dependencies: { '@vendure/core': '3.7.2' },
+    });
+    return root;
+}
+
+export function jsonResponse(value: unknown, status = 200): Response {
+    return new Response(JSON.stringify(value), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+export function createConsoleFetch(
+    options: {
+        supports?: string[];
+        tokenStatus?: number;
+        tokenBody?: unknown;
+        onTokenRequest?: () => void;
+        grants?: Array<Record<string, string>>;
+        verificationPath?: string;
+    } = {},
+) {
+    return async (input: string, init?: RequestInit): Promise<Response> => {
+        const url = new URL(input);
+        if (url.pathname === '/v1/project-links') {
+            return jsonResponse({
+                ...createResponse(),
+                verificationPath: options.verificationPath ?? `/?link=${LINK_ID}`,
+                ...(options.supports ? { supports: options.supports } : {}),
+            });
+        }
+        if (url.pathname.endsWith('/poll')) {
+            return jsonResponse({ state: 'approved', expiresAt: expiry(), manifest });
+        }
+        if (url.pathname === '/v1/auth/cli/token') {
+            options.onTokenRequest?.();
+            options.grants?.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, string>);
+            if ((options.tokenStatus ?? 200) !== 200) {
+                return jsonResponse({}, options.tokenStatus);
+            }
+            return jsonResponse(
+                options.tokenBody ?? {
+                    access_token: ACCESS_TOKEN,
+                    token_type: 'Bearer',
+                    expires_in: 3600,
+                    refresh_token: REFRESH_TOKEN,
+                },
+            );
+        }
+        throw new Error(`Unexpected request to ${input}`);
     };
 }

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -308,46 +308,66 @@ async function link(
     }
     const request = await createProjectLink(endpoints, dependencies, signal);
     let login = await startConsoleLogin(request, endpoints, dependencies);
-    dependencies.reporter.info('Approve the Project link in your browser.');
-    let opened = true;
     try {
-        await dependencies.openUrl(login?.verificationUrl ?? request.verificationUrl);
-    } catch {
-        opened = false;
-    }
-    if (!opened) {
-        if (login) {
-            // The callback address is on this machine, so a browser somewhere
-            // else can never reach it. Ask for the link alone rather than
-            // advertise a callback that cannot be called, and say now what that
-            // costs rather than after the person has approved.
-            login.close();
-            login = undefined;
+        dependencies.reporter.info('Approve the Project link in your browser.');
+        try {
+            await dependencies.openUrl(login?.verificationUrl ?? request.verificationUrl);
+        } catch {
+            if (login) {
+                // The callback address is on this machine, so a browser
+                // somewhere else can never reach it. Ask for the link alone
+                // rather than advertise a callback nothing will call, and say
+                // now what that costs rather than after the approval.
+                login.close();
+                login = undefined;
+                dependencies.reporter.warn(noSessionFromThisLink());
+            }
             dependencies.reporter.warn(
-                'No browser here, so this link will not obtain a Console session. Approving on ' +
-                    'another machine completes the link; run vendure console link again on this ' +
-                    'machine to finish the setup.',
+                'Could not open the browser automatically. Open this URL to continue:',
             );
+            dependencies.reporter.url(request.verificationUrl);
         }
-        dependencies.reporter.warn('Could not open the browser automatically. Open this URL to continue:');
-        dependencies.reporter.url(request.verificationUrl);
+
+        const manifest = await waitForApproval(request, endpoints, dependencies, signal);
+        throwIfAborted(signal);
+        // The manifest goes to disk before the login runs. A session is
+        // optional and takes seconds to obtain; the link is neither, and an
+        // interrupt in that window used to leave an approved Project Link with
+        // nothing recorded locally, which the next run cannot repair.
+        const manifestPath = await writeProjectLinkManifestAtomic(projectRoot, manifest);
+        state.outcome = 'linked';
+        state.manifestPath = manifestPath;
+        dependencies.reporter.success(`Linked ${manifest.project.name} to ${manifest.account.name}.`);
+        dependencies.reporter.info(`Wrote ${manifestPath}`);
+        reportProjectLinkGitignore(projectRoot, dependencies.reporter);
+
+        const session = login
+            ? await completeConsoleLogin(login, endpoints, dependencies, signal)
+            : undefined;
+
+        return runConsoleLinkHooks(
+            { projectRoot, manifest, manifestPath, endpoints, outcome: 'linked', session },
+            options,
+            dependencies,
+            signal,
+        );
+    } finally {
+        login?.close();
     }
+}
 
-    const manifest = await waitForApproval(request, endpoints, dependencies, signal);
-    throwIfAborted(signal);
-    const session = login && (await completeConsoleLogin(login, endpoints, dependencies, signal));
-    const manifestPath = await writeProjectLinkManifestAtomic(projectRoot, manifest);
-    state.outcome = 'linked';
-    state.manifestPath = manifestPath;
-    dependencies.reporter.success(`Linked ${manifest.project.name} to ${manifest.account.name}.`);
-    dependencies.reporter.info(`Wrote ${manifestPath}`);
-    reportProjectLinkGitignore(projectRoot, dependencies.reporter);
-
-    return runConsoleLinkHooks(
-        { projectRoot, manifest, manifestPath, endpoints, outcome: 'linked', session: session || undefined },
-        options,
-        dependencies,
-        signal,
+/**
+ * What to say when the link will stand and no session comes with it.
+ *
+ * Re-running the command runs the plugin setup again, and a plugin that needs
+ * a session signs in there. The command itself cannot: a repair asks Console
+ * nothing and opens no browser, so it never mints one. Promising that it would
+ * is how a person ends up running it twice and getting the same answer.
+ */
+function noSessionFromThisLink(): string {
+    return (
+        'This link will not obtain a Console session. Run vendure console link again on this ' +
+        'machine to run the plugin setup again, where a plugin that needs a session can sign in.'
     );
 }
 
@@ -355,17 +375,25 @@ async function link(
  * Starts a command line login alongside the Project Link, when both sides
  * allow one.
  *
- * The origins have to be an official Console: approving a custom endpoint
- * approves creating a Project Link, never receiving a credential, so the login
- * is not offered there at all. The Console has to say it settles one, because
- * an older Console ignores the request, redirects nowhere and would leave the
- * listener waiting. Neither is a failure, and neither stops the link.
+ * A plugin has to want one, because an unused token is still a live token. The
+ * origins have to be an official Console, since approving a custom endpoint
+ * approves creating a Project Link and never receiving a credential. The
+ * Console has to say it settles a login, because one that does not redirects
+ * nowhere and would leave the listener waiting.
+ *
+ * None of these stop the link, and neither does failing to bind the callback.
  */
 async function startConsoleLogin(
     request: ProjectLinkRequest,
     endpoints: ConsoleEndpoints,
     dependencies: ConsoleCommandDependencies,
 ): Promise<ConsoleLogin | undefined> {
+    // Nobody asked for a session, so do not obtain one. The token is worth as
+    // much as the person's Console password across every project they own, and
+    // a link with no plugin behind it has nothing to do with it but drop it.
+    if (dependencies.hooks.length === 0) {
+        return undefined;
+    }
     if (officialConsoleEnvironment(endpoints) === undefined) {
         return undefined;
     }
@@ -378,10 +406,28 @@ async function startConsoleLogin(
         );
         return undefined;
     }
+    if (browserIsElsewhere(dependencies.env)) {
+        dependencies.reporter.warn(noSessionFromThisLink());
+        return undefined;
+    }
+
+    const state = createLoginState();
+    let callback;
+    try {
+        callback = await startLoopbackCallback(state);
+    } catch (error) {
+        // A port this process cannot bind is a reason to skip the login, not a
+        // reason to fail a link that has nothing to do with it.
+        dependencies.reporter.warn(
+            `Could not listen for a Console sign-in: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+        dependencies.reporter.warn(noSessionFromThisLink());
+        return undefined;
+    }
 
     const { verifier, challenge } = createPkceChallenge();
-    const state = createLoginState();
-    const callback = await startLoopbackCallback(state);
     const url = new URL(request.verificationUrl);
     for (const [name, value] of Object.entries(
         cliAuthSearchParams({ redirectUri: callback.redirectUri, state, challenge }),
@@ -389,6 +435,23 @@ async function startConsoleLogin(
         url.searchParams.set(name, value);
     }
     return { ...callback, verifier, verificationUrl: url.toString() };
+}
+
+/**
+ * Whether the browser this command can reach is likely on another machine.
+ *
+ * `openUrl` resolves when the helper process starts, not when a browser opens,
+ * so `xdg-open` on a headless box succeeds and then fails unobserved. The
+ * callback address only means anything on the machine that bound it, so a URL
+ * carrying one is a URL that sends an authorization code to whatever happens to
+ * hold that port wherever it is finally opened. These two signals are the ones
+ * that are cheap and right far more often than not.
+ */
+function browserIsElsewhere(env: NodeJS.ProcessEnv): boolean {
+    if (env.SSH_CONNECTION || env.SSH_TTY) {
+        return true;
+    }
+    return process.platform === 'linux' && !env.DISPLAY && !env.WAYLAND_DISPLAY;
 }
 
 /**
@@ -411,12 +474,11 @@ async function completeConsoleLogin(
             dependencies.sleep(CALLBACK_GRACE_MS, signal).then(() => undefined),
         ]);
         if (!code) {
-            dependencies.reporter.warn(
-                'The link is in place, and no Console session was obtained. Run vendure console ' +
-                    'link again on this machine to finish the setup.',
-            );
+            dependencies.reporter.warn(`The link is in place. ${noSessionFromThisLink()}`);
             return undefined;
         }
+        // Sampled before the round trip, so the expiry is not overstated by it.
+        const issuedAt = dependencies.now();
         const value = await requestJson(
             `${endpoints.apiUrl}${CLI_TOKEN_PATH}`,
             {
@@ -429,16 +491,17 @@ async function completeConsoleLogin(
             dependencies,
             signal,
         );
-        return parseConsoleSession(value, dependencies.now());
+        return parseConsoleSession(value, issuedAt);
     } catch (error) {
         if (error instanceof CommandInterruptedError) {
             throw error;
         }
         dependencies.reporter.warn(
-            `The link is in place, and the Console session could not be obtained: ${
+            `The Console session could not be obtained: ${
                 error instanceof Error ? error.message : String(error)
             }`,
         );
+        dependencies.reporter.warn(`The link is in place. ${noSessionFromThisLink()}`);
         return undefined;
     } finally {
         login.close();

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -11,6 +11,18 @@ import {
     RegisteredConsoleLinkHook,
     getConsoleLinkHooks,
 } from './console-link-hook';
+import {
+    CLI_AUTH_CAPABILITY,
+    CLI_TOKEN_PATH,
+    ConsoleSession,
+    LoopbackCallback,
+    authorizationCodeGrant,
+    cliAuthSearchParams,
+    createLoginState,
+    createPkceChallenge,
+    parseConsoleSession,
+    startLoopbackCallback,
+} from './cli-auth';
 import { DEFAULT_CONSOLE_API_URL, DEFAULT_CONSOLE_URL, officialConsoleEnvironment } from './console-origins';
 import { ensureProjectLinkGitignore } from './project-link-gitignore';
 import {
@@ -30,6 +42,16 @@ const POLL_INTERVAL_MS = 2_000;
 const REQUEST_TIMEOUT_MS = 10_000;
 const MAX_RESPONSE_BYTES = 64 * 1024;
 const MAX_RETRY_DELAY_MS = 2_000;
+/**
+ * How long the callback is still accepted after the poll has already returned
+ * the manifest.
+ *
+ * Approval mints the code and returns the redirect in one transaction, so the
+ * browser's navigation and the next poll run on unrelated clocks. Closing the
+ * moment the poll wins would lose a session that was on its way, and hand
+ * somebody who did everything right the report meant for a remote approval.
+ */
+const CALLBACK_GRACE_MS = 2_000;
 
 export interface ConsoleCommandOptions {
     allowCustomConsole?: boolean;
@@ -68,6 +90,15 @@ interface ProjectLinkRequest {
     id: string;
     expiresAt: number;
     pollingSecret: string;
+    verificationUrl: string;
+    /** What a decision on this link can also settle. Empty on an older Console. */
+    supports: string[];
+}
+
+/** A command line login waiting on its callback, alongside a Project Link. */
+interface ConsoleLogin extends LoopbackCallback {
+    verifier: string;
+    /** The verification URL carrying the login request. */
     verificationUrl: string;
 }
 
@@ -276,16 +307,35 @@ async function link(
         return endpointApproval === 'cancelled' ? 0 : 1;
     }
     const request = await createProjectLink(endpoints, dependencies, signal);
+    let login = await startConsoleLogin(request, endpoints, dependencies);
     dependencies.reporter.info('Approve the Project link in your browser.');
+    let opened = true;
     try {
-        await dependencies.openUrl(request.verificationUrl);
+        await dependencies.openUrl(login?.verificationUrl ?? request.verificationUrl);
     } catch {
+        opened = false;
+    }
+    if (!opened) {
+        if (login) {
+            // The callback address is on this machine, so a browser somewhere
+            // else can never reach it. Ask for the link alone rather than
+            // advertise a callback that cannot be called, and say now what that
+            // costs rather than after the person has approved.
+            login.close();
+            login = undefined;
+            dependencies.reporter.warn(
+                'No browser here, so this link will not obtain a Console session. Approving on ' +
+                    'another machine completes the link; run vendure console link again on this ' +
+                    'machine to finish the setup.',
+            );
+        }
         dependencies.reporter.warn('Could not open the browser automatically. Open this URL to continue:');
         dependencies.reporter.url(request.verificationUrl);
     }
 
     const manifest = await waitForApproval(request, endpoints, dependencies, signal);
     throwIfAborted(signal);
+    const session = login && (await completeConsoleLogin(login, endpoints, dependencies, signal));
     const manifestPath = await writeProjectLinkManifestAtomic(projectRoot, manifest);
     state.outcome = 'linked';
     state.manifestPath = manifestPath;
@@ -294,11 +344,105 @@ async function link(
     reportProjectLinkGitignore(projectRoot, dependencies.reporter);
 
     return runConsoleLinkHooks(
-        { projectRoot, manifest, manifestPath, endpoints, outcome: 'linked' },
+        { projectRoot, manifest, manifestPath, endpoints, outcome: 'linked', session: session || undefined },
         options,
         dependencies,
         signal,
     );
+}
+
+/**
+ * Starts a command line login alongside the Project Link, when both sides
+ * allow one.
+ *
+ * The origins have to be an official Console: approving a custom endpoint
+ * approves creating a Project Link, never receiving a credential, so the login
+ * is not offered there at all. The Console has to say it settles one, because
+ * an older Console ignores the request, redirects nowhere and would leave the
+ * listener waiting. Neither is a failure, and neither stops the link.
+ */
+async function startConsoleLogin(
+    request: ProjectLinkRequest,
+    endpoints: ConsoleEndpoints,
+    dependencies: ConsoleCommandDependencies,
+): Promise<ConsoleLogin | undefined> {
+    if (officialConsoleEnvironment(endpoints) === undefined) {
+        return undefined;
+    }
+    if (!request.supports.includes(CLI_AUTH_CAPABILITY)) {
+        // Said out loud, because the alternative is a link that quietly obtains
+        // no session and a plugin that later cannot say why.
+        dependencies.reporter.warn(
+            'This Console does not settle a command line login with a Project Link approval, so ' +
+                'this link obtains no Console session.',
+        );
+        return undefined;
+    }
+
+    const { verifier, challenge } = createPkceChallenge();
+    const state = createLoginState();
+    const callback = await startLoopbackCallback(state);
+    const url = new URL(request.verificationUrl);
+    for (const [name, value] of Object.entries(
+        cliAuthSearchParams({ redirectUri: callback.redirectUri, state, challenge }),
+    )) {
+        url.searchParams.set(name, value);
+    }
+    return { ...callback, verifier, verificationUrl: url.toString() };
+}
+
+/**
+ * Exchanges the authorization code, once the link itself is settled.
+ *
+ * The poll owns the link and this owns only the session, so nothing here fails
+ * the command. A refusal, a browser that approved on another machine, or an
+ * exchange that does not complete all end the same way: the link stands, no
+ * session was obtained, and the report says so.
+ */
+async function completeConsoleLogin(
+    login: ConsoleLogin,
+    endpoints: ConsoleEndpoints,
+    dependencies: ConsoleCommandDependencies,
+    signal: AbortSignal,
+): Promise<ConsoleSession | undefined> {
+    try {
+        const code = await Promise.race([
+            login.code(),
+            dependencies.sleep(CALLBACK_GRACE_MS, signal).then(() => undefined),
+        ]);
+        if (!code) {
+            dependencies.reporter.warn(
+                'The link is in place, and no Console session was obtained. Run vendure console ' +
+                    'link again on this machine to finish the setup.',
+            );
+            return undefined;
+        }
+        const value = await requestJson(
+            `${endpoints.apiUrl}${CLI_TOKEN_PATH}`,
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(
+                    authorizationCodeGrant({ code, verifier: login.verifier, redirectUri: login.redirectUri }),
+                ),
+            },
+            dependencies,
+            signal,
+        );
+        return parseConsoleSession(value, dependencies.now());
+    } catch (error) {
+        if (error instanceof CommandInterruptedError) {
+            throw error;
+        }
+        dependencies.reporter.warn(
+            `The link is in place, and the Console session could not be obtained: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+        return undefined;
+    } finally {
+        login.close();
+    }
 }
 
 /**
@@ -394,6 +538,7 @@ interface ConsoleLinkHookInputs {
     manifestPath: string;
     endpoints: ConsoleEndpoints;
     outcome: ConsoleLinkOutcome;
+    session?: ConsoleSession;
 }
 
 /**
@@ -473,6 +618,7 @@ function createConsoleLinkContext(
             official: officialConsoleEnvironment(inputs.endpoints),
         },
         outcome: inputs.outcome,
+        session: inputs.session,
         signal,
         reporter: dependencies.reporter,
         confirm: message => confirmForHook(message, dependencies),
@@ -683,7 +829,10 @@ async function createProjectLink(
     if (verificationUrl.includes(pollingSecret)) {
         throw new Error('Console returned an unsafe verification URL.');
     }
-    return { id, expiresAt, pollingSecret, verificationUrl };
+    const supports = Array.isArray(object.supports)
+        ? object.supports.filter((entry): entry is string => typeof entry === 'string')
+        : [];
+    return { id, expiresAt, pollingSecret, verificationUrl, supports };
 }
 
 async function waitForApproval(

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -4,7 +4,6 @@ import { ChildProcess, spawn } from 'node:child_process';
 import { CliCommandExit } from '../../shared/cli-command-exit';
 import { isNonInteractiveEnvironment, withInteractiveTimeout } from '../../utilities/utils';
 
-import { ConsoleLinkContext, ConsoleLinkOutcome, RegisteredConsoleLinkHook } from './console-link-hook';
 import {
     CLI_TOKEN_PATH,
     ConsoleSession,
@@ -16,6 +15,7 @@ import {
     parseConsoleSession,
     startLoopbackCallback,
 } from './cli-auth';
+import { ConsoleLinkContext, ConsoleLinkOutcome, RegisteredConsoleLinkHook } from './console-link-hook';
 import {
     DEFAULT_CONSOLE_API_URL,
     DEFAULT_CONSOLE_URL,
@@ -51,7 +51,7 @@ const MAX_RETRY_DELAY_MS = 2_000;
  * moment the poll wins would lose a session that was on its way, and hand
  * somebody who did everything right the report meant for a remote approval.
  */
-export const CALLBACK_GRACE_MS = 2_000;
+export const CALLBACK_GRACE_MS = 2_500;
 
 export interface ConsoleCommandOptions {
     allowCustomConsole?: boolean;
@@ -77,6 +77,7 @@ export interface ConsoleCommandDependencies {
     reporter: ConsoleReporter;
     signal?: AbortSignal;
     sleep: (milliseconds: number, signal: AbortSignal) => Promise<void>;
+    startLoopbackCallback: typeof startLoopbackCallback;
 }
 
 interface ConsoleEndpoints {
@@ -153,6 +154,7 @@ function createDefaultDependencies(): ConsoleCommandDependencies {
         },
         reporter: defaultReporter,
         sleep: abortableSleep,
+        startLoopbackCallback,
     };
 }
 
@@ -320,10 +322,7 @@ async function link(
 
         const manifest = await waitForApproval(request, endpoints, dependencies, signal);
         throwIfAborted(signal);
-        // The manifest goes to disk before the login runs. A session is
-        // optional and takes seconds to obtain; the link is neither, and an
-        // interrupt in that window used to leave an approved Project Link with
-        // nothing recorded locally, which the next run cannot repair.
+        // Record the approved link before the optional session exchange.
         const manifestPath = await writeProjectLinkManifestAtomic(projectRoot, manifest);
         state.outcome = 'linked';
         state.manifestPath = manifestPath;
@@ -346,14 +345,6 @@ async function link(
     }
 }
 
-/**
- * What to say when the link will stand and no session comes with it.
- *
- * Re-running the command runs the plugin setup again, and a plugin that needs
- * a session signs in there. The command itself cannot: a repair asks Console
- * nothing and opens no browser, so it never mints one. Promising that it would
- * is how a person ends up running it twice and getting the same answer.
- */
 function noSessionFromThisLink(): string {
     return (
         'This link will not obtain a Console session. Run vendure console link again on this ' +
@@ -378,17 +369,13 @@ async function startConsoleLogin(
     endpoints: ConsoleEndpoints,
     dependencies: ConsoleCommandDependencies,
 ): Promise<ConsoleLogin | undefined> {
-    // Nobody asked for a session, so do not obtain one. The token is worth as
-    // much as the person's Console password across every project they own, and
-    // a link with no plugin behind it has nothing to do with it but drop it.
-    //
-    // Coarse on purpose for now: any registered hook causes one to be minted,
-    // and every hook then receives it. A plugin cannot yet say that it wants a
-    // session, so this narrows the case from "always" rather than closing it.
-    if (dependencies.hooks.length === 0) {
+    if (!dependencies.hooks.some(hook => hook.requiresSession)) {
         return undefined;
     }
     if (officialConsoleEnvironment(endpoints) === undefined) {
+        dependencies.reporter.warn(
+            'This link uses endpoints that are not an official Vendure Console, so it obtains no Console session.',
+        );
         return undefined;
     }
     if (!request.supports.includes(CLI_AUTH_CAPABILITY)) {
@@ -415,7 +402,7 @@ async function startConsoleLogin(
     const state = createLoginState();
     let callback;
     try {
-        callback = await startLoopbackCallback(state);
+        callback = await dependencies.startLoopbackCallback(state);
     } catch (error) {
         // A port this process cannot bind is a reason to skip the login, not a
         // reason to fail a link that has nothing to do with it.
@@ -430,10 +417,17 @@ async function startConsoleLogin(
 
     const { verifier, challenge } = createPkceChallenge();
     const url = new URL(request.verificationUrl);
-    for (const [name, value] of Object.entries(
-        cliAuthSearchParams({ redirectUri: callback.redirectUri, state, challenge }),
-    )) {
-        url.searchParams.set(name, value);
+    const searchParams = cliAuthSearchParams({ redirectUri: callback.redirectUri, state, challenge });
+    const reservedName = Object.keys(searchParams).find(name => url.searchParams.has(name));
+    if (reservedName) {
+        callback.close();
+        dependencies.reporter.warn(
+            `Console returned a verification URL with the reserved authentication parameter "${reservedName}", so this link obtains no Console session.`,
+        );
+        return undefined;
+    }
+    for (const [name, value] of Object.entries(searchParams)) {
+        url.searchParams.append(name, value);
     }
     return { ...callback, verifier, verificationUrl: url.toString() };
 }
@@ -441,13 +435,8 @@ async function startConsoleLogin(
 /**
  * Whether this shell is attached from another machine.
  *
- * `openUrl` resolves when the helper process starts, not when a browser opens,
- * so a URL carrying a callback address can still reach a browser that cannot
- * return to the port this process bound. An absent `DISPLAY` looks like the
- * same thing and is not: VS Code Remote, devcontainers and WSL all reach a
- * browser without one, and refusing them would turn the feature off for people
- * it works for. Being wrong the other way costs a code that PKCE already makes
- * useless without the verifier, which never leaves this process.
+ * An absent `DISPLAY` does not imply a remote browser. VS Code Remote,
+ * devcontainers and WSL can open a local browser without it.
  */
 function shellIsRemote(env: NodeJS.ProcessEnv): boolean {
     return Boolean(env.SSH_CONNECTION || env.SSH_TTY);
@@ -467,11 +456,15 @@ async function completeConsoleLogin(
     dependencies: ConsoleCommandDependencies,
     signal: AbortSignal,
 ): Promise<ConsoleSession | undefined> {
+    const graceController = new AbortController();
+    const abortGrace = () => graceController.abort();
+    signal.addEventListener('abort', abortGrace, { once: true });
     try {
         const code = await Promise.race([
             login.code(),
-            dependencies.sleep(CALLBACK_GRACE_MS, signal).then(() => undefined),
+            dependencies.sleep(CALLBACK_GRACE_MS, graceController.signal).then(() => undefined),
         ]);
+        throwIfAborted(signal);
         if (!code) {
             dependencies.reporter.warn(`The link is in place. ${noSessionFromThisLink()}`);
             return undefined;
@@ -507,6 +500,8 @@ async function completeConsoleLogin(
         dependencies.reporter.warn(`The link is in place. ${noSessionFromThisLink()}`);
         return undefined;
     } finally {
+        signal.removeEventListener('abort', abortGrace);
+        graceController.abort();
         login.close();
     }
 }
@@ -596,9 +591,16 @@ async function runConsoleLinkHooks(
     dependencies: ConsoleCommandDependencies,
     signal: AbortSignal,
 ): Promise<number> {
-    for (const { pluginId, hook } of dependencies.hooks) {
+    for (const { pluginId, hook, requiresSession } of dependencies.hooks) {
         try {
-            await hook(createConsoleLinkContext(inputs, options, dependencies, signal));
+            await hook(
+                createConsoleLinkContext(
+                    { ...inputs, session: requiresSession ? inputs.session : undefined },
+                    options,
+                    dependencies,
+                    signal,
+                ),
+            );
         } catch (error) {
             // Ctrl-C during a hook is an interrupt whatever the hook threw, so
             // it is reported by the one handler that knows the exit code.
@@ -648,7 +650,7 @@ function createConsoleLinkContext(
             official: officialConsoleEnvironment(inputs.endpoints),
         },
         outcome: inputs.outcome,
-        session: inputs.session,
+        session: inputs.session ? structuredClone(inputs.session) : undefined,
         signal,
         reporter: dependencies.reporter,
         confirm: message => confirmForHook(message, isNonInteractive, dependencies.prompt),

--- a/packages/cli/src/commands/console/console.ts
+++ b/packages/cli/src/commands/console/console.ts
@@ -5,13 +5,6 @@ import { CliCommandExit } from '../../shared/cli-command-exit';
 import { isNonInteractiveEnvironment, withInteractiveTimeout } from '../../utilities/utils';
 
 import {
-    ConsoleLinkContext,
-    ConsoleLinkOutcome,
-    ConsoleReporter,
-    RegisteredConsoleLinkHook,
-    getConsoleLinkHooks,
-} from './console-link-hook';
-import {
     CLI_AUTH_CAPABILITY,
     CLI_TOKEN_PATH,
     ConsoleSession,
@@ -23,6 +16,13 @@ import {
     parseConsoleSession,
     startLoopbackCallback,
 } from './cli-auth';
+import {
+    ConsoleLinkContext,
+    ConsoleLinkOutcome,
+    ConsoleReporter,
+    RegisteredConsoleLinkHook,
+    getConsoleLinkHooks,
+} from './console-link-hook';
 import { DEFAULT_CONSOLE_API_URL, DEFAULT_CONSOLE_URL, officialConsoleEnvironment } from './console-origins';
 import { ensureProjectLinkGitignore } from './project-link-gitignore';
 import {
@@ -51,7 +51,7 @@ const MAX_RETRY_DELAY_MS = 2_000;
  * moment the poll wins would lose a session that was on its way, and hand
  * somebody who did everything right the report meant for a remote approval.
  */
-const CALLBACK_GRACE_MS = 2_000;
+export const CALLBACK_GRACE_MS = 2_000;
 
 export interface ConsoleCommandOptions {
     allowCustomConsole?: boolean;
@@ -391,6 +391,10 @@ async function startConsoleLogin(
     // Nobody asked for a session, so do not obtain one. The token is worth as
     // much as the person's Console password across every project they own, and
     // a link with no plugin behind it has nothing to do with it but drop it.
+    //
+    // Coarse on purpose for now: any registered hook causes one to be minted,
+    // and every hook then receives it. A plugin cannot yet say that it wants a
+    // session, so this narrows the case from "always" rather than closing it.
     if (dependencies.hooks.length === 0) {
         return undefined;
     }
@@ -406,8 +410,15 @@ async function startConsoleLogin(
         );
         return undefined;
     }
-    if (browserIsElsewhere(dependencies.env)) {
-        dependencies.reporter.warn(noSessionFromThisLink());
+    if (shellIsRemote(dependencies.env)) {
+        // Not a failure and not something a rerun changes, so it does not get
+        // the "run it again" advice: the callback address only means anything
+        // on the machine that bound it, and that is not where the browser is.
+        dependencies.reporter.warn(
+            'This looks like a remote shell, so a browser cannot return an approval to this ' +
+                'machine. The link is made without a Console session, and a plugin that needs ' +
+                'one signs in itself.',
+        );
         return undefined;
     }
 
@@ -438,20 +449,18 @@ async function startConsoleLogin(
 }
 
 /**
- * Whether the browser this command can reach is likely on another machine.
+ * Whether this shell is attached from another machine.
  *
  * `openUrl` resolves when the helper process starts, not when a browser opens,
- * so `xdg-open` on a headless box succeeds and then fails unobserved. The
- * callback address only means anything on the machine that bound it, so a URL
- * carrying one is a URL that sends an authorization code to whatever happens to
- * hold that port wherever it is finally opened. These two signals are the ones
- * that are cheap and right far more often than not.
+ * so a URL carrying a callback address can still reach a browser that cannot
+ * return to the port this process bound. An absent `DISPLAY` looks like the
+ * same thing and is not: VS Code Remote, devcontainers and WSL all reach a
+ * browser without one, and refusing them would turn the feature off for people
+ * it works for. Being wrong the other way costs a code that PKCE already makes
+ * useless without the verifier, which never leaves this process.
  */
-function browserIsElsewhere(env: NodeJS.ProcessEnv): boolean {
-    if (env.SSH_CONNECTION || env.SSH_TTY) {
-        return true;
-    }
-    return process.platform === 'linux' && !env.DISPLAY && !env.WAYLAND_DISPLAY;
+function shellIsRemote(env: NodeJS.ProcessEnv): boolean {
+    return Boolean(env.SSH_CONNECTION || env.SSH_TTY);
 }
 
 /**
@@ -485,7 +494,11 @@ async function completeConsoleLogin(
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(
-                    authorizationCodeGrant({ code, verifier: login.verifier, redirectUri: login.redirectUri }),
+                    authorizationCodeGrant({
+                        code,
+                        verifier: login.verifier,
+                        redirectUri: login.redirectUri,
+                    }),
                 ),
             },
             dependencies,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -51,6 +51,16 @@ export type {
     ConsoleLinkOutcome,
     ConsoleReporter,
 } from './commands/console/console-link-hook';
+export {
+    CLI_AUTH_CAPABILITY,
+    CLI_TOKEN_PATH,
+    authorizationCodeGrant,
+    cliAuthSearchParams,
+    createLoginState,
+    createPkceChallenge,
+    startLoopbackCallback,
+} from './commands/console/cli-auth';
+export type { CliAuthClient, ConsoleSession, LoopbackCallback } from './commands/console/cli-auth';
 export type { ConsoleOriginEnvironment } from './commands/console/console-origins';
 export type { ProjectLinkManifest } from './commands/console/project-link-manifest';
 export { readCommandContext, readCommandOptions } from './shared/cli-command-definition';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -51,16 +51,8 @@ export type {
     ConsoleLinkOutcome,
     ConsoleReporter,
 } from './commands/console/console-link-hook';
-export {
-    CLI_AUTH_CAPABILITY,
-    CLI_TOKEN_PATH,
-    authorizationCodeGrant,
-    cliAuthSearchParams,
-    createLoginState,
-    createPkceChallenge,
-    startLoopbackCallback,
-} from './commands/console/cli-auth';
-export type { CliAuthClient, ConsoleSession, LoopbackCallback } from './commands/console/cli-auth';
+export { CLI_AUTH_CAPABILITY } from './commands/console/cli-auth';
+export type { ConsoleSession } from './commands/console/cli-auth';
 export type { ConsoleOriginEnvironment } from './commands/console/console-origins';
 export type { ProjectLinkManifest } from './commands/console/project-link-manifest';
 export { readCommandContext, readCommandOptions } from './shared/cli-command-definition';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -44,6 +44,8 @@
  * ```
  */
 export { builtinCommands } from './commands/builtins';
+export { CLI_AUTH_CAPABILITY } from './commands/console/cli-auth';
+export type { ConsoleSession } from './commands/console/cli-auth';
 export type {
     ConsoleLinkContext,
     ConsoleLinkEndpoints,
@@ -51,8 +53,6 @@ export type {
     ConsoleLinkOutcome,
     ConsoleReporter,
 } from './commands/console/console-link-hook';
-export { CLI_AUTH_CAPABILITY } from './commands/console/cli-auth';
-export type { ConsoleSession } from './commands/console/cli-auth';
 export type { ConsoleOriginEnvironment } from './commands/console/console-origins';
 export type { ProjectLinkManifest } from './commands/console/project-link-manifest';
 export { readCommandContext, readCommandOptions } from './shared/cli-command-definition';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -44,12 +44,13 @@
  * ```
  */
 export { builtinCommands } from './commands/builtins';
-export { CLI_AUTH_CAPABILITY } from './commands/console/cli-auth';
 export type { ConsoleSession } from './commands/console/cli-auth';
 export type {
     ConsoleLinkContext,
     ConsoleLinkEndpoints,
     ConsoleLinkHook,
+    ConsoleLinkHookRegistration,
+    ConsoleLinkHookWithSession,
     ConsoleLinkOutcome,
 } from './commands/console/console-link-hook';
 export type { ConsoleOriginEnvironment } from './commands/console/console-origins';

--- a/packages/cli/src/shared/cli-plugin.ts
+++ b/packages/cli/src/shared/cli-plugin.ts
@@ -1,4 +1,4 @@
-import type { ConsoleLinkHook } from '../commands/console/console-link-hook';
+import type { ConsoleLinkHookRegistration } from '../commands/console/console-link-hook';
 
 import {
     CliCommandDefinition,
@@ -65,7 +65,7 @@ export interface CliPlugin {
      *
      * @since 3.8.0
      */
-    afterConsoleLink?: ConsoleLinkHook;
+    afterConsoleLink?: ConsoleLinkHookRegistration;
 }
 
 interface CliPluginExtensionEntry {
@@ -143,8 +143,17 @@ export function assertCliPlugin(value: unknown): asserts value is CliPlugin {
     }
     assertExtensions(plugin.id, extensions, rootOptions);
 
-    if (plugin.afterConsoleLink !== undefined && typeof plugin.afterConsoleLink !== 'function') {
-        throw new TypeError(`CLI plugin "${plugin.id}" afterConsoleLink must be a function`);
+    if (
+        plugin.afterConsoleLink !== undefined &&
+        typeof plugin.afterConsoleLink !== 'function' &&
+        (!plugin.afterConsoleLink ||
+            typeof plugin.afterConsoleLink !== 'object' ||
+            plugin.afterConsoleLink.requiresSession !== true ||
+            typeof plugin.afterConsoleLink.hook !== 'function')
+    ) {
+        throw new TypeError(
+            `CLI plugin "${plugin.id}" afterConsoleLink must be a function or a session-requesting hook`,
+        );
     }
 }
 


### PR DESCRIPTION
**Stacked on #5314 (stack #5316). Review that first; this PR's base is that branch, not `minor`.**

**Both land in `minor` together, then a prerelease is published.** #5314 adds the hook and runs it; it does not add `ConsoleLinkContext.session`, which arrives here. A plugin registered against #5314 alone therefore runs normally and finds no session, which is the absence of the auth capability rather than a broken hook — a consumer is expected to report incomplete credential setup and carry on. An intermediate canary cut between the two would behave that way; final consumer validation targets a release containing both.

Linking already takes the developer through a browser approval, and Console already mints a CLI Session from a signed-in browser. They were two approvals because nothing joined them: the link approval could not settle a login, so a plugin needing a session had to start a second browser round trip of its own.

Console now advertises `cli-auth` on the create response and accepts a login request alongside a decision (vendurehq/console#129, merged). This carries one: it generates an S256 challenge, binds a loopback callback before the browser opens, puts the five parameters Console reads on the verification URL it already returned, and exchanges the code at Console's `POST /v1/auth/cli/token`. The result reaches a plugin as `ConsoleLinkContext.session`.

The route, the grant types and the field names are Console's, so every client of that exchange speaks the same one.

## Nothing here can fail the link

The poll owns the link and the callback owns only the session. The manifest is written before the exchange runs, so an interrupt during the login cannot leave an approved Project Link with nothing on disk. Beyond that, the link stands with no session and a report saying which when:

- no plugin registered a hook, so no token is minted at all;
- the origins are not an official Console;
- the Console does not advertise `cli-auth`;
- the shell is attached over SSH, so a browser cannot return to this machine;
- the callback port cannot be bound;
- the browser could not be opened here, in which case the URL offered for another machine carries no callback address;
- the approval happened elsewhere, was refused, or the exchange did not complete.

The listener has no deadline of its own; the link expiry governs. It is accepted briefly after the poll returns, because approval mints the code and returns the redirect in one transaction, so the browser's navigation and the next poll run on unrelated clocks.

The CLI writes no credential. A plugin that stores the session owns that, including keeping a user-scoped token out of the project directory. A repair never carries a session: it asks Console nothing and opens no browser.

## Verification

The unit and integration tests use a contract fixture and a real loopback listener, with no network and no database: the official origins open the gate, every request is served in memory, and the stub browser follows the approval to the advertised callback. They assert that the exchange proves possession of the verifier behind the challenge, that the fallback URL carries no callback address, and that the manifest is on disk before the exchange can be interrupted.

Separately, the Console repository extracted this module read-only and drove its own acceptance suite with it against a real Console on real PostgreSQL: 15 cases pass, covering both the `cli` and `create` client values.

The auth primitives are deliberately not exported from the package index. A loopback-listener factory with no origin check is not something to hand plugin authors on a semver promise; a cross-repository test pins the module path instead.

## Checks

Typecheck clean, 584 tests pass and 1 skipped, lint at the 7 errors already present on `minor`. `build_and_test.yml` filters `pull_request` to `master`, `major` and `minor`, so a PR based on a feature branch gets no substantive run; the full matrix is dispatched against this branch through the workflow's declared `workflow_dispatch` trigger instead.

Relates to EE-308