### PR TITLE
fix(dashboard): add json import attributes when compiling in esm mode

### DIFF
--- a/packages/dashboard/vite/tests/fixtures-json/attributed-data.json
+++ b/packages/dashboard/vite/tests/fixtures-json/attributed-data.json
@@ -1,0 +1,1 @@
+{ "label": "attributed" }

--- a/packages/dashboard/vite/tests/fixtures-json/empty-attributes-data.json
+++ b/packages/dashboard/vite/tests/fixtures-json/empty-attributes-data.json
@@ -1,0 +1,1 @@
+{ "label": "empty-attributes" }

--- a/packages/dashboard/vite/tests/fixtures-json/reexported-data.json
+++ b/packages/dashboard/vite/tests/fixtures-json/reexported-data.json
@@ -1,0 +1,1 @@
+{ "label": "reexported" }

--- a/packages/dashboard/vite/tests/fixtures-json/vendure-config.ts
+++ b/packages/dashboard/vite/tests/fixtures-json/vendure-config.ts
@@ -4,12 +4,15 @@ import { VendureConfig } from '@vendure/core';
 // second one. TypeScript flags it here only because this fixture targets CommonJS.
 import attributedData from './attributed-data.json' with { type: 'json' };
 import configData from './config-data.json';
+// #5330 — an empty attribute list has no `type`, so the esm emit must still add one.
+import emptyAttributesData from './empty-attributes-data.json' with {};
 import { MyPlugin } from './my-plugin/src/my.plugin.js';
 
 // #5330 — a re-export of JSON needs the attribute in esm mode as much as an import does.
 export { default as reexportedData } from './reexported-data.json';
 
 export const attributedLabel = attributedData.label;
