### PR TITLE
fix(dashboard): warn when a package.json import is skipped

### DIFF
--- a/packages/dashboard/vite/tests/fixtures-json-pkg/type-only-vendure-config.ts
+++ b/packages/dashboard/vite/tests/fixtures-json-pkg/type-only-vendure-config.ts
@@ -1,0 +1,16 @@
+import type { VendureConfig } from '@vendure/core';
+
+import type packageMetadata from './package.json';
+import { type name } from './package.json';
+
+export { type version } from './package.json';
+
+export const config: VendureConfig = {
+    apiOptions: { port: 3000 },
+    authOptions: { tokenMethod: 'bearer' },
+    dbConnectionOptions: { type: 'postgres' },
+    paymentOptions: { paymentMethodHandlers: [] },
+    plugins: [],
+};
+
+export type FixturePackageMetadata = typeof packageMetadata & { name: typeof name };

--- a/packages/dashboard/vite/tests/json-imports.spec.ts
+++ b/packages/dashboard/vite/tests/json-imports.spec.ts
@@ -73,6 +73,21 @@ describe('compiling a config which imports .json files', () => {
         expect(packageJsonWarning).toContain(join('my-plugin', 'package.json'));
     });
 
+    it('should not warn when package.json is imported only for types', { timeout: 60_000 }, async () => {
+        const tempDir = join(__dirname, './__temp/json-pkg-types');
+        await rm(tempDir, { recursive: true, force: true });
+        const warnings: string[] = [];
+
+        await compile({
+            outputPath: tempDir,
+            vendureConfigPath: join(__dirname, 'fixtures-json-pkg', 'type-only-vendure-config.ts'),
+            logger: { ...noopLogger, warn: (message: string) => warnings.push(message) },
+            module: 'commonjs',
+        });
+
+        expect(warnings.some(warning => warning.includes('package.json cannot be copied'))).toBe(false);
+    });
+
     // A package.json reached through the import graph must not be copied. In a
     // nested directory its "type" field decides how the compiled .js files beside
     // it are loaded, so copying it makes those files fail to load.

--- a/packages/dashboard/vite/tests/json-imports.spec.ts
+++ b/packages/dashboard/vite/tests/json-imports.spec.ts
@@ -54,6 +54,25 @@ describe('compiling a config which imports .json files', () => {
             JSON.parse(await readFile(join(tempDir, 'my-plugin', 'src', 'plugin-data.json'), 'utf-8')),
         ).toEqual({ sheetId: 'abc123' });
     });
+    // Skipping the package.json silently leaves the import in the emitted output, so
+    // the config fails to load with a bare "Cannot find module". Say so up front.
+    it('should warn when a package.json import is skipped', { timeout: 60_000 }, async () => {
+        const tempDir = join(__dirname, './__temp/json-pkg-warn');
+        await rm(tempDir, { recursive: true, force: true });
+        const warnings: string[] = [];
+
+        await compile({
+            outputPath: tempDir,
+            vendureConfigPath: join(__dirname, 'fixtures-json-pkg', 'vendure-config.ts'),
+            logger: { ...noopLogger, warn: (message: string) => warnings.push(message) },
+            module: 'commonjs',
+        }).catch(() => undefined);
+
+        const packageJsonWarning = warnings.find(w => w.includes('package.json'));
+        expect(packageJsonWarning).toBeDefined();
+        expect(packageJsonWarning).toContain(join('my-plugin', 'package.json'));
+    });
+
     // A package.json reached through the import graph must not be copied. In a
     // nested directory its "type" field decides how the compiled .js files beside
     // it are loaded, so copying it makes those files fail to load.

