### PR TITLE
chore: restrict Dependabot major updates to development tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,31 @@ updates:
           semver-patch-days: 7
           semver-minor-days: 7
           semver-major-days: 14
+      # Major updates are raised for development tooling only, the same rule
+      # the bun workspace applies further down. Here it can be written the
+      # short way, for two reasons that do not hold there. npm is one of the
+      # ecosystems where Dependabot supports `dependency-type`, and this
+      # project's manifest splits cleanly along that line:
+      # @vendure-io/docs-provider is the only production dependency, and
+      # @types/node, tsx and typescript are all development. The bun entry has
+      # to spell the same rule out as a list of dependency names instead; the
+      # comment there explains why.
+      #
+      # Nothing in this project is published, so a major held back here costs
+      # the docs build a version rather than reaching any downstream Vendure
+      # project. It is held back to keep it out of the review queue until
+      # someone chooses to take it deliberately.
+      allow:
+          # An allow list replaces the default rather than narrowing it, so the
+          # first entry restates the default. `all` is the same set as `direct`
+          # for npm, which has no indirect updates.
+          - dependency-type: all
+            update-types:
+                - version-update:semver-minor
+                - version-update:semver-patch
+          - dependency-type: development
+            update-types:
+                - version-update:semver-major
       groups:
           docs:
               patterns:
@@ -83,6 +108,84 @@ updates:
       # range, so a patch update always falls inside the existing range and no
       # strategy rewrites the manifest.
       versioning-strategy: increase-if-necessary
+      # Major updates are raised for development tooling only. A major version
+      # of anything that ships to users is a migration for every Vendure
+      # project downstream, so it belongs in a deliberate release rather than
+      # arriving unannounced as a pull request in the queue.
+      #
+      # This is written as an allow list of names rather than the more obvious
+      # `dependency-type: development`, for two independent reasons.
+      #
+      # First, dependency-type is not supported for the bun ecosystem. GitHub
+      # documents `production` and `development` for bundler, composer, mix,
+      # maven, npm, pip and uv only, so the key would be honoured by nothing
+      # here.
+      #
+      # Second, the manifests do not split along that line even where the key
+      # does work. typescript is a production dependency of packages/cli,
+      # eslint of the root manifest, ts-node and the @typescript-eslint family
+      # likewise, and @types/express of core and asset-server-plugin. Thirteen
+      # of the tooling packages named below are declared as a production
+      # dependency of some package, so a development-scoped rule would block
+      # exactly the major updates that are wanted. The same finding is recorded
+      # in dependabot_auto_merge.yml, which had to reject dependency-type as an
+      # auto-merge gate for the same reason.
+      #
+      # An allow list replaces the default rather than narrowing it, so the
+      # first entry has to restate the default: every dependency still gets
+      # minor and patch updates. Each entry after it adds majors back for one
+      # tooling family, and those families mirror the typescript, types,
+      # linting and dev-tooling groups below. The remaining groups — nestjs,
+      # graphql, typeorm, opentelemetry and dashboard — are runtime, and are
+      # deliberately absent.
+      #
+      # Note that ignore beats allow: a dependency matched by both is ignored.
+      # The Angular families in the ignore block below therefore stay ignored
+      # at every level, and are not resurrected by the '*' entry here.
+      allow:
+          - dependency-name: '*'
+            update-types:
+                - version-update:semver-minor
+                - version-update:semver-patch
+          - dependency-name: 'typescript'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: '@types/*'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'eslint'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'eslint-*'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: '@typescript-eslint/*'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'prettier'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'prettier-*'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'vitest'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: '@vitest/*'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'rimraf'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'concurrently'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'cross-env'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'ts-node'
+            update-types:
+                - version-update:semver-major
       ignore:
           # Workspace-internal packages are versioned by the release process.
           - dependency-name: '@vendure/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,29 +44,24 @@ updates:
           semver-patch-days: 7
           semver-minor-days: 7
           semver-major-days: 14
-      # Major updates are raised for development tooling only. The bun
-      # workspace entry below applies the same rule and sets out the reasoning
-      # in full.
+      # Major updates are held back for production dependencies, the same rule
+      # the bun workspace entry below applies across the workspace.
+      # @vendure-io/docs-provider is the only name this entry needs.
+      # @types/node, tsx and typescript are development dependencies and keep
+      # offering majors.
       #
