### PR TITLE
fix(core): treat localeText custom fields as localized everywhere

### DIFF
--- a/packages/core/src/api/config/graphql-custom-fields.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.ts
@@ -13,6 +13,7 @@ import {
     BaseTypedCustomFieldConfig,
     CustomFieldConfig,
     CustomFields,
+    isLocalizedCustomFieldType,
     StructCustomFieldConfig,
     StructFieldConfig,
 } from '../../config/custom-field/custom-field-types';
@@ -84,11 +85,9 @@ export function addGraphQLCustomFields(
             }
         }
 
-        const localizedFields = customEntityFields.filter(
-            field => field.type === 'localeString' || field.type === 'localeText',
-        );
+        const localizedFields = customEntityFields.filter(field => isLocalizedCustomFieldType(field.type));
         const nonLocalizedFields = customEntityFields.filter(
-            field => field.type !== 'localeString' && field.type !== 'localeText',
+            field => !isLocalizedCustomFieldType(field.type),
         );
         const writeableLocalizedFields = localizedFields.filter(field => !field.readonly);
         const writeableNonLocalizedFields = nonLocalizedFields.filter(field => !field.readonly);

--- a/packages/core/src/config/custom-field/custom-field-types.ts
+++ b/packages/core/src/config/custom-field/custom-field-types.ts
@@ -33,6 +33,22 @@ import { RequestContext } from '../../api/common/request-context';
 import { Injector } from '../../common/injector';
 import { VendureEntity } from '../../entity/base/base.entity';
 
+/**
+ * @description
+ * Returns `true` if the given custom field type is a localized type, i.e. one whose values are
+ * stored on the entity's translation entity rather than on the entity itself.
+ *
+ * Prefer this over comparing against `'localeString'` and `'localeText'` individually, so that
+ * every site which needs to know about localized custom fields stays correct if further
+ * localized types are added.
+ *
+ * @docsCategory custom-fields
+ * @since 3.7.4
+ */
+export function isLocalizedCustomFieldType(type: CustomFieldType | StructFieldType | undefined): boolean {
+    return type === 'localeString' || type === 'localeText';
+}
+
 // prettier-ignore
 export type DefaultValueType<T extends CustomFieldType | StructFieldType> =
     T extends 'string' | 'localeString' | 'text' | 'localeText' ? string :

--- a/packages/core/src/config/custom-field/custom-field-types.ts
+++ b/packages/core/src/config/custom-field/custom-field-types.ts
@@ -38,14 +38,10 @@ import { VendureEntity } from '../../entity/base/base.entity';
  * Returns `true` if the given custom field type is a localized type, i.e. one whose values are
  * stored on the entity's translation entity rather than on the entity itself.
  *
- * Prefer this over comparing against `'localeString'` and `'localeText'` individually, so that
- * every site which needs to know about localized custom fields stays correct if further
- * localized types are added.
- *
  * @docsCategory custom-fields
  * @since 3.7.4
  */
-export function isLocalizedCustomFieldType(type: CustomFieldType | StructFieldType | undefined): boolean {
+export function isLocalizedCustomFieldType(type: CustomFieldType | undefined): boolean {
     return type === 'localeString' || type === 'localeText';
 }
 

--- a/packages/core/src/data-import/providers/import-parser/import-parser.spec.ts
+++ b/packages/core/src/data-import/providers/import-parser/import-parser.spec.ts
@@ -31,6 +31,19 @@ const mockConfigService = {
     },
 } as ConfigService;
 