--- a/packages/dashboard/vite/utils/compiler.ts
+++ b/packages/dashboard/vite/utils/compiler.ts
@@ -517,6 +517,7 @@ async function collectLocalSourceFiles(
 
         ts.forEachChild(sf, node => {
             if (!ts.isImportDeclaration(node) && !ts.isExportDeclaration(node)) return;
+            if (isTypeOnlyImportOrExport(node)) return;
             const moduleSpecifier = node.moduleSpecifier;
             if (!moduleSpecifier || !ts.isStringLiteral(moduleSpecifier)) return;
             const importPath = moduleSpecifier.text;
@@ -540,6 +541,36 @@ async function collectLocalSourceFiles(
 
     await processFile(entryFile);
     return { sourceFiles: [...visited], skippedPackageJsonFiles: [...skippedPackageJson] };
+}
+
+function isTypeOnlyImportOrExport(node: ts.ImportDeclaration | ts.ExportDeclaration) {
+    if (ts.isImportDeclaration(node)) {
+        const importClause = node.importClause;
+        if (!importClause) {
+            return false;
+        }
+        if (importClause.isTypeOnly) {
+            return true;
+        }
+        const namedBindings = importClause.namedBindings;
+        return (
+            !importClause.name &&
+            !!namedBindings &&
+            ts.isNamedImports(namedBindings) &&
+            namedBindings.elements.length > 0 &&
+            namedBindings.elements.every(element => element.isTypeOnly)
+        );
+    }
+
+    if (node.isTypeOnly) {
+        return true;
+    }
+    return (
+        !!node.exportClause &&
+        ts.isNamedExports(node.exportClause) &&
+        node.exportClause.elements.length > 0 &&
+        node.exportClause.elements.every(element => element.isTypeOnly)
+    );
 }
 
 async function registerTsConfigPaths(options: {

--- a/packages/dashboard/vite/utils/compiler.ts
+++ b/packages/dashboard/vite/utils/compiler.ts
@@ -296,8 +296,22 @@ async function resolveSourceContext(
 
     // Collect all local source files by walking the import tree
     const collectStart = Date.now();
-    const sourceFiles = await collectLocalSourceFiles(inputPath, originalTsConfigInfo);
+    const { sourceFiles, skippedPackageJsonFiles } = await collectLocalSourceFiles(
+        inputPath,
+        originalTsConfigInfo,
+    );
     logger.debug(`Collected ${sourceFiles.length} source files in ${Date.now() - collectStart}ms`);
+
+    // The import stays in the emitted JavaScript, so leaving this silent means the
+    // config fails to load with a bare "Cannot find module" naming a file the author
+    // can see on disk.
+    if (skippedPackageJsonFiles.length) {
+        logger.warn(
+            `A package.json cannot be copied into the compiled config output, because its "type" field ` +
+                `decides how the compiled files beside it are loaded. Loading the config will fail on ` +
+                `${skippedPackageJsonFiles.join(', ')}. Read the file at runtime instead of importing it.`,
+        );
+    }
 
     let sourceRoot = customSourceRoot;
     if (!sourceRoot) {
@@ -468,8 +482,9 @@ function assertWithinOutputPath(outputFilePath: string, outputPath: string): voi
 async function collectLocalSourceFiles(
     entryFile: string,
     tsConfigInfo?: { baseUrl: string; paths: Record<string, string[]> },
-): Promise<string[]> {
+): Promise<{ sourceFiles: string[]; skippedPackageJsonFiles: string[] }> {
     const visited = new Set<string>();
+    const skippedPackageJson = new Set<string>();
 
     async function processFile(filePath: string) {
         const resolved = await resolveSourceFile(filePath);
@@ -483,7 +498,10 @@ async function collectLocalSourceFiles(
         // the one written there to declare the module type, and in any nested
         // directory its own "type" field decides how the compiled .js files beside
         // it are loaded, which breaks them.
-        if (path.basename(resolved) === 'package.json') return;
+        if (path.basename(resolved) === 'package.json') {
+            skippedPackageJson.add(resolved);
+            return;
+        }
 
         if (visited.has(resolved)) return;
         visited.add(resolved);
@@ -521,7 +539,7 @@ async function collectLocalSourceFiles(
     }
 
     await processFile(entryFile);
-    return [...visited];
+    return { sourceFiles: [...visited], skippedPackageJsonFiles: [...skippedPackageJson] };
 }
 
 async function registerTsConfigPaths(options: {


### PR DESCRIPTION
Follow-up to #4808, which taught the dashboard config compiler to copy imported JSON into its output.

A `package.json` is deliberately excluded from that copying. At the output root it would collide with the one written there to declare the module type, and in any nested directory its own `type` field decides how the compiled `.js` files beside it are loaded, which breaks them.

The import itself stays in the emitted JavaScript, so excluding the file silently left the config failing to load with a bare `Cannot find module '../package.json'` naming a file the author can see on disk. This adds a warning that names the skipped files and says what to do instead, matching the warning #4808 already emits for JSON imports under `module: 'esm'`.

`collectLocalSourceFiles` now returns the skipped paths alongside the collected source files, and `resolveSourceContext` reports them once.

## Tests

`packages/dashboard/vite/tests/json-imports.spec.ts` gains a case asserting the warning fires and names the skipped file, using the `fixtures-json-pkg` fixture added in #4808.

- `bun run test -- json-imports` — 4 passed
- `bun run test` in `packages/dashboard` — 37 files passed, 508 passed, 4 skipped

## Breaking changes

None. This adds a warning; no behaviour changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791550383&installation_model_id=20193&pr_number=5329&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5329&signature=f4e4a2a24f95e3abb82c6c0c4cd2b39a5efcc877bb2ab5037ef2d716424e65f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->