-      # This entry states the rule as a `dependency-type`, which the bun entry
-      # cannot. npm is one of the ecosystems where Dependabot supports the key,
-      # and this project's manifest splits along it: @vendure-io/docs-provider
-      # is the only production dependency, and @types/node, tsx and typescript
-      # are all development.
-      #
-      # Nothing here is published, so a major blocked at this entry reaches no
-      # Vendure project downstream and holds back the docs build alone. The
-      # rule keeps majors out of the review queue until a maintainer picks one
-      # up.
-      allow:
-          # The first entry restates Dependabot's default, which an allow list
-          # replaces rather than narrows. `all` and `direct` are the same set
-          # for npm, which has no indirect updates.
-          - dependency-type: all
-            update-types:
-                - version-update:semver-minor
-                - version-update:semver-patch
-          - dependency-type: development
+      # This is an ignore rule where the bun entry uses an allow list, and the
+      # difference is deliberate. An allow list narrows security updates as
+      # well as version updates. npm is an ecosystem where Dependabot raises
+      # security updates, and the documented default covers every vulnerable
+      # dependency in the lock file, transitive ones included. No
+      # `dependency-type` names that set for npm — `all` stops at explicitly
+      # declared dependencies — so an allow list here would have dropped
+      # advisories for anything transitive under @vendure-io/docs-provider.
+      # `update-types` under ignore applies to version updates only, so this
+      # rule leaves security updates untouched.
+      ignore:
+          - dependency-name: '@vendure-io/docs-provider'
             update-types:
                 - version-update:semver-major
       groups:
@@ -121,26 +116,36 @@ updates:
       # versioning-strategy, because Dependabot documents support per option
       # rather than per ecosystem.
       #
-      # Second, the workspace manifests do not split along that line. All of
-      # these are production dependencies: typescript and ts-node of
-      # packages/cli, eslint, eslint-config-prettier and the
-      # @typescript-eslint packages of the root manifest, @types/express of
-      # core and asset-server-plugin, @types/react of dashboard. Thirteen of
-      # the tooling packages named below are a production dependency of some
-      # package, so a rule scoped to development dependencies would block the
-      # tooling majors this list exists to permit. dependabot_auto_merge.yml
-      # rejected dependency-type as an auto-merge gate for the same reason.
+      # Second, the workspace manifests do not split along that line, in either
+      # direction. eslint, eslint-config-prettier and the @typescript-eslint
+      # packages are production dependencies of the root manifest, typescript
+      # and ts-node of packages/cli, @types/express of core and
+      # asset-server-plugin, so a rule scoped to development dependencies
+      # would block tooling majors. dependabot_auto_merge.yml rejected
+      # dependency-type as an auto-merge gate for the same reason.
+      #
+      # The reverse holds too, which is why this list names tooling rather
+      # than every development dependency. bullmq, ioredis, pg, mysql2 and
+      # better-sqlite3 are declared as development dependencies here, but
+      # plugins peer-depend on them, so a major is a downstream migration.
       #
       # An allow list replaces the default set rather than narrowing it, so the
       # first entry has to restate the default: every dependency gets minor and
       # patch updates. Each entry after it adds majors back for one tooling
-      # family. Those families mirror the typescript, types, linting and
-      # dev-tooling groups below. The runtime groups — nestjs, graphql,
-      # typeorm, opentelemetry and dashboard — are absent on purpose.
+      # family. The runtime families — nestjs, graphql, typeorm, opentelemetry
+      # and the dashboard packages — are absent on purpose.
+      #
+      # A tooling package with no entry here stops offering majors, and the
+      # symptom is a pull request that never arrives, which nobody notices.
+      # When adding a development tool to any manifest, add it here too.
       #
       # ignore beats allow: a dependency matched by both is ignored. The
       # Angular families in the ignore block below therefore stay ignored at
       # every level, and the '*' entry here does not re-enable them.
+      #
+      # Narrowing the set costs nothing here, because Dependabot raises no
+      # security updates for bun at all, as noted above. That is not true of
+      # npm, which is why the /docs entry states its rule as an ignore.
       allow:
           - dependency-name: '*'
             update-types:
@@ -183,6 +188,75 @@ updates:
             update-types:
                 - version-update:semver-major
           - dependency-name: 'ts-node'
