### PR TITLE
fix(core): report and tolerate apply-collection-filters failures

### DIFF
--- a/packages/core/e2e/collection-filters-error-handling.e2e-spec.ts
+++ b/packages/core/e2e/collection-filters-error-handling.e2e-spec.ts
@@ -1,0 +1,101 @@
+import { JobState, LanguageCode } from '@vendure/common/lib/generated-types';
+import { CollectionFilter, defaultCollectionFilters, mergeConfig } from '@vendure/core';
+import { createTestEnvironment } from '@vendure/testing';
+import * as path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { initialData } from '../../../e2e-common/e2e-initial-data';
+import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
+
+import {
+    createCollectionDocument,
+    getRunningJobsDocument,
+    updateCollectionDocument,
+} from './graphql/shared-definitions';
+import { awaitRunningJobs } from './utils/await-running-jobs';
+
+/**
+ * Stands in for the ways in which applying a Collection's filters can fail in production: a
+ * CollectionFilter implementation throwing, or the database rejecting the membership write.
+ */
+let filterShouldFail = false;
+const flakyCollectionFilter = new CollectionFilter({
+    args: {},
+    code: 'flaky-collection-filter',
+    description: [{ languageCode: LanguageCode.en, value: 'Fails when told to' }],
+    apply: qb => {
+        if (filterShouldFail) {
+            throw new Error('Simulated failure while applying the collection filter');
+        }
+        return qb.andWhere('1 = 1');
+    },
+});
+
+/**
+ * The apply-collection-filters job used to swallow any failure and still report a successful run,
+ * which left the Collection's contents silently out of sync with its filters.
+ */
+describe('Collection filters error handling', () => {
+    const { server, adminClient } = createTestEnvironment(
+        mergeConfig(testConfig(), {
+            catalogOptions: {
+                collectionFilters: [...defaultCollectionFilters, flakyCollectionFilter],
+            },
+        }),
+    );
+
+    let collectionId: string;
+
+    beforeAll(async () => {
+        await server.init({
+            initialData,
+            productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-full.csv'),
+            customerCount: 1,
+        });
+        await adminClient.asSuperAdmin();
+    }, TEST_SETUP_TIMEOUT_MS);
+
+    afterAll(async () => {
+        filterShouldFail = false;
+        await server.destroy();
+    });
+
+    async function getApplyFiltersJobStates(): Promise<string[]> {
+        const { jobs } = await adminClient.query(getRunningJobsDocument, {
+            options: { filter: { queueName: { eq: 'apply-collection-filters' } } },
+        });
+        return jobs.items.map(job => job.state);
+    }
+
+    it('completes the job when the filters apply successfully', async () => {
+        filterShouldFail = false;
+        const { createCollection } = await adminClient.query(createCollectionDocument, {
+            input: {
+                filters: [{ code: flakyCollectionFilter.code, arguments: [] }],
+                translations: [
+                    { languageCode: LanguageCode.en, name: 'flaky', description: '', slug: 'flaky' },
+                ],
+            },
+        });
+        collectionId = createCollection.id;
+        await awaitRunningJobs(adminClient);
+
+        const states = await getApplyFiltersJobStates();
+        expect(states.length).toBeGreaterThan(0);
+        expect(states.every(state => state === JobState.COMPLETED)).toBe(true);
+    });
+
+    it('fails the job when the filters cannot be applied', async () => {
+        filterShouldFail = true;
+        await adminClient.query(updateCollectionDocument, {
+            input: {
+                id: collectionId,
+                filters: [{ code: flakyCollectionFilter.code, arguments: [] }],
+            },
+        });
+        await awaitRunningJobs(adminClient);
+
+        const states = await getApplyFiltersJobStates();
+        expect(states).toContain(JobState.FAILED);
+    });
+});