+export const emptyAttributesLabel = emptyAttributesData.label;
 
 export const config: VendureConfig = {
     apiOptions: { port: 3000 },

--- a/packages/dashboard/vite/tests/fixtures-json/vendure-config.ts
+++ b/packages/dashboard/vite/tests/fixtures-json/vendure-config.ts
@@ -1,7 +1,15 @@
 import { VendureConfig } from '@vendure/core';
 
+// #5330 — this import already has the attribute, so the esm emit must not add a
+// second one. TypeScript flags it here only because this fixture targets CommonJS.
+import attributedData from './attributed-data.json' with { type: 'json' };
 import configData from './config-data.json';
 import { MyPlugin } from './my-plugin/src/my.plugin.js';
+
+// #5330 — a re-export of JSON needs the attribute in esm mode as much as an import does.
+export { default as reexportedData } from './reexported-data.json';
+
+export const attributedLabel = attributedData.label;
 
 export const config: VendureConfig = {
     apiOptions: { port: 3000 },

--- a/packages/dashboard/vite/tests/json-imports.spec.ts
+++ b/packages/dashboard/vite/tests/json-imports.spec.ts
@@ -65,13 +65,15 @@ describe('compiling a config which imports .json files', () => {
         expect(attributedImport?.match(/type:/g)).toHaveLength(1);
 
         const script = [
-            'const { config, reexportedData, attributedLabel } = await import(process.argv[1]);',
+            'const { config, reexportedData, attributedLabel, emptyAttributesLabel } =',
+            '    await import(process.argv[1]);',
             'const [MyPlugin] = config.plugins;',
             'console.log(JSON.stringify([',
             '    config.customFields.Product[0].name,',
             '    MyPlugin.sheetId,',
             '    reexportedData.label,',
             '    attributedLabel,',
+            '    emptyAttributesLabel,',
             ']));',
         ].join('\n');
         const { stdout } = await execFileAsync(process.execPath, [
@@ -80,7 +82,7 @@ describe('compiling a config which imports .json files', () => {
             script,
             pathToFileURL(join(tempDir, 'vendure-config.js')).href,
         ]);
-        expect(JSON.parse(stdout)).toEqual(['bar', 'abc123', 'reexported', 'attributed']);
+        expect(JSON.parse(stdout)).toEqual(['bar', 'abc123', 'reexported', 'attributed', 'empty-attributes']);
     });
     // Skipping the package.json silently leaves the import in the emitted output, so
     // the config fails to load with a bare "Cannot find module". Say so up front.

--- a/packages/dashboard/vite/tests/json-imports.spec.ts
+++ b/packages/dashboard/vite/tests/json-imports.spec.ts
@@ -1,9 +1,14 @@
+import { execFile } from 'node:child_process';
 import { readFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
 import { describe, expect, it } from 'vitest';
 
 import { compile } from '../utils/compiler.js';
 import { debugLogger, noopLogger } from '../utils/logger.js';
+
+const execFileAsync = promisify(execFile);
 
 // #4807 — a config or plugin which imports a .json file must still compile. The
 // compiler copies the JSON into the output alongside the emitted .js files, so
@@ -38,13 +43,11 @@ describe('compiling a config which imports .json files', () => {
         expect(result.vendureConfig.customFields?.Product?.[0].name).toBe('bar');
     });
 
-    // ESM mode emits a bare `import data from './x.json'`, which Node rejects with
-    // ERR_IMPORT_ATTRIBUTE_MISSING because it wants `with { type: 'json' }`. Copying
-    // the file is therefore necessary but not sufficient there, so this asserts only
-    // the copying. Loading is not asserted: it succeeds under Vitest, whose loader
-    // resolves JSON without the attribute, and would pass here while still failing
-    // for a real `module: 'esm'` project.
-    it('should copy imported JSON into the output in esm mode', { timeout: 60_000 }, async () => {
+    // #5330 — Node refuses to load a JSON module in ESM without `with { type: 'json' }`,
+    // so the emitted imports must carry that attribute. The config is loaded in a
+    // plain Node process, because Vitest's loader resolves JSON without the
+    // attribute and would pass here while a real `module: 'esm'` project fails.
+    it('should load a config which imports JSON in esm mode', { timeout: 60_000 }, async () => {
         const { tempDir } = await compileFixture('esm');
 
         expect(JSON.parse(await readFile(join(tempDir, 'config-data.json'), 'utf-8'))).toEqual({
@@ -53,6 +56,31 @@ describe('compiling a config which imports .json files', () => {
         expect(
             JSON.parse(await readFile(join(tempDir, 'my-plugin', 'src', 'plugin-data.json'), 'utf-8')),
         ).toEqual({ sheetId: 'abc123' });
+
+        // An import which already has the attribute keeps exactly one.
+        const emittedConfig = await readFile(join(tempDir, 'vendure-config.js'), 'utf-8');
+        const attributedImport = emittedConfig
+            .split('\n')
+            .find(line => line.includes('attributed-data.json'));
+        expect(attributedImport?.match(/type:/g)).toHaveLength(1);
+
+        const script = [
+            'const { config, reexportedData, attributedLabel } = await import(process.argv[1]);',
+            'const [MyPlugin] = config.plugins;',
+            'console.log(JSON.stringify([',
+            '    config.customFields.Product[0].name,',
+            '    MyPlugin.sheetId,',
+            '    reexportedData.label,',
+            '    attributedLabel,',
+            ']));',
+        ].join('\n');
+        const { stdout } = await execFileAsync(process.execPath, [
+            '--input-type=module',
+            '-e',
+            script,
+            pathToFileURL(join(tempDir, 'vendure-config.js')).href,
+        ]);
+        expect(JSON.parse(stdout)).toEqual(['bar', 'abc123', 'reexported', 'attributed']);
     });
     // Skipping the package.json silently leaves the import in the emitted output, so
     // the config fails to load with a bare "Cannot find module". Say so up front.

--- a/packages/dashboard/vite/utils/compiler.ts
+++ b/packages/dashboard/vite/utils/compiler.ts
@@ -451,8 +451,9 @@ async function compileTypeScript({
 }
 
 /**
- * Adds `with { type: 'json' }` to import and export declarations of `.json`
- * specifiers that do not already carry import attributes.
+ * Adds `type: 'json'` to the import attributes of import and export declarations
+ * of `.json` specifiers that do not already carry a `type` attribute. Any other
+ * attributes, including an empty `with {}`, are kept and the entry is appended.
  *
  * Matching on the `.json` suffix is a superset of the rule `collectLocalSourceFiles`
  * uses to copy a JSON file. Bare specifiers such as `some-pkg/data.json` are never
@@ -461,17 +462,21 @@ async function compileTypeScript({
 function createJsonImportAttributeTransformer(): ts.TransformerFactory<ts.SourceFile> {
     return context => {
         const { factory } = context;
-        const jsonAttributes = () =>
-            factory.createImportAttributes(
-                factory.createNodeArray([
-                    factory.createImportAttribute(
-                        factory.createIdentifier('type'),
-                        factory.createStringLiteral('json'),
-                    ),
-                ]),
+        const withJsonAttribute = (attributes: ts.ImportAttributes | undefined) => {
+            const typeJson = factory.createImportAttribute(
+                factory.createIdentifier('type'),
+                factory.createStringLiteral('json'),
             );
+            return attributes
+                ? factory.updateImportAttributes(
+                      attributes,
+                      factory.createNodeArray([...attributes.elements, typeJson]),
+                      attributes.multiLine,
+                  )
+                : factory.createImportAttributes(factory.createNodeArray([typeJson]));
+        };
         const needsJsonAttributes = (node: ts.ImportDeclaration | ts.ExportDeclaration) =>
-            !node.attributes &&
+            !node.attributes?.elements.some(attribute => attribute.name.text === 'type') &&
             !!node.moduleSpecifier &&
             ts.isStringLiteral(node.moduleSpecifier) &&
             node.moduleSpecifier.text.endsWith('.json');
@@ -483,7 +488,7 @@ function createJsonImportAttributeTransformer(): ts.TransformerFactory<ts.Source
                     node.modifiers,
                     node.importClause,
                     node.moduleSpecifier,
-                    jsonAttributes(),
+                    withJsonAttribute(node.attributes),
                 );
             }
             if (ts.isExportDeclaration(node) && needsJsonAttributes(node)) {
@@ -493,7 +498,7 @@ function createJsonImportAttributeTransformer(): ts.TransformerFactory<ts.Source
                     node.isTypeOnly,
                     node.exportClause,
                     node.moduleSpecifier,
-                    jsonAttributes(),
+                    withJsonAttribute(node.attributes),
                 );
             }
             return node;

--- a/packages/dashboard/vite/utils/compiler.ts
+++ b/packages/dashboard/vite/utils/compiler.ts
@@ -369,31 +369,27 @@ async function compileTypeScript({
 }): Promise<void> {
     await fs.ensureDir(outputPath);
 
-    // Copying the JSON is enough for CommonJS, whose require() reads it directly.
-    // ESM emits the import unchanged, and Node refuses to load a JSON module
-    // without an `with { type: 'json' }` attribute that TypeScript will not emit
-    // for a source file targeting CommonJS. Say so here, naming the files, so the
-    // ERR_IMPORT_ATTRIBUTE_MISSING that follows has an explanation above it.
-    if (module === 'esm') {
-        const jsonFiles = sourceFiles.filter(file => file.endsWith('.json'));
-        if (jsonFiles.length) {
-            logger.warn(
-                `Imported JSON is not yet supported with module: 'esm', so loading the config will fail on ` +
-                    `${jsonFiles.join(', ')}. Use module: 'commonjs', or read the file at runtime instead of importing it.`,
-            );
-        }
-    }
+    const afterTransformers: Array<ts.TransformerFactory<ts.SourceFile>> = [];
 
     // Build path transformer for ESM mode
     // This is necessary because tsconfig-paths.register() only works for CommonJS require(),
     // not for ESM import(). We need to transform the import paths during transpilation.
-    let pathTransformer: ts.TransformerFactory<ts.SourceFile> | undefined;
     if (module === 'esm' && tsConfigInfo) {
         logger.debug('Adding path transformer for ESM mode');
-        pathTransformer = createPathTransformer({
-            baseUrl: tsConfigInfo.baseUrl,
-            paths: tsConfigInfo.paths,
-        });
+        afterTransformers.push(
+            createPathTransformer({
+                baseUrl: tsConfigInfo.baseUrl,
+                paths: tsConfigInfo.paths,
+            }),
+        );
+    }
+
+    // Copying the JSON is enough for CommonJS, whose require() reads it directly.
+    // ESM emits the import unchanged, and Node refuses to load a JSON module
+    // without a `with { type: 'json' }` attribute, which the author cannot write
+    // in a source file that also targets CommonJS for the server build.
+    if (module === 'esm') {
+        afterTransformers.push(createJsonImportAttributeTransformer());
     }
 
     // Note: emitDecoratorMetadata with transpileModule emits `Object` for all
@@ -411,8 +407,8 @@ async function compileTypeScript({
         emitDecoratorMetadata: true,
         esModuleInterop: true,
     };
-    const transformers: ts.CustomTransformers | undefined = pathTransformer
-        ? { after: [pathTransformer] }
+    const transformers: ts.CustomTransformers | undefined = afterTransformers.length
+        ? { after: afterTransformers }
         : undefined;
 
     // Transpile first and validate every destination before writing anything,
@@ -452,6 +448,59 @@ async function compileTypeScript({
         await fs.ensureDir(path.dirname(emit.outputFilePath));
         await fs.writeFile(emit.outputFilePath, emit.outputText);
     }
+}
+
+/**
+ * Adds `with { type: 'json' }` to import and export declarations of `.json`
+ * specifiers that do not already carry import attributes.
+ *
+ * Matching on the `.json` suffix is a superset of the rule `collectLocalSourceFiles`
+ * uses to copy a JSON file. Bare specifiers such as `some-pkg/data.json` are never
+ * copied, but still get the attribute, because Node requires it for them too.
+ */
+function createJsonImportAttributeTransformer(): ts.TransformerFactory<ts.SourceFile> {
+    return context => {
+        const { factory } = context;
+        const jsonAttributes = () =>
+            factory.createImportAttributes(
+                factory.createNodeArray([
+                    factory.createImportAttribute(
+                        factory.createIdentifier('type'),
+                        factory.createStringLiteral('json'),
+                    ),
+                ]),
+            );
+        const needsJsonAttributes = (node: ts.ImportDeclaration | ts.ExportDeclaration) =>
+            !node.attributes &&
+            !!node.moduleSpecifier &&
+            ts.isStringLiteral(node.moduleSpecifier) &&
+            node.moduleSpecifier.text.endsWith('.json');
+
+        const visitor: ts.Visitor = node => {
+            if (ts.isImportDeclaration(node) && needsJsonAttributes(node)) {
+                return factory.updateImportDeclaration(
+                    node,
+                    node.modifiers,
+                    node.importClause,
+                    node.moduleSpecifier,
+                    jsonAttributes(),
+                );
+            }
+            if (ts.isExportDeclaration(node) && needsJsonAttributes(node)) {
+                return factory.updateExportDeclaration(
+                    node,
+                    node.modifiers,
+                    node.isTypeOnly,
+                    node.exportClause,
+                    node.moduleSpecifier,
+                    jsonAttributes(),
+                );
+            }
+            return node;
+        };
+
+        return sourceFile => ts.visitEachChild(sourceFile, visitor, context);
+    };
 }
 
 function assertWithinOutputPath(outputFilePath: string, outputPath: string): void {


### PR DESCRIPTION
# Description

Fixes #5330

With `vendureDashboardPlugin({ module: 'esm' })`, a config or plugin that imports JSON compiled but could not be loaded. The compiler transpiles with `ModuleKind.ESNext` and writes `"type": "module"` into the output, so the emitted config kept a bare import:

```js
import configData from './config-data.json';
```

Node rejects that with:

```
TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]: Module ".../config-data.json" needs an import attribute of "type: json"
```

The author can't add the attribute in their own source, because TypeScript rejects `with { type: 'json' }` in a file that targets CommonJS for the server build.

This PR takes the first approach from the issue. `compileTypeScript` now runs a small `after` transformer whenever the target is ESM. It adds `with { type: 'json' }` to import and export declarations whose specifier ends in `.json` and that don't already carry attributes. The existing path transformer still runs only when `module === 'esm' && tsConfigInfo`. The JSON transformer is gated on `module === 'esm'` alone, so it also runs for projects without tsconfig paths. Both go into one `after` array. The path transformer passes `node.attributes` through, so an aliased JSON import ends up with both the rewritten path and the attribute. The emitted output now reads:

```js
import configData from './config-data.json' with { type: "json" };
```

A few details:
- Matching on the `.json` suffix is a superset of the rule `collectLocalSourceFiles` uses to copy a JSON file, so every copied JSON import gets the attribute. Bare specifiers such as `some-pkg/data.json` are never copied, and neither is a `package.json` (#5329), but they still get the attribute, because Node requires it for them too.
- Re-exports (`export { default as x } from './x.json'`) are handled too, because the collector follows export declarations.
- Dynamic `import()` is left alone. The collector doesn't follow it, so that JSON is never copied in the first place.
- CommonJS output is unchanged. It still emits `require("./config-data.json")`.
- The #4808 warning that said imported JSON is unsupported with `module: 'esm'` is removed, since it is no longer true.

`path-transformer.ts` is not touched. `convertExtension` leaving `.json` alone is what this approach needs.

# Breaking changes

None. Only the `module: 'esm'` path (developer preview) changes, and there it turns a load failure into a working config.

# Screenshots

n/a

# Testing

`json-imports.spec.ts`: the ESM case used to assert only that the JSON was copied. It now also loads the emitted `vendure-config.js` in a plain Node child process (`process.execPath --input-type=module`) and reads back one value per JSON import. It runs outside Vitest on purpose, because Vitest's loader accepts JSON without the attribute.

The `fixtures-json` fixture gains two cases, so the test covers:
- the config's own JSON import (`config.customFields.Product[0].name`);
- the plugin's transitive JSON import (`MyPlugin.sheetId`);
- a re-export, `export { default as reexportedData } from './reexported-data.json'`;
- an import that already has `with { type: 'json' }`. The test also checks that its emitted line still has exactly one `type:`, so the attribute isn't added twice.

The fixture's `package.json` is `"type": "commonjs"`, so an editor type-checking the fixture under NodeNext flags the pre-attributed import (TS2856). That's expected, and the line has a comment saying why it's there. `vite/tests` is excluded from `check-types`. The CommonJS case compiles the same fixture and still passes.

Before the fix, the new test fails with the error from the issue:

```
× should load a config which imports JSON in esm mode
TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]: Module "file:///.../__temp/json-esm/config-data.json" needs an import attribute of "type: json"
```

After the fix it passes. Commands run from `packages/dashboard`, after `bun run build:core-common` at the repo root:

```bash
bunx vitest run vite/tests/json-imports.spec.ts
bunx vitest run vite/ --exclude 'vite/tests/bundle-singleton*'   # 16 files, 135 tests pass
bun run check-types
bunx prettier --check vite/utils/compiler.ts vite/tests/json-imports.spec.ts vite/tests/fixtures-json/
```

I also checked by hand, with a throwaway fixture compiled in ESM mode and loaded under plain Node 22, that a tsconfig alias to a JSON file (`@data/z.json`) is rewritten to a relative path and gets the attribute.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791718313&installation_model_id=20193&pr_number=5361&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5361&signature=9ce707c0a52956cbb76fc7bab1d6f9b329d69c805b673d7818c55e7a11b3e36e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->