### PR TITLE
feat(cli): group the CLI help output by the package that provided each command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -195,10 +195,10 @@
       },
       "dependencies": {
         "@clack/prompts": "^0.7.0",
-        "@vendure/common": "3.7.0",
+        "@vendure/common": "3.7.2",
         "change-case": "^4.1.2",
         "chokidar": "^3.6.0",
-        "commander": "^11.0.0",
+        "commander": "^14.0.1",
         "cross-spawn": "^7.0.6",
         "dotenv": "^16.4.5",
         "fs-extra": "^11.2.0",
@@ -211,8 +211,8 @@
         "vite": "^7.3.1",
       },
       "devDependencies": {
-        "@vendure/core": "3.7.0",
-        "@vendure/testing": "3.7.0",
+        "@vendure/core": "3.7.2",
+        "@vendure/testing": "3.7.2",
         "cross-env": "^7.0.3",
       },
     },
@@ -3098,7 +3098,7 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
-    "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "comment-parser": ["comment-parser@1.3.1", "", {}, "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA=="],
 
@@ -5132,7 +5132,7 @@
 
     "selfsigned": ["selfsigned@2.4.1", "", { "dependencies": { "@types/node-forge": "^1.3.0", "node-forge": "^1" } }, "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q=="],
 
-    "semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
 
@@ -5908,6 +5908,8 @@
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
+    "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
     "@dotenvx/dotenvx/dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
 
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
@@ -6264,8 +6266,6 @@
 
     "@vendure/create/@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, ""],
 
-    "@vendure/create/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
     "@vendure/dashboard/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
     "@vendure/dashboard/eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "bin": "bin/eslint.js" }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
@@ -6323,6 +6323,8 @@
     "body-parser/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "body-parser/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
+
+    "bullmq/semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "cacache/@npmcli/fs": ["@npmcli/fs@5.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og=="],
 
@@ -6503,8 +6505,6 @@
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "hpack.js/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
-
-    "htmlnano/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "husky/cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
@@ -6990,8 +6990,6 @@
 
     "set-value/is-plain-object": ["is-plain-object@2.0.4", "", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
 
-    "shadcn/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
     "shadcn/dedent": ["dedent@1.7.2", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA=="],
 
     "shadcn/diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
@@ -7013,8 +7011,6 @@
     "shadcn/ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
 
     "shadcn/validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
-
-    "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "socket.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
@@ -7041,6 +7037,8 @@
     "subscriptions-transport-ws/symbol-observable": ["symbol-observable@1.2.0", "", {}, "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="],
 
     "subscriptions-transport-ws/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "svgo/sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
@@ -7597,8 +7595,6 @@
     "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "@types/pg-pool/@types/pg/pg-protocol": ["pg-protocol@1.10.3", "", {}, "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ=="],
 
     "@typescript-eslint/utils/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -558,8 +558,41 @@ Declare the entry point in that package's `package.json`:
 }
 ```
 
-The optional `cliCommands` list lets the CLI give actionable errors for unknown
-commands without loading the plugin.
+The optional `cliCommands` list is what the CLI can read without loading the
+plugin. It uses it to give an actionable error for an unknown command, and to
+say what an installed but not yet enabled package would add when you run
+`vendure plugins`. Once a plugin is enabled the CLI reads its commands from the
+plugin itself, so this list only has to be right for a package that is not
+enabled yet.
+
+### How plugin commands appear in the help
+
+`vendure --help` lists the commands and shared options a plugin registers under
+a heading naming the package, so it is clear where each one came from:
+
+```
+Options:
+  -V, --version             output the version number
+  -h, --help                display help for command
+
+Options from @example/vendure-cli-plugin:
+  --token <token>           API token
+
+Commands:
+  add [options]             Add a feature to your Vendure project
+  ...
+
+Commands from @example/vendure-cli-plugin:
+  hello [options]           Say hello
+```
+
+The heading uses the package name exactly as it is installed, so it names the
+thing to enable or remove. Nothing changes about how a command is run: `vendure
+hello` is still `vendure hello`.
+
+A command extended through `extendCommands` rather than registered outright
+stays under the heading it already had, because the command is still the one
+that declared it.
 
 ### Nested commands
 

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -558,10 +558,10 @@ Declare the entry point in that package's `package.json`:
 }
 ```
 
-The optional `cliCommands` list is what the CLI can read without loading the
-plugin. It uses it to give an actionable error for an unknown command, and to
-say what an installed but not yet enabled package would add when you run
-`vendure plugins`. Once a plugin is enabled the CLI reads its commands from the
+The CLI can read the optional `cliCommands` list without loading the plugin.
+It uses the list to give an actionable error for an unknown command, and to say
+what an installed but not yet enabled package would add when you run `vendure
+plugins`. Once a plugin is enabled the CLI reads its commands from the
 plugin itself, so this list only has to be right for a package that is not
 enabled yet.
 

--- a/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
@@ -249,6 +249,37 @@ describe('CLI plugin help output', () => {
         }
     });
 
