### PR TITLE
Allow multiple option-less variants via createProductVariants

### DIFF
--- a/packages/core/e2e/product.e2e-spec.ts
+++ b/packages/core/e2e/product.e2e-spec.ts
@@ -1796,6 +1796,55 @@ describe('Product resolver', () => {
                     expect(product2?.variantList.items.length).toBe(1);
                 });
             });
+
+            // #5325 — multiple option-less variants can be created for the same product
+            it('createProductVariants creates multiple variants for a product without option groups', async () => {
+                const { createProduct } = await adminClient.query(createProductDocument, {
+                    input: {
+                        translations: [
+                            {
+                                languageCode: LanguageCode.en,
+                                name: 'Product without options',
+                                slug: 'product-without-options',
+                            },
+                        ],
+                    },
+                });
+
+                const { createProductVariants: firstCreate } = await adminClient.query(
+                    createProductVariantsDocument,
+                    {
+                        input: [
+                            {
+                                productId: createProduct.id,
+                                sku: 'OPTIONLESS-1',
+                                optionIds: [],
+                                translations: [{ languageCode: LanguageCode.en, name: 'Option-less 1' }],
+                            },
+                        ],
+                    },
+                );
+                const { createProductVariants: secondCreate } = await adminClient.query(
+                    createProductVariantsDocument,
+                    {
+                        input: [
+                            {
+                                productId: createProduct.id,
+                                sku: 'OPTIONLESS-2',
+                                optionIds: [],
+                                translations: [{ languageCode: LanguageCode.en, name: 'Option-less 2' }],
+                            },
+                        ],
+                    },
+                );
+
+                const firstVariant = firstCreate[0];
+                const secondVariant = secondCreate[0];
+                variantGuard.assertSuccess(firstVariant);
+                variantGuard.assertSuccess(secondVariant);
+                expect(firstVariant.options).toEqual([]);
+                expect(secondVariant.options).toEqual([]);
+            });
         });
     });
 

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -1117,7 +1117,7 @@ export class ProductVariantService {
             .filter(v => !v.deletedAt)
             .forEach(variant => {
                 const variantOptionIds = this.sortJoin(variant.options, ',', 'id');
-                if (isUpdateOperation) return;
+                if (isUpdateOperation || activeOptions.length === 0) return;
                 if (variantOptionIds === inputOptionIds) {
                     throw new UserInputError('error.product-variant-options-combination-already-exists', {
                         variantName: this.translator.translate(variant, ctx).name,


### PR DESCRIPTION
`validateVariantOptionIds` only skips its duplicate-combination check on the update path. A product with zero option groups always has `optionIds: []`, so every option-less variant's `sortJoin` collapses to the same empty string, and the second `createProductVariants` call for such a product collides against the first variant's empty string and throws `error.product-variant-options-combination-already-exists`, even though there's no real combination to conflict on.

`updateProductVariant` already carves this out via `isUpdateOperation`, and `FastImporterService` bypasses the check entirely, so editing and bulk import already allow this shape — this just extends the same carve-out to `createProductVariants` when the product has no option groups at all.

Added an e2e test for creating two option-less variants one at a time on a fresh product.

Fixes #5325

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791687387&installation_model_id=20193&pr_number=5355&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5355&signature=b6e93d92abc590c5e00662dade83e02dcb9200e434b5db6cbc21ab43e52d3755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->