### PR TITLE
fix(docs): update js-yaml to 3.15.2 to resolve security advisories

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1527,9 +1527,9 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+            "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",


### PR DESCRIPTION
## What this does

Updates `js-yaml` from 3.14.2 to 3.15.2 in the docs lockfile. This resolves three open Dependabot alerts:

| Advisory | Severity | Vulnerable range | First patched |
|---|---|---|---|
| GHSA-5p4m-2wfm-xmqj | high | >= 3.0.0, < 3.15.1 | 3.15.1 |
| GHSA-52cp-r559-cp3m | high | >= 3.0.0, < 3.15.0 | 3.15.0 |
| GHSA-h67p-54hq-rp68 | medium | < 3.15.0 | 3.15.0 |

`js-yaml` is a transitive dependency. It arrives through `@vendure-io/docs-provider` and then `gray-matter@4.0.3`, which declares `js-yaml: "^3.13.1"`. Version 3.15.2 falls inside that range, so only the lockfile changes and no manifest is touched.

## Why 3.15.2

3.15.2 is the newest version in the 3.x line, published on 2026-08-26. It carries all three fixes. The lowest version that carries all three is 3.15.1. The `minimumReleaseAge` gate in `bunfig.toml` does not apply here, because `/docs` is a separate npm project with its own lockfile.

No Dependabot pull request had been raised for these three alerts, so this pull request was opened by hand.

## Why the diff is three lines

Running `npm update js-yaml --package-lock-only` also removes `"dev": true` from twenty `@typescript/typescript-*` optional platform entries. Those removals are npm recomputing the dev flag across the whole tree. They have nothing to do with this advisory, so this commit leaves them out and changes only the three lines that identify the `js-yaml` version.

## Verification

- `npm ci` in `/docs` installs from the edited lockfile without error.
- `npm ls js-yaml` reports `js-yaml@3.15.2` under `gray-matter`.
- `npm audit` reports 0 vulnerabilities.
- `bun run test:mdx` passes: frontmatter 831 files, admonitions 831 files, code languages 4772 blocks, MDX compilation 831 of 831. The frontmatter check is the code path that runs through `gray-matter` into `js-yaml`.
- `bun run docs:compile-manifest` compiles 10 top-level sections and leaves the working tree unchanged.

The last two are the checks Docs CI runs.

## A separate problem this turned up

`npm run typecheck` in `/docs` fails on master, both before and after this change:

```
tsconfig.json(4,9): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
```

`/docs` declares TypeScript 7.0.2, which removed the `baseUrl` option. `docs/tsconfig.json` still sets `"baseUrl": "."`. Docs CI runs `test:mdx` and `docs:compile-manifest` but never `typecheck`, so no CI job reports this failure. This change does not fix it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791472280&installation_model_id=20193&pr_number=5319&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5319&signature=57a5fc2e7081e4e1ecb3f8256078618064992d0d97421c0e29c6be51a25db1c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->