+    it('lists the plugin commands under a heading naming the package', async () => {
+        const result = await project.runCliCommand(['--help']);
+
+        const heading = 'Commands from @vendure-e2e/cloud-cli-plugin:';
+        expect(result.stdout).toContain(heading);
+
+        // The built-ins keep Commander's own heading, and every plugin command
+        // sits below the plugin's, so the section a command is listed in is
+        // what actually says where it came from.
+        const builtinsAt = result.stdout.indexOf('\nCommands:');
+        const pluginAt = result.stdout.indexOf(heading);
+        expect(builtinsAt).toBeGreaterThan(-1);
+        expect(builtinsAt).toBeLessThan(pluginAt);
+        expect(result.stdout.indexOf('Manage Cloud projects')).toBeGreaterThan(pluginAt);
+        expect(result.stdout.indexOf('Add a feature to your Vendure project')).toBeLessThan(pluginAt);
+    });
+
+    it('lists the plugin shared options under a heading naming the package', async () => {
+        const result = await project.runCliCommand(['--help']);
+
+        const heading = 'Options from @vendure-e2e/cloud-cli-plugin:';
+        expect(result.stdout).toContain(heading);
+
+        const optionsAt = result.stdout.indexOf('\nOptions:');
+        const pluginAt = result.stdout.indexOf(heading);
+        expect(optionsAt).toBeLessThan(pluginAt);
+        // --help is the CLI's own and stays put; --token came from the plugin.
+        expect(result.stdout.indexOf('--token')).toBeGreaterThan(pluginAt);
+        expect(result.stdout.indexOf('-h, --help')).toBeLessThan(pluginAt);
+    });
+
     it('shows the options valid at every level in leaf help', async () => {
         const result = await project.runCliCommand(['config', 'server', 'set', '--help']);
 

--- a/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
@@ -280,6 +280,14 @@ describe('CLI plugin help output', () => {
         expect(result.stdout.indexOf('-h, --help')).toBeLessThan(pluginAt);
     });
 
+    it('names the commands a plugin provides in the plugins listing', async () => {
+        const result = await project.runCliCommand(['plugins']);
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('@vendure-e2e/cloud-cli-plugin');
+        expect(result.stdout).toMatch(/commands:.*\bdeploy\b/);
+    });
+
     it('shows the options valid at every level in leaf help', async () => {
         const result = await project.runCliCommand(['config', 'server', 'set', '--help']);
 

--- a/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
@@ -278,15 +278,13 @@ describe('CLI plugin help output', () => {
         expect(builtinSection).not.toContain('--token');
     });
 
-    // Whether the CLI colours its output depends on the environment it is
-    // spawned in, so both directions are pinned here: the suite itself runs
-    // both ways depending on whether it is invoked through Lerna.
+    // The suite runs with colour when it is invoked through Lerna and without
+    // colour otherwise, so both outcomes are asserted.
     it('colours the headings only when the environment allows colour', async () => {
         const coloured = await project.runCliCommand(['--help'], { env: { FORCE_COLOR: '1' } });
 
-        // Bold heading, with the package name tinted inside the same bold run.
+        // Bold heading, with the package name cyan inside the same bold run.
         expect(coloured.rawStdout).toContain('\u001b[1mCommands from \u001b[36m');
-        // Assertions are made against the stripped output, whatever the colour.
         expect(coloured.stdout).toContain('Commands from @vendure-e2e/cloud-cli-plugin:');
     });
 

--- a/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
@@ -278,6 +278,27 @@ describe('CLI plugin help output', () => {
         expect(builtinSection).not.toContain('--token');
     });
 
+    // Whether the CLI colours its output depends on the environment it is
+    // spawned in, so both directions are pinned here: the suite itself runs
+    // both ways depending on whether it is invoked through Lerna.
+    it('colours the headings only when the environment allows colour', async () => {
+        const coloured = await project.runCliCommand(['--help'], { env: { FORCE_COLOR: '1' } });
+
+        // Bold heading, with the package name tinted inside the same bold run.
+        expect(coloured.rawStdout).toContain('\u001b[1mCommands from \u001b[36m');
+        // Assertions are made against the stripped output, whatever the colour.
+        expect(coloured.stdout).toContain('Commands from @vendure-e2e/cloud-cli-plugin:');
+    });
+
+    it('emits no colour when NO_COLOR is set', async () => {
+        const plain = await project.runCliCommand(['--help'], {
+            env: { NO_COLOR: '1', FORCE_COLOR: '1' },
+        });
+
+        expect(plain.rawStdout).not.toContain('\u001b[');
+        expect(plain.rawStdout).toContain('Commands from @vendure-e2e/cloud-cli-plugin:');
+    });
+
     it('names the commands a plugin provides in the plugins listing', async () => {
         const result = await project.runCliCommand(['plugins']);
 

--- a/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
+++ b/packages/cli/e2e/cli-plugin-commands.e2e-spec.ts
@@ -10,6 +10,8 @@
  */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { sectionAfter } from '../src/shared/__tests__/help-sections';
+
 import {
     CliTestProject,
     createTestProject,
@@ -252,32 +254,28 @@ describe('CLI plugin help output', () => {
     it('lists the plugin commands under a heading naming the package', async () => {
         const result = await project.runCliCommand(['--help']);
 
-        const heading = 'Commands from @vendure-e2e/cloud-cli-plugin:';
-        expect(result.stdout).toContain(heading);
+        // Asserted by section, not by string offset: the section a command is
+        // listed in is what says where it came from.
+        const pluginSection = sectionAfter(result.stdout, 'Commands from @vendure-e2e/cloud-cli-plugin:');
+        expect(pluginSection).toMatch(/^\s+project\s+Manage Cloud projects$/m);
+        expect(pluginSection).toMatch(/^\s+deploy \[options\]\s+Deploy the application$/m);
 
-        // The built-ins keep Commander's own heading, and every plugin command
-        // sits below the plugin's, so the section a command is listed in is
-        // what actually says where it came from.
-        const builtinsAt = result.stdout.indexOf('\nCommands:');
-        const pluginAt = result.stdout.indexOf(heading);
-        expect(builtinsAt).toBeGreaterThan(-1);
-        expect(builtinsAt).toBeLessThan(pluginAt);
-        expect(result.stdout.indexOf('Manage Cloud projects')).toBeGreaterThan(pluginAt);
-        expect(result.stdout.indexOf('Add a feature to your Vendure project')).toBeLessThan(pluginAt);
+        const builtinSection = sectionAfter(result.stdout, 'Commands:');
+        expect(builtinSection).toMatch(/^\s+add \[options\]\s+Add a feature to your Vendure project$/m);
+        expect(builtinSection).not.toContain('Manage Cloud projects');
     });
 
     it('lists the plugin shared options under a heading naming the package', async () => {
         const result = await project.runCliCommand(['--help']);
 
-        const heading = 'Options from @vendure-e2e/cloud-cli-plugin:';
-        expect(result.stdout).toContain(heading);
+        const pluginSection = sectionAfter(result.stdout, 'Options from @vendure-e2e/cloud-cli-plugin:');
+        expect(pluginSection).toMatch(/^\s+--token /m);
+        expect(pluginSection).toMatch(/^\s+--project /m);
 
-        const optionsAt = result.stdout.indexOf('\nOptions:');
-        const pluginAt = result.stdout.indexOf(heading);
-        expect(optionsAt).toBeLessThan(pluginAt);
-        // --help is the CLI's own and stays put; --token came from the plugin.
-        expect(result.stdout.indexOf('--token')).toBeGreaterThan(pluginAt);
-        expect(result.stdout.indexOf('-h, --help')).toBeLessThan(pluginAt);
+        // --help is the CLI's own and stays under Commander's own heading.
+        const builtinSection = sectionAfter(result.stdout, 'Options:');
+        expect(builtinSection).toMatch(/^\s+-h, --help/m);
+        expect(builtinSection).not.toContain('--token');
     });
 
     it('names the commands a plugin provides in the plugins listing', async () => {

--- a/packages/cli/e2e/cli-test-utils.ts
+++ b/packages/cli/e2e/cli-test-utils.ts
@@ -35,7 +35,7 @@ export interface CliCommandResult {
  * its own output is coloured. Its output is coloured when the suite runs
  * through Lerna and plain when it runs in the package directly, so one command
  * gives different bytes depending on how the suite was started. A test
- * asserting on what the CLI said should not turn on that.
+ * asserting on what the CLI said should not depend on how it was started.
  */
 function stripAnsi(text: string): string {
     // eslint-disable-next-line no-control-regex

--- a/packages/cli/e2e/cli-test-utils.ts
+++ b/packages/cli/e2e/cli-test-utils.ts
@@ -11,8 +11,34 @@ export interface CliTestProject {
     fileExists: (relativePath: string) => boolean;
     runCliCommand: (
         args: string[],
-        options?: { expectError?: boolean },
-    ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+        options?: { expectError?: boolean; env?: Record<string, string> },
+    ) => Promise<CliCommandResult>;
+}
+
+export interface CliCommandResult {
+    /** Output with any colour removed. Assert against this. */
+    stdout: string;
+    /** Errors with any colour removed. Assert against this. */
+    stderr: string;
+    exitCode: number;
+    /** Output as the CLI wrote it, for a test about colour itself. */
+    rawStdout: string;
+    /** Errors as the CLI wrote them, for a test about colour itself. */
+    rawStderr: string;
+}
+
+/**
+ * Removes ANSI escape codes.
+ *
+ * Whether the CLI colours its output depends on the environment it is spawned
+ * in, not on the command: Vitest exports FORCE_COLOR to child processes when
+ * its own output is coloured, which it is when the suite runs through Lerna in
+ * CI but not when it runs in the package directly. A test asserting on what the
+ * CLI said should not pass or fail on that.
+ */
+function stripAnsi(text: string): string {
+    // eslint-disable-next-line no-control-regex
+    return text.replace(/\u001b\[[0-9;]*m/g, '');
 }
 
 /**
@@ -98,7 +124,10 @@ export const config: VendureConfig = {
         fileExists: (relativePath: string) => {
             return existsSync(join(projectDir, relativePath));
         },
-        runCliCommand: async (args: string[], options: { expectError?: boolean } = {}) => {
+        runCliCommand: async (
+            args: string[],
+            options: { expectError?: boolean; env?: Record<string, string> } = {},
+        ) => {
             return new Promise((resolve, reject) => {
                 // Use the built CLI from the dist directory
                 const cliPath = join(__dirname, '..', 'dist', 'cli.js');
@@ -109,6 +138,7 @@ export const config: VendureConfig = {
                         ...process.env,
                         // Ensure we don't inherit any CLI environment variables
                         VENDURE_RUNNING_IN_CLI: undefined,
+                        ...options.env,
                     },
                     stdio: ['pipe', 'pipe', 'pipe'],
                 });
@@ -130,7 +160,13 @@ export const config: VendureConfig = {
                     if (!options.expectError && exitCode !== 0) {
                         reject(new Error(`CLI command failed with exit code ${exitCode}. stderr: ${stderr}`));
                     } else {
-                        resolve({ stdout, stderr, exitCode });
+                        resolve({
+                            stdout: stripAnsi(stdout),
+                            stderr: stripAnsi(stderr),
+                            exitCode,
+                            rawStdout: stdout,
+                            rawStderr: stderr,
+                        });
                     }
                 });
 

--- a/packages/cli/e2e/cli-test-utils.ts
+++ b/packages/cli/e2e/cli-test-utils.ts
@@ -31,10 +31,11 @@ export interface CliCommandResult {
  * Removes ANSI escape codes.
  *
  * Whether the CLI colours its output depends on the environment it is spawned
- * in, not on the command: Vitest exports FORCE_COLOR to child processes when
- * its own output is coloured, which it is when the suite runs through Lerna in
- * CI but not when it runs in the package directly. A test asserting on what the
- * CLI said should not pass or fail on that.
+ * in, not on the command. Vitest exports FORCE_COLOR to child processes when
+ * its own output is coloured. Its output is coloured when the suite runs
+ * through Lerna and plain when it runs in the package directly, so one command
+ * gives different bytes depending on how the suite was started. A test
+ * asserting on what the CLI said should not turn on that.
  */
 function stripAnsi(text: string): string {
     // eslint-disable-next-line no-control-regex

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,7 @@
         "@vendure/common": "3.7.2",
         "change-case": "^4.1.2",
         "chokidar": "^3.6.0",
-        "commander": "^11.0.0",
+        "commander": "^14.0.1",
         "cross-spawn": "^7.0.6",
         "dotenv": "^16.4.5",
         "fs-extra": "^11.2.0",

--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -473,14 +473,12 @@ for plugin authors; this file covers what a contributor to the CLI itself needs.
   Commander passed to the action, and onto the `Command`, so both readings
   agree. Registration rejects the two declarations if they disagree about
   whether a value follows the flag. Covered in `command-registry.spec.ts`.
-- **Help is grouped by the package things came from.** `vendure --help` lists
-  the CLI's own commands and options under Commander's `Commands:` and
-  `Options:` headings, and what a plugin registered under
-  `Commands from <package>:` and `Options from <package>:`. The registry
-  already tracks this as `RegisteredCommand.source` and `RegisteredOption.source`;
-  `getCommandSources()` and `getRootOptionSources()` hand it to
-  `registerCommands()`, which sets Commander's `helpGroup()`. Nothing about how
-  a command is invoked changes.
+- **Help is grouped by the package a command or option came from.**
+  `getCommandTree()` and `getRootOptions()` return each node paired with the
+  plugin that registered it, and `registerCommands()` turns that into
+  Commander's `helpGroup()`. They are returned paired rather than as a
+  separate name-keyed map so the two cannot disagree. Nothing about how a
+  command is invoked changes.
 - **Only the root help is grouped.** A subcommand's help shows shared options
   in the `Global Options:` section, which Commander builds as one flat list
   whatever group the options are in, so it mixes the CLI's own with a plugin's.
@@ -490,12 +488,11 @@ for plugin authors; this file covers what a contributor to the CLI itself needs.
   nested under, which already says where that came from.
 - **A sub-option is grouped with its parent**, since the help lists it indented
   under the parent. Splitting them would leave the indented line under nothing.
-- **A sub-option may belong to two parents.** `vendure add` takes
-  `--selected-plugin` with either `-e` or `-s`. Sub-options are flattened onto
-  the command, so the flag is declared twice; `declareOption()` keeps the first
-  and drops the rest. Commander 11 allowed the repeat and matched the first
-  when parsing, and Commander 13 onwards throws on it, which would fail at
-  startup and take the whole CLI down rather than one command.
+- **Nothing validates the built-in command definitions at runtime.** A plugin
+  goes through `assertCliPlugin()` when it loads, so a duplicate option flag is
+  rejected by name; the built-ins reach Commander unchecked, which throws from
+  v13 onwards and fails the whole CLI at startup. `builtins.spec.ts` holds them
+  to the same rule.
 - **Extensions cannot add positional arguments.** Commander passes one argument
   slot per declared positional, so an appended argument would shift the options,
   `Command` and context that an existing action expects.

--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -483,9 +483,9 @@ for plugin authors; this file covers what a contributor to the CLI itself needs.
   in the `Global Options:` section, which Commander builds as one flat list
   whatever group the options are in, so it mixes the CLI's own with a plugin's.
   Grouping it would mean overriding `Help#formatHelp` and owning a copy of
-  Commander's layout. Top-level commands are grouped for the same reason in
-  reverse: a subcommand only ever appears in the help of the command it is
-  nested under, which already says where that came from.
+  Commander's layout. Only top-level commands need a group: a subcommand
+  appears only in the help of the command it is nested under, and that
+  command's heading already names the package.
 - **A sub-option is grouped with its parent**, since the help lists it indented
   under the parent. Splitting them would leave the indented line under nothing.
 - **Nothing validates the built-in command definitions at runtime.** A plugin

--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -458,7 +458,8 @@ for plugin authors; this file covers what a contributor to the CLI itself needs.
    all registered or none are.
 4. A plugin that conflicts is reported on stderr and skipped. Built-ins stay
    registered, which is what keeps `vendure plugins remove` reachable.
-5. `registerCommands()` walks the resulting tree onto Commander.
+5. `registerCommands()` walks the resulting tree onto Commander, and groups
+   each top-level command under the package that registered it.
 
 ### Things worth knowing before changing this code
 
@@ -472,6 +473,29 @@ for plugin authors; this file covers what a contributor to the CLI itself needs.
   Commander passed to the action, and onto the `Command`, so both readings
   agree. Registration rejects the two declarations if they disagree about
   whether a value follows the flag. Covered in `command-registry.spec.ts`.
+- **Help is grouped by the package things came from.** `vendure --help` lists
+  the CLI's own commands and options under Commander's `Commands:` and
+  `Options:` headings, and what a plugin registered under
+  `Commands from <package>:` and `Options from <package>:`. The registry
+  already tracks this as `RegisteredCommand.source` and `RegisteredOption.source`;
+  `getCommandSources()` and `getRootOptionSources()` hand it to
+  `registerCommands()`, which sets Commander's `helpGroup()`. Nothing about how
+  a command is invoked changes.
+- **Only the root help is grouped.** A subcommand's help shows shared options
+  in the `Global Options:` section, which Commander builds as one flat list
+  whatever group the options are in, so it mixes the CLI's own with a plugin's.
+  Grouping it would mean overriding `Help#formatHelp` and owning a copy of
+  Commander's layout. Top-level commands are grouped for the same reason in
+  reverse: a subcommand only ever appears in the help of the command it is
+  nested under, which already says where that came from.
+- **A sub-option is grouped with its parent**, since the help lists it indented
+  under the parent. Splitting them would leave the indented line under nothing.
+- **A sub-option may belong to two parents.** `vendure add` takes
+  `--selected-plugin` with either `-e` or `-s`. Sub-options are flattened onto
+  the command, so the flag is declared twice; `declareOption()` keeps the first
+  and drops the rest. Commander 11 allowed the repeat and matched the first
+  when parsing, and Commander 13 onwards throws on it, which would fail at
+  startup and take the whole CLI down rather than one command.
 - **Extensions cannot add positional arguments.** Commander passes one argument
   slot per declared positional, so an appended argument would shift the options,
   `Command` and context that an existing action expects.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -61,11 +61,9 @@ Y88  88P 88888888 888  888 888  888 888  888 888    88888888
         }
     }
 
-    registerCommands(program, registry.toArray(), {
+    registerCommands(program, registry.getCommandTree(), {
         rootOptions: registry.getRootOptions(),
         getPluginExtensions: extensionPoint => registry.getPluginExtensions(extensionPoint),
-        commandSources: registry.getCommandSources(),
-        rootOptionSources: registry.getRootOptionSources(),
     });
 
     program.on('command:*', operands => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,7 +4,7 @@ import { Command } from 'commander';
 import pc from 'picocolors';
 
 import { builtinCommandDefs } from './commands/builtins';
-import { registerCommands } from './shared/command-registry';
+import { registerCommands, styleHelpTitle } from './shared/command-registry';
 import { CommandRegistry } from './shared/command-registry-store';
 import {
     findInactivePluginProvidingCommand,
@@ -41,7 +41,7 @@ Y88  88P 88888888 888  888 888  888 888  888 888    88888888
     // subcommand help needs Commander's "Global Options" section to be
     // complete. Commander copies the help configuration into each subcommand as
     // it is created, so this must be set first.
-    program.configureHelp({ showGlobalOptions: true });
+    program.configureHelp({ showGlobalOptions: true, styleTitle: styleHelpTitle });
 
     const registry = new CommandRegistry();
     registry.registerAll(builtinCommandDefs);
@@ -61,9 +61,12 @@ Y88  88P 88888888 888  888 888  888 888  888 888    88888888
         }
     }
 
-    registerCommands(program, registry.toArray(), registry.getRootOptions(), extensionPoint =>
-        registry.getPluginExtensions(extensionPoint),
-    );
+    registerCommands(program, registry.toArray(), {
+        rootOptions: registry.getRootOptions(),
+        getPluginExtensions: extensionPoint => registry.getPluginExtensions(extensionPoint),
+        commandSources: registry.getCommandSources(),
+        rootOptionSources: registry.getRootOptionSources(),
+    });
 
     program.on('command:*', operands => {
         const unknown = operands[0] ?? '';

--- a/packages/cli/src/commands/add/command.ts
+++ b/packages/cli/src/commands/add/command.ts
@@ -38,7 +38,10 @@ export const addCommandDef: CliCommandDefinition = {
             subOptions: [
                 {
                     long: '--selected-plugin <name>',
-                    description: 'Name of the plugin to add the entity to (required with -e)',
+                    // Declared once, but valid with -s too: every sub-option is
+                    // flattened onto `add`, so a second declaration under -s
+                    // would be the same flag and is dropped.
+                    description: 'Name of the plugin to add the entity or service to (required with -e or -s)',
                     required: false,
                 },
                 {
@@ -62,11 +65,6 @@ export const addCommandDef: CliCommandDefinition = {
             interactiveCategory: 'Plugin: Service',
             interactiveFn: addService,
             subOptions: [
-                {
-                    long: '--selected-plugin <name>',
-                    description: 'Name of the plugin to add the service to (required with -s)',
-                    required: false,
-                },
                 {
                     long: '--type <type>',
                     description: 'Type of service: basic or entity (default: basic)',
@@ -95,7 +93,9 @@ export const addCommandDef: CliCommandDefinition = {
                 },
                 {
                     long: '--selected-service <name>',
-                    description: 'Name of the service to add the job queue to (required with -j)',
+                    // Valid with -a as well; see --selected-plugin above.
+                    description:
+                        'Name of the service to add the job queue or API extension to (required with -j or -a)',
                     required: false,
                 },
             ],
@@ -126,11 +126,6 @@ export const addCommandDef: CliCommandDefinition = {
                 {
                     long: '--mutation-name <name>',
                     description: 'Name for the mutation (used with -a)',
-                    required: false,
-                },
-                {
-                    long: '--selected-service <name>',
-                    description: 'Name of the service to add the API extension to (required with -a)',
                     required: false,
                 },
             ],

--- a/packages/cli/src/commands/add/command.ts
+++ b/packages/cli/src/commands/add/command.ts
@@ -38,10 +38,8 @@ export const addCommandDef: CliCommandDefinition = {
             subOptions: [
                 {
                     long: '--selected-plugin <name>',
-                    // Declared once, but valid with -s too: every sub-option is
-                    // flattened onto `add`, so a second declaration under -s
-                    // would be the same flag and is dropped.
-                    description: 'Name of the plugin to add the entity or service to (required with -e or -s)',
+                    description:
+                        'Name of the plugin to add the entity or service to (required with -e or -s)',
                     required: false,
                 },
                 {
@@ -93,7 +91,6 @@ export const addCommandDef: CliCommandDefinition = {
                 },
                 {
                     long: '--selected-service <name>',
-                    // Valid with -a as well; see --selected-plugin above.
                     description:
                         'Name of the service to add the job queue or API extension to (required with -j or -a)',
                     required: false,

--- a/packages/cli/src/commands/builtins.spec.ts
+++ b/packages/cli/src/commands/builtins.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertCliPlugin } from '../shared/cli-plugin';
+
+import { builtinCommandDefs } from './builtins';
+
+describe('builtinCommandDefs', () => {
+    /**
+     * Holds the built-ins to the rules every plugin is already held to.
+     *
+     * A plugin is validated by `assertCliPlugin` when it loads, so a plugin
+     * that declares one flag twice is rejected by name. Nothing validates the
+     * built-ins, so the same mistake reached Commander instead — which accepted
+     * it until v11 and throws from v13 onwards, failing the whole CLI at
+     * startup rather than the one command. `vendure add` had exactly that: it
+     * declared `--selected-plugin` under both `-e` and `-s`, and
+     * `--selected-service` under both `-j` and `-a`.
+     */
+    it('satisfies the rules a CLI plugin is validated against', () => {
+        expect(() => assertCliPlugin({ id: 'builtins', commands: builtinCommandDefs })).not.toThrow();
+    });
+});

--- a/packages/cli/src/commands/builtins.spec.ts
+++ b/packages/cli/src/commands/builtins.spec.ts
@@ -8,13 +8,16 @@ describe('builtinCommandDefs', () => {
     /**
      * Holds the built-ins to the rules every plugin is already held to.
      *
-     * A plugin is validated by `assertCliPlugin` when it loads, so a plugin
-     * that declares one flag twice is rejected by name. Nothing validates the
-     * built-ins, so the same mistake reached Commander instead — which accepted
-     * it until v11 and throws from v13 onwards, failing the whole CLI at
-     * startup rather than the one command. `vendure add` had exactly that: it
-     * declared `--selected-plugin` under both `-e` and `-s`, and
-     * `--selected-service` under both `-j` and `-a`.
+     * `assertCliPlugin` validates a plugin when it loads, so a plugin that
+     * declares one flag twice is rejected by name. Nothing validates the
+     * built-ins, so the same mistake reaches Commander instead. Commander
+     * accepts a repeated flag up to v11 and throws from v13. The throw happens
+     * while a built-in is registered, so every `vendure` command fails at
+     * startup, not just the one that declared the flag.
+     *
+     * One sub-option declared under two parent options is how a built-in gets
+     * there: every sub-option is flattened onto the same command, so the flag
+     * arrives twice.
      */
     it('satisfies the rules a CLI plugin is validated against', () => {
         expect(() => assertCliPlugin({ id: 'builtins', commands: builtinCommandDefs })).not.toThrow();

--- a/packages/cli/src/commands/builtins.spec.ts
+++ b/packages/cli/src/commands/builtins.spec.ts
@@ -15,9 +15,9 @@ describe('builtinCommandDefs', () => {
      * while a built-in is registered, so every `vendure` command fails at
      * startup, not just the one that declared the flag.
      *
-     * One sub-option declared under two parent options is how a built-in gets
-     * there: every sub-option is flattened onto the same command, so the flag
-     * arrives twice.
+     * A built-in repeats a flag when one sub-option is declared under two
+     * parent options: every sub-option is flattened onto the same command, so
+     * the flag arrives twice.
      */
     it('satisfies the rules a CLI plugin is validated against', () => {
         expect(() => assertCliPlugin({ id: 'builtins', commands: builtinCommandDefs })).not.toThrow();

--- a/packages/cli/src/commands/plugins/plugins.ts
+++ b/packages/cli/src/commands/plugins/plugins.ts
@@ -229,11 +229,14 @@ function statusHint(plugin: DiscoveredCliPlugin): string {
     }
 }
 
+/** A hint shares one line with the package name, so it cannot list 22 commands. */
+const MAX_COMMANDS_IN_HINT = 6;
+
 /**
  * The commands a package contributes, appended to its status so the picker
- * says what enabling or disabling it would change. Long lists are cut off:
- * the hint sits on one line next to the package name, and `vendure plugins
- * --json` is there for the whole list.
+ * says what enabling or disabling it would change. Cut off at
+ * {@link MAX_COMMANDS_IN_HINT}, unlike the full list `printTextList` writes,
+ * which has a line of its own.
  */
 function withCommands(status: string, plugin: DiscoveredCliPlugin): string {
     const commands = cliPluginCommandNames(plugin);
@@ -245,8 +248,6 @@ function withCommands(status: string, plugin: DiscoveredCliPlugin): string {
     const suffix = rest > 0 ? `, +${rest} more` : '';
     return `${status} — ${shown.join(', ')}${suffix}`;
 }
-
-const MAX_COMMANDS_IN_HINT = 6;
 
 function printTextList(plugins: DiscoveredCliPlugin[]): void {
     if (plugins.length === 0) {
@@ -276,7 +277,6 @@ function printJson(plugins: DiscoveredCliPlugin[]): void {
                     entryPath: plugin.entryPath,
                     declaredCommands: plugin.declaredCommands,
                     loadedCommands: plugin.loadedCommands,
-                    commands: cliPluginCommandNames(plugin),
                 })),
             },
             null,

--- a/packages/cli/src/commands/plugins/plugins.ts
+++ b/packages/cli/src/commands/plugins/plugins.ts
@@ -10,6 +10,7 @@ import {
     writeCliPluginProjectConfig,
 } from '../../shared/cli-plugin-project-config';
 import {
+    cliPluginCommandNames,
     DiscoveredCliPlugin,
     discoverCliPlugins,
     getCliPluginProjectContext,
@@ -218,15 +219,34 @@ async function runInteractiveManager(): Promise<void> {
 function statusHint(plugin: DiscoveredCliPlugin): string {
     switch (plugin.status) {
         case 'enabled':
-            return 'enabled';
+            return withCommands('enabled', plugin);
         case 'not-enabled':
-            return 'not enabled';
+            return withCommands('not enabled', plugin);
         case 'failed':
             return plugin.reason ?? 'failed';
         default:
             return plugin.status;
     }
 }
+
+/**
+ * The commands a package contributes, appended to its status so the picker
+ * says what enabling or disabling it would change. Long lists are cut off:
+ * the hint sits on one line next to the package name, and `vendure plugins
+ * --json` is there for the whole list.
+ */
+function withCommands(status: string, plugin: DiscoveredCliPlugin): string {
+    const commands = cliPluginCommandNames(plugin);
+    if (commands.length === 0) {
+        return status;
+    }
+    const shown = commands.slice(0, MAX_COMMANDS_IN_HINT);
+    const rest = commands.length - shown.length;
+    const suffix = rest > 0 ? `, +${rest} more` : '';
+    return `${status} — ${shown.join(', ')}${suffix}`;
+}
+
+const MAX_COMMANDS_IN_HINT = 6;
 
 function printTextList(plugins: DiscoveredCliPlugin[]): void {
     if (plugins.length === 0) {
@@ -236,6 +256,12 @@ function printTextList(plugins: DiscoveredCliPlugin[]): void {
     for (const plugin of plugins) {
         const detail = plugin.status === 'failed' && plugin.reason ? ` — ${plugin.reason}` : '';
         process.stdout.write(`${plugin.packageName}\t${plugin.status}${detail}\n`);
+        const commands = cliPluginCommandNames(plugin);
+        if (commands.length > 0) {
+            // Indented under its package, so the tab-separated first line of
+            // each plugin stays as it was for anything reading this output.
+            process.stdout.write(`\tcommands: ${commands.join(', ')}\n`);
+        }
     }
 }
 
@@ -249,6 +275,8 @@ function printJson(plugins: DiscoveredCliPlugin[]): void {
                     reason: plugin.reason,
                     entryPath: plugin.entryPath,
                     declaredCommands: plugin.declaredCommands,
+                    loadedCommands: plugin.loadedCommands,
+                    commands: cliPluginCommandNames(plugin),
                 })),
             },
             null,

--- a/packages/cli/src/commands/plugins/plugins.ts
+++ b/packages/cli/src/commands/plugins/plugins.ts
@@ -229,14 +229,14 @@ function statusHint(plugin: DiscoveredCliPlugin): string {
     }
 }
 
-/** A hint shares one line with the package name, so it cannot list 22 commands. */
+/** How many commands a hint can name beside the package on one line. */
 const MAX_COMMANDS_IN_HINT = 6;
 
 /**
  * The commands a package contributes, appended to its status so the picker
  * says what enabling or disabling it would change. Cut off at
- * {@link MAX_COMMANDS_IN_HINT}, unlike the full list `printTextList` writes,
- * which has a line of its own.
+ * {@link MAX_COMMANDS_IN_HINT}. `printTextList` writes the full list, which
+ * has a line of its own.
  */
 function withCommands(status: string, plugin: DiscoveredCliPlugin): string {
     const commands = cliPluginCommandNames(plugin);
@@ -259,8 +259,8 @@ function printTextList(plugins: DiscoveredCliPlugin[]): void {
         process.stdout.write(`${plugin.packageName}\t${plugin.status}${detail}\n`);
         const commands = cliPluginCommandNames(plugin);
         if (commands.length > 0) {
-            // Indented under its package, so the tab-separated first line of
-            // each plugin stays as it was for anything reading this output.
+            // Indented under its package, so each plugin's first line stays a
+            // single tab-separated record for anything parsing this output.
             process.stdout.write(`\tcommands: ${commands.join(', ')}\n`);
         }
     }

--- a/packages/cli/src/shared/__tests__/help-sections.ts
+++ b/packages/cli/src/shared/__tests__/help-sections.ts
@@ -2,10 +2,10 @@
  * The body of one help section: everything from `heading` up to the blank line
  * that ends it.
  *
- * Lets a test say which section something is listed in, which neither
- * `toContain` over the whole screen nor comparing string offsets can do —
- * `indexOf` returns -1 for text that is absent, and -1 is less than every
- * offset, so an ordering assertion passes when the text is missing entirely.
+ * Lets a test say which section something is listed in. `toContain` over the
+ * whole screen cannot say that. Comparing string offsets passes when the text
+ * is absent, because `indexOf` returns -1 and -1 sorts below every real
+ * offset.
  *
  * Returns an empty string when the heading is absent, so an assertion about
  * the section's contents fails rather than passing by accident.

--- a/packages/cli/src/shared/__tests__/help-sections.ts
+++ b/packages/cli/src/shared/__tests__/help-sections.ts
@@ -1,0 +1,21 @@
+/**
+ * The body of one help section: everything from `heading` up to the blank line
+ * that ends it.
+ *
+ * Lets a test say which section something is listed in, which neither
+ * `toContain` over the whole screen nor comparing string offsets can do —
+ * `indexOf` returns -1 for text that is absent, and -1 is less than every
+ * offset, so an ordering assertion passes when the text is missing entirely.
+ *
+ * Returns an empty string when the heading is absent, so an assertion about
+ * the section's contents fails rather than passing by accident.
+ */
+export function sectionAfter(help: string, heading: string): string {
+    const start = help.indexOf(`\n${heading}`);
+    if (start === -1) {
+        return '';
+    }
+    const body = help.slice(start + heading.length + 1);
+    const end = body.indexOf('\n\n');
+    return end === -1 ? body : body.slice(0, end);
+}

--- a/packages/cli/src/shared/__tests__/run-cli.ts
+++ b/packages/cli/src/shared/__tests__/run-cli.ts
@@ -4,6 +4,20 @@ import { vi } from 'vitest';
 import { CliCommandNode, CliCommandOption } from '../cli-command-definition';
 import { CliPluginExtensionAccessor } from '../cli-plugin-extension';
 import { registerCommands } from '../command-registry';
+import { CommandTreeEntry, RootOptionEntry } from '../command-registry-store';
+
+/**
+ * Accepts either shape so a test can pass a bare fixture when it does not care
+ * where a command came from, or an entry when it does. A bare node never has a
+ * `node` property, which is what tells the two apart.
+ */
+function toCommandEntry(command: CliCommandNode | CommandTreeEntry): CommandTreeEntry {
+    return 'node' in command ? command : { node: command };
+}
+
+function toOptionEntry(option: CliCommandOption | RootOptionEntry): RootOptionEntry {
+    return 'option' in option ? option : { option };
+}
 
 /**
  * Thrown in place of `process.exit` so a test can observe the exit code the
@@ -37,14 +51,10 @@ export interface CliRun {
  * capturing everything the host would have written or exited with.
  */
 export async function runCli(
-    commands: CliCommandNode[],
-    sharedOptions: CliCommandOption[],
+    commands: Array<CliCommandNode | CommandTreeEntry>,
+    sharedOptions: Array<CliCommandOption | RootOptionEntry>,
     argv: string[],
     getPluginExtensions?: CliPluginExtensionAccessor,
-    sources: {
-        commands?: ReadonlyMap<string, string>;
-        rootOptions?: ReadonlyMap<string, string>;
-    } = {},
 ): Promise<CliRun> {
     let stdout = '';
     let commanderStderr = '';
@@ -62,11 +72,9 @@ export async function runCli(
             commanderStderr += str;
         },
     });
-    registerCommands(program, commands, {
-        rootOptions: sharedOptions,
+    registerCommands(program, commands.map(toCommandEntry), {
+        rootOptions: sharedOptions.map(toOptionEntry),
         getPluginExtensions,
-        commandSources: sources.commands,
-        rootOptionSources: sources.rootOptions,
     });
 
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {

--- a/packages/cli/src/shared/__tests__/run-cli.ts
+++ b/packages/cli/src/shared/__tests__/run-cli.ts
@@ -41,6 +41,10 @@ export async function runCli(
     sharedOptions: CliCommandOption[],
     argv: string[],
     getPluginExtensions?: CliPluginExtensionAccessor,
+    sources: {
+        commands?: ReadonlyMap<string, string>;
+        rootOptions?: ReadonlyMap<string, string>;
+    } = {},
 ): Promise<CliRun> {
     let stdout = '';
     let commanderStderr = '';
@@ -58,7 +62,12 @@ export async function runCli(
             commanderStderr += str;
         },
     });
-    registerCommands(program, commands, sharedOptions, getPluginExtensions);
+    registerCommands(program, commands, {
+        rootOptions: sharedOptions,
+        getPluginExtensions,
+        commandSources: sources.commands,
+        rootOptionSources: sources.rootOptions,
+    });
 
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
         throw new ExitSignal(code ?? 0);

--- a/packages/cli/src/shared/command-extensions.spec.ts
+++ b/packages/cli/src/shared/command-extensions.spec.ts
@@ -273,13 +273,13 @@ describe('Command extensions: registration through Commander', () => {
         registry.applyPlugin(credentialsPlugin());
         registry.applyPlugin(telemetryPlugin());
 
-        const help = await runCli(registry.toArray(), registry.getRootOptions(), ['dev', '--help']);
+        const help = await runCli(registry.getCommandTree(), registry.getRootOptions(), ['dev', '--help']);
         expect(help.stdout).toContain('--rotate-credential');
         expect(help.stdout).toContain('--cloud-env');
         expect(help.stdout).toContain('--no-reload');
         expect(help.stdout).toContain('Run Vendure in development mode with linked credentials');
 
-        const run = await runCli(registry.toArray(), registry.getRootOptions(), [
+        const run = await runCli(registry.getCommandTree(), registry.getRootOptions(), [
             'dev',
             'server',
             '--rotate-credential',
@@ -301,7 +301,7 @@ describe('Command extensions: registration through Commander', () => {
         registry.registerAll([{ name: 'dev', description: 'Dev', action: async () => 7 }]);
         registry.applyPlugin(credentialsPlugin());
 
-        const run = await runCli(registry.toArray(), [], ['dev']);
+        const run = await runCli(registry.getCommandTree(), [], ['dev']);
 
         expect(run.exitCode).toBe(7);
         expect(trace).toEqual(['credentials:before', 'credentials:after']);
@@ -422,7 +422,9 @@ describe('Command extensions: collisions', () => {
             commands: [{ name: 'dev', description: 'My dev', replaces: true, action: async () => 0 }],
         });
 
-        expect(() => registry.applyPlugin(replacer)).toThrow(/has been extended by @example\/credentials-cli-plugin/);
+        expect(() => registry.applyPlugin(replacer)).toThrow(
+            /has been extended by @example\/credentials-cli-plugin/,
+        );
         expect(devCommand(registry).description).toContain('linked credentials');
     });
 
@@ -803,7 +805,7 @@ describe('Command extensions: nested composition', () => {
         registry.applyPlugin(nestedExtender('@b/first', '--first'));
         registry.applyPlugin(nestedExtender('@c/second', '--second'));
 
-        const help = await runCli(registry.toArray(), registry.getRootOptions(), [
+        const help = await runCli(registry.getCommandTree(), registry.getRootOptions(), [
             'console',
             'link',
             '--help',
@@ -969,7 +971,7 @@ describe('Command extensions: reserved names and shared-option scope', () => {
             }),
         );
 
-        await runCli(registry.toArray(), registry.getRootOptions(), ['--env', 'staging', 'g', 'run']);
+        await runCli(registry.getCommandTree(), registry.getRootOptions(), ['--env', 'staging', 'g', 'run']);
 
         expect(inherited).toEqual({ env: 'staging' });
     });
@@ -1260,7 +1262,7 @@ describe('Command extensions: sub-option depth', () => {
             },
         ]);
 
-        const run = await runCli(registry.toArray(), [], ['deep', '--a', '1', '--b', '2']);
+        const run = await runCli(registry.getCommandTree(), [], ['deep', '--a', '1', '--b', '2']);
 
         expect(run.exitCode).toBe(0);
         expect(seen).toEqual({ a: '1', b: '2' });
@@ -1383,7 +1385,7 @@ describe('Command extensions: value shape across levels', () => {
             }),
         );
 
-        const run = await runCli(registry.toArray(), registry.getRootOptions(), [
+        const run = await runCli(registry.getCommandTree(), registry.getRootOptions(), [
             'config',
             '--dry-run',
             'server',
@@ -1413,9 +1415,9 @@ describe('Shared root options with sub-options', () => {
         );
 
         // The parent still carries its sub-option, so the host expands it once.
-        expect(registry.getRootOptions().map(option => option.long)).toEqual(['--auth <mode>']);
+        expect(registry.getRootOptions().map(entry => entry.option.long)).toEqual(['--auth <mode>']);
 
-        const help = await runCli(registry.toArray(), registry.getRootOptions(), ['--help']);
+        const help = await runCli(registry.getCommandTree(), registry.getRootOptions(), ['--help']);
         const authTokenLines = help.stdout.split('\n').filter(line => line.includes('--auth-token'));
         expect(authTokenLines).toHaveLength(1);
     });
@@ -1537,7 +1539,7 @@ describe('Command extensions: runnable parent commands', () => {
             }),
         );
 
-        await runCli(registry.toArray(), registry.getRootOptions(), ['deploy']);
+        await runCli(registry.getCommandTree(), registry.getRootOptions(), ['deploy']);
 
         expect(trace).toEqual(['credentials:before', 'core:deploy']);
     });
@@ -1562,7 +1564,7 @@ describe('Command extensions: runnable parent commands', () => {
             }),
         );
 
-        await runCli(registry.toArray(), registry.getRootOptions(), ['deploy', 'plan']);
+        await runCli(registry.getCommandTree(), registry.getRootOptions(), ['deploy', 'plan']);
 
         // The decorator wraps the parent action only, so running a subcommand
         // does not go through it.
@@ -1666,10 +1668,10 @@ describe('Command extensions: runnable parent commands', () => {
             }),
         );
 
-        await runCli(registry.toArray(), registry.getRootOptions(), ['deploy']);
-        await runCli(registry.toArray(), registry.getRootOptions(), ['deploy', 'verify']);
+        await runCli(registry.getCommandTree(), registry.getRootOptions(), ['deploy']);
+        await runCli(registry.getCommandTree(), registry.getRootOptions(), ['deploy', 'verify']);
         // The subcommand the replaced command had is gone with it.
-        const stale = await runCli(registry.toArray(), registry.getRootOptions(), ['deploy', 'plan']);
+        const stale = await runCli(registry.getCommandTree(), registry.getRootOptions(), ['deploy', 'plan']);
 
         expect(trace).toEqual(['replacement:deploy', 'replacement:verify']);
         expect(stale.exitCode).toBe(1);
@@ -1708,7 +1710,7 @@ describe('Command extensions: runnable parent commands', () => {
             }),
         );
 
-        await runCli(registry.toArray(), registry.getRootOptions(), ['deploy', 'plan']);
+        await runCli(registry.getCommandTree(), registry.getRootOptions(), ['deploy', 'plan']);
 
         expect(trace).toEqual(['credentials:plan', 'core:plan']);
     });
@@ -1738,11 +1740,11 @@ describe('Command extensions: runnable parent commands', () => {
             }),
         );
 
-        await runCli(registry.toArray(), registry.getRootOptions(), ['deploy', 'plan', '--dry-run']);
+        await runCli(registry.getCommandTree(), registry.getRootOptions(), ['deploy', 'plan', '--dry-run']);
 
         expect(inherited).toEqual({ dryRun: true });
 
-        const help = await runCli(registry.toArray(), registry.getRootOptions(), [
+        const help = await runCli(registry.getCommandTree(), registry.getRootOptions(), [
             'deploy',
             'plan',
             '--help',

--- a/packages/cli/src/shared/command-registry-store.spec.ts
+++ b/packages/cli/src/shared/command-registry-store.spec.ts
@@ -16,6 +16,7 @@ import { defineCliPlugin } from './cli-plugin';
 import { CliPluginRegistrationError, CommandRegistry } from './command-registry-store';
 import {
     PackageJsonLike,
+    cliPluginCommandNames,
     discoverCliPlugins,
     findInactivePluginProvidingCommand,
     listDirectDependencyNames,
@@ -1116,6 +1117,108 @@ describe('resolveCliPlugins()', () => {
         });
         expect(withValidation[0].status).toBe('failed');
         expect(withValidation[0].reason).toMatch(/must provide an action function/);
+    });
+
+    // `vendure.cliCommands` is hand-maintained, so it drifts. An enabled
+    // plugin is loaded anyway, and what it actually registers is the truth.
+    it('reads the commands of an enabled plugin from the plugin itself', () => {
+        const fixture = makeTempProject({
+            project: {
+                name: 'demo',
+                dependencies: { '@example/a': '1.0.0' },
+                vendure: { cli: { plugins: ['@example/a'] } },
+            },
+            plugins: [
+                {
+                    name: '@example/a',
+                    packageJson: {
+                        name: '@example/a',
+                        vendure: { cliPlugin: './cli-plugin.js', cliCommands: ['stale'] },
+                    },
+                    entrySource: `
+                        module.exports = {
+                            id: '@example/a',
+                            commands: [
+                                { name: 'deploy', description: 'Deploy', action: async () => 0 },
+                                { name: 'status', description: 'Status', action: async () => 0 },
+                            ],
+                        };
+                    `,
+                },
+            ],
+        });
+        const projectPackageJson = fs.readJsonSync(
+            path.join(fixture.root, 'package.json'),
+        ) as PackageJsonLike;
+
+        const [plugin] = discoverCliPlugins({
+            cwd: fixture.root,
+            projectPackageJson,
+            resolvePackage: fixture.resolvePackage,
+            validate: true,
+        });
+
+        expect(plugin.loadedCommands).toEqual(['deploy', 'status']);
+        expect(cliPluginCommandNames(plugin)).toEqual(['deploy', 'status']);
+    });
+
+    // An installed but not-enabled package is never executed, so what it
+    // declares is the only thing there is to go on.
+    it('falls back to the declared commands of a package that is not enabled', () => {
+        const fixture = makeTempProject({
+            project: {
+                name: 'demo',
+                dependencies: { '@example/a': '1.0.0' },
+            },
+            plugins: [
+                {
+                    name: '@example/a',
+                    packageJson: {
+                        name: '@example/a',
+                        vendure: { cliPlugin: './cli-plugin.js', cliCommands: ['deploy'] },
+                    },
+                    entrySource: `throw new Error('must not be loaded');`,
+                },
+            ],
+        });
+        const projectPackageJson = fs.readJsonSync(
+            path.join(fixture.root, 'package.json'),
+        ) as PackageJsonLike;
+
+        const [plugin] = discoverCliPlugins({
+            cwd: fixture.root,
+            projectPackageJson,
+            resolvePackage: fixture.resolvePackage,
+            validate: true,
+        });
+
+        expect(plugin.status).toBe('not-enabled');
+        expect(plugin.loadedCommands).toBeUndefined();
+        expect(cliPluginCommandNames(plugin)).toEqual(['deploy']);
+    });
+
+    it('reports no commands for a package that declares none and is not loaded', () => {
+        const fixture = makeTempProject({
+            project: {
+                name: 'demo',
+                dependencies: { '@example/a': '1.0.0' },
+            },
+            plugins: [
+                {
+                    name: '@example/a',
+                    packageJson: { name: '@example/a', vendure: { cliPlugin: './cli-plugin.js' } },
+                    entrySource: `module.exports = { id: '@example/a', commands: [] };`,
+                },
+            ],
+        });
+
+        const [plugin] = discoverCliPlugins({
+            cwd: fixture.root,
+            projectPackageJson: fs.readJsonSync(path.join(fixture.root, 'package.json')) as PackageJsonLike,
+            resolvePackage: fixture.resolvePackage,
+        });
+
+        expect(cliPluginCommandNames(plugin)).toEqual([]);
     });
 
     it('lists direct dependency names from all dependency sections', () => {

--- a/packages/cli/src/shared/command-registry-store.spec.ts
+++ b/packages/cli/src/shared/command-registry-store.spec.ts
@@ -76,7 +76,7 @@ describe('CommandRegistry', () => {
             },
         ]);
         expect(registry.get('dev')?.description).toBe('Built-in dev');
-        expect(registry.toArray()).toHaveLength(1);
+        expect(registry.getCommandTree()).toHaveLength(1);
     });
 
     it('replaces an existing command and notifies on stderr', () => {
@@ -131,8 +131,8 @@ describe('CommandRegistry', () => {
         );
         expect(
             registry
-                .toArray()
-                .map(c => c.name)
+                .getCommandTree()
+                .map(entry => entry.node.name)
                 .sort(),
         ).toEqual(['cloud', 'dev']);
     });
@@ -224,7 +224,10 @@ describe('CommandRegistry nested commands and shared options', () => {
         const project = registry.get('project');
         expect(project && isCliCommandGroup(project)).toBe(true);
         expect((project as CliCommandGroupDefinition).subcommands.map(c => c.name)).toEqual(['list']);
-        expect(registry.getRootOptions().map(o => o.long)).toEqual(['--token <token>', '--json']);
+        expect(registry.getRootOptions().map(entry => entry.option.long)).toEqual([
+            '--token <token>',
+            '--json',
+        ]);
     });
 
     it('accepts a shared option that an existing command also declares', () => {
@@ -233,7 +236,10 @@ describe('CommandRegistry nested commands and shared options', () => {
         const registry = registryWithBuiltins();
         registry.applyPlugin(cloudPlugin());
 
-        expect(registry.getRootOptions().map(option => option.long)).toEqual(['--token <token>', '--json']);
+        expect(registry.getRootOptions().map(entry => entry.option.long)).toEqual([
+            '--token <token>',
+            '--json',
+        ]);
     });
 
     it('rejects a plugin that replaces a built-in without opting in', () => {

--- a/packages/cli/src/shared/command-registry-store.spec.ts
+++ b/packages/cli/src/shared/command-registry-store.spec.ts
@@ -1125,8 +1125,9 @@ describe('resolveCliPlugins()', () => {
         expect(withValidation[0].reason).toMatch(/must provide an action function/);
     });
 
-    // `vendure.cliCommands` is hand-maintained, so it drifts. An enabled
-    // plugin is loaded anyway, and what it actually registers is the truth.
+    // `vendure.cliCommands` is hand-maintained, so it can disagree with what
+    // the plugin registers. An enabled plugin is loaded anyway, so the names
+    // are read from the plugin.
     it('reads the commands of an enabled plugin from the plugin itself', () => {
         const fixture = makeTempProject({
             project: {

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -46,6 +46,24 @@ function reservedCommandConflict(name: string): string {
     return `Command "${name}" is reserved by the CLI, because ${RESERVED_COMMAND_REASONS[name]}.`;
 }
 
+/**
+ * A top-level command and the plugin that registered it, as the CLI host
+ * receives them. `source` is undefined for a built-in.
+ */
+export interface CommandTreeEntry {
+    node: CliCommandNode;
+    source?: string;
+}
+
+/**
+ * A shared option and the plugin that registered it. `source` is undefined for
+ * one the CLI itself declares.
+ */
+export interface RootOptionEntry {
+    option: CliCommandOption;
+    source?: string;
+}
+
 interface RegisteredCommand {
     node: CliCommandNode;
     /** Plugin id, or undefined for a built-in. */
@@ -188,54 +206,38 @@ export class CommandRegistry {
         return this.state.commands.has(name);
     }
 
-    toArray(): CliCommandNode[] {
-        return Array.from(this.state.commands.values(), entry => entry.node);
-    }
-
     /**
-     * Top-level command name to the id of the plugin that registered it.
-     * Built-in commands are absent, having no plugin behind them.
+     * The top-level commands, each with the plugin that registered it.
      *
-     * Only top-level names are listed. A subcommand is only ever shown in the
-     * help of the command it is nested under, which already says which package
-     * that command came from.
-     */
-    getCommandSources(): Map<string, string> {
-        const sources = new Map<string, string>();
-        for (const [name, entry] of this.state.commands) {
-            if (entry.source) {
-                sources.set(name, entry.source);
-            }
-        }
-        return sources;
-    }
-
-    /**
-     * Root option attribute name to the id of the plugin that registered it.
+     * Kept together rather than handed out as a command list and a separate
+     * name-keyed map of sources, so the two cannot disagree about which
+     * commands exist.
      *
-     * Sub-options are left out, exactly as {@link getRootOptions} leaves them
-     * out: the parent carries them, and the help lists each one under its
-     * parent, so it belongs in whatever section the parent is in.
+     * A source is only ever recorded against a top-level command, so a
+     * subcommand does not carry one: it is only shown in the help of the
+     * command it is nested under, which already says where that came from.
+     *
+     * `extendCommands` does not set a source either, so a built-in that a
+     * plugin has extended stays listed as a built-in. The command is still the
+     * CLI's, and a plugin that only extends `dev` has not provided `dev`.
      */
-    getRootOptionSources(): Map<string, string> {
-        const sources = new Map<string, string>();
-        for (const [attributeName, entry] of this.state.rootOptions) {
-            if (entry.source && !entry.isSubOption) {
-                sources.set(attributeName, entry.source);
-            }
-        }
-        return sources;
+    getCommandTree(): CommandTreeEntry[] {
+        return Array.from(this.state.commands.values(), entry => ({
+            node: entry.node,
+            source: entry.source,
+        }));
     }
 
     /**
-     * Options registered on the `vendure` command itself by plugins.
+     * Options registered on the `vendure` command itself, each with the plugin
+     * that registered it. See {@link getCommandTree} for why they are paired.
      */
-    getRootOptions(): CliCommandOption[] {
+    getRootOptions(): RootOptionEntry[] {
         // Sub-options are excluded: their parent still carries them, and the
         // host expands each parent once when it registers the option.
         return Array.from(this.state.rootOptions.values())
             .filter(entry => !entry.isSubOption)
-            .map(entry => entry.option);
+            .map(entry => ({ option: entry.option, source: entry.source }));
     }
 
     /**

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -213,9 +213,9 @@ export class CommandRegistry {
      * name-keyed map of sources, so the two cannot disagree about which
      * commands exist.
      *
-     * A source is only ever recorded against a top-level command, so a
-     * subcommand does not carry one: it is only shown in the help of the
-     * command it is nested under, which already says where that came from.
+     * A source is only ever recorded against a top-level command. A subcommand
+     * appears only in the help of the command it is nested under, and that
+     * command's heading already names the package.
      *
      * `extendCommands` does not set a source either, so a built-in that a
      * plugin has extended stays listed as a built-in. The command is still the

--- a/packages/cli/src/shared/command-registry-store.ts
+++ b/packages/cli/src/shared/command-registry-store.ts
@@ -193,6 +193,41 @@ export class CommandRegistry {
     }
 
     /**
+     * Top-level command name to the id of the plugin that registered it.
+     * Built-in commands are absent, having no plugin behind them.
+     *
+     * Only top-level names are listed. A subcommand is only ever shown in the
+     * help of the command it is nested under, which already says which package
+     * that command came from.
+     */
+    getCommandSources(): Map<string, string> {
+        const sources = new Map<string, string>();
+        for (const [name, entry] of this.state.commands) {
+            if (entry.source) {
+                sources.set(name, entry.source);
+            }
+        }
+        return sources;
+    }
+
+    /**
+     * Root option attribute name to the id of the plugin that registered it.
+     *
+     * Sub-options are left out, exactly as {@link getRootOptions} leaves them
+     * out: the parent carries them, and the help lists each one under its
+     * parent, so it belongs in whatever section the parent is in.
+     */
+    getRootOptionSources(): Map<string, string> {
+        const sources = new Map<string, string>();
+        for (const [attributeName, entry] of this.state.rootOptions) {
+            if (entry.source && !entry.isSubOption) {
+                sources.set(attributeName, entry.source);
+            }
+        }
+        return sources;
+    }
+
+    /**
      * Options registered on the `vendure` command itself by plugins.
      */
     getRootOptions(): CliCommandOption[] {

--- a/packages/cli/src/shared/command-registry.spec.ts
+++ b/packages/cli/src/shared/command-registry.spec.ts
@@ -738,20 +738,18 @@ describe('styleHelpTitle()', () => {
         const styled = style('Commands from @vendure/cloud:');
 
         expect(styled).toContain(`${CYAN_ON}@vendure/cloud`);
-        // The label and the colon are outside the tint, so only the package
-        // name carries the hue.
+        // The label and the colon are outside the cyan run, so only the
+        // package name is coloured.
         expect(styled).not.toContain(`${CYAN_ON}Commands from`);
     });
 
-    // The thing a reader notices first is a change in weight, so a heading
-    // that is bold in one part and not another reads as two things.
     it('keeps one weight across the whole plugin heading', () => {
         const styled = style('Options from @vendure/cloud:');
 
         expect(styled.startsWith(BOLD_ON)).toBe(true);
         expect(styled.endsWith(BOLD_OFF)).toBe(true);
-        // One bold span, not one per fragment: a `bold off` in the middle is
-        // exactly what makes the tinted part look thinner than the rest.
+        // One bold span, not one per fragment: a `bold off` in the middle
+        // leaves the rest of the heading at normal weight.
         expect(styled.split(BOLD_OFF)).toHaveLength(2);
         expect(styled.split(BOLD_ON)).toHaveLength(2);
     });

--- a/packages/cli/src/shared/command-registry.spec.ts
+++ b/packages/cli/src/shared/command-registry.spec.ts
@@ -544,6 +544,71 @@ describe('registerCommands() help output', () => {
     });
 });
 
+describe('registerCommands() with a sub-option shared by two parents', () => {
+    /**
+     * The shape `vendure add` uses: `--selected-plugin` is valid with either
+     * `-e` or `-s`, so both parents declare it and both flatten onto the same
+     * command. Commander 13 onwards throws on the repeated flag, which would
+     * take down the whole CLI at startup rather than one command.
+     */
+    function sharedSubOptionCommands(): CliCommandNode[] {
+        return [
+            recordingCommand('add', 'Add a feature', {
+                options: [
+                    {
+                        short: '-e',
+                        long: '--entity <name>',
+                        description: 'Add an entity',
+                        subOptions: [
+                            { long: '--selected-plugin <name>', description: 'Target plugin' },
+                            { long: '--translatable', description: 'Make it translatable' },
+                        ],
+                    },
+                    {
+                        short: '-s',
+                        long: '--service <name>',
+                        description: 'Add a service',
+                        subOptions: [{ long: '--selected-plugin <name>', description: 'Target plugin' }],
+                    },
+                ],
+            }),
+        ];
+    }
+
+    it('registers the command instead of failing', async () => {
+        const result = await runCli(sharedSubOptionCommands(), [], ['add', '--help']);
+
+        expect(result.stdout).toContain('Usage: vendure add');
+    });
+
+    it('parses the shared flag', async () => {
+        const result = await runCli(sharedSubOptionCommands(), [], [
+            'add',
+            '-s',
+            'MyService',
+            '--selected-plugin',
+            'MyPlugin',
+        ]);
+
+        expect(result.exitCode).toBe(0);
+        expect(calls[0].options.selectedPlugin).toBe('MyPlugin');
+    });
+
+    it('lists the shared flag once', async () => {
+        const result = await runCli(sharedSubOptionCommands(), [], ['add', '--help']);
+
+        const listings = result.stdout.match(/^\s+--selected-plugin /gm) ?? [];
+        expect(listings).toHaveLength(1);
+    });
+
+    it('keeps the other sub-options of both parents', async () => {
+        const result = await runCli(sharedSubOptionCommands(), [], ['add', '--help']);
+
+        expect(result.stdout).toMatch(/^\s+--translatable/m);
+        expect(result.stdout).toMatch(/^\s+-s, --service/m);
+    });
+});
+
 describe('registerCommands() error handling', () => {
     it('fails on an unknown subcommand', async () => {
         const result = await runCli(cloudCommands(), rootOptions, ['project', 'destroy']);

--- a/packages/cli/src/shared/command-registry.spec.ts
+++ b/packages/cli/src/shared/command-registry.spec.ts
@@ -2,8 +2,8 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { createColors } from 'picocolors';
 
+import { sectionAfter } from './__tests__/help-sections';
 import { runCli } from './__tests__/run-cli';
-import { styleHelpTitle } from './command-registry';
 import {
     CliCommandDefinition,
     CliCommandNode,
@@ -12,6 +12,9 @@ import {
     readCommandOptions,
 } from './cli-command-definition';
 import { exitCliCommand } from './cli-command-exit';
+import { parseOptionFlags } from './cli-command-options';
+import { styleHelpTitle } from './command-registry';
+import { CommandTreeEntry, RootOptionEntry } from './command-registry-store';
 
 interface RecordedCall {
     commandPath: string[];
@@ -108,22 +111,6 @@ function cloudCommands(): CliCommandNode[] {
             ],
         },
     ];
-}
-
-
-/**
- * The lines of one help section: everything from `heading` up to the blank
- * line that ends it. Lets a test say which section a command is listed in,
- * which `toContain` on the whole screen cannot.
- */
-function sectionAfter(help: string, heading: string): string {
-    const start = help.indexOf(`\n${heading}`);
-    if (start === -1) {
-        return '';
-    }
-    const body = help.slice(start + heading.length + 1);
-    const end = body.indexOf('\n\n');
-    return end === -1 ? body : body.slice(0, end);
 }
 
 describe('registerCommands() with nested commands', () => {
@@ -563,71 +550,6 @@ describe('registerCommands() help output', () => {
     });
 });
 
-describe('registerCommands() with a sub-option shared by two parents', () => {
-    /**
-     * The shape `vendure add` uses: `--selected-plugin` is valid with either
-     * `-e` or `-s`, so both parents declare it and both flatten onto the same
-     * command. Commander 13 onwards throws on the repeated flag, which would
-     * take down the whole CLI at startup rather than one command.
-     */
-    function sharedSubOptionCommands(): CliCommandNode[] {
-        return [
-            recordingCommand('add', 'Add a feature', {
-                options: [
-                    {
-                        short: '-e',
-                        long: '--entity <name>',
-                        description: 'Add an entity',
-                        subOptions: [
-                            { long: '--selected-plugin <name>', description: 'Target plugin' },
-                            { long: '--translatable', description: 'Make it translatable' },
-                        ],
-                    },
-                    {
-                        short: '-s',
-                        long: '--service <name>',
-                        description: 'Add a service',
-                        subOptions: [{ long: '--selected-plugin <name>', description: 'Target plugin' }],
-                    },
-                ],
-            }),
-        ];
-    }
-
-    it('registers the command instead of failing', async () => {
-        const result = await runCli(sharedSubOptionCommands(), [], ['add', '--help']);
-
-        expect(result.stdout).toContain('Usage: vendure add');
-    });
-
-    it('parses the shared flag', async () => {
-        const result = await runCli(sharedSubOptionCommands(), [], [
-            'add',
-            '-s',
-            'MyService',
-            '--selected-plugin',
-            'MyPlugin',
-        ]);
-
-        expect(result.exitCode).toBe(0);
-        expect(calls[0].options.selectedPlugin).toBe('MyPlugin');
-    });
-
-    it('lists the shared flag once', async () => {
-        const result = await runCli(sharedSubOptionCommands(), [], ['add', '--help']);
-
-        const listings = result.stdout.match(/^\s+--selected-plugin /gm) ?? [];
-        expect(listings).toHaveLength(1);
-    });
-
-    it('keeps the other sub-options of both parents', async () => {
-        const result = await runCli(sharedSubOptionCommands(), [], ['add', '--help']);
-
-        expect(result.stdout).toMatch(/^\s+--translatable/m);
-        expect(result.stdout).toMatch(/^\s+-s, --service/m);
-    });
-});
-
 /**
  * A built-in alongside the plugin commands, so a test can tell the grouped
  * section from the ungrouped one rather than just counting headings.
@@ -636,18 +558,22 @@ function mixedCommands(): CliCommandNode[] {
     return [recordingCommand('dev', 'Run Vendure in development mode'), ...cloudCommands()];
 }
 
-function sources(entries: Record<string, string>): ReadonlyMap<string, string> {
-    return new Map(Object.entries(entries));
+/** Tags the named commands with a source; the rest stay built-ins. */
+function withCommandSources(commands: CliCommandNode[], sources: Record<string, string>): CommandTreeEntry[] {
+    return commands.map(node => ({ node, source: sources[node.name] }));
+}
+
+/** Tags the named options with a source, keyed by Commander attribute name. */
+function withOptionSources(options: CliCommandOption[], sources: Record<string, string>): RootOptionEntry[] {
+    return options.map(option => ({ option, source: sources[parseOptionFlags(option).attributeName] }));
 }
 
 describe('registerCommands() help grouping', () => {
     it('lists a plugin command under a heading naming its package', async () => {
         const result = await runCli(
-            mixedCommands(),
+            withCommandSources(mixedCommands(), { project: '@vendure/cloud', config: '@vendure/cloud' }),
             rootOptions,
             ['--help'],
-            undefined,
-            { commands: sources({ project: '@vendure/cloud', config: '@vendure/cloud' }) },
         );
 
         expect(result.stdout).toContain('Commands from @vendure/cloud:');
@@ -657,11 +583,9 @@ describe('registerCommands() help grouping', () => {
 
     it('leaves commands with no source under the default heading', async () => {
         const result = await runCli(
-            mixedCommands(),
+            withCommandSources(mixedCommands(), { project: '@vendure/cloud' }),
             rootOptions,
             ['--help'],
-            undefined,
-            { commands: sources({ project: '@vendure/cloud' }) },
         );
 
         const defaultSection = sectionAfter(result.stdout, 'Commands:');
@@ -672,11 +596,13 @@ describe('registerCommands() help grouping', () => {
 
     it('puts every command from one package in a single section', async () => {
         const result = await runCli(
-            mixedCommands(),
+            withCommandSources(mixedCommands(), {
+                project: '@vendure/cloud',
+                config: '@vendure/cloud',
+                backup: '@vendure/cloud',
+            }),
             rootOptions,
             ['--help'],
-            undefined,
-            { commands: sources({ project: '@vendure/cloud', config: '@vendure/cloud', backup: '@vendure/cloud' }) },
         );
 
         const headings = result.stdout.match(/^Commands from @vendure\/cloud:$/gm) ?? [];
@@ -689,11 +615,12 @@ describe('registerCommands() help grouping', () => {
 
     it('gives two packages a section each', async () => {
         const result = await runCli(
-            mixedCommands(),
+            withCommandSources(mixedCommands(), {
+                project: '@vendure/cloud',
+                backup: 'vendure-plugin-backups',
+            }),
             rootOptions,
             ['--help'],
-            undefined,
-            { commands: sources({ project: '@vendure/cloud', backup: 'vendure-plugin-backups' }) },
         );
 
         expect(sectionAfter(result.stdout, 'Commands from @vendure/cloud:')).toMatch(
@@ -706,11 +633,9 @@ describe('registerCommands() help grouping', () => {
 
     it('lists the built-ins first', async () => {
         const result = await runCli(
-            mixedCommands(),
+            withCommandSources(mixedCommands(), { project: '@vendure/cloud' }),
             rootOptions,
             ['--help'],
-            undefined,
-            { commands: sources({ project: '@vendure/cloud' }) },
         );
 
         expect(result.stdout.indexOf('\nCommands:')).toBeLessThan(
@@ -719,9 +644,11 @@ describe('registerCommands() help grouping', () => {
     });
 
     it('lists a shared option under a heading naming its package', async () => {
-        const result = await runCli(mixedCommands(), rootOptions, ['--help'], undefined, {
-            rootOptions: sources({ token: '@vendure/cloud', json: '@vendure/cloud' }),
-        });
+        const result = await runCli(
+            mixedCommands(),
+            withOptionSources(rootOptions, { token: '@vendure/cloud', json: '@vendure/cloud' }),
+            ['--help'],
+        );
 
         const pluginSection = sectionAfter(result.stdout, 'Options from @vendure/cloud:');
         expect(pluginSection).toMatch(/^\s+--token /m);
@@ -729,9 +656,11 @@ describe('registerCommands() help grouping', () => {
     });
 
     it("leaves the CLI's own options under the default heading", async () => {
-        const result = await runCli(mixedCommands(), rootOptions, ['--help'], undefined, {
-            rootOptions: sources({ token: '@vendure/cloud' }),
-        });
+        const result = await runCli(
+            mixedCommands(),
+            withOptionSources(rootOptions, { token: '@vendure/cloud' }),
+            ['--help'],
+        );
 
         const defaultSection = sectionAfter(result.stdout, 'Options:');
         expect(defaultSection).toMatch(/^\s+-h, --help/m);
@@ -749,9 +678,11 @@ describe('registerCommands() help grouping', () => {
             },
         ];
 
-        const result = await runCli(mixedCommands(), withSubOption, ['--help'], undefined, {
-            rootOptions: sources({ token: '@vendure/cloud' }),
-        });
+        const result = await runCli(
+            mixedCommands(),
+            withOptionSources(withSubOption, { token: '@vendure/cloud' }),
+            ['--help'],
+        );
 
         // The sub-option is listed indented under its parent, so splitting them
         // into different sections would put the indented line under nothing.
@@ -776,11 +707,9 @@ describe('registerCommands() help grouping', () => {
 
     it('does not group a subcommand of a plugin command', async () => {
         const result = await runCli(
-            mixedCommands(),
+            withCommandSources(mixedCommands(), { project: '@vendure/cloud', list: '@vendure/cloud' }),
             rootOptions,
             ['project', '--help'],
-            undefined,
-            { commands: sources({ project: '@vendure/cloud', list: '@vendure/cloud' }) },
         );
 
         // `list` is a subcommand of `project`, so the source map's top-level
@@ -830,10 +759,11 @@ describe('styleHelpTitle()', () => {
     // styleHelpTitle parses a string the heading builders produced, so a
     // change to either format has to keep the other working.
     it('recognises the headings the registry actually builds', async () => {
-        const result = await runCli(mixedCommands(), rootOptions, ['--help'], undefined, {
-            commands: sources({ project: '@vendure/cloud' }),
-            rootOptions: sources({ token: '@vendure/cloud' }),
-        });
+        const result = await runCli(
+            withCommandSources(mixedCommands(), { project: '@vendure/cloud' }),
+            withOptionSources(rootOptions, { token: '@vendure/cloud' }),
+            ['--help'],
+        );
 
         for (const heading of ['Commands from @vendure/cloud:', 'Options from @vendure/cloud:']) {
             expect(result.stdout).toContain(heading);

--- a/packages/cli/src/shared/command-registry.spec.ts
+++ b/packages/cli/src/shared/command-registry.spec.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { createColors } from 'picocolors';
+
 import { runCli } from './__tests__/run-cli';
+import { styleHelpTitle } from './command-registry';
 import {
     CliCommandDefinition,
     CliCommandNode,
@@ -105,6 +108,22 @@ function cloudCommands(): CliCommandNode[] {
             ],
         },
     ];
+}
+
+
+/**
+ * The lines of one help section: everything from `heading` up to the blank
+ * line that ends it. Lets a test say which section a command is listed in,
+ * which `toContain` on the whole screen cannot.
+ */
+function sectionAfter(help: string, heading: string): string {
+    const start = help.indexOf(`\n${heading}`);
+    if (start === -1) {
+        return '';
+    }
+    const body = help.slice(start + heading.length + 1);
+    const end = body.indexOf('\n\n');
+    return end === -1 ? body : body.slice(0, end);
 }
 
 describe('registerCommands() with nested commands', () => {
@@ -606,6 +625,225 @@ describe('registerCommands() with a sub-option shared by two parents', () => {
 
         expect(result.stdout).toMatch(/^\s+--translatable/m);
         expect(result.stdout).toMatch(/^\s+-s, --service/m);
+    });
+});
+
+/**
+ * A built-in alongside the plugin commands, so a test can tell the grouped
+ * section from the ungrouped one rather than just counting headings.
+ */
+function mixedCommands(): CliCommandNode[] {
+    return [recordingCommand('dev', 'Run Vendure in development mode'), ...cloudCommands()];
+}
+
+function sources(entries: Record<string, string>): ReadonlyMap<string, string> {
+    return new Map(Object.entries(entries));
+}
+
+describe('registerCommands() help grouping', () => {
+    it('lists a plugin command under a heading naming its package', async () => {
+        const result = await runCli(
+            mixedCommands(),
+            rootOptions,
+            ['--help'],
+            undefined,
+            { commands: sources({ project: '@vendure/cloud', config: '@vendure/cloud' }) },
+        );
+
+        expect(result.stdout).toContain('Commands from @vendure/cloud:');
+        expect(result.stdout).toMatch(/^\s+project\s+Manage projects$/m);
+        expect(result.stdout).toMatch(/^\s+config \[options\]\s+Manage configuration$/m);
+    });
+
+    it('leaves commands with no source under the default heading', async () => {
+        const result = await runCli(
+            mixedCommands(),
+            rootOptions,
+            ['--help'],
+            undefined,
+            { commands: sources({ project: '@vendure/cloud' }) },
+        );
+
+        const defaultSection = sectionAfter(result.stdout, 'Commands:');
+        expect(defaultSection).toMatch(/^\s+dev\s+Run Vendure in development mode$/m);
+        expect(defaultSection).toMatch(/^\s+backup\s+Manage backups$/m);
+        expect(defaultSection).not.toContain('Manage projects');
+    });
+
+    it('puts every command from one package in a single section', async () => {
+        const result = await runCli(
+            mixedCommands(),
+            rootOptions,
+            ['--help'],
+            undefined,
+            { commands: sources({ project: '@vendure/cloud', config: '@vendure/cloud', backup: '@vendure/cloud' }) },
+        );
+
+        const headings = result.stdout.match(/^Commands from @vendure\/cloud:$/gm) ?? [];
+        expect(headings).toHaveLength(1);
+
+        const pluginSection = sectionAfter(result.stdout, 'Commands from @vendure/cloud:');
+        expect(pluginSection).toMatch(/^\s+project\s+Manage projects$/m);
+        expect(pluginSection).toMatch(/^\s+backup\s+Manage backups$/m);
+    });
+
+    it('gives two packages a section each', async () => {
+        const result = await runCli(
+            mixedCommands(),
+            rootOptions,
+            ['--help'],
+            undefined,
+            { commands: sources({ project: '@vendure/cloud', backup: 'vendure-plugin-backups' }) },
+        );
+
+        expect(sectionAfter(result.stdout, 'Commands from @vendure/cloud:')).toMatch(
+            /^\s+project\s+Manage projects$/m,
+        );
+        expect(sectionAfter(result.stdout, 'Commands from vendure-plugin-backups:')).toMatch(
+            /^\s+backup\s+Manage backups$/m,
+        );
+    });
+
+    it('lists the built-ins first', async () => {
+        const result = await runCli(
+            mixedCommands(),
+            rootOptions,
+            ['--help'],
+            undefined,
+            { commands: sources({ project: '@vendure/cloud' }) },
+        );
+
+        expect(result.stdout.indexOf('\nCommands:')).toBeLessThan(
+            result.stdout.indexOf('Commands from @vendure/cloud:'),
+        );
+    });
+
+    it('lists a shared option under a heading naming its package', async () => {
+        const result = await runCli(mixedCommands(), rootOptions, ['--help'], undefined, {
+            rootOptions: sources({ token: '@vendure/cloud', json: '@vendure/cloud' }),
+        });
+
+        const pluginSection = sectionAfter(result.stdout, 'Options from @vendure/cloud:');
+        expect(pluginSection).toMatch(/^\s+--token /m);
+        expect(pluginSection).toMatch(/^\s+--json /m);
+    });
+
+    it("leaves the CLI's own options under the default heading", async () => {
+        const result = await runCli(mixedCommands(), rootOptions, ['--help'], undefined, {
+            rootOptions: sources({ token: '@vendure/cloud' }),
+        });
+
+        const defaultSection = sectionAfter(result.stdout, 'Options:');
+        expect(defaultSection).toMatch(/^\s+-h, --help/m);
+        expect(defaultSection).not.toContain('--token');
+        // Not every shared option came from the plugin, so the rest stay put.
+        expect(defaultSection).toMatch(/^\s+--project /m);
+    });
+
+    it('groups a sub-option with its parent', async () => {
+        const withSubOption: CliCommandOption[] = [
+            {
+                long: '--token <token>',
+                description: 'API token',
+                subOptions: [{ long: '--token-file <path>', description: 'Read the token from a file' }],
+            },
+        ];
+
+        const result = await runCli(mixedCommands(), withSubOption, ['--help'], undefined, {
+            rootOptions: sources({ token: '@vendure/cloud' }),
+        });
+
+        // The sub-option is listed indented under its parent, so splitting them
+        // into different sections would put the indented line under nothing.
+        const pluginSection = sectionAfter(result.stdout, 'Options from @vendure/cloud:');
+        expect(pluginSection).toMatch(/^\s+--token /m);
+        expect(pluginSection).toMatch(/^\s+--token-file /m);
+    });
+
+    it('groups no options when no option sources are given', async () => {
+        const result = await runCli(mixedCommands(), rootOptions, ['--help']);
+
+        expect(result.stdout).not.toContain('Options from');
+        expect(sectionAfter(result.stdout, 'Options:')).toMatch(/^\s+--token /m);
+    });
+
+    it('groups nothing when no sources are given', async () => {
+        const result = await runCli(mixedCommands(), rootOptions, ['--help']);
+
+        expect(result.stdout).not.toContain('Commands from');
+        expect(sectionAfter(result.stdout, 'Commands:')).toMatch(/^\s+project\s+Manage projects$/m);
+    });
+
+    it('does not group a subcommand of a plugin command', async () => {
+        const result = await runCli(
+            mixedCommands(),
+            rootOptions,
+            ['project', '--help'],
+            undefined,
+            { commands: sources({ project: '@vendure/cloud', list: '@vendure/cloud' }) },
+        );
+
+        // `list` is a subcommand of `project`, so the source map's top-level
+        // `list` entry must not reach it: its parent's help already says which
+        // package it came from.
+        expect(result.stdout).not.toContain('Commands from');
+        expect(result.stdout).toMatch(/^\s+list\s+List projects$/m);
+    });
+});
+
+describe('styleHelpTitle()', () => {
+    const BOLD_ON = '\u001b[1m';
+    const BOLD_OFF = '\u001b[22m';
+    const CYAN_ON = '\u001b[36m';
+    // picocolors emits nothing when stdout is not a terminal, which it is not
+    // under vitest, so colour has to be forced on to see the escape codes.
+    const colors = createColors(true);
+    const style = (title: string) => styleHelpTitle(title, colors);
+
+    it("bolds the CLI's own headings", () => {
+        expect(style('Commands:')).toBe(`${BOLD_ON}Commands:${BOLD_OFF}`);
+        expect(style('Options:')).toBe(`${BOLD_ON}Options:${BOLD_OFF}`);
+    });
+
+    it('tints the package name inside a plugin heading', () => {
+        const styled = style('Commands from @vendure/cloud:');
+
+        expect(styled).toContain(`${CYAN_ON}@vendure/cloud`);
+        // The label and the colon are outside the tint, so only the package
+        // name carries the hue.
+        expect(styled).not.toContain(`${CYAN_ON}Commands from`);
+    });
+
+    // The thing a reader notices first is a change in weight, so a heading
+    // that is bold in one part and not another reads as two things.
+    it('keeps one weight across the whole plugin heading', () => {
+        const styled = style('Options from @vendure/cloud:');
+
+        expect(styled.startsWith(BOLD_ON)).toBe(true);
+        expect(styled.endsWith(BOLD_OFF)).toBe(true);
+        // One bold span, not one per fragment: a `bold off` in the middle is
+        // exactly what makes the tinted part look thinner than the rest.
+        expect(styled.split(BOLD_OFF)).toHaveLength(2);
+        expect(styled.split(BOLD_ON)).toHaveLength(2);
+    });
+
+    // styleHelpTitle parses a string the heading builders produced, so a
+    // change to either format has to keep the other working.
+    it('recognises the headings the registry actually builds', async () => {
+        const result = await runCli(mixedCommands(), rootOptions, ['--help'], undefined, {
+            commands: sources({ project: '@vendure/cloud' }),
+            rootOptions: sources({ token: '@vendure/cloud' }),
+        });
+
+        for (const heading of ['Commands from @vendure/cloud:', 'Options from @vendure/cloud:']) {
+            expect(result.stdout).toContain(heading);
+            expect(style(heading)).toContain(CYAN_ON);
+        }
+    });
+
+    it('leaves a heading it does not recognise merely bold', () => {
+        expect(style('Global Options:')).toBe(`${BOLD_ON}Global Options:${BOLD_OFF}`);
+        expect(style('Arguments:')).toBe(`${BOLD_ON}Arguments:${BOLD_OFF}`);
     });
 });
 

--- a/packages/cli/src/shared/command-registry.ts
+++ b/packages/cli/src/shared/command-registry.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import pc from 'picocolors';
 
 import {
     CliCommandAction,
@@ -22,25 +23,129 @@ interface SharedOption {
     owner: Command;
 }
 
+export interface RegisterCommandsOptions {
+    /** Options declared on the program itself, and so shared by every command. */
+    rootOptions?: CliCommandOption[];
+    /** Reads plugin contributions registered for a named extension point. */
+    getPluginExtensions?: CliPluginExtensionAccessor;
+    /**
+     * Top-level command name to the id of the plugin that registered it, as
+     * {@link CommandRegistry.getCommandSources} returns it. Commands absent
+     * from the map are built-ins.
+     *
+     * Used only to group the help output: a command behaves the same whether
+     * a plugin or the CLI itself provides it, and is typed the same way.
+     */
+    commandSources?: ReadonlyMap<string, string>;
+    /**
+     * Root option attribute name to the id of the plugin that registered it,
+     * as {@link CommandRegistry.getRootOptionSources} returns it. Options
+     * absent from the map belong to the CLI itself.
+     *
+     * Used only to group the help output, like {@link commandSources}. Note
+     * that only the root help groups them: the "Global Options" section a
+     * subcommand's help shows is one flat list in Commander, whatever group
+     * the options are in.
+     */
+    rootOptionSources?: ReadonlyMap<string, string>;
+}
+
+/**
+ * The help heading commands from `packageName` are listed under.
+ *
+ * The package name is used unchanged rather than a prettier display name, so
+ * the heading names the exact thing to install, enable or remove.
+ */
+function pluginCommandsHeading(packageName: string): string {
+    return `Commands from ${packageName}:`;
+}
+
+/**
+ * The help heading the shared options registered by `packageName` are listed
+ * under. Worded to match {@link pluginCommandsHeading}, so one package reads
+ * the same way wherever it appears.
+ */
+function pluginOptionsHeading(packageName: string): string {
+    return `Options from ${packageName}:`;
+}
+
+/**
+ * Splits a heading built by {@link pluginCommandsHeading} or
+ * {@link pluginOptionsHeading} back into its parts, so
+ * {@link styleHelpTitle} can pick the package name out of it. Kept beside the
+ * two builders: it has to match what they produce, and `styleTitle` hands
+ * Commander's help back nothing but the finished string.
+ */
+const PLUGIN_HEADING = /^((?:Commands|Options) from )(.+)(:)$/;
+
+/**
+ * Styles one help section heading.
+ *
+ * Every heading is bold, including the CLI's own `Commands:` and `Options:`,
+ * so the sections read as peers rather than a plugin's looking like an aside.
+ * Within a plugin's heading the package name is tinted as well, which is what
+ * visibly pairs its "Commands from" section with its "Options from" one. The
+ * tint is bold too, so the heading is one weight throughout.
+ *
+ * Nothing is said by colour alone — the heading names the package in words —
+ * so a monochrome terminal loses nothing. Commander strips the escape codes
+ * itself when the output is not a terminal, or when NO_COLOR is set.
+ */
+export function styleHelpTitle(title: string, colors: HeadingColors = pc): string {
+    const match = PLUGIN_HEADING.exec(title);
+    if (!match) {
+        return colors.bold(title);
+    }
+    const [, label, packageName, colon] = match;
+    // Nested rather than concatenated: styling the parts separately would
+    // close the bold run before the tint opens, leaving the package name at
+    // normal weight beside a bold label.
+    return colors.bold(label + colors.cyan(packageName) + colon);
+}
+
+/**
+ * The palette {@link styleHelpTitle} paints with. It defaults to picocolors,
+ * which emits nothing unless the terminal supports colour, so a test has to
+ * pass `createColors(true)` to see what a colour terminal would get.
+ */
+export type HeadingColors = Pick<typeof pc, 'bold' | 'cyan'>;
+
 export function registerCommands(
     program: Command,
     commands: CliCommandNode[],
-    rootOptions: CliCommandOption[] = [],
-    getPluginExtensions: CliPluginExtensionAccessor = () => [],
+    options: RegisterCommandsOptions = {},
 ): void {
-    const sharedOptions = declareOptions(program, rootOptions);
+    const {
+        rootOptions = [],
+        getPluginExtensions = () => [],
+        commandSources,
+        rootOptionSources,
+    } = options;
+    const sharedOptions = declareOptions(program, rootOptions, rootOptionSources);
     for (const node of commands) {
-        registerNode(program, node, [], sharedOptions, getPluginExtensions);
+        const command = registerNode(program, node, [], sharedOptions, getPluginExtensions);
+        const source = commandSources?.get(node.name);
+        if (source) {
+            // Commander groups by the heading text itself, so every command
+            // from one package lands in one section without further
+            // bookkeeping. Commands left ungrouped keep Commander's own
+            // "Commands:" heading, which is where the built-ins stay.
+            command.helpGroup(pluginCommandsHeading(source));
+        }
     }
 }
 
+/**
+ * Registers a node and everything nested under it, returning the Commander
+ * command it created so the caller can group it in the help output.
+ */
 function registerNode(
     parent: Command,
     node: CliCommandNode,
     path: string[],
     sharedOptions: SharedOption[],
     getPluginExtensions: CliPluginExtensionAccessor,
-): void {
+): Command {
     const command = parent.command(node.name).description(node.description);
     const commandPath = [...path, node.name];
     const runnable = isRunnableCliCommand(node) ? node : undefined;
@@ -78,7 +183,7 @@ function registerNode(
     if (!runnable) {
         // A group has no action: Commander prints its help and exits non-zero
         // when it is run without a subcommand.
-        return;
+        return command;
     }
 
     command.action(async (...args: any[]) => {
@@ -99,6 +204,8 @@ function registerNode(
         // Exit is owned by the host so plugins can wrap built-in actions.
         process.exit(await runAction(runnable.action, args, context));
     });
+
+    return command;
 }
 
 /**
@@ -144,14 +251,26 @@ async function runAction(action: CliCommandAction, args: any[], context: CliComm
  * Declares options on a command and describes them for any descendants, which
  * inherit them when the command has subcommands or is the root program.
  */
-function declareOptions(command: Command, options: CliCommandOption[]): SharedOption[] {
+function declareOptions(
+    command: Command,
+    options: CliCommandOption[],
+    sources?: ReadonlyMap<string, string>,
+): SharedOption[] {
     const declared: SharedOption[] = [];
     for (const option of options) {
-        declareOption(command, option, declared);
+        const source = sources?.get(parseOptionFlags(option).attributeName);
+        const helpGroup = source === undefined ? undefined : pluginOptionsHeading(source);
+        declareOption(command, option, declared, helpGroup);
 
         for (const subOption of option.subOptions ?? []) {
             // Indent the description so the help output shows the nesting.
-            declareOption(command, { ...subOption, description: `  └─ ${subOption.description}` }, declared);
+            // Grouped with its parent, which is the option it is indented under.
+            declareOption(
+                command,
+                { ...subOption, description: `  └─ ${subOption.description}` },
+                declared,
+                helpGroup,
+            );
         }
     }
     return declared;
@@ -163,15 +282,20 @@ function declareOptions(command: Command, options: CliCommandOption[]): SharedOp
  * One sub-option can belong to more than one parent — `vendure add` takes
  * `--selected-plugin` with either `-e` or `-s` — and every sub-option is
  * flattened onto the same command, so the flag arrives twice. Commander 11
- * accepts the repeat, lists it twice in help and matches the first declaration
- * when parsing. Commander 13 onwards throws instead, which would fail at
- * startup and take down the whole CLI rather than one command.
+ * accepted the repeat, listed it twice in help and matched the first
+ * declaration when parsing. Commander 13 onwards throws instead, which would
+ * fail at startup and take down the whole CLI rather than one command.
  *
- * Keeping the first declaration parses exactly as Commander 11 does, and drops
+ * Keeping the first declaration parses exactly as Commander 11 did, and drops
  * the duplicate help line. A plugin can hit this as readily as a built-in, so
  * it is handled here rather than in any one command's definition.
  */
-function declareOption(command: Command, option: CliCommandOption, declared: SharedOption[]): void {
+function declareOption(
+    command: Command,
+    option: CliCommandOption,
+    declared: SharedOption[],
+    helpGroup?: string,
+): void {
     const parsed = parseOptionFlags(option);
     const alreadyDeclared = command.options.some(
         existing =>
@@ -181,12 +305,22 @@ function declareOption(command: Command, option: CliCommandOption, declared: Sha
     if (alreadyDeclared) {
         return;
     }
-    addOption(command, option);
+    addOption(command, option, helpGroup);
     declared.push({ attributeName: parsed.attributeName, owner: command });
 }
 
-function addOption(command: Command, option: CliCommandOption): void {
-    command.option(buildOptionFlags(option), option.description, option.defaultValue);
+/**
+ * Builds the option the way `Command#option` does — create it, give it the
+ * default value, add it — with the chance to put it in a help group on the
+ * way, which `Command#option` gives no way to do.
+ */
+function addOption(command: Command, option: CliCommandOption, helpGroup?: string): void {
+    const created = command.createOption(buildOptionFlags(option), option.description);
+    created.default(option.defaultValue);
+    if (helpGroup !== undefined) {
+        created.helpGroup(helpGroup);
+    }
+    command.addOption(created);
 }
 
 /**

--- a/packages/cli/src/shared/command-registry.ts
+++ b/packages/cli/src/shared/command-registry.ts
@@ -61,8 +61,9 @@ const PLUGIN_HEADING = /^((?:Commands|Options) from )(.+)(:)$/;
  * heading's package name is cyan as well.
  *
  * Colour is decoration only: the heading names the package in words, so a
- * monochrome terminal loses nothing. Commander strips the escape codes when
- * the output is not a terminal or NO_COLOR is set.
+ * monochrome terminal loses nothing. Commander strips the escape codes when it
+ * detects no colour support, which covers a pipe or a file unless FORCE_COLOR
+ * is set, and covers NO_COLOR whatever the output is.
  */
 export function styleHelpTitle(title: string, colors: HeadingColors = pc): string {
     const match = PLUGIN_HEADING.exec(title);
@@ -71,13 +72,13 @@ export function styleHelpTitle(title: string, colors: HeadingColors = pc): strin
     }
     const [, label, packageName, colon] = match;
     // Nested, not concatenated: styling the parts separately closes the bold
-    // run before the tint opens, leaving the package name at normal weight.
+    // run before the cyan one opens, leaving the package name at normal weight.
     return colors.bold(label + colors.cyan(packageName) + colon);
 }
 
 /**
- * Defaults to picocolors, which emits nothing unless the terminal supports
- * colour, so a test passes `createColors(true)` to see the escape codes.
+ * Defaults to picocolors, which emits nothing unless it detects colour
+ * support, so a test passes `createColors(true)` to see the escape codes.
  */
 export type HeadingColors = Pick<typeof pc, 'bold' | 'cyan'>;
 
@@ -239,7 +240,6 @@ function declareOptions(command: Command, entries: RootOptionEntry[]): SharedOpt
     return declared;
 }
 
-/** Declares one option on a command and records it for descendants to read. */
 function declareOption(
     command: Command,
     option: CliCommandOption,

--- a/packages/cli/src/shared/command-registry.ts
+++ b/packages/cli/src/shared/command-registry.ts
@@ -62,8 +62,8 @@ const PLUGIN_HEADING = /^((?:Commands|Options) from )(.+)(:)$/;
  *
  * Colour is decoration only: the heading names the package in words, so a
  * monochrome terminal loses nothing. Commander strips the escape codes when it
- * detects no colour support, which covers a pipe or a file unless FORCE_COLOR
- * is set, and covers NO_COLOR whatever the output is.
+ * detects no colour support. A pipe or a file counts as no support unless
+ * FORCE_COLOR is set. NO_COLOR counts as no support whatever the output is.
  */
 export function styleHelpTitle(title: string, colors: HeadingColors = pc): string {
     const match = PLUGIN_HEADING.exec(title);

--- a/packages/cli/src/shared/command-registry.ts
+++ b/packages/cli/src/shared/command-registry.ts
@@ -147,20 +147,42 @@ async function runAction(action: CliCommandAction, args: any[], context: CliComm
 function declareOptions(command: Command, options: CliCommandOption[]): SharedOption[] {
     const declared: SharedOption[] = [];
     for (const option of options) {
-        addOption(command, option);
-        declared.push({ attributeName: parseOptionFlags(option).attributeName, owner: command });
+        declareOption(command, option, declared);
 
         for (const subOption of option.subOptions ?? []) {
             // Indent the description so the help output shows the nesting.
-            const indentedSubOption = { ...subOption, description: `  └─ ${subOption.description}` };
-            addOption(command, indentedSubOption);
-            declared.push({
-                attributeName: parseOptionFlags(indentedSubOption).attributeName,
-                owner: command,
-            });
+            declareOption(command, { ...subOption, description: `  └─ ${subOption.description}` }, declared);
         }
     }
     return declared;
+}
+
+/**
+ * Declares one option on a command, unless that flag is already declared there.
+ *
+ * One sub-option can belong to more than one parent — `vendure add` takes
+ * `--selected-plugin` with either `-e` or `-s` — and every sub-option is
+ * flattened onto the same command, so the flag arrives twice. Commander 11
+ * accepts the repeat, lists it twice in help and matches the first declaration
+ * when parsing. Commander 13 onwards throws instead, which would fail at
+ * startup and take down the whole CLI rather than one command.
+ *
+ * Keeping the first declaration parses exactly as Commander 11 does, and drops
+ * the duplicate help line. A plugin can hit this as readily as a built-in, so
+ * it is handled here rather than in any one command's definition.
+ */
+function declareOption(command: Command, option: CliCommandOption, declared: SharedOption[]): void {
+    const parsed = parseOptionFlags(option);
+    const alreadyDeclared = command.options.some(
+        existing =>
+            existing.attributeName() === parsed.attributeName ||
+            (parsed.short !== undefined && existing.short === parsed.short),
+    );
+    if (alreadyDeclared) {
+        return;
+    }
+    addOption(command, option);
+    declared.push({ attributeName: parsed.attributeName, owner: command });
 }
 
 function addOption(command: Command, option: CliCommandOption): void {

--- a/packages/cli/src/shared/command-registry.ts
+++ b/packages/cli/src/shared/command-registry.ts
@@ -12,6 +12,7 @@ import {
 import { CliCommandExit } from './cli-command-exit';
 import { buildOptionFlags, parseOptionFlags } from './cli-command-options';
 import { CliPluginExtensionAccessor } from './cli-plugin-extension';
+import { CommandTreeEntry, RootOptionEntry } from './command-registry-store';
 
 /**
  * An option declared on an ancestor of a command. Commander stores the parsed
@@ -24,30 +25,13 @@ interface SharedOption {
 }
 
 export interface RegisterCommandsOptions {
-    /** Options declared on the program itself, and so shared by every command. */
-    rootOptions?: CliCommandOption[];
+    /**
+     * Options declared on the program itself, and so shared by every command,
+     * each with the plugin that registered it.
+     */
+    rootOptions?: RootOptionEntry[];
     /** Reads plugin contributions registered for a named extension point. */
     getPluginExtensions?: CliPluginExtensionAccessor;
-    /**
-     * Top-level command name to the id of the plugin that registered it, as
-     * {@link CommandRegistry.getCommandSources} returns it. Commands absent
-     * from the map are built-ins.
-     *
-     * Used only to group the help output: a command behaves the same whether
-     * a plugin or the CLI itself provides it, and is typed the same way.
-     */
-    commandSources?: ReadonlyMap<string, string>;
-    /**
-     * Root option attribute name to the id of the plugin that registered it,
-     * as {@link CommandRegistry.getRootOptionSources} returns it. Options
-     * absent from the map belong to the CLI itself.
-     *
-     * Used only to group the help output, like {@link commandSources}. Note
-     * that only the root help groups them: the "Global Options" section a
-     * subcommand's help shows is one flat list in Commander, whatever group
-     * the options are in.
-     */
-    rootOptionSources?: ReadonlyMap<string, string>;
 }
 
 /**
@@ -60,36 +44,25 @@ function pluginCommandsHeading(packageName: string): string {
     return `Commands from ${packageName}:`;
 }
 
-/**
- * The help heading the shared options registered by `packageName` are listed
- * under. Worded to match {@link pluginCommandsHeading}, so one package reads
- * the same way wherever it appears.
- */
+/** As {@link pluginCommandsHeading}, for the shared options of a package. */
 function pluginOptionsHeading(packageName: string): string {
     return `Options from ${packageName}:`;
 }
 
 /**
- * Splits a heading built by {@link pluginCommandsHeading} or
- * {@link pluginOptionsHeading} back into its parts, so
- * {@link styleHelpTitle} can pick the package name out of it. Kept beside the
- * two builders: it has to match what they produce, and `styleTitle` hands
- * Commander's help back nothing but the finished string.
+ * Splits a heading built above back into its parts. Kept beside the builders
+ * because it has to match what they produce: Commander's `styleTitle` hands
+ * back the finished string and nothing else.
  */
 const PLUGIN_HEADING = /^((?:Commands|Options) from )(.+)(:)$/;
 
 /**
- * Styles one help section heading.
+ * Styles one help section heading. Every heading is bold, and a plugin
+ * heading's package name is cyan as well.
  *
- * Every heading is bold, including the CLI's own `Commands:` and `Options:`,
- * so the sections read as peers rather than a plugin's looking like an aside.
- * Within a plugin's heading the package name is tinted as well, which is what
- * visibly pairs its "Commands from" section with its "Options from" one. The
- * tint is bold too, so the heading is one weight throughout.
- *
- * Nothing is said by colour alone — the heading names the package in words —
- * so a monochrome terminal loses nothing. Commander strips the escape codes
- * itself when the output is not a terminal, or when NO_COLOR is set.
+ * Colour is decoration only: the heading names the package in words, so a
+ * monochrome terminal loses nothing. Commander strips the escape codes when
+ * the output is not a terminal or NO_COLOR is set.
  */
 export function styleHelpTitle(title: string, colors: HeadingColors = pc): string {
     const match = PLUGIN_HEADING.exec(title);
@@ -97,34 +70,26 @@ export function styleHelpTitle(title: string, colors: HeadingColors = pc): strin
         return colors.bold(title);
     }
     const [, label, packageName, colon] = match;
-    // Nested rather than concatenated: styling the parts separately would
-    // close the bold run before the tint opens, leaving the package name at
-    // normal weight beside a bold label.
+    // Nested, not concatenated: styling the parts separately closes the bold
+    // run before the tint opens, leaving the package name at normal weight.
     return colors.bold(label + colors.cyan(packageName) + colon);
 }
 
 /**
- * The palette {@link styleHelpTitle} paints with. It defaults to picocolors,
- * which emits nothing unless the terminal supports colour, so a test has to
- * pass `createColors(true)` to see what a colour terminal would get.
+ * Defaults to picocolors, which emits nothing unless the terminal supports
+ * colour, so a test passes `createColors(true)` to see the escape codes.
  */
 export type HeadingColors = Pick<typeof pc, 'bold' | 'cyan'>;
 
 export function registerCommands(
     program: Command,
-    commands: CliCommandNode[],
+    tree: CommandTreeEntry[],
     options: RegisterCommandsOptions = {},
 ): void {
-    const {
-        rootOptions = [],
-        getPluginExtensions = () => [],
-        commandSources,
-        rootOptionSources,
-    } = options;
-    const sharedOptions = declareOptions(program, rootOptions, rootOptionSources);
-    for (const node of commands) {
+    const { rootOptions = [], getPluginExtensions = () => [] } = options;
+    const sharedOptions = declareOptions(program, rootOptions);
+    for (const { node, source } of tree) {
         const command = registerNode(program, node, [], sharedOptions, getPluginExtensions);
-        const source = commandSources?.get(node.name);
         if (source) {
             // Commander groups by the heading text itself, so every command
             // from one package lands in one section without further
@@ -154,7 +119,10 @@ function registerNode(
     for (const arg of runnable?.arguments ?? []) {
         command.argument(arg.required ? `<${arg.name}>` : `[${arg.name}]`, arg.description);
     }
-    const ownOptions = declareOptions(command, node.options ?? []);
+    const ownOptions = declareOptions(
+        command,
+        (node.options ?? []).map(option => ({ option })),
+    );
 
     if (subcommands) {
         // A node with subcommands shares its options with every command below
@@ -251,14 +219,9 @@ async function runAction(action: CliCommandAction, args: any[], context: CliComm
  * Declares options on a command and describes them for any descendants, which
  * inherit them when the command has subcommands or is the root program.
  */
-function declareOptions(
-    command: Command,
-    options: CliCommandOption[],
-    sources?: ReadonlyMap<string, string>,
-): SharedOption[] {
+function declareOptions(command: Command, entries: RootOptionEntry[]): SharedOption[] {
     const declared: SharedOption[] = [];
-    for (const option of options) {
-        const source = sources?.get(parseOptionFlags(option).attributeName);
+    for (const { option, source } of entries) {
         const helpGroup = source === undefined ? undefined : pluginOptionsHeading(source);
         declareOption(command, option, declared, helpGroup);
 
@@ -276,44 +239,18 @@ function declareOptions(
     return declared;
 }
 
-/**
- * Declares one option on a command, unless that flag is already declared there.
- *
- * One sub-option can belong to more than one parent — `vendure add` takes
- * `--selected-plugin` with either `-e` or `-s` — and every sub-option is
- * flattened onto the same command, so the flag arrives twice. Commander 11
- * accepted the repeat, listed it twice in help and matched the first
- * declaration when parsing. Commander 13 onwards throws instead, which would
- * fail at startup and take down the whole CLI rather than one command.
- *
- * Keeping the first declaration parses exactly as Commander 11 did, and drops
- * the duplicate help line. A plugin can hit this as readily as a built-in, so
- * it is handled here rather than in any one command's definition.
- */
+/** Declares one option on a command and records it for descendants to read. */
 function declareOption(
     command: Command,
     option: CliCommandOption,
     declared: SharedOption[],
     helpGroup?: string,
 ): void {
-    const parsed = parseOptionFlags(option);
-    const alreadyDeclared = command.options.some(
-        existing =>
-            existing.attributeName() === parsed.attributeName ||
-            (parsed.short !== undefined && existing.short === parsed.short),
-    );
-    if (alreadyDeclared) {
-        return;
-    }
     addOption(command, option, helpGroup);
-    declared.push({ attributeName: parsed.attributeName, owner: command });
+    declared.push({ attributeName: parseOptionFlags(option).attributeName, owner: command });
 }
 
-/**
- * Builds the option the way `Command#option` does — create it, give it the
- * default value, add it — with the chance to put it in a help group on the
- * way, which `Command#option` gives no way to do.
- */
+/** Mirrors `Command#option`, which gives no way to set a help group. */
 function addOption(command: Command, option: CliCommandOption, helpGroup?: string): void {
     const created = command.createOption(buildOptionFlags(option), option.description);
     created.default(option.defaultValue);

--- a/packages/cli/src/shared/resolve-cli-plugins.ts
+++ b/packages/cli/src/shared/resolve-cli-plugins.ts
@@ -198,8 +198,9 @@ export function discoverCliPlugins(options: DiscoverCliPluginsOptions = {}): Dis
             if (entry?.entryPath) {
                 try {
                     const plugin = loadCliPluginModule(entry.entryPath, packageName);
-                    // The module is already loaded here, so its real command
-                    // names cost nothing and beat whatever package.json claims.
+                    // The module is already loaded here, so reading its command
+                    // names adds no work, and they take precedence over
+                    // whatever `vendure.cliCommands` declares.
                     discovered.set(packageName, {
                         ...entry,
                         loadedCommands: plugin.commands.map(command => command.name),

--- a/packages/cli/src/shared/resolve-cli-plugins.ts
+++ b/packages/cli/src/shared/resolve-cli-plugins.ts
@@ -57,6 +57,25 @@ export interface DiscoveredCliPlugin {
      * Command names from package.json `vendure.cliCommands` when declared.
      */
     declaredCommands?: string[];
+    /**
+     * Top-level command names read from the plugin module itself. Only known
+     * when the plugin was actually loaded, which `validate` does for enabled
+     * plugins. Read it through {@link cliPluginCommandNames}, which falls back
+     * to {@link declaredCommands} for a package that was not loaded.
+     */
+    loadedCommands?: string[];
+}
+
+/**
+ * The commands a package contributes, as accurately as is known.
+ *
+ * An enabled plugin is loaded, so its real command names are used. A package
+ * that is only installed is not executed, so what it declares in
+ * `vendure.cliCommands` is the best available answer, and an empty list means
+ * the package declared nothing rather than that it contributes nothing.
+ */
+export function cliPluginCommandNames(plugin: DiscoveredCliPlugin): string[] {
+    return plugin.loadedCommands ?? plugin.declaredCommands ?? [];
 }
 
 export interface ResolveCliPluginsOptions {
@@ -178,7 +197,13 @@ export function discoverCliPlugins(options: DiscoverCliPluginsOptions = {}): Dis
             const entry = discovered.get(packageName);
             if (entry?.entryPath) {
                 try {
-                    loadCliPluginModule(entry.entryPath, packageName);
+                    const plugin = loadCliPluginModule(entry.entryPath, packageName);
+                    // The module is already loaded here, so its real command
+                    // names cost nothing and beat whatever package.json claims.
+                    discovered.set(packageName, {
+                        ...entry,
+                        loadedCommands: plugin.commands.map(command => command.name),
+                    });
                 } catch (e: any) {
                     discovered.set(packageName, {
                         ...entry,


### PR DESCRIPTION
# Description

When a plugin extends the Vendure CLI, its commands and options are currently mixed in with the built-in ones in `vendure --help`, so there is no way to tell where anything came from. With `@vendure/cloud` installed that is a flat list of 33 commands. This came out of a Slack discussion about whether Cloud commands should be namespaced under `vendure cloud ...`; grouping the help gives the same clarity without making anyone type an extra word.

The help now groups both commands and shared options by the package that registered them:

```
Options:
  -V, --version                             output the version number
  -h, --help                                display help for command

Options from @vendure/cloud:
  --token <token>                           Cloud API token
  --project <slug>                          Cloud project slug

Commands:
  add [options]                             Add a feature to your Vendure project
  ...

Commands from @vendure/cloud:
  deploy [options]                          Deploy the current environment
  ...
```

Nothing about how a command is invoked changes. `vendure deploy` is still `vendure deploy`.

The heading uses the package name exactly as installed, so it names the thing to enable or remove. A command reached through `extendCommands` rather than registered outright stays under the heading it already had, because the command is still the one that declared it.

## Colour

Section headings are now bold, and a plugin heading's package name is also cyan, so a package's "Commands from" and "Options from" sections pair up visually. Commander applies this through its `styleTitle` hook, which covers every heading — `Usage:` and `Arguments:` are now bold too.

Colour is decoration only. The heading names the package in words, so a monochrome terminal, a colourblind reader or a piped log loses nothing.

Whether colour is emitted follows the usual rules, and both directions are covered by tests:

- No colour when stdout is not a terminal, or when `NO_COLOR` is set.
- Colour when `FORCE_COLOR` is set, **including when stdout is not a terminal**. This is worth knowing when writing tests: Vitest exports `FORCE_COLOR` to child processes when its own output is coloured, which it is when the suite runs through Lerna. `runCliCommand` in the CLI e2e helpers therefore returns output with colour stripped, and exposes `rawStdout` for a test that is about colour itself.

## `vendure plugins`

The listing now shows the commands each package provides, read from the plugin itself for an enabled one and from `vendure.cliCommands` for one that is only installed:

```
@vendure/cloud	enabled
	commands: project, config, backup, deploy, restore
```

## The commander upgrade, and the bug it exposed

Grouping needs Commander's `helpGroup()`, added in v14. `packages/cli` was still on `^11.0.0`, set in September 2023 and never touched since; `packages/dev-server` is on `^12` and `packages/create` on `^14`, so this was drift rather than a deliberate pin.

The upgrade turned up a latent bug. Commander 13 began throwing on duplicate option flags. `vendure add` declared `--selected-plugin` under both `-e` and `-s`, and `--selected-service` under both `-j` and `-a`, because every sub-option is flattened onto the same command. Commander 11 accepted the repeat, matched the first when parsing, and printed the flag twice in help. Under Commander 14 it throws while registering a built-in, so **every** `vendure` invocation would have failed, not just `add`.

The fix is in the `add` definition, which now declares each shared sub-option once with a description naming both parents. Nothing enforced this, which is why it was there in the first place: a plugin is validated by `assertCliPlugin` when it loads, so a duplicate flag is rejected by name, but the built-in definitions reach Commander unchecked. `builtins.spec.ts` now runs them through the same validation, so the built-ins are held to the rule plugins already were. Checked against the base commit, that test fails with `CLI plugin "builtins" declares "--selected-plugin" twice in options of command "add"`.

The first commit does this ahead of the upgrade, so no commit in this PR leaves the CLI broken.

## Known limitation

Only the root help is grouped. A subcommand's help shows shared options under `Global Options:`, which Commander builds as one flat list regardless of group, so it still mixes the CLI's own options with a plugin's. Grouping that would mean overriding `Help#formatHelp` and owning a copy of Commander's layout, which did not seem worth it — the root help is where the problem actually is.

# Breaking changes

None for users or plugin authors. `CliPlugin`, `CliCommandDefinition` and the rest of the public API are unchanged, and no command changes how it is invoked.

Internal signatures changed, none of them exported from the package:

- `CommandRegistry.toArray()` is now `getCommandTree()` and returns `{ node, source }` per command; `getRootOptions()` returns `{ option, source }`. They are returned paired rather than alongside a separate name-keyed map of sources, so the two cannot disagree about which commands exist.
- `registerCommands()` takes an options object instead of four positional arguments.
- `runCliCommand()` in the CLI e2e helpers returns colour-stripped `stdout` and `stderr`, plus `rawStdout` and `rawStderr`, and accepts an `env` option.

# Screenshots

See the help output above.

# Checklist

Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed

## Testing

620 unit tests across 39 files and 88 e2e tests across 7 files, all passing, on Node 20, 22 and 24 and against sqljs, mysql, mariadb and postgres.

The e2e suite was verified both ways round — in the package directly and through Lerna as CI runs it — because only the second sets `FORCE_COLOR` and so exercises the coloured output.

Each commit was verified on its own, including the first on Commander 11 to confirm the option fix stands alone. The grouping and styling tests were mutation-checked: disabling each behaviour fails exactly the tests asserting it and leaves the negative controls passing.

`docs/docs/guides/developer-guide/cli/index.mdx` documents the grouping, and `packages/cli/src/README.md` covers the internals.