+const mockConfigServiceWithLocaleText = {
+    defaultLanguageCode: LanguageCode.en,
+    customFields: {
+        Product: [
+            {
+                name: 'blurb',
+                type: 'localeText',
+            },
+        ],
+        ProductVariant: [],
+    },
+} as ConfigService;
+
 describe('ImportParser', () => {
     beforeAll(async () => {
         await ensureConfigLoaded();
@@ -114,6 +127,25 @@ describe('ImportParser', () => {
             expect(product.optionGroups[1].code).toBeUndefined();
             expect(product.optionGroups[1].translations[0].name).toBe('color');
             expect(product.optionGroups[1].translations[0].values).toEqual(['Red', 'Blue']);
+        });
+
+        // #5328 — a localeText custom field must be treated as translatable on import, like localeString
+        it('reads translations for a localeText custom field', async () => {
+            const importParser = new ImportParser(mockConfigServiceWithLocaleText);
+
+            const input = await loadTestFixture('locale-text-custom-field.csv');
+            const result = await importParser.parseProducts(input);
+
+            expect(result.errors).toEqual([]);
+            expect(result.results.length).toBe(1);
+
+            const translations = result.results[0].product.translations;
+            expect(translations.find(t => t.languageCode === LanguageCode.en)?.customFields).toEqual({
+                blurb: 'Long form English blurb',
+            });
+            expect(translations.find(t => t.languageCode === LanguageCode.de)?.customFields).toEqual({
+                blurb: 'Langer deutscher Fließtext',
+            });
         });
 
         describe('error conditions', () => {

--- a/packages/core/src/data-import/providers/import-parser/import-parser.ts
+++ b/packages/core/src/data-import/providers/import-parser/import-parser.ts
@@ -7,7 +7,10 @@ import { Stream } from 'stream';
 
 import { InternalServerError } from '../../../common/error/errors';
 import { ConfigService } from '../../../config/config.service';
-import { CustomFieldConfig } from '../../../config/custom-field/custom-field-types';
+import {
+    CustomFieldConfig,
+    isLocalizedCustomFieldType,
+} from '../../../config/custom-field/custom-field-types';
 
 const baseTranslatableColumns = [
     'name',
@@ -316,7 +319,7 @@ export class ImportParser {
                     `Could not find custom field config for column header '${baseKey}'`,
                 );
             }
-            return customFieldConfig.type === 'localeString';
+            return isLocalizedCustomFieldType(customFieldConfig.type);
         }
         throw new InternalServerError(`Invalid column header '${baseKey}'`);
     }

--- a/packages/core/src/data-import/providers/import-parser/test-fixtures/locale-text-custom-field.csv
+++ b/packages/core/src/data-import/providers/import-parser/test-fixtures/locale-text-custom-field.csv
@@ -1,0 +1,2 @@
+name:en,name:de,slug,description:en,description:de,assets,facets:en,facets:de,optionGroups,optionValues:en,optionValues:de,sku,price,taxCategory,stockOnHand,trackInventory,variantAssets,variantFacets,product:blurb:en,product:blurb:de
+Laptop,Notebook,laptop,A laptop.,Ein Laptop.,,,,size,15 inch,15 Zoll,L-15,1299,standard,10,false,,,Long form English blurb,Langer deutscher Fließtext

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -16,7 +16,11 @@ import {
 import { EmbeddedMetadataArgs } from 'typeorm/metadata-args/EmbeddedMetadataArgs';
 import { DateUtils } from 'typeorm/util/DateUtils';
 
-import { CustomFieldConfig, CustomFields } from '../config/custom-field/custom-field-types';
+import {
+    CustomFieldConfig,
+    CustomFields,
+    isLocalizedCustomFieldType,
+} from '../config/custom-field/custom-field-types';
 import { Logger } from '../config/logger/vendure-logger';
 import { VendureConfig } from '../config/vendure-config';
 
@@ -106,18 +110,18 @@ function registerCustomFieldsForEntity(
             };
 
             if (translation) {
-                if (customField.type === 'localeString' || customField.type === 'localeText') {
+                if (isLocalizedCustomFieldType(customField.type)) {
                     registerColumn();
                 }
             } else {
-                if (customField.type !== 'localeString' && customField.type !== 'localeText') {
+                if (!isLocalizedCustomFieldType(customField.type)) {
                     registerColumn();
                 }
             }
 
             const relationFieldsCount = customFields.filter(f => f.type === 'relation').length;
             const nonLocaleStringFieldsCount = customFields.filter(
-                f => f.type !== 'localeString' && f.type !== 'localeText' && f.type !== 'relation',
+                f => !isLocalizedCustomFieldType(f.type) && f.type !== 'relation',
             ).length;
 
             if (0 < relationFieldsCount && nonLocaleStringFieldsCount === 0) {
@@ -237,7 +241,7 @@ function assertLocaleFieldsNotSpecified(config: VendureConfig, entityName: keyof
     const customFields = config.customFields && config.customFields[entityName];
     if (customFields) {
         for (const customField of customFields) {
-            if (customField.type === 'localeString' || customField.type === 'localeText') {
+            if (isLocalizedCustomFieldType(customField.type)) {
                 Logger.error(
                     `Custom field "${customField.name}" on entity "${entityName}" cannot be of type "localeString" or "localeText". ` +
                         `This entity does not support localization.`,

--- a/packages/core/src/entity/validate-custom-fields-config.spec.ts
+++ b/packages/core/src/entity/validate-custom-fields-config.spec.ts
@@ -35,6 +35,33 @@ describe('validateCustomFieldsConfig()', () => {
         expect(result.errors).toEqual(['User entity does not support custom fields of type "localeString"']);
     });
 
+    // #5328 — a localeText custom field must be rejected on non-localized entities, like localeString
+    it('invalid localeText', () => {
+        const config: CustomFields = {
+            User: [
+                { name: 'foo', type: 'string' },
+                { name: 'bar', type: 'localeText' },
+            ],
+        };
+        const result = validateCustomFieldsConfig(config, allEntities);
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(['User entity does not support custom fields of type "localeText"']);
+    });
+
+    it('valid localeText on a translatable entity', () => {
+        const config: CustomFields = {
+            Product: [
+                { name: 'foo', type: 'string' },
+                { name: 'bar', type: 'localeText' },
+            ],
+        };
+        const result = validateCustomFieldsConfig(config, allEntities);
+
+        expect(result.valid).toBe(true);
+        expect(result.errors.length).toBe(0);
+    });
+
     it('valid names', () => {
         const config: CustomFields = {
             User: [

--- a/packages/core/src/entity/validate-custom-fields-config.ts
+++ b/packages/core/src/entity/validate-custom-fields-config.ts
@@ -1,7 +1,11 @@
 import { Type } from '@vendure/common/lib/shared-types';
 import { getMetadataArgsStorage } from 'typeorm';
 
-import { CustomFieldConfig, CustomFields } from '../config/custom-field/custom-field-types';
+import {
+    CustomFieldConfig,
+    CustomFields,
+    isLocalizedCustomFieldType,
+} from '../config/custom-field/custom-field-types';
 
 import { VendureEntity } from './base/base.entity';
 
@@ -14,7 +18,7 @@ function validateCustomFieldsForEntity(
         ...assertNoNameConflictsWithEntity(entity, customFields),
         ...assertNoDuplicatedCustomFieldNames(entity.name, customFields),
         ...assetNonNullablesHaveDefaults(entity.name, customFields),
-        ...(isTranslatable(entity) ? [] : assertNoLocaleStringFields(entity.name, customFields)),
+        ...(isTranslatable(entity) ? [] : assertNoLocalizedFields(entity.name, customFields)),
     ];
 }
 
@@ -70,11 +74,12 @@ function assertNoDuplicatedCustomFieldNames(entityName: string, customFields: Cu
 
 /**
  * For entities which are not localized (Address, Customer), we assert that none of the custom fields
- * have a type "localeString".
+ * have a localized type, i.e. "localeString" or "localeText".
  */
-function assertNoLocaleStringFields(entityName: string, customFields: CustomFieldConfig[]): string[] {
-    if (!!customFields.find(f => f.type === 'localeString')) {
-        return [`${entityName} entity does not support custom fields of type "localeString"`];
+function assertNoLocalizedFields(entityName: string, customFields: CustomFieldConfig[]): string[] {
+    const localizedField = customFields.find(f => isLocalizedCustomFieldType(f.type));
+    if (localizedField) {
+        return [`${entityName} entity does not support custom fields of type "${localizedField.type}"`];
     }
     return [];
 }

--- a/packages/core/src/service/helpers/list-query-builder/parse-sort-params.ts
+++ b/packages/core/src/service/helpers/list-query-builder/parse-sort-params.ts
@@ -6,7 +6,10 @@ import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata';
 
 import { UserInputError } from '../../../common/error/errors';
 import { NullOptionals, SortParameter } from '../../../common/types/common-types';
-import { CustomFieldConfig } from '../../../config/custom-field/custom-field-types';
+import {
+    CustomFieldConfig,
+    isLocalizedCustomFieldType,
+} from '../../../config/custom-field/custom-field-types';
 import { VendureEntity } from '../../../entity/base/base.entity';
 
 import { escapeCalculatedColumnExpression, getColumnMetadata } from './connection-utils';
@@ -47,9 +50,7 @@ export function parseSortParams<T extends VendureEntity>(
 
             const pathParts = [translationsAlias];
             const customFieldType = customFields?.find(f => f.name === key)?.type;
-            const isLocalizedCustomField =
-                customFieldType === 'localeString' || customFieldType === 'localeText';
-            if (isLocalizedCustomField) {
+            if (isLocalizedCustomFieldType(customFieldType)) {
                 pathParts.push('customFields');
             }
             pathParts.push(key);


### PR DESCRIPTION
`localeText` custom fields were missed at two sites which only checked for `localeString`:

- `ImportParser.isTranslatable()` returned false for a `localeText` custom field, so a CSV using its translation columns was rejected with "The '<field>' field is not translatable."
- `validateCustomFieldsConfig()` did not reject `localeText` custom fields configured on non-localized entities.

To stop the `localeString`/`localeText` pair from drifting apart again, this adds an exported `isLocalizedCustomFieldType()` predicate alongside the custom field types and uses it at every site that needs to distinguish localized custom fields.

The config validation error now names the offending type, so the existing `localeString` message is unchanged.

Fixes #5328

# Description

Please include a summary of the changes and the related issue.

# Breaking changes

Does this PR include any breaking changes we should be aware of?

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791639039&installation_model_id=20193&pr_number=5349&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5349&signature=0109cdd464b186b81a53affc592b41652f051ca4da636090a03676dae7f4320c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->