### PR TITLE
docs: note that field resolvers only get guards and how to hook per-field logic

### DIFF
--- a/docs/docs/guides/developer-guide/the-api-layer/index.mdx
+++ b/docs/docs/guides/developer-guide/the-api-layer/index.mdx
@@ -196,6 +196,41 @@ export const config: VendureConfig = {
 };
 ```
 
+:::note
+Field resolvers — those declared with `@ResolveField()` — only get guards. A globally-registered interceptor or
+exception filter runs for queries and mutations, but never for a field resolver. This is deliberate: the other
+enhancers would then run once per resolved field, which for a list of products means once per field per product.
+
+If you need per-field behaviour such as timing or logging, use an
+[`apiOptions.apolloServerPlugins`](/reference/typescript-api/configuration/api-options#apolloserverplugins)
+plugin with the `willResolveField` hook, which _does_ fire for every field:
+
+```ts
+const perfPlugin: ApolloServerPlugin = {
+    async requestDidStart() {
+        return {
+            async executionDidStart() {
+                return {
+                    willResolveField({ info }) {
+                        const start = process.hrtime.bigint();
+                        return () => {
+                            const ms = Number(process.hrtime.bigint() - start) / 1e6;
+                            if (10 < ms) {
+                                Logger.info(`${info.parentType.name}.${info.fieldName}: ${ms}ms`);
+                            }
+                        };
+                    },
+                };
+            },
+        };
+    },
+};
+```
+
+If you want traces rather than log lines, the [`@vendure/telemetry-plugin`](/reference/core-plugins/telemetry-plugin/)
+package already emits a span per resolver, field resolvers included.
+:::
+
 
 
 ### Apollo Server plugins


### PR DESCRIPTION
# Description

Closes #5268.

Adds a note to the "Global NestJS middleware" section of the API layer guide. That section currently says these middleware classes apply "to all requests", which is not quite true for field resolvers: they only get guards, so a globally-registered interceptor or exception filter never runs for a `@ResolveField()` resolver. The note says so, explains why the default is what it is, and points at the two things that do work per field — an `apiOptions.apolloServerPlugins` plugin with Apollo's `willResolveField` hook (short timing example included), and `@vendure/telemetry-plugin` for traces.

This follows @michaelbromley's suggestion on #5269, which proposed making the enhancer set configurable; that PR is closed in favour of this. The example is adapted from his comment there.

Docs only — no code changes. `bun run test:mdx` in `docs/` passes (frontmatter, admonitions, code languages, MDX compilation).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791471830&installation_model_id=20193&pr_number=5318&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5318&signature=837681822a0d11030c8228b9fa01862a3af91ef5b0de88c822a3351459066f94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->