+            update-types:
+                - version-update:semver-major
+          # Tooling that belongs to no group above, so a major arrives on its
+          # own. @eslint/js and globals are listed because the flat config
+          # requires them to move with an eslint major.
+          - dependency-name: '@eslint/js'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'globals'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: '@commitlint/*'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'husky'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'lint-staged'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'lerna'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'conventional-changelog-core'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: '@playwright/test'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'playwright'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'jsdom'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'tinybench'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'storybook'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: '@storybook/*'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: '@graphql-codegen/*'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: '@gql.tada/cli-utils'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: '@swc/core'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'unplugin-swc'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'rollup'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: '@rollup/*'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'rollup-plugin-typescript2'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: 'vite-plugin-dts'
+            update-types:
+                - version-update:semver-major
+          - dependency-name: '@typescript/native-preview'
             update-types:
                 - version-update:semver-major
       ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,23 +44,23 @@ updates:
           semver-patch-days: 7
           semver-minor-days: 7
           semver-major-days: 14
-      # Major updates are raised for development tooling only, the same rule
-      # the bun workspace applies further down. Here it can be written the
-      # short way, for two reasons that do not hold there. npm is one of the
-      # ecosystems where Dependabot supports `dependency-type`, and this
-      # project's manifest splits cleanly along that line:
-      # @vendure-io/docs-provider is the only production dependency, and
-      # @types/node, tsx and typescript are all development. The bun entry has
-      # to spell the same rule out as a list of dependency names instead; the
-      # comment there explains why.
+      # Major updates are raised for development tooling only. The bun
+      # workspace entry below applies the same rule and sets out the reasoning
+      # in full.
       #
-      # Nothing in this project is published, so a major held back here costs
-      # the docs build a version rather than reaching any downstream Vendure
-      # project. It is held back to keep it out of the review queue until
-      # someone chooses to take it deliberately.
+      # This entry states the rule as a `dependency-type`, which the bun entry
+      # cannot. npm is one of the ecosystems where Dependabot supports the key,
+      # and this project's manifest splits along it: @vendure-io/docs-provider
+      # is the only production dependency, and @types/node, tsx and typescript
+      # are all development.
+      #
+      # Nothing here is published, so a major blocked at this entry reaches no
+      # Vendure project downstream and holds back the docs build alone. The
+      # rule keeps majors out of the review queue until a maintainer picks one
+      # up.
       allow:
-          # An allow list replaces the default rather than narrowing it, so the
-          # first entry restates the default. `all` is the same set as `direct`
+          # The first entry restates Dependabot's default, which an allow list
+          # replaces rather than narrows. `all` and `direct` are the same set
           # for npm, which has no indirect updates.
           - dependency-type: all
             update-types:
@@ -109,39 +109,38 @@ updates:
       # strategy rewrites the manifest.
       versioning-strategy: increase-if-necessary
       # Major updates are raised for development tooling only. A major version
-      # of anything that ships to users is a migration for every Vendure
-      # project downstream, so it belongs in a deliberate release rather than
-      # arriving unannounced as a pull request in the queue.
+      # of a package that ships to users is a migration for every Vendure
+      # project downstream, so it belongs in a planned release.
       #
-      # This is written as an allow list of names rather than the more obvious
+      # The rule is written as a list of dependency names rather than
       # `dependency-type: development`, for two independent reasons.
       #
-      # First, dependency-type is not supported for the bun ecosystem. GitHub
-      # documents `production` and `development` for bundler, composer, mix,
-      # maven, npm, pip and uv only, so the key would be honoured by nothing
-      # here.
+      # First, GitHub documents the `dependency-type` values `production` and
+      # `development` for bundler, composer, mix, maven, npm, pip and uv. bun
+      # is absent. That list differs from the one above for
+      # versioning-strategy, because Dependabot documents support per option
+      # rather than per ecosystem.
       #
-      # Second, the manifests do not split along that line even where the key
-      # does work. typescript is a production dependency of packages/cli,
-      # eslint of the root manifest, ts-node and the @typescript-eslint family
-      # likewise, and @types/express of core and asset-server-plugin. Thirteen
-      # of the tooling packages named below are declared as a production
-      # dependency of some package, so a development-scoped rule would block
-      # exactly the major updates that are wanted. The same finding is recorded
-      # in dependabot_auto_merge.yml, which had to reject dependency-type as an
-      # auto-merge gate for the same reason.
+      # Second, the workspace manifests do not split along that line. All of
+      # these are production dependencies: typescript and ts-node of
+      # packages/cli, eslint, eslint-config-prettier and the
+      # @typescript-eslint packages of the root manifest, @types/express of
+      # core and asset-server-plugin, @types/react of dashboard. Thirteen of
+      # the tooling packages named below are a production dependency of some
+      # package, so a rule scoped to development dependencies would block the
+      # tooling majors this list exists to permit. dependabot_auto_merge.yml
+      # rejected dependency-type as an auto-merge gate for the same reason.
       #