--- a/packages/core/src/service/services/collection.service.spec.ts
+++ b/packages/core/src/service/services/collection.service.spec.ts
@@ -1,0 +1,248 @@
+import { JobState } from '@vendure/common/lib/generated-types';
+import { ID } from '@vendure/common/lib/shared-types';
+import { NEVER } from 'rxjs';
+import { UpsertType } from 'typeorm/driver/types/UpsertType';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Collection } from '../../entity/collection/collection.entity';
+import { CollectionModificationEvent } from '../../event-bus/events/collection-modification-event';
+
+import { ApplyCollectionFiltersJobData, CollectionService } from './collection.service';
+
+/**
+ * Unit tests for the `apply-collection-filters` job handler. The write which updates the
+ * Collection <-> ProductVariant junction table used to be wrapped in a catch which only logged, so
+ * a failed write was reported back as a successful run: the affected variants were reindexed
+ * against membership rows which were never written, and the job settled as COMPLETED.
+ */
+
+const junctionEntityMetadata = {
+    tableName: 'collection_product_variants_product_variant',
+    ownerColumns: [{ databaseName: 'collectionId' }],
+    inverseColumns: [{ databaseName: 'productVariantId' }],
+};
+
+type RecordedCall = { method: string; args: any[] };
+
+/** A QueryBuilder which answers every call with itself, and every `getRawMany()` with `rawResults`. */
+function mockQueryBuilder(rawResults: any[], recordInto?: RecordedCall[]): any {
+    const qb: any = new Proxy(
+        { getRawMany: () => Promise.resolve(rawResults) },
+        {
+            get: (target: any, prop) => {
+                if (prop in target) {
+                    return target[prop];
+                }
+                // Must not look like a thenable, or awaiting it would never settle.
+                if (prop === 'then') {
+                    return undefined;
+                }
+                return (...args: any[]) => {
+                    recordInto?.push({ method: String(prop), args });
+                    return String(prop) === 'execute' ? Promise.resolve() : qb;
+                };
+            },
+        },
+    );
+    return qb;
+}
+
+describe('CollectionService apply-collection-filters job', () => {
+    /** Resolves/rejects in place of the transaction which writes the membership rows. */
+    let write: () => Promise<void>;
+    let publish: ReturnType<typeof vi.fn>;
+    let collections: Collection[];
+    let supportedUpsertTypes: UpsertType[];
+    /** One entry per QueryBuilder created inside the write transaction. */
+    let writeQueryBuilders: RecordedCall[][];
+    let process: (job: any) => Promise<any>;
+
+    function mockJob(data: Partial<ApplyCollectionFiltersJobData> = {}) {
+        return {
+            state: JobState.RUNNING,
+            setProgress: vi.fn(),
+            data: {
+                ctx: { channelToken: 'test-channel', languageCode: 'en' },
+                collectionIds: collections.map(c => c.id),
+                ...data,
+            },
+        };
+    }
+
+    /** The calls made on the QueryBuilder which inserted the new membership rows. */
+    function insertCalls(): RecordedCall[] {
+        return writeQueryBuilders.find(calls => calls.some(call => call.method === 'insert')) ?? [];
+    }
+
+    beforeEach(async () => {
+        write = () => Promise.resolve();
+        publish = vi.fn();
+        supportedUpsertTypes = ['on-conflict-do-update'];
+        writeQueryBuilders = [];
+        collections = [new Collection({ id: 42, inheritFilters: false, filters: [] })];
+
+        // Every query issued before the write reports a single variant which needs adding, so that
+        // a successful run has something to write and to publish a CollectionModificationEvent for.
+        const masterConnection = {
+            getRepository: () => ({ createQueryBuilder: () => mockQueryBuilder([{ id: 1 }]) }),
+            createQueryBuilder: () => mockQueryBuilder([{ id: 1 }]),
+        };
+        const transactionalEntityManager = {
+            createQueryBuilder: () => {
+                const calls: RecordedCall[] = [];
+                writeQueryBuilders.push(calls);
+                return mockQueryBuilder([], calls);
+            },
+        };
+        const mockConnection = {
+            getEntityOrThrow: (ctx: any, entity: any, id: ID) => {
+                const collection = collections.find(c => c.id === id);
+                return collection ? Promise.resolve(collection) : Promise.reject(new Error('not found'));
+            },
+            rawConnection: {
+                driver: {
+                    get supportedUpsertTypes() {
+                        return supportedUpsertTypes;
+                    },
+                },
+                createQueryRunner: () => ({ connection: masterConnection }),
+                getMetadata: () => ({
+                    findRelationWithPropertyPath: () => ({ junctionEntityMetadata }),
+                }),
+                transaction: (cb: (em: any) => Promise<void>) =>
+                    write().then(() => cb(transactionalEntityManager)),
+            },
+        } as any;
+
+        const mockJobQueueService = {
+            createQueue: vi.fn((config: any) => {
+                process = config.process;
+                return Promise.resolve({ add: vi.fn() });
+            }),
+        } as any;
+
+        const service = new CollectionService(
+            mockConnection,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            { ofType: () => NEVER, publish } as any,
+            mockJobQueueService,
+            { catalogOptions: { collectionFilters: [] } } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            { translate: (collection: Collection) => collection } as any,
+            {} as any,
+            { create: () => Promise.resolve({}) } as any,
+            {} as any,
+        );
+        await service.onModuleInit();
+    });
+
+    describe('reporting failures', () => {
+        it('completes and publishes the modification when the membership write succeeds', async () => {
+            const result = await process(mockJob());
+
+            expect(result).toEqual({ processedCollections: 1 });
+            expect(publish).toHaveBeenCalledTimes(1);
+            expect(publish.mock.calls[0][0]).toBeInstanceOf(CollectionModificationEvent);
+        });
+
+        it('fails the job when the membership write fails, rather than reporting a successful run', async () => {
+            const queryFailed = new Error(
+                'duplicate key value violates unique constraint "PK_6faa7b72422d9c4f5f5db35f8e0"',
+            );
+            queryFailed.name = 'QueryFailedError';
+            write = () => Promise.reject(queryFailed);
+
+            await expect(process(mockJob())).rejects.toThrow(
+                /Could not apply the filters of 1 of 1 Collections \(ids: 42 \(QueryFailedError: duplicate key value/,
+            );
+            // Nothing may be reindexed against membership rows which were not written.
+            expect(publish).not.toHaveBeenCalled();
+        });
+
+        it('still processes the other Collections in the batch when one of them fails', async () => {
+            collections = [
+                new Collection({ id: 42, inheritFilters: false, filters: [] }),
+                new Collection({ id: 43, inheritFilters: false, filters: [] }),
+            ];
+            let attempt = 0;
+            write = () => (attempt++ === 0 ? Promise.reject(new Error('boom')) : Promise.resolve());
+
+            await expect(process(mockJob())).rejects.toThrow(
+                'Could not apply the filters of 1 of 2 Collections (ids: 42 (Error: boom)). ' +
+                    'See the preceding errors for details.',
+            );
+            expect(publish).toHaveBeenCalledTimes(1);
+        });
+
+        it('keeps the message within the length of the JobRecord error column', async () => {
+            collections = Array.from(
+                { length: 20 },
+                (_, i) => new Collection({ id: i + 1, inheritFilters: false, filters: [] }),
+            );
+            write = () => Promise.reject(new Error('x'.repeat(500)));
+
+            const error: Error = await process(mockJob()).catch((e: Error) => e);
+
+            expect(error.message).toMatch(
+                /^Could not apply the filters of 20 of 20 Collections \(ids: 1 \(Error: x+\.\.\.\), /,
+            );
+            expect(error.message).toContain('See the preceding errors for details.');
+            expect(error.message.length).toBeLessThanOrEqual(255);
+            expect(error.message).not.toContain('\n');
+        });
+    });
+
+    describe('tolerating rows which are already there', () => {
+        it('names the junction table and its columns from the relation metadata', async () => {
+            await process(mockJob());
+
+            expect(insertCalls()).toContainEqual({
+                method: 'into',
+                args: [junctionEntityMetadata.tableName, ['collectionId', 'productVariantId']],
+            });
+            expect(insertCalls()).toContainEqual({
+                method: 'values',
+                args: [[{ collectionId: 42, productVariantId: 1 }]],
+            });
+        });
+
+        it('uses ON CONFLICT DO NOTHING where the driver supports it', async () => {
+            supportedUpsertTypes = ['on-conflict-do-update'];
+
+            await process(mockJob());
+
+            expect(insertCalls().map(call => call.method)).toContain('orIgnore');
+            expect(insertCalls().map(call => call.method)).not.toContain('orUpdate');
+        });
+
+        it('uses a no-op ON DUPLICATE KEY UPDATE on MySQL & MariaDB, not INSERT IGNORE', async () => {
+            supportedUpsertTypes = ['on-duplicate-key-update'];
+
+            await process(mockJob());
+
+            // `orIgnore()` would compile to `INSERT IGNORE`, which also downgrades unrelated errors
+            // such as foreign key and not-null violations to warnings.
+            expect(insertCalls().map(call => call.method)).not.toContain('orIgnore');
+            expect(insertCalls()).toContainEqual({ method: 'orUpdate', args: [['collectionId']] });
+        });
+
+        it('leaves the insert alone on drivers whose only upsert form is MERGE INTO', async () => {
+            // TypeORM compiles a conflict clause on mssql/oracle/sap to `MERGE INTO`, which needs
+            // the target table's entity metadata. The junction table has none, so asking for one
+            // would throw where the previous plain insert simply worked.
+            supportedUpsertTypes = ['merge-into'];
+
+            await process(mockJob());
+
+            const methods = insertCalls().map(call => call.method);
+            expect(methods).not.toContain('orIgnore');
+            expect(methods).not.toContain('orUpdate');
+            expect(methods).toContain('execute');
+        });
+    });
+});

--- a/packages/core/src/service/services/collection.service.ts
+++ b/packages/core/src/service/services/collection.service.ts
@@ -20,12 +20,17 @@ import { ID, PaginatedList } from '@vendure/common/lib/shared-types';
 import { unique } from '@vendure/common/lib/unique';
 import { merge } from 'rxjs';
 import { debounceTime, filter } from 'rxjs/operators';
-import { In, IsNull, QueryRunner } from 'typeorm';
+import { In, InsertQueryBuilder, IsNull, ObjectLiteral, QueryRunner } from 'typeorm';
 
 import { RequestContext } from '../../api/common/request-context';
 import { RelationPaths } from '../../api/decorators/relations.decorator';
 import { TRANSACTION_MANAGER_KEY } from '../../common/constants';
-import { ForbiddenError, IllegalOperationError, UserInputError } from '../../common/error/errors';
+import {
+    ForbiddenError,
+    IllegalOperationError,
+    InternalServerError,
+    UserInputError,
+} from '../../common/error/errors';
 import { Instrument } from '../../common/instrument-decorator';
 import { ListQueryOptions } from '../../common/types/common-types';
 import { Translated } from '../../common/types/locale-types';
@@ -70,6 +75,43 @@ export type ApplyCollectionFiltersJobData = {
     applyToChangedVariantsOnly?: boolean;
 };
 
+type CollectionProductVariantJunction = {
+    tableName: string;
+    collectionIdColumn: string;
+    productVariantIdColumn: string;
+};
+
+/**
+ * `Job.fail()` records only `error.message`, and it goes into a JobRecord column which is a plain
+ * `varchar` — 255 characters on most drivers. The message therefore has to name the underlying
+ * causes itself, on one line and within that budget, or the job list shows which Collections
+ * failed but nothing about why.
+ */
+const MAX_JOB_ERROR_LENGTH = 250;
+const MAX_UNDERLYING_ERROR_LENGTH = 120;
+
+function truncate(value: string, maxLength: number): string {
+    if (maxLength <= 3) {
+        return '';
+    }
+    return value.length <= maxLength ? value : `${value.slice(0, maxLength - 3)}...`;
+}
+
+function summarizeError(e: unknown): string {
+    const message = e instanceof Error ? `${e.name}: ${e.message}` : String(e);
+    return truncate(message.replace(/\s+/g, ' ').trim(), MAX_UNDERLYING_ERROR_LENGTH);
+}
+
+function summarizeCollectionFilterFailures(
+    failures: Array<{ id: ID; error: string }>,
+    totalCollections: number,
+): string {
+    const prefix = `Could not apply the filters of ${failures.length} of ${totalCollections} Collections (ids: `;
+    const suffix = '). See the preceding errors for details.';
+    const details = failures.map(failure => `${String(failure.id)} (${failure.error})`).join(', ');
+    return prefix + truncate(details, MAX_JOB_ERROR_LENGTH - prefix.length - suffix.length) + suffix;
+}
+
 /**
  * @description
  * Contains methods relating to {@link Collection} entities.
@@ -82,6 +124,7 @@ export class CollectionService implements OnModuleInit {
     private rootCollection: Translated<Collection> | undefined;
     private applyFiltersQueue: JobQueue<ApplyCollectionFiltersJobData>;
     private applyAllFiltersOnProductUpdates = true;
+    private productVariantJunction: CollectionProductVariantJunction | undefined;
 
     constructor(
         private connection: TransactionalConnection,
@@ -147,6 +190,7 @@ export class CollectionService implements OnModuleInit {
                 }
                 Logger.verbose(`Processing ${collectionIds.length} Collections`);
                 let completed = 0;
+                const failures: Array<{ id: ID; error: string }> = [];
                 for (const collectionId of collectionIds) {
                     if (job.state === JobState.CANCELLED) {
                         throw new Error(`Job was cancelled`);
@@ -175,6 +219,7 @@ export class CollectionService implements OnModuleInit {
                                     `the collection "${translatedCollection.name}" (id: ${collection.id})`,
                             );
                             Logger.error(e.message);
+                            failures.push({ id: collection.id, error: summarizeError(e) });
                             continue;
                         }
                         job.setProgress(Math.ceil((completed / collectionIds.length) * 100));
@@ -187,6 +232,13 @@ export class CollectionService implements OnModuleInit {
                             );
                         }
                     }
+                }
+                if (failures.length) {
+                    // The other Collections were still processed, but the contents of these ones are
+                    // now out of sync with their filters and will stay that way until the job is run
+                    // again. Failing the job makes that visible, rather than reporting a successful
+                    // run which silently left stale Collection contents behind.
+                    throw new Error(summarizeCollectionFilterFailures(failures, collectionIds.length));
                 }
                 return { processedCollections: completed };
             },
@@ -859,32 +911,51 @@ export class CollectionService implements OnModuleInit {
             removeQb.getRawMany().then(results => results.map(result => result.id)),
         ]);
 
-        try {
-            await this.connection.rawConnection.transaction(async transactionalEntityManager => {
-                const chunkedDeleteIds = this.chunkArray(toRemoveIds, 5000);
-                const chunkedAddIds = this.chunkArray(toAddIds, 5000);
-                await Promise.all([
-                    // Delete variants that should no longer be in the collection
-                    ...chunkedDeleteIds.map(chunk =>
+        const junction = this.getProductVariantJunction();
+
+        // A failure here must not be swallowed: the caller treats the returned ids as variants
+        // whose membership has been written, and goes on to reindex them and publish events for
+        // them. Reporting success for a write which did not happen leaves the Collection contents
+        // permanently out of sync with the search index and the storefront.
+        await this.connection.rawConnection.transaction(async transactionalEntityManager => {
+            const chunkedDeleteIds = this.chunkArray(toRemoveIds, 5000);
+            const chunkedAddIds = this.chunkArray(toAddIds, 5000);
+            await Promise.all([
+                // Delete variants that should no longer be in the collection
+                ...chunkedDeleteIds.map(chunk =>
+                    transactionalEntityManager
+                        .createQueryBuilder()
+                        .relation(Collection, 'productVariants')
+                        .of(collection)
+                        .remove(chunk),
+                ),
+                // Add the variants that should be in the collection. `toAddIds` was computed from a
+                // snapshot taken before this transaction, so a concurrent run of this method for
+                // the same Collection may have inserted some of these rows in the meantime. Rows
+                // which are already there are ignored rather than failing on a duplicate key.
+                ...chunkedAddIds.map(chunk =>
+                    this.ignoreExistingRows(
                         transactionalEntityManager
                             .createQueryBuilder()
-                            .relation(Collection, 'productVariants')
-                            .of(collection)
-                            .remove(chunk),
-                    ),
-                    // Adding options that should be in the collection
-                    ...chunkedAddIds.map(chunk =>
-                        transactionalEntityManager
-                            .createQueryBuilder()
-                            .relation(Collection, 'productVariants')
-                            .of(collection)
-                            .add(chunk),
-                    ),
-                ]);
-            });
-        } catch (e: any) {
-            Logger.error(e);
-        }
+                            .insert()
+                            // The junction table has no entity metadata, so without an explicit
+                            // column list a multi-row insert would fall back on the physical column
+                            // order of the table.
+                            .into(junction.tableName, [
+                                junction.collectionIdColumn,
+                                junction.productVariantIdColumn,
+                            ])
+                            .values(
+                                chunk.map(id => ({
+                                    [junction.collectionIdColumn]: collection.id,
+                                    [junction.productVariantIdColumn]: id,
+                                })),
+                            ),
+                        junction,
+                    ).execute(),
+                ),
+            ]);
+        });
 
         if (applyToChangedVariantsOnly) {
             return [...toAddIds, ...toRemoveIds];
@@ -894,6 +965,59 @@ export class CollectionService implements OnModuleInit {
             ...(await existingVariantsQb.getRawMany().then(results => results.map(result => result.id))),
             ...toRemoveIds,
         ];
+    }
+
+    /**
+     * Returns the table and column names of the junction table which holds the
+     * Collection <-> ProductVariant relation.
+     */
+    private getProductVariantJunction(): CollectionProductVariantJunction {
+        if (!this.productVariantJunction) {
+            const junction = this.connection.rawConnection
+                .getMetadata(Collection)
+                .findRelationWithPropertyPath('productVariants')?.junctionEntityMetadata;
+            if (!junction) {
+                throw new InternalServerError(
+                    'Could not resolve the junction table of the Collection.productVariants relation',
+                );
+            }
+            this.productVariantJunction = {
+                tableName: junction.tableName,
+                collectionIdColumn: junction.ownerColumns[0].databaseName,
+                productVariantIdColumn: junction.inverseColumns[0].databaseName,
+            };
+        }
+        return this.productVariantJunction;
+    }
+
+    /**
+     * Makes an insert into the Collection <-> ProductVariant junction table tolerant of rows which
+     * are already there.
+     *
+     * The clause is chosen from the driver's `supportedUpsertTypes` rather than from its name, so
+     * that any driver which supports one of these forms gets it:
+     *
+     * - `on-conflict-do-update` (postgres, cockroach, the sqlite family): `ON CONFLICT DO NOTHING`.
+     * - `on-duplicate-key-update` (mysql, mariadb): a no-op `ON DUPLICATE KEY UPDATE`. TypeORM's
+     *   `orIgnore()` compiles to `INSERT IGNORE` there, which also downgrades unrelated errors such
+     *   as foreign key violations to warnings, so only duplicates are tolerated here instead.
+     * - anything else (mssql, oracle, sap, spanner): the insert is left alone. TypeORM would
+     *   compile a conflict clause on those drivers to `MERGE INTO`, which needs the target table's
+     *   entity metadata — the junction table has none — so the plain insert used before this change
+     *   is kept.
+     */
+    private ignoreExistingRows(
+        qb: InsertQueryBuilder<ObjectLiteral>,
+        junction: CollectionProductVariantJunction,
+    ): InsertQueryBuilder<ObjectLiteral> {
+        const supportedUpsertTypes = this.connection.rawConnection.driver.supportedUpsertTypes;
+        if (supportedUpsertTypes.includes('on-conflict-do-update')) {
+            return qb.orIgnore();
+        }
+        if (supportedUpsertTypes.includes('on-duplicate-key-update')) {
+            return qb.orUpdate([junction.collectionIdColumn]);
+        }
+        return qb;
     }
 
     /**


### PR DESCRIPTION
Supersedes https://github.com/vendurehq/vendure/pull/5281 following its retarget to `minor`.

This preserves @brmk's original implementation, tests, and commit authorship. The replacement applies that single change directly to `minor` without carrying unrelated `master` history.

Fixes https://github.com/vendurehq/vendure/issues/5280.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791575885&installation_model_id=20193&pr_number=5335&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5335&signature=2c7bf149b77b61db2c6a01485c0a3518f2b8d8f0e0096e86d434727fb32c3455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->