### PR TITLE
docs: note that field resolvers only get guards and how to hook per-field logic

### DIFF
--- a/docs/docs/guides/developer-guide/the-api-layer/index.mdx
+++ b/docs/docs/guides/developer-guide/the-api-layer/index.mdx
@@ -196,6 +196,41 @@ export const config: VendureConfig = {
 };
 ```
 
+:::note
+Field resolvers — those declared with `@ResolveField()` — only get guards. A globally-registered interceptor or
+exception filter runs for queries and mutations, but never for a field resolver. This is deliberate: the other
+enhancers would then run once per resolved field, which for a list of products means once per field per product.
+
+If you need per-field behaviour such as timing or logging, use an
+[`apiOptions.apolloServerPlugins`](/reference/typescript-api/configuration/api-options#apolloserverplugins)
+plugin with the `willResolveField` hook, which _does_ fire for every field:
+
+```ts
+const perfPlugin: ApolloServerPlugin = {
+    async requestDidStart() {
+        return {
+            async executionDidStart() {
+                return {
+                    willResolveField({ info }) {
+                        const start = process.hrtime.bigint();
+                        return () => {
+                            const ms = Number(process.hrtime.bigint() - start) / 1e6;
+                            if (10 < ms) {
+                                Logger.info(`${info.parentType.name}.${info.fieldName}: ${ms}ms`);
+                            }
+                        };
+                    },
+                };
+            },
+        };
+    },
+};
+```
+
+If you want traces rather than log lines, the [`@vendure/telemetry-plugin`](/reference/core-plugins/telemetry-plugin/)
+package already emits a span per resolver, field resolvers included.
+:::
+
 
 
 ### Apollo Server plugins

--- a/docs/docs/guides/developer-guide/the-api-layer/index.mdx
+++ b/docs/docs/guides/developer-guide/the-api-layer/index.mdx
@@ -206,6 +206,9 @@ If you need per-field behaviour such as timing or logging, use an
 plugin with the `willResolveField` hook, which _does_ fire for every field:
 
 ```ts
+import { ApolloServerPlugin } from '@apollo/server';
+import { Logger, VendureConfig } from '@vendure/core';
+
 const perfPlugin: ApolloServerPlugin = {
     async requestDidStart() {
         return {
@@ -223,6 +226,13 @@ const perfPlugin: ApolloServerPlugin = {
                 };
             },
         };
+    },
+};
+
+export const config: VendureConfig = {
+    // ...
+    apiOptions: {
+        apolloServerPlugins: [perfPlugin],
     },
 };
 ```


### PR DESCRIPTION
# Description

Supersedes https://github.com/vendurehq/vendure/pull/5318 because maintainer changes could not be pushed to the contributor's fork.

The original documentation change was authored by @brmk. It clarifies that field resolvers receive guards but not globally registered interceptors or exception filters, and documents supported per-field alternatives.

This superseding pull request preserves the contributor's original commit and adds a separate maintainer commit that completes the Apollo plugin example with the required imports and registration.

Closes https://github.com/vendurehq/vendure/issues/5268.

# Verification

- `cd docs && bun run test:mdx`
- Frontmatter: 831 files passed
- Admonitions: 831 files passed
- Code languages: 4,774 blocks passed
- MDX compilation: 831/831 files passed
- Total errors: 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791577735&installation_model_id=20193&pr_number=5336&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5336&signature=922448e91bfe113145949018a6dd0e1ef33002484f418611bea52a6e532ae50e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->