-      # An allow list replaces the default rather than narrowing it, so the
-      # first entry has to restate the default: every dependency still gets
-      # minor and patch updates. Each entry after it adds majors back for one
-      # tooling family, and those families mirror the typescript, types,
-      # linting and dev-tooling groups below. The remaining groups — nestjs,
-      # graphql, typeorm, opentelemetry and dashboard — are runtime, and are
-      # deliberately absent.
+      # An allow list replaces the default set rather than narrowing it, so the
+      # first entry has to restate the default: every dependency gets minor and
+      # patch updates. Each entry after it adds majors back for one tooling
+      # family. Those families mirror the typescript, types, linting and
+      # dev-tooling groups below. The runtime groups — nestjs, graphql,
+      # typeorm, opentelemetry and dashboard — are absent on purpose.
       #
-      # Note that ignore beats allow: a dependency matched by both is ignored.
-      # The Angular families in the ignore block below therefore stay ignored
-      # at every level, and are not resurrected by the '*' entry here.
+      # ignore beats allow: a dependency matched by both is ignored. The
+      # Angular families in the ignore block below therefore stay ignored at
+      # every level, and the '*' entry here does not re-enable them.
       allow:
           - dependency-name: '*'
             update-types:


### PR DESCRIPTION
## What this changes

Dependabot no longer raises major-version pull requests for dependencies that ship to users. Major updates are still raised for development tooling.

Two entries are affected: the bun workspace at `/` and the npm project at `/docs`. The `github-actions` entry is deliberately unchanged. Actions have no production or development split, and excluding majors there would move them out of the weekly grouped pull request into separate ones rather than suppress them.

## The bun workspace: an allow list of names

Dependabot has no single option for "no majors except development dependencies". The `ignore` option supports only `dependency-name`, `versions` and `update-types`, so the rule cannot be expressed there. Only `allow` has `dependency-type`, and `allow` replaces the default set rather than narrowing it, which is why the first entry restates the default of minor and patch for everything.

The obvious `dependency-type: development` does not work here, for two independent reasons:

1. GitHub documents the `dependency-type` values `production` and `development` for bundler, composer, mix, maven, npm, pip and uv. bun is absent. Note this is a different list from the one for `versioning-strategy` already cited in the file, because support is documented per option rather than per ecosystem.
2. The workspace manifests do not split along that line, in either direction. `eslint`, `eslint-config-prettier` and the `@typescript-eslint` packages are production dependencies of the root manifest, `typescript` and `ts-node` of `packages/cli`, `@types/express` of `core` and `asset-server-plugin`. Going the other way, `bullmq`, `ioredis`, `pg`, `mysql2` and `better-sqlite3` are declared as development dependencies but plugins peer-depend on them, so a major there is a downstream migration.

`dependabot_auto_merge.yml` rejected `dependency-type` as an auto-merge gate for the same reason, and the comment cross-references it.

## The /docs project: an ignore rule, not an allow list

`/docs` uses `ignore` rather than the same allow list, and the difference is load-bearing.

`allow` applies to security updates as well as version updates. npm is an ecosystem where Dependabot raises security updates, and the documented default covers every vulnerable dependency in the lock file, transitive ones included. No `dependency-type` value names that set for npm: `all` stops at explicitly declared dependencies, and `indirect` is unsupported. `update-types` does not help either, because it applies to version updates only.

An allow list on `/docs` would therefore have silently dropped security advisories for anything transitive under `@vendure-io/docs-provider`. An ignore rule scoped to `version-update:semver-major` leaves security updates untouched and achieves the same thing for version updates in one entry instead of two.

## Known trade-off

The allow list is hand-maintained, and it is duplicated in spirit by the `typescript`, `types`, `linting` and `dev-tooling` groups below it. A development tool added to a manifest but not to this list stops offering majors, and the symptom is a pull request that never arrives, which is easy to miss. The comment says so directly. An inverted form, ignoring majors on the runtime families instead, would fail safe, but it would only cover the families that happen to be grouped and would leave majors flowing for the many runtime dependencies that are in no group at all, such as `stripe`, `braintree` and `express`.

## Verification

The file parses and validates against the SchemaStore Dependabot v2 schema, and prettier passes. That confirms the YAML is legal and nothing more. Whether Dependabot applies these rules as intended is only observable in next Monday's queue.