### PR TITLE
fix(dashboard): restore display component precedence over core cell fn

### DIFF
--- a/docs/docs/guides/extending-the-dashboard/customizing-pages/customizing-list-pages.mdx
+++ b/docs/docs/guides/extending-the-dashboard/customizing-pages/customizing-list-pages.mdx
@@ -45,6 +45,8 @@ defineDashboardExtension({
 
 Use [Dev Mode](/extending-the-dashboard/extending-overview/#dev-mode) or the [Extension Targets reference](/extending-the-dashboard/customizing-pages/extension-targets/) to find the `pageId` and `blockId`.
 
+A display component replaces whatever the Dashboard would otherwise render in that column, including the built-in renderers that some columns come with. The `price` and `priceWithTax` columns, for example, are rendered as formatted money by default, and registering a display component for one of them replaces that rendering.
+
 ## Custom table cell components
 
 You can define your own custom components to render specific table cells:

--- a/packages/dashboard/src/lib/components/data-table/use-generated-columns.spec.tsx
+++ b/packages/dashboard/src/lib/components/data-table/use-generated-columns.spec.tsx
@@ -1,38 +1,51 @@
+import {
+    defineDashboardExtension,
+    executeDashboardExtensionCallbacks,
+} from '@/vdb/framework/extension-api/define-dashboard-extension.js';
 import { addDisplayComponent } from '@/vdb/framework/extension-api/display-component-extensions.js';
 import { PageBlockContext } from '@/vdb/framework/layout-engine/page-block-provider.js';
 import { PageContext } from '@/vdb/framework/layout-engine/page-provider.js';
-import { CellContext } from '@tanstack/react-table';
+import { CellContext, flexRender } from '@tanstack/react-table';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
 import { useGeneratedColumns } from './use-generated-columns.js';
 
-const fakeCellContext = {
-    cell: { getValue: () => undefined },
-    row: { original: {} },
+// The display component registry is a module-level Map with no removal API, so an entry
+// registered by one test stays visible to every later test. Each test therefore uses its
+// own pageId; reusing one would let an earlier registration decide a later result.
+const BLOCK_ID = 'test-block';
+
+const PRICE = 1234;
+
+const fields = [
+    { name: 'sku', type: 'String', nullable: false, list: false, isPaginatedList: false, isScalar: true },
+    { name: 'price', type: 'Int', nullable: false, list: false, isPaginatedList: false, isScalar: true },
+];
+
+// Mirrors product-variants-table.tsx, which supplies a `cell` for `price` but not for `sku`.
+// That asymmetry is why the documented example works on `sku` and silently fails on `price`.
+const customizeColumns = {
+    price: { cell: () => <span>core-money-cell</span> },
+} as any;
+
+const cellContext = {
+    cell: { getValue: () => PRICE },
+    row: { original: { sku: 'SKU-1', price: PRICE } },
 } as unknown as CellContext<any, any>;
 
-function renderColumnCell(pageId: string, blockId: string, columnId: string, coreCellLabel: string) {
+/**
+ * Renders one generated column's cell the way TanStack renders it. `flexRender` calls
+ * `createElement` for any function cell, so a cell using hooks behaves here as it does in
+ * a real table; calling `column.cell(context)` directly would not.
+ */
+function renderColumnCell(pageId: string, columnId: string): string {
     const captured: { columns?: Array<{ id?: string; cell?: any }> } = {};
 
     function Harness() {
         const { columns } = useGeneratedColumns({
-            fields: [
-                {
-                    name: columnId,
-                    type: 'Int',
-                    nullable: false,
-                    list: false,
-                    isPaginatedList: false,
-                    isScalar: true,
-                },
-            ],
-            customizeColumns: {
-                [columnId]: {
-                    // Simulates a core-supplied `cell` function, e.g. the Money cell on price columns.
-                    cell: () => <span>{coreCellLabel}</span>,
-                },
-            } as any,
+            fields,
+            customizeColumns,
             includeSelectionColumn: false,
             includeActionsColumn: false,
         });
@@ -42,7 +55,7 @@ function renderColumnCell(pageId: string, blockId: string, columnId: string, cor
 
     renderToStaticMarkup(
         <PageContext.Provider value={{ pageId }}>
-            <PageBlockContext.Provider value={{ blockId, column: 'main' }}>
+            <PageBlockContext.Provider value={{ blockId: BLOCK_ID, column: 'main' }}>
                 <Harness />
             </PageBlockContext.Provider>
         </PageContext.Provider>,
@@ -52,35 +65,73 @@ function renderColumnCell(pageId: string, blockId: string, columnId: string, cor
     if (!column?.cell) {
         throw new Error(`Column "${columnId}" was not generated`);
     }
-    return renderToStaticMarkup(column.cell(fakeCellContext));
+    return renderToStaticMarkup(<>{flexRender(column.cell, cellContext)}</>);
 }
 
-describe('useGeneratedColumns', () => {
+describe('useGeneratedColumns display component precedence', () => {
     it('gives precedence to a registered display component over a core-supplied cell function', () => {
         const pageId = 'test-page-registered';
-        const blockId = 'test-block';
-        const columnId = 'price';
 
         addDisplayComponent({
             pageId,
-            blockId,
-            field: columnId,
+            blockId: BLOCK_ID,
+            field: 'price',
             component: () => <span>registered-display-component</span>,
         });
 
-        const html = renderColumnCell(pageId, blockId, columnId, 'core-cell');
+        expect(renderColumnCell(pageId, 'price')).toBe('<span>registered-display-component</span>');
+    });
 
-        expect(html).toContain('registered-display-component');
-        expect(html).not.toContain('core-cell');
+    it('passes the cell value to a display component that overrides a core-supplied cell', () => {
+        const pageId = 'test-page-value';
+
+        addDisplayComponent({
+            pageId,
+            blockId: BLOCK_ID,
+            field: 'price',
+            component: ({ value }) => <span>{`value:${value as number}`}</span>,
+        });
+
+        expect(renderColumnCell(pageId, 'price')).toBe(`<span>value:${PRICE}</span>`);
     });
 
     it('falls back to the core-supplied cell function when no display component is registered', () => {
-        const pageId = 'test-page-unregistered';
-        const blockId = 'test-block';
-        const columnId = 'price';
+        expect(renderColumnCell('test-page-unregistered', 'price')).toBe('<span>core-money-cell</span>');
+    });
 
-        const html = renderColumnCell(pageId, blockId, columnId, 'core-cell');
+    it('still renders a registered display component on a column with no core-supplied cell', () => {
+        const pageId = 'test-page-no-core-cell';
 
-        expect(html).toContain('core-cell');
+        addDisplayComponent({
+            pageId,
+            blockId: BLOCK_ID,
+            field: 'sku',
+            component: () => <span>sku-display-component</span>,
+        });
+
+        expect(renderColumnCell(pageId, 'sku')).toBe('<span>sku-display-component</span>');
+    });
+
+    it('renders the default display component when a column has neither a core cell nor a registration', () => {
+        expect(renderColumnCell('test-page-default', 'sku')).toBe(String(PRICE));
+    });
+
+    it('applies a display component registered through defineDashboardExtension', () => {
+        // The route real extensions take. registerDataTableExtensions defaults blockId to
+        // 'list-table', so the block has to be named explicitly to target this table.
+        const pageId = 'test-page-extension-api';
+
+        defineDashboardExtension({
+            dataTables: [
+                {
+                    pageId,
+                    blockId: BLOCK_ID,
+                    displayComponents: [{ column: 'price', component: () => <span>via-extension-api</span> }],
+                },
+            ],
+        });
+        executeDashboardExtensionCallbacks();
+
+        expect(renderColumnCell(pageId, 'price')).toBe('<span>via-extension-api</span>');
     });
 });

--- a/packages/dashboard/src/lib/components/data-table/use-generated-columns.spec.tsx
+++ b/packages/dashboard/src/lib/components/data-table/use-generated-columns.spec.tsx
@@ -1,0 +1,86 @@
+import { addDisplayComponent } from '@/vdb/framework/extension-api/display-component-extensions.js';
+import { PageBlockContext } from '@/vdb/framework/layout-engine/page-block-provider.js';
+import { PageContext } from '@/vdb/framework/layout-engine/page-provider.js';
+import { CellContext } from '@tanstack/react-table';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { useGeneratedColumns } from './use-generated-columns.js';
+
+const fakeCellContext = {
+    cell: { getValue: () => undefined },
+    row: { original: {} },
+} as unknown as CellContext<any, any>;
+
+function renderColumnCell(pageId: string, blockId: string, columnId: string, coreCellLabel: string) {
+    const captured: { columns?: Array<{ id?: string; cell?: any }> } = {};
+
+    function Harness() {
+        const { columns } = useGeneratedColumns({
+            fields: [
+                {
+                    name: columnId,
+                    type: 'Int',
+                    nullable: false,
+                    list: false,
+                    isPaginatedList: false,
+                    isScalar: true,
+                },
+            ],
+            customizeColumns: {
+                [columnId]: {
+                    // Simulates a core-supplied `cell` function, e.g. the Money cell on price columns.
+                    cell: () => <span>{coreCellLabel}</span>,
+                },
+            } as any,
+            includeSelectionColumn: false,
+            includeActionsColumn: false,
+        });
+        captured.columns = columns as any;
+        return null;
+    }
+
+    renderToStaticMarkup(
+        <PageContext.Provider value={{ pageId }}>
+            <PageBlockContext.Provider value={{ blockId, column: 'main' }}>
+                <Harness />
+            </PageBlockContext.Provider>
+        </PageContext.Provider>,
+    );
+
+    const column = captured.columns?.find(c => c.id === columnId);
+    if (!column?.cell) {
+        throw new Error(`Column "${columnId}" was not generated`);
+    }
+    return renderToStaticMarkup(column.cell(fakeCellContext));
+}
+
+describe('useGeneratedColumns', () => {
+    it('gives precedence to a registered display component over a core-supplied cell function', () => {
+        const pageId = 'test-page-registered';
+        const blockId = 'test-block';
+        const columnId = 'price';
+
+        addDisplayComponent({
+            pageId,
+            blockId,
+            field: columnId,
+            component: () => <span>registered-display-component</span>,
+        });
+
+        const html = renderColumnCell(pageId, blockId, columnId, 'core-cell');
+
+        expect(html).toContain('registered-display-component');
+        expect(html).not.toContain('core-cell');
+    });
+
+    it('falls back to the core-supplied cell function when no display component is registered', () => {
+        const pageId = 'test-page-unregistered';
+        const blockId = 'test-block';
+        const columnId = 'price';
+
+        const html = renderColumnCell(pageId, blockId, columnId, 'core-cell');
+
+        expect(html).toContain('core-cell');
+    });
+});

--- a/packages/dashboard/src/lib/components/data-table/use-generated-columns.tsx
+++ b/packages/dashboard/src/lib/components/data-table/use-generated-columns.tsx
@@ -138,20 +138,24 @@ export function useGeneratedColumns<T extends TypedDocumentNode<any, any>>({
                 pageId && pageBlock?.blockId
                     ? generateDisplayComponentKey(pageId, pageBlock.blockId, fieldInfo.name)
                     : undefined;
-            // A component registered via addDisplayComponent() must take precedence over a
-            // core-supplied `cell` function (e.g. the Money cell on price columns), otherwise
-            // registering an override for such a column silently does nothing.
-            const hasRegisteredDisplayComponent = !!(
-                displayComponentId && getDisplayComponent(displayComponentId)
-            );
+            // A component registered via addDisplayComponent() takes precedence over a
+            // core-supplied `cell` function (e.g. the Money cell on price columns). Without
+            // this, registering an override for such a column silently does nothing.
+            //
+            // The registry is read here rather than at cell-render time, so a column keeps
+            // whichever renderer was chosen when this memo last ran. Extensions register
+            // during executeDashboardExtensionCallbacks(), which completes before any data
+            // table mounts, so the answer is settled by the time a column is generated.
+            const registeredDisplayComponent = displayComponentId
+                ? getDisplayComponent(displayComponentId)
+                : undefined;
 
-            // If a custom cell function is provided and no display component is registered for
-            // this column, use it directly (like additionalColumns does). This preserves the
-            // same behavior and prevents cell unmounting issues.
-            // Only use CellWrapper for columns without custom cells, or where a registered
-            // display component needs to take precedence over the custom cell function.
+            // Where nothing is registered, a custom cell function is used directly rather
+            // than through CellWrapper, which is what keeps the cell from unmounting on
+            // every table re-render. Everything else goes through CellWrapper, which is the
+            // only place the display component registry is consulted.
             const cellFn =
-                typeof customCell === 'function' && !hasRegisteredDisplayComponent
+                typeof customCell === 'function' && !registeredDisplayComponent
                     ? customCell
                     : (cellContext: CellContext<any, any>) => (
                           <CellWrapper
@@ -242,7 +246,19 @@ export function useGeneratedColumns<T extends TypedDocumentNode<any, any>>({
         }
 
         return { columns: finalColumns, customFieldColumnNames };
-    }, [fields, customizeColumns, rowActions, deleteMutation, additionalColumns, defaultColumnOrder]);
+        // `pageId` and `pageBlock?.blockId` are dependencies because they form the display
+        // component registry key, so a column generated under one page or block must not be
+        // reused under another.
+    }, [
+        fields,
+        customizeColumns,
+        rowActions,
+        deleteMutation,
+        additionalColumns,
+        defaultColumnOrder,
+        pageId,
+        pageBlock?.blockId,
+    ]);
 
     return { columns, customFieldColumnNames };
 }

--- a/packages/dashboard/src/lib/components/data-table/use-generated-columns.tsx
+++ b/packages/dashboard/src/lib/components/data-table/use-generated-columns.tsx
@@ -138,12 +138,20 @@ export function useGeneratedColumns<T extends TypedDocumentNode<any, any>>({
                 pageId && pageBlock?.blockId
                     ? generateDisplayComponentKey(pageId, pageBlock.blockId, fieldInfo.name)
                     : undefined;
+            // A component registered via addDisplayComponent() must take precedence over a
+            // core-supplied `cell` function (e.g. the Money cell on price columns), otherwise
+            // registering an override for such a column silently does nothing.
+            const hasRegisteredDisplayComponent = !!(
+                displayComponentId && getDisplayComponent(displayComponentId)
+            );
 
-            // If a custom cell function is provided, use it directly (like additionalColumns does).
-            // This preserves the same behavior and prevents cell unmounting issues.
-            // Only use CellWrapper for columns without custom cells.
+            // If a custom cell function is provided and no display component is registered for
+            // this column, use it directly (like additionalColumns does). This preserves the
+            // same behavior and prevents cell unmounting issues.
+            // Only use CellWrapper for columns without custom cells, or where a registered
+            // display component needs to take precedence over the custom cell function.
             const cellFn =
-                typeof customCell === 'function'
+                typeof customCell === 'function' && !hasRegisteredDisplayComponent
                     ? customCell
                     : (cellContext: CellContext<any, any>) => (
                           <CellWrapper


### PR DESCRIPTION
# Description

Fixes #5201.

`useGeneratedColumns` decides how to render each column's cell like this: if `customizeColumns` supplies a `cell` function, use it directly; otherwise render through `CellWrapper`, which is the only place that looks up the `displayComponents` registry (`addDisplayComponent`/`generateDisplayComponentKey`). That means any column where the core already supplies a `cell` — money columns being the obvious example — can never be overridden through the registry. Registering a display component for that `pageId_blockId_field` key silently does nothing.

This was a regression from #4064. Before that PR (since #2e9f8629), the cell renderer checked the registry first and only fell back to the custom cell function if nothing was registered. #4064 replaced that with today's straight short-circuit while fixing an unrelated facet-values re-render/unmounting issue.

The fix restores the registry-first precedence: a column now checks whether a display component is registered for its key, and only bypasses `CellWrapper` for the direct-custom-cell-function path when nothing is registered there. When nothing's registered, behavior is unchanged from today (still bypasses `CellWrapper`, so #4064's fix stays intact).

Added a test alongside `use-generated-columns.tsx` covering both cases: a registered display component wins over a core-supplied cell, and the core cell still renders when nothing is registered. Confirmed the new test fails against the current code and passes with the fix.

# Breaking changes

None. This restores prior, documented precedence for the `displayComponents` registry; a column with a registered display component now shows it instead of silently ignoring it.

# Screenshots

N/A — data-table cell rendering logic, covered by the added unit test.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed (not applicable — no docs describe this precedence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791583864&installation_model_id=20193&pr_number=5339&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5339&signature=5cea329c4349b62a52e713b47c0c7d28e406fbb28585f76fa37ade3fd8e3179b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->