### PR TITLE
docs: lowercase the PR title example in the localization guide

### DIFF
--- a/docs/docs/guides/extending-the-dashboard/localization/index.mdx
+++ b/docs/docs/guides/extending-the-dashboard/localization/index.mdx
@@ -198,7 +198,7 @@ locale. The interface re-renders with your catalog; any string you left untransl
 
 Commit the changed `.po` file(s) (and, for a new language, the `lingui.config.js` and
 `vite/constants.ts` changes) and open a PR against `master`. A translation change is a `fix`, so title
-it accordingly, e.g. `fix(dashboard): Add Ukrainian UI translations`. Translations are always welcome,
+it accordingly, e.g. `fix(dashboard): add Ukrainian UI translations`. Translations are always welcome,
 including partial ones — you don't have to translate every string to contribute.
 
 Two CI checks gate a translation PR: **`dashboard i18n sync`** (runs `lingui extract` and fails if the


### PR DESCRIPTION
Follow-up to #5290, per the review note there.

The localization guide told translators to title their PR `fix(dashboard): Add Ukrainian UI translations`, but commitlint's `subject-case` rule in `lint_pr_title.yml` rejects a capitalised subject, so anyone copying the example hit a red check.

I grepped the rest of the docs for other `type(scope): Capital...` commit or PR title examples and this was the only one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791474169&installation_model_id=20193&pr_number=5320&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5320&signature=1efbd1dc10a1194c9d06dba0875762b3d8adc1315c19db5fa74bc6432a4b2f9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->