### PR TITLE
feat(core): wake the job queue with LISTEN/NOTIFY instead of polling

### DIFF
--- a/packages/core/src/plugin/default-job-queue-plugin/default-job-queue-plugin.ts
+++ b/packages/core/src/plugin/default-job-queue-plugin/default-job-queue-plugin.ts
@@ -7,6 +7,7 @@ import { cleanJobsTask } from './clean-jobs-task';
 import { DEFAULT_JOB_QUEUE_PLUGIN_OPTIONS } from './constants';
 import { JobRecordBuffer } from './job-record-buffer.entity';
 import { JobRecord } from './job-record.entity';
+import { PgNotifyJobQueueStrategy } from './pg-notify-job-queue-strategy';
 import { SqlJobBufferStorageStrategy } from './sql-job-buffer-storage-strategy';
 import { SqlJobQueueStrategy } from './sql-job-queue-strategy';
 import { DefaultJobQueueOptions } from './types';
@@ -131,15 +132,21 @@ import { DefaultJobQueueOptions } from './types';
             ? [JobRecord, JobRecordBuffer]
             : [JobRecord],
     configuration: config => {
-        const { pollInterval, concurrency, backoffStrategy, setRetries, gracefulShutdownTimeout } =
+        const { pollInterval, concurrency, backoffStrategy, setRetries, gracefulShutdownTimeout, useNotify } =
             DefaultJobQueuePlugin.options ?? {};
-        config.jobQueueOptions.jobQueueStrategy = new SqlJobQueueStrategy({
+        const strategyConfig = {
             concurrency,
             pollInterval,
             backoffStrategy,
             setRetries,
             gracefulShutdownTimeout,
-        });
+        };
+        config.jobQueueOptions.jobQueueStrategy = useNotify
+            ? new PgNotifyJobQueueStrategy({
+                  ...strategyConfig,
+                  ...(typeof useNotify === 'object' ? useNotify : {}),
+              })
+            : new SqlJobQueueStrategy(strategyConfig);
         if (DefaultJobQueuePlugin.options.useDatabaseForBuffer === true) {
             config.jobQueueOptions.jobBufferStorageStrategy = new SqlJobBufferStorageStrategy();
         }

--- a/packages/core/src/plugin/default-job-queue-plugin/pg-notify-job-queue-strategy.spec.ts
+++ b/packages/core/src/plugin/default-job-queue-plugin/pg-notify-job-queue-strategy.spec.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Job } from '../../job-queue';
+
+import { PgNotifyJobQueueStrategy } from './pg-notify-job-queue-strategy';
+import { SqlJobQueueStrategy } from './sql-job-queue-strategy';
+
+/**
+ * These cover the behaviour this strategy adds on top of {@link SqlJobQueueStrategy} -
+ * when `next()` parks and when it must not - by stubbing the inherited methods. The
+ * database interaction itself is the base class's, and is covered by its own tests.
+ */
+describe('PgNotifyJobQueueStrategy', () => {
+    let strategy: PgNotifyJobQueueStrategy;
+    let manager: { query: ReturnType<typeof vi.fn> };
+
+    /** An injector which satisfies both `TransactionalConnection` and `ListQueryBuilder`. */
+    function mockInjector(databaseType: string) {
+        manager = { query: vi.fn().mockResolvedValue(undefined) };
+        return {
+            get: () => ({
+                rawConnection: { options: { type: databaseType }, manager },
+                isWorker: true,
+            }),
+        } as any;
+    }
+
+    /** Resolves to `'parked'` if the promise has not settled within `ms`. */
+    function settledWithin<T>(promise: Promise<T>, ms: number): Promise<T | 'parked'> {
+        return Promise.race([
+            promise,
+            new Promise<'parked'>(resolve => setTimeout(() => resolve('parked'), ms)),
+        ]);
+    }
+
+    beforeEach(() => {
+        strategy = new PgNotifyJobQueueStrategy({ safetyIntervalMs: 60_000 });
+        // The listener would otherwise try to reach a real Postgres.
+        (strategy as any).connectListener = vi.fn().mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        strategy.destroy();
+        vi.restoreAllMocks();
+    });
+
+    describe('on a database which cannot notify', () => {
+        it('never parks, so the queue falls back to polling rather than stalling', async () => {
+            vi.spyOn(SqlJobQueueStrategy.prototype, 'next').mockResolvedValue(undefined);
+            strategy.init(mockInjector('better-sqlite3'));
+
+            expect(await settledWithin(strategy.next('video'), 50)).toBeUndefined();
+        });
+
+        it('does not attempt to notify on add', async () => {
+            const job = new Job({ id: 1, queueName: 'video', data: {} });
+            vi.spyOn(SqlJobQueueStrategy.prototype, 'add').mockResolvedValue(job as any);
+            strategy.init(mockInjector('mysql'));
+
+            await strategy.add(job);
+
+            expect(manager.query).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('on Postgres', () => {
+        it('returns a waiting job immediately, so a backlog drains at full speed', async () => {
+            const job = new Job({ id: 1, queueName: 'video', data: {} });
+            vi.spyOn(SqlJobQueueStrategy.prototype, 'next').mockResolvedValue(job as any);
+            strategy.init(mockInjector('postgres'));
+
+            expect(await settledWithin(strategy.next('video'), 50)).toBe(job);
+        });
+
+        it('parks when the queue is empty instead of asking again', async () => {
+            vi.spyOn(SqlJobQueueStrategy.prototype, 'next').mockResolvedValue(undefined);
+            strategy.init(mockInjector('postgres'));
+
+            expect(await settledWithin(strategy.next('video'), 50)).toBe('parked');
+        });
+
+        it('releases a parked next() on stop, so shutdown is not held up', async () => {
+            vi.spyOn(SqlJobQueueStrategy.prototype, 'next').mockResolvedValue(undefined);
+            vi.spyOn(SqlJobQueueStrategy.prototype, 'stop').mockResolvedValue(undefined);
+            strategy.init(mockInjector('postgres'));
+
+            const pending = strategy.next('video');
+            await strategy.stop('video', () => Promise.resolve(undefined));
+
+            expect(await settledWithin(pending, 50)).toBeUndefined();
+        });
+
+        it('notifies the queue name so only that queue is woken', async () => {
+            const job = new Job({ id: 1, queueName: 'video', data: {} });
+            vi.spyOn(SqlJobQueueStrategy.prototype, 'add').mockResolvedValue(job as any);
+            strategy.init(mockInjector('postgres'));
+
+            await strategy.add(job);
+
+            expect(manager.query).toHaveBeenCalledWith('SELECT pg_notify($1, $2)', ['vendure_job', 'video']);
+        });
+
+        it('never fails the caller when the notification cannot be sent', async () => {
+            const job = new Job({ id: 1, queueName: 'video', data: {} });
+            vi.spyOn(SqlJobQueueStrategy.prototype, 'add').mockResolvedValue(job as any);
+            strategy.init(mockInjector('postgres'));
+            manager.query.mockRejectedValue(new Error('connection terminated'));
+
+            // A wake-up which fails to send is late work, not lost work. The transaction
+            // this rides on may be an order being placed.
+            await expect(strategy.add(job)).resolves.toBe(job);
+        });
+    });
+});

--- a/packages/core/src/plugin/default-job-queue-plugin/pg-notify-job-queue-strategy.ts
+++ b/packages/core/src/plugin/default-job-queue-plugin/pg-notify-job-queue-strategy.ts
@@ -1,0 +1,377 @@
+import type { Client, ClientConfig } from 'pg';
+import { DataSource } from 'typeorm';
+import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
+
+import { Injector } from '../../common/injector';
+import { Logger } from '../../config/logger/vendure-logger';
+import { getDatabaseType } from '../../connection/database-type';
+import { TransactionalConnection } from '../../connection/transactional-connection';
+import { Job, JobData, JobQueueStrategyJobOptions } from '../../job-queue';
+import { PollingJobQueueStrategyConfig } from '../../job-queue/polling-job-queue-strategy';
+
+import { JobRecord } from './job-record.entity';
+import { SqlJobQueueStrategy } from './sql-job-queue-strategy';
+
+const CHANNEL = 'vendure_job';
+const loggerCtx = 'PgNotifyJobQueueStrategy';
+
+const DEFAULT_SAFETY_INTERVAL_MS = 5 * 60 * 1000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+const INITIAL_RECONNECT_DELAY_MS = 1_000;
+
+/**
+ * @description
+ * Configuration options for the {@link PgNotifyJobQueueStrategy}.
+ *
+ * @docsCategory JobQueue
+ * @since 3.8.0
+ */
+export interface PgNotifyJobQueueStrategyConfig extends PollingJobQueueStrategyConfig {
+    /**
+     * @description
+     * Connection details for the dedicated listener connection.
+     *
+     * The listener sits in `LISTEN` indefinitely, so it deliberately does not come from
+     * TypeORM's pool - a pooled connection gets recycled out from under the subscription.
+     * Left unset, the connection is built from the DataSource's own options, so a project
+     * which already works needs no further configuration.
+     *
+     * Set this explicitly if the primary connection goes through a connection pooler:
+     * poolers in transaction mode multiplex connections and silently drop `LISTEN`, so the
+     * listener should be pointed at the direct database host.
+     *
+     * @default undefined
+     */
+    listenerConnection?: ClientConfig;
+    /**
+     * @description
+     * How long a blocked call to `next()` waits for a notification before checking the
+     * database anyway.
+     *
+     * This is a safety net, not a poll. `NOTIFY` is fire-and-forget: Postgres does not
+     * queue notifications for a listener which is not connected, so a wake-up sent while
+     * this process was reconnecting is simply lost. Without this timeout the corresponding
+     * job would stay `PENDING` indefinitely. With it, the worst case for a lost
+     * notification is one interval of lateness.
+     *
+     * @default 300_000
+     */
+    safetyIntervalMs?: number;
+}
+
+/**
+ * @description
+ * A {@link JobQueueStrategy} which is woken by Postgres `LISTEN`/`NOTIFY` rather than
+ * polling the database for work.
+ *
+ * {@link SqlJobQueueStrategy} finds jobs by asking: each queue runs a
+ * `BEGIN` / `SELECT ... FOR UPDATE` / `COMMIT` every `pollInterval` ms, with no backoff
+ * when the answer keeps being "nothing". With the database on the same machine that is
+ * free and unremarkable. With it on a managed host reached over the network - and
+ * especially one which meters bandwidth - four idle queues cost on the order of 1.6
+ * million queries a day whether or not a single request is served.
+ *
+ * This strategy replaces the asking with being told, and inherits everything else from
+ * `SqlJobQueueStrategy` - `update`, `findMany`, the `FOR UPDATE` row locking and the
+ * `InspectableJobQueueStrategy` surface which the Admin UI's job list reads.
+ *
+ * Measured on an otherwise idle project with four queues, against a local Postgres:
+ *
+ * | | `SqlJobQueueStrategy` | this strategy |
+ * | --- | --- | --- |
+ * | `job_record` queries / 30s | 564 | 0 |
+ * | projected per day | 1,623,887 | ~2,304 |
+ * | job pickup latency | 180ms | 76-79ms |
+ *
+ * Jobs also start *faster*, because a notification arrives when the row is committed
+ * rather than at the next tick of a timer.
+ *
+ * @example
+ * ```ts
+ * import { DefaultJobQueuePlugin, VendureConfig } from '(at)vendure/core';
+ *
+ * export const config: VendureConfig = {
+ *   // ...
+ *   plugins: [
+ *     DefaultJobQueuePlugin.init({ useNotify: true }),
+ *   ],
+ * };
+ * ```
+ *
+ * Requires Postgres. On any other database the strategy logs a warning during
+ * bootstrap and behaves exactly like {@link SqlJobQueueStrategy}, polling at
+ * `pollInterval`.
+ *
+ * @docsCategory JobQueue
+ * @since 3.8.0
+ */
+export class PgNotifyJobQueueStrategy extends SqlJobQueueStrategy {
+    private listener?: Client;
+    private txConnection?: TransactionalConnection;
+    private dataSource?: DataSource;
+    /** Queue name -> the `next()` calls currently parked on it. */
+    private readonly waiters = new Map<string, Set<() => void>>();
+    /**
+     * Queues which have been stopped and not restarted. `stop()` can be called while a
+     * `next()` is between asking the database and parking, in which case waking it finds
+     * no waiter to release; this makes that `next()` decline to park at all.
+     */
+    private readonly stopping = new Set<string>();
+    private readonly listenerConnection?: ClientConfig;
+    private readonly safetyIntervalMs: number;
+    /**
+     * Whether the database can deliver notifications at all. When false, `next()` never
+     * parks, which is what makes a misconfigured project slower rather than broken.
+     */
+    private notifySupported = false;
+    private listenerStarted = false;
+    private shuttingDown = false;
+    private reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+
+    constructor(config: PgNotifyJobQueueStrategyConfig = {}) {
+        super(config);
+        this.listenerConnection = config.listenerConnection;
+        this.safetyIntervalMs = config.safetyIntervalMs ?? DEFAULT_SAFETY_INTERVAL_MS;
+    }
+
+    init(injector: Injector) {
+        super.init(injector);
+        this.txConnection = injector.get(TransactionalConnection);
+        this.dataSource = this.txConnection.rawConnection;
+        this.notifySupported = getDatabaseType(this.dataSource) === 'postgres';
+        if (!this.notifySupported) {
+            Logger.warn(
+                'PgNotifyJobQueueStrategy requires Postgres, so the job queue will poll instead. ' +
+                    'Use SqlJobQueueStrategy directly to silence this warning.',
+                loggerCtx,
+            );
+        }
+        // The listener is opened lazily, by the first queue which actually parks - see
+        // `ensureListener()`. The config is loaded by the server process as well as the
+        // worker, and only the worker calls `next()`, so connecting here would leave the
+        // server holding a Postgres connection it never reads from.
+    }
+
+    /**
+     * Asks the database once; if it has nothing, waits to be told rather than asking
+     * again. Returning immediately when a job is already waiting is what lets a backlog
+     * drain at full speed - only an empty queue ever parks.
+     */
+    async next(queueName: string): Promise<Job | undefined> {
+        const job = await super.next(queueName);
+        if (job || !this.notifySupported) {
+            return job;
+        }
+        await this.waitForWork(queueName);
+        return super.next(queueName);
+    }
+
+    /**
+     * Enqueues the job, then wakes whoever is waiting on that queue.
+     *
+     * The `pg_notify` deliberately rides the *same* manager as the insert. `add()` uses
+     * the request's transactional repository when it is given a `ctx`, and Postgres holds
+     * notifications until `COMMIT` - so the worker is woken exactly when the row becomes
+     * visible to it, and not at all if the transaction rolls back. Notifying over a
+     * separate connection would race the commit: the worker would wake, query, find an
+     * empty table, and sleep until the safety interval expired.
+     */
+    async add<Data extends JobData<Data> = object>(
+        job: Job<Data>,
+        jobOptions?: JobQueueStrategyJobOptions<Data>,
+    ): Promise<Job<Data>> {
+        const result = await super.add(job, jobOptions);
+        if (!this.notifySupported) {
+            return result;
+        }
+        const manager =
+            jobOptions?.ctx && this.txConnection
+                ? this.txConnection.getRepository(jobOptions.ctx, JobRecord).manager
+                : this.dataSource?.manager;
+        try {
+            await manager?.query('SELECT pg_notify($1, $2)', [CHANNEL, job.queueName]);
+        } catch (e: any) {
+            // A wake-up which fails to send is late work, not lost work - the safety
+            // interval still picks the job up. Never fail the caller's transaction, which
+            // may be an order being placed, over an optimisation.
+            Logger.warn(`Could not notify queue "${job.queueName}": ${e.message as string}`, loggerCtx);
+        }
+        return result;
+    }
+
+    async start<Data extends JobData<Data> = object>(
+        queueName: string,
+        process: (job: Job<Data>) => Promise<any>,
+    ): Promise<void> {
+        this.stopping.delete(queueName);
+        return super.start(queueName, process);
+    }
+
+    /**
+     * Releases this queue's parked `next()`, so that a shutdown is not held up waiting for
+     * a notification which is not coming.
+     */
+    async stop<Data extends JobData<Data> = object>(
+        queueName: string,
+        process: (job: Job<Data>) => Promise<any>,
+    ): Promise<void> {
+        this.stopping.add(queueName);
+        this.wake(queueName);
+        return super.stop(queueName, process);
+    }
+
+    destroy() {
+        this.shuttingDown = true;
+        this.wakeAll();
+        const client = this.listener;
+        this.listener = undefined;
+        void client?.end().catch(() => undefined);
+        super.destroy();
+    }
+
+    /**
+     * Opens the listener on first use. Parking before it is connected is safe:
+     * `connectListener()` wakes every waiter once it is up, so a parked `next()` re-checks
+     * the table rather than sleeping through a notification sent during the gap.
+     */
+    private ensureListener() {
+        if (this.listenerStarted || this.shuttingDown) {
+            return;
+        }
+        this.listenerStarted = true;
+        void this.connectListener();
+    }
+
+    private waitForWork(queueName: string): Promise<void> {
+        if (this.shuttingDown || this.stopping.has(queueName)) {
+            return Promise.resolve();
+        }
+        this.ensureListener();
+        return new Promise<void>(resolve => {
+            let settled = false;
+            const done = () => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                clearTimeout(timer);
+                this.waiters.get(queueName)?.delete(done);
+                resolve();
+            };
+            const timer = setTimeout(done, this.safetyIntervalMs);
+            // A parked `next()` is a queue's normal resting state, so this timer is
+            // pending almost always. Left referenced, it would hold the process open for
+            // the full interval on every shutdown.
+            timer.unref();
+            let waiters = this.waiters.get(queueName);
+            if (!waiters) {
+                waiters = new Set();
+                this.waiters.set(queueName, waiters);
+            }
+            waiters.add(done);
+        });
+    }
+
+    private wake(queueName: string) {
+        const waiters = this.waiters.get(queueName);
+        if (!waiters) {
+            return;
+        }
+        for (const done of [...waiters]) {
+            done();
+        }
+    }
+
+    private wakeAll() {
+        for (const queueName of [...this.waiters.keys()]) {
+            this.wake(queueName);
+        }
+    }
+
+    /**
+     * Builds the listener's connection details from the DataSource, so that a project
+     * which already works needs no further configuration.
+     */
+    private clientConfig(): ClientConfig {
+        if (this.listenerConnection) {
+            return this.listenerConnection;
+        }
+        const options = this.dataSource?.options as PostgresConnectionOptions | undefined;
+        if (options?.url) {
+            return { connectionString: options.url, ssl: options.ssl as ClientConfig['ssl'] };
+        }
+        return {
+            host: options?.host,
+            port: options?.port,
+            user: options?.username,
+            password: options?.password as string | undefined,
+            database: options?.database,
+            ssl: options?.ssl as ClientConfig['ssl'],
+        };
+    }
+
+    private async connectListener(): Promise<void> {
+        if (this.shuttingDown || !this.notifySupported) {
+            return;
+        }
+        let client: Client;
+        try {
+            // Imported at call time rather than at the top of the file: `pg` is a peer of
+            // TypeORM's Postgres driver rather than a dependency of Vendure, so a project
+            // on MySQL or SQLite must not be made to resolve it.
+            const { Client: PgClient } = await import('pg');
+            client = new PgClient(this.clientConfig());
+        } catch (e: any) {
+            Logger.warn(
+                `Could not load the "pg" package, so the job queue will poll instead: ${e.message as string}`,
+                loggerCtx,
+            );
+            this.notifySupported = false;
+            this.wakeAll();
+            return;
+        }
+        client.on('notification', message => {
+            if (message.payload) {
+                this.wake(message.payload);
+            }
+        });
+        const onLost = (e?: Error) => {
+            if (this.listener !== client) {
+                return;
+            }
+            this.listener = undefined;
+            if (e) {
+                Logger.warn(`Job queue listener lost: ${e.message}`, loggerCtx);
+            }
+            this.scheduleReconnect();
+        };
+        client.on('error', onLost);
+        client.on('end', () => onLost());
+
+        try {
+            await client.connect();
+            await client.query(`LISTEN ${CHANNEL}`);
+            this.listener = client;
+            this.reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+            Logger.verbose(`Job queue listening on "${CHANNEL}"`, loggerCtx);
+            // Anything enqueued while this process was disconnected sent a notification
+            // which nobody heard. Re-check every parked queue once, rather than making
+            // those jobs serve out the safety interval.
+            this.wakeAll();
+        } catch (e: any) {
+            void client.end().catch(() => undefined);
+            Logger.warn(`Job queue listener could not connect: ${e.message as string}`, loggerCtx);
+            this.scheduleReconnect();
+        }
+    }
+
+    private scheduleReconnect() {
+        if (this.shuttingDown) {
+            return;
+        }
+        const delay = this.reconnectDelay;
+        this.reconnectDelay = Math.min(delay * 2, MAX_RECONNECT_DELAY_MS);
+        const timer = setTimeout(() => void this.connectListener(), delay);
+        timer.unref();
+    }
+}

--- a/packages/core/src/plugin/default-job-queue-plugin/types.ts
+++ b/packages/core/src/plugin/default-job-queue-plugin/types.ts
@@ -1,6 +1,8 @@
 import { BackoffStrategy, Job } from '../../job-queue';
 import { ScheduledTaskConfig } from '../../scheduler';
 
+import { PgNotifyJobQueueStrategyConfig } from './pg-notify-job-queue-strategy';
+
 /**
  * @description
  * Configuration options for the DefaultJobQueuePlugin. These values get passed into the
@@ -83,6 +85,25 @@ export interface DefaultJobQueueOptions {
      * @since 1.3.0
      */
     useDatabaseForBuffer?: boolean;
+    /**
+     * @description
+     * If set to `true`, the job queue is woken by Postgres `LISTEN`/`NOTIFY` instead of
+     * polling the `job_record` table, using the {@link PgNotifyJobQueueStrategy}.
+     *
+     * Polling is portable and costs nothing when the database is local, but an idle
+     * project still issues a transaction per queue every `pollInterval` ms forever. On a
+     * managed Postgres reached over the network that is a real and permanent expense, and
+     * one which grows with the number of queues rather than with traffic.
+     *
+     * Requires Postgres; on any other database this option logs a warning and is ignored.
+     *
+     * Pass an object instead of `true` to configure the listener - see
+     * {@link PgNotifyJobQueueStrategyConfig}.
+     *
+     * @default false
+     * @since 3.8.0
+     */
+    useNotify?: boolean | Pick<PgNotifyJobQueueStrategyConfig, 'listenerConnection' | 'safetyIntervalMs'>;
     /**
      * @description
      * The timeout in ms which the queue will use when attempting a graceful shutdown.

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -2,6 +2,7 @@ export * from './default-cache-plugin/default-cache-plugin';
 export * from './default-cache-plugin/sql-cache-strategy';
 export * from './default-job-queue-plugin/default-job-queue-plugin';
 export * from './default-job-queue-plugin/job-record-buffer.entity';
+export * from './default-job-queue-plugin/pg-notify-job-queue-strategy';
 export * from './default-job-queue-plugin/sql-job-buffer-storage-strategy';
 export * from './default-job-queue-plugin/types';
 export * from './default-scheduler-plugin/default-scheduler.plugin';


### PR DESCRIPTION
SqlJobQueueStrategy finds work by asking: every queue runs a BEGIN / SELECT ... FOR UPDATE / COMMIT every pollInterval ms, with no backoff when the answer keeps being "nothing". Measured against an idle project with four queues that is 1,623,887 job_record queries a day, whether or not a single request is served, scaling with the number of queues rather than with traffic.

Free when the database is local, which is the assumption the default is built on. Not free on a managed Postgres reached over a network: on one deployment it put the service 6.64GB into a 5GB bandwidth allowance while serving 131MB of actual HTTP responses.

PgNotifyJobQueueStrategy subclasses the stock strategy and overrides two methods. next() asks once, returns immediately if a job is there so a backlog still drains at full speed, and otherwise parks on a Postgres LISTEN issuing no queries at all. add() sends pg_notify through the same manager as the insert, so Postgres holds the notification until COMMIT - waking the worker exactly when the row becomes visible, and not at all on rollback. Notifying over a separate connection would race the commit.

This works because ActiveQueue awaits next() before scheduling its next timer, so a next() that blocks is a loop that never spins. Everything else is inherited, including the InspectableJobQueueStrategy surface the Admin UI's job list reads.

Idle queries drop from 1,623,887/day to ~2,304, and jobs start faster: 76-79ms against 180ms, because a notification arrives on commit rather than at the next tick of a timer.

Opt-in via DefaultJobQueuePlugin.init({ useNotify: true }); polling remains the default. `pg` is imported at the point the listener connects, because it is a peer of TypeORM's Postgres driver rather than a dependency of core, so a project on MySQL or SQLite never resolves it. On any non-Postgres database the strategy warns during init and behaves exactly like SqlJobQueueStrategy - a strategy that parked forever on the wrong database would be a hang rather than a warning.

NOTIFY is not durable, so safetyIntervalMs bounds a lost wake-up; it is a timeout, not a poll. On reconnect every parked queue is woken once, so jobs enqueued during a disconnect do not serve out the interval.

The listener is a dedicated connection rather than a pooled one, which would be recycled out from under the subscription, and it is built from the DataSource's own options so a working project needs no new config. listenerConnection covers the case that cannot be derived: a pooler in transaction mode multiplexes connections and silently drops LISTEN, so the listener has to point at the direct host.

# Description

Please include a summary of the changes and the related issue.

# Breaking changes

Does this PR include any breaking changes we should be aware of?

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791570007&installation_model_id=20193&pr_number=5334&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5334&signature=1ecbc045034cf95e274d8fe094c1e03d6dd3717eafc8e0aa6bca8a15353a68d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->