### PR TITLE
ci: skip the dashboard deploy on fork pull requests

### DIFF
--- a/.github/workflows/deploy_dashboard.yml
+++ b/.github/workflows/deploy_dashboard.yml
@@ -30,6 +30,12 @@ concurrency:
 
 jobs:
     deploy:
+        # A pull request from a fork cannot read repository secrets, so VERCEL_TOKEN
+        # resolves empty and the first `vercel` command exits 1. Skipping is safe: the
+        # preview deployment is a convenience, and the push to master or minor after the
+        # merge still deploys. The PR comment step would fail on a fork too, since the
+        # GITHUB_TOKEN is read-only there.
+        if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
         runs-on: ubuntu-latest
         permissions:
             contents: read


### PR DESCRIPTION
# Description

Relates to #5082.

A pull request from a fork cannot read repository secrets. `secrets.VERCEL_TOKEN` resolves empty, so the first step of the `deploy` job fails:

```
Error: You defined "--token", but it's missing a value
```

Every fork pull request that touches `packages/dashboard`, `packages/core` or `packages/common` therefore reports a failing `deploy` check that the contributor cannot fix. #5082 is the current example.

## What changed

The `deploy` job is skipped for fork pull requests. This matches what the `sonarqube` job in `build_and_test.yml` already does, for the same reason.

Nothing else changes: pushes to `master` and `minor` still deploy, and pull requests from branches on this repository still get a preview deployment and its PR comment.

Skipping is also the right call rather than switching to `pull_request_target`, which would hand repository secrets to code from a fork.

# Breaking changes

None.

# Screenshots

Not applicable, CI configuration only.

# Checklist

📌 Always:

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:

- [ ] I have added or updated test cases (not applicable, CI configuration)
- [ ] I have updated the README if needed (not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791567727&installation_model_id=20193&pr_number=5333&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5333&signature=b4490fd993bb093af1f54ba36f1a0c6588f7b14a703dc254f8b6743f19e9d8a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->