### PR TITLE
fix(dashboard): warn when editing shared option groups

### DIFF
--- a/packages/dashboard/e2e/tests/catalog/products.spec.ts
+++ b/packages/dashboard/e2e/tests/catalog/products.spec.ts
@@ -200,15 +200,25 @@ for (const productCount of [0, 1, 2]) {
                 }
             }
         } finally {
+            const cleanupErrors: unknown[] = [];
             for (const id of products) {
-                await client.gql(`mutation ($id: ID!) { deleteProduct(id: $id) { result } }`, { id });
+                try {
+                    await client.gql(`mutation ($id: ID!) { deleteProduct(id: $id) { result } }`, { id });
+                } catch (error) {
+                    cleanupErrors.push(error);
+                }
             }
             if (groupId) {
-                await client.gql(
-                    `mutation ($id: ID!) { deleteProductOptionGroup(id: $id, force: true) { result } }`,
-                    { id: groupId },
-                );
+                try {
+                    await client.gql(
+                        `mutation ($id: ID!) { deleteProductOptionGroup(id: $id, force: true) { result } }`,
+                        { id: groupId },
+                    );
+                } catch (error) {
+                    cleanupErrors.push(error);
+                }
             }
+            expect(cleanupErrors, 'Fixture cleanup failures').toEqual([]);
         }
     });
 }

--- a/packages/dashboard/e2e/tests/catalog/products.spec.ts
+++ b/packages/dashboard/e2e/tests/catalog/products.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { createCrudTestSuite } from '../../utils/crud-test-factory.js';
+import { VendureAdminClient } from '../../utils/vendure-admin-client.js';
 
 createCrudTestSuite({
     entityName: 'product',
@@ -120,3 +121,94 @@ test.describe('Product detail features', () => {
         // If no custom fields configured in the fixture, this test passes silently
     });
 });
+
+// #5348 — shared option edits affect every product using the same group.
+for (const productCount of [0, 1, 2]) {
+    test(`shared option warning with ${productCount} assigned products`, async ({ page }) => {
+        const client = new VendureAdminClient(page);
+        await client.login();
+        const suffix = `${productCount}-${Date.now()}`;
+        const products: string[] = [];
+        let groupId: string | undefined;
+        try {
+            const group = await client.gql(
+                `mutation ($input: CreateProductOptionGroupInput!) {
+                    createProductOptionGroup(input: $input) { id options { id } }
+                }`,
+                {
+                    input: {
+                        code: `shared-warning-${suffix}`,
+                        translations: [{ languageCode: 'en', name: `Shared Size ${suffix}` }],
+                        options: [
+                            {
+                                code: `small-${suffix}`,
+                                translations: [{ languageCode: 'en', name: 'Small' }],
+                            },
+                        ],
+                    },
+                },
+            );
+            groupId = group.createProductOptionGroup.id;
+            const optionId = group.createProductOptionGroup.options[0].id;
+            for (let i = 0; i < productCount; i++) {
+                const product = await client.gql(
+                    `mutation ($input: CreateProductInput!) { createProduct(input: $input) { id } }`,
+                    {
+                        input: {
+                            translations: [
+                                {
+                                    languageCode: 'en',
+                                    name: `Shared product ${suffix}-${i}`,
+                                    slug: `shared-${suffix}-${i}`,
+                                    description: '',
+                                },
+                            ],
+                        },
+                    },
+                );
+                const productId = product.createProduct.id;
+                products.push(productId);
+                await client.gql(
+                    `mutation ($productId: ID!, $groupId: ID!) {
+                        addOptionGroupToProduct(productId: $productId, optionGroupId: $groupId) { id }
+                    }`,
+                    { productId, groupId },
+                );
+            }
+            const routes = [
+                ...products.map(id => `/products/${id}`),
+                `/option-groups/${groupId}`,
+                `/option-groups/${groupId}/options/${optionId}`,
+                `/option-groups/${groupId}/options/new`,
+            ];
+            for (const route of routes) {
+                await page.goto(route);
+                await expect(
+                    page.getByRole('button', {
+                        name: route.endsWith('/new') ? 'Create' : 'Update',
+                        exact: true,
+                    }),
+                ).toBeVisible();
+                const warning = page.getByText(
+                    'This option group is shared across 2 products. Changes will affect all of them.',
+                    { exact: true },
+                );
+                if (productCount > 1) {
+                    await expect(warning).toBeVisible();
+                } else {
+                    await expect(page.getByText(/This option group is (shared|used)/)).toHaveCount(0);
+                }
+            }
+        } finally {
+            for (const id of products) {
+                await client.gql(`mutation ($id: ID!) { deleteProduct(id: $id) { result } }`, { id });
+            }
+            if (groupId) {
+                await client.gql(
+                    `mutation ($id: ID!) { deleteProductOptionGroup(id: $id, force: true) { result } }`,
+                    { id: groupId },
+                );
+            }
+        }
+    });
+}

--- a/packages/dashboard/src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
@@ -5,6 +5,9 @@ import { TranslatableFormFieldWrapper } from '@/vdb/components/shared/translatab
 import { Button } from '@/vdb/components/ui/button.js';
 import { Input } from '@/vdb/components/ui/input.js';
 import { NEW_ENTITY_PATH } from '@/vdb/constants.js';
+import { extendDetailFormQuery } from '@/vdb/framework/document-extension/extend-detail-form-query.js';
+import { addCustomFields } from '@/vdb/framework/document-introspection/add-custom-fields.js';
+import { ActionBarItem } from '@/vdb/framework/layout-engine/action-bar-item-wrapper.js';
 import {
     CustomFieldsPageBlock,
     DetailFormGrid,
@@ -14,14 +17,12 @@ import {
     PageLayout,
     PageTitle,
 } from '@/vdb/framework/layout-engine/page-layout.js';
-import { ActionBarItem } from '@/vdb/framework/layout-engine/action-bar-item-wrapper.js';
-import { extendDetailFormQuery } from '@/vdb/framework/document-extension/extend-detail-form-query.js';
-import { addCustomFields } from '@/vdb/framework/document-introspection/add-custom-fields.js';
 import { getDetailQueryOptions, useDetailPage } from '@/vdb/framework/page/use-detail-page.js';
 import { api } from '@/vdb/graphql/api.js';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { createFileRoute, ParsedLocation, useNavigate } from '@tanstack/react-router';
 import { toast } from 'sonner';
+import { SharedOptionGroupWarning } from '../_products/components/shared-option-group-warning.js';
 import {
     createProductOptionDocument,
     productIdNameDocument,
@@ -32,11 +33,17 @@ import {
 
 const pageId = 'option-group-option-detail';
 
-export const Route = createFileRoute(
-    '/_authenticated/_option-groups/option-groups_/$groupId/options_/$id',
-)({
+export const Route = createFileRoute('/_authenticated/_option-groups/option-groups_/$groupId/options_/$id')({
     component: OptionGroupOptionDetailPage,
-    loader: async ({ context, params, location }: { context: any; params: any; location: ParsedLocation }) => {
+    loader: async ({
+        context,
+        params,
+        location,
+    }: {
+        context: any;
+        params: any;
+        location: ParsedLocation;
+    }) => {
         if (!params.id) {
             throw new Error('ID param is required');
         }
@@ -56,14 +63,17 @@ export const Route = createFileRoute(
         }
 
         let optionGroupName: string | undefined;
+        let productCount = 0;
         if (isNew) {
             const optionGroupResult = await context.queryClient.fetchQuery({
                 queryKey: [pageId, 'optionGroupIdName', params.groupId],
                 queryFn: () => api.query(productOptionGroupIdNameDocument, { id: params.groupId }),
             });
             optionGroupName = optionGroupResult.productOptionGroup?.name;
+            productCount = optionGroupResult.productOptionGroup?.productCount ?? 0;
         } else {
             optionGroupName = result.productOption.group.name;
+            productCount = result.productOption.group.productCount;
         }
 
         const search = location.search as Record<string, string>;
@@ -75,6 +85,7 @@ export const Route = createFileRoute(
                 queryFn: () => api.query(productIdNameDocument, { id: search.productId }),
             });
             return {
+                productCount,
                 breadcrumb: [
                     { path: '/products', label: <Trans>Products</Trans> },
                     { path: `/products/${search.productId}`, label: productResult.product.name },
@@ -86,6 +97,7 @@ export const Route = createFileRoute(
         }
 
         return {
+            productCount,
             breadcrumb: [
                 { path: '/option-groups', label: <Trans>Option Groups</Trans> },
                 ...(isNew
@@ -102,6 +114,7 @@ export const Route = createFileRoute(
 
 function OptionGroupOptionDetailPage() {
     const params = Route.useParams();
+    const { productCount } = Route.useLoaderData();
     const navigate = useNavigate();
     const creatingNewEntity = params.id === NEW_ENTITY_PATH;
     const { t } = useLingui();
@@ -146,9 +159,7 @@ function OptionGroupOptionDetailPage() {
         },
         onError: err => {
             toast.error(
-                creatingNewEntity
-                    ? t`Failed to create product option`
-                    : t`Failed to update product option`,
+                creatingNewEntity ? t`Failed to create product option` : t`Failed to update product option`,
                 {
                     description: err instanceof Error ? err.message : 'Unknown error',
                 },
@@ -159,17 +170,10 @@ function OptionGroupOptionDetailPage() {
     return (
         <Page pageId={pageId} form={form} submitHandler={submitHandler} entity={entity}>
             <PageTitle>
-                {creatingNewEntity ? (
-                    <Trans>New product option</Trans>
-                ) : (
-                    (entity as any)?.name ?? ''
-                )}
+                {creatingNewEntity ? <Trans>New product option</Trans> : ((entity as any)?.name ?? '')}
             </PageTitle>
             <PageActionBar>
-                <ActionBarItem
-                    itemId="save-button"
-                    requiresPermission={['UpdateProduct', 'UpdateCatalog']}
-                >
+                <ActionBarItem itemId="save-button" requiresPermission={['UpdateProduct', 'UpdateCatalog']}>
                     <Button
                         type="submit"
                         disabled={!form.formState.isDirty || !form.formState.isValid || isPending}
@@ -179,18 +183,19 @@ function OptionGroupOptionDetailPage() {
                 </ActionBarItem>
             </PageActionBar>
             <PageLayout>
+                {productCount > 1 && (
+                    <PageBlock column="main" blockId="shared-option-group-warning">
+                        <SharedOptionGroupWarning productCount={productCount} />
+                    </PageBlock>
+                )}
                 {entity?.group && (
                     <PageBlock column="side" blockId="option-group-info">
                         <div className="space-y-2">
                             <div className="text-sm font-medium">
                                 <Trans>Option Group</Trans>
                             </div>
-                            <div className="text-sm text-muted-foreground">
-                                {entity?.group.name}
-                            </div>
-                            <div className="text-xs text-muted-foreground">
-                                {entity?.group.code}
-                            </div>
+                            <div className="text-sm text-muted-foreground">{entity?.group.name}</div>
+                            <div className="text-xs text-muted-foreground">{entity?.group.code}</div>
                         </div>
                     </PageBlock>
                 )}
@@ -218,11 +223,7 @@ function OptionGroupOptionDetailPage() {
                         />
                     </DetailFormGrid>
                 </PageBlock>
-                <CustomFieldsPageBlock
-                    column="main"
-                    entityType="ProductOption"
-                    control={form.control}
-                />
+                <CustomFieldsPageBlock column="main" entityType="ProductOption" control={form.control} />
             </PageLayout>
         </Page>
     );

--- a/packages/dashboard/src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
@@ -1,11 +1,14 @@
 import { SlugInput } from '@/vdb/components/data-input/index.js';
+import { AssignedChannels } from '@/vdb/components/shared/assigned-channels.js';
 import { ErrorPage } from '@/vdb/components/shared/error-page.js';
 import { FormFieldWrapper } from '@/vdb/components/shared/form-field-wrapper.js';
 import { TranslatableFormFieldWrapper } from '@/vdb/components/shared/translatable-form-field.js';
 import { Button } from '@/vdb/components/ui/button.js';
 import { Input } from '@/vdb/components/ui/input.js';
 import { NEW_ENTITY_PATH } from '@/vdb/constants.js';
-import { useChannel } from '@/vdb/hooks/use-channel.js';
+import { extendDetailFormQuery } from '@/vdb/framework/document-extension/extend-detail-form-query.js';
+import { addCustomFields } from '@/vdb/framework/document-introspection/add-custom-fields.js';
+import { ActionBarItem } from '@/vdb/framework/layout-engine/action-bar-item-wrapper.js';
 import {
     CustomFieldsPageBlock,
     DetailFormGrid,
@@ -15,33 +18,39 @@ import {
     PageLayout,
     PageTitle,
 } from '@/vdb/framework/layout-engine/page-layout.js';
-import { ActionBarItem } from '@/vdb/framework/layout-engine/action-bar-item-wrapper.js';
-import { extendDetailFormQuery } from '@/vdb/framework/document-extension/extend-detail-form-query.js';
-import { addCustomFields } from '@/vdb/framework/document-introspection/add-custom-fields.js';
 import { getDetailQueryOptions, useDetailPage } from '@/vdb/framework/page/use-detail-page.js';
+import { api } from '@/vdb/graphql/api.js';
+import { useChannel } from '@/vdb/hooks/use-channel.js';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { createFileRoute, ParsedLocation, useLocation, useNavigate } from '@tanstack/react-router';
 import { toast } from 'sonner';
-import { AssignedChannels } from '@/vdb/components/shared/assigned-channels.js';
-import { api } from '@/vdb/graphql/api.js';
-import { OptionGroupProductsBlock } from './components/option-group-products-block.js';
 import { ProductOptionsTable } from '../_products/components/product-options-table.js';
-import {
-    assignOptionGroupsToChannelDocument,
-    removeOptionGroupsFromChannelDocument,
-} from './option-groups.graphql.js';
+import { SharedOptionGroupWarning } from '../_products/components/shared-option-group-warning.js';
 import {
     createProductOptionGroupDocument,
     productIdNameDocument,
     productOptionGroupDetailDocument,
     updateProductOptionGroupDocument,
 } from '../_products/product-option-groups.graphql.js';
+import { OptionGroupProductsBlock } from './components/option-group-products-block.js';
+import {
+    assignOptionGroupsToChannelDocument,
+    removeOptionGroupsFromChannelDocument,
+} from './option-groups.graphql.js';
 
 const pageId = 'option-group-detail';
 
 export const Route = createFileRoute('/_authenticated/_option-groups/option-groups_/$id')({
     component: OptionGroupDetailPage,
-    loader: async ({ context, params, location }: { context: any; params: any; location: ParsedLocation }) => {
+    loader: async ({
+        context,
+        params,
+        location,
+    }: {
+        context: any;
+        params: any;
+        location: ParsedLocation;
+    }) => {
         if (!params.id) {
             throw new Error('ID param is required');
         }
@@ -133,9 +142,7 @@ function OptionGroupDetailPage() {
         },
         onError: err => {
             toast.error(
-                creatingNewEntity
-                    ? t`Failed to create option group`
-                    : t`Failed to update option group`,
+                creatingNewEntity ? t`Failed to create option group` : t`Failed to update option group`,
                 {
                     description: err instanceof Error ? err.message : 'Unknown error',
                 },
@@ -149,10 +156,7 @@ function OptionGroupDetailPage() {
                 {creatingNewEntity ? <Trans>New option group</Trans> : (entity?.name ?? '')}
             </PageTitle>
             <PageActionBar>
-                <ActionBarItem
-                    itemId="save-button"
-                    requiresPermission={['UpdateProduct', 'UpdateCatalog']}
-                >
+                <ActionBarItem itemId="save-button" requiresPermission={['UpdateProduct', 'UpdateCatalog']}>
                     <Button
                         type="submit"
                         disabled={!form.formState.isDirty || !form.formState.isValid || isPending}
@@ -162,6 +166,11 @@ function OptionGroupDetailPage() {
                 </ActionBarItem>
             </PageActionBar>
             <PageLayout>
+                {entity && entity.productCount > 1 && (
+                    <PageBlock column="main" blockId="shared-option-group-warning">
+                        <SharedOptionGroupWarning productCount={entity.productCount} />
+                    </PageBlock>
+                )}
                 <PageBlock column="main" blockId="main-form">
                     <DetailFormGrid>
                         <TranslatableFormFieldWrapper
@@ -186,22 +195,12 @@ function OptionGroupDetailPage() {
                         />
                     </DetailFormGrid>
                 </PageBlock>
-                <CustomFieldsPageBlock
-                    column="main"
-                    entityType="ProductOptionGroup"
-                    control={form.control}
-                />
+                <CustomFieldsPageBlock column="main" entityType="ProductOptionGroup" control={form.control} />
                 {entity && (
-                    <PageBlock
-                        column="main"
-                        blockId="product-options"
-                        title={<Trans>Product Options</Trans>}
-                    >
+                    <PageBlock column="main" blockId="product-options" title={<Trans>Product Options</Trans>}>
                         <ProductOptionsTable
                             productOptionGroupId={entity.id}
-                            getOptionHref={optionId =>
-                                `/option-groups/${entity.id}/options/${optionId}`
-                            }
+                            getOptionHref={optionId => `/option-groups/${entity.id}/options/${optionId}`}
                             newOptionHref={`/option-groups/${entity.id}/options/new`}
                             linkSearch={search.from === 'product' ? search : undefined}
                         />

--- a/packages/dashboard/src/app/routes/_authenticated/_products/product-option-groups.graphql.ts
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/product-option-groups.graphql.ts
@@ -39,6 +39,7 @@ export const productOptionGroupIdNameDocument = graphql(`
         productOptionGroup(id: $id) {
             id
             name
+            productCount
         }
     }
 `);
@@ -77,6 +78,7 @@ export const productOptionDetailDocument = graphql(`
                 id
                 name
                 code
+                productCount
             }
             customFields
         }

--- a/packages/dashboard/src/app/routes/_authenticated/_products/products.graphql.ts
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/products.graphql.ts
@@ -54,6 +54,7 @@ export const productDetailFragment = graphql(
                 id
                 code
                 name
+                productCount
                 options {
                     id
                     code

--- a/packages/dashboard/src/app/routes/_authenticated/_products/products_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/products_.$id.tsx
@@ -1,5 +1,7 @@
 import { RichTextInput } from '@/vdb/components/data-input/rich-text-input.js';
 import { SlugInput } from '@/vdb/components/data-input/slug-input.js';
+import { usePriceFactor } from '@/vdb/components/shared/assign-to-channel-dialog.js';
+import { AssignedChannels } from '@/vdb/components/shared/assigned-channels.js';
 import { AssignedFacetValues } from '@/vdb/components/shared/assigned-facet-values.js';
 import { EntityAssets } from '@/vdb/components/shared/entity-assets.js';
 import { ErrorPage } from '@/vdb/components/shared/error-page.js';
@@ -10,7 +12,9 @@ import { Field } from '@/vdb/components/ui/field.js';
 import { Input } from '@/vdb/components/ui/input.js';
 import { Switch } from '@/vdb/components/ui/switch.js';
 import { NEW_ENTITY_PATH } from '@/vdb/constants.js';
-import {    CustomFieldsPageBlock,
+import { ActionBarItem } from '@/vdb/framework/layout-engine/action-bar-item-wrapper.js';
+import {
+    CustomFieldsPageBlock,
     DetailFormGrid,
     Page,
     PageActionBar,
@@ -18,9 +22,10 @@ import {    CustomFieldsPageBlock,
     PageLayout,
     PageTitle,
 } from '@/vdb/framework/layout-engine/page-layout.js';
-import { ActionBarItem } from '@/vdb/framework/layout-engine/action-bar-item-wrapper.js';
 import { detailPageRouteLoader } from '@/vdb/framework/page/detail-page-route-loader.js';
 import { useDetailPage } from '@/vdb/framework/page/use-detail-page.js';
+import { api } from '@/vdb/graphql/api.js';
+import { useChannel } from '@/vdb/hooks/use-channel.js';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { Layers, Package, PlusIcon } from 'lucide-react';
@@ -30,6 +35,7 @@ import { AddOptionGroupDialog } from './components/add-option-group-dialog.js';
 import { GenerateVariantsPanel } from './components/generate-variants-panel.js';
 import { ProductOptionGroupBadge } from './components/product-option-group-badge.js';
 import { ProductVariantsTable } from './components/product-variants-table.js';
+import { SharedOptionGroupWarning } from './components/shared-option-group-warning.js';
 import { useRemoveOptionGroup } from './hooks/use-remove-option-group.js';
 import {
     assignProductsToChannelDocument,
@@ -38,10 +44,6 @@ import {
     removeProductsFromChannelDocument,
     updateProductDocument,
 } from './products.graphql.js';
-import { api } from '@/vdb/graphql/api.js';
-import { AssignedChannels } from '@/vdb/components/shared/assigned-channels.js';
-import { usePriceFactor } from '@/vdb/components/shared/assign-to-channel-dialog.js';
-import { useChannel } from '@/vdb/hooks/use-channel.js';
 
 const pageId = 'product-detail';
 
@@ -93,7 +95,9 @@ function NoVariantsPrompt({
                 className="flex flex-col items-center gap-2 rounded-md border border-dashed border-border p-6 text-center transition-colors hover:border-primary hover:bg-accent cursor-pointer"
             >
                 <Package className="h-8 w-8 text-muted-foreground" />
-                <span className="font-medium"><Trans>Simple product</Trans></span>
+                <span className="font-medium">
+                    <Trans>Simple product</Trans>
+                </span>
                 <span className="text-sm text-muted-foreground">
                     <Trans>Single variant, no options</Trans>
                 </span>
@@ -108,7 +112,9 @@ function NoVariantsPrompt({
                         className="flex w-full flex-col items-center gap-2 rounded-md border border-dashed border-border p-6 text-center transition-colors hover:border-primary hover:bg-accent cursor-pointer"
                     >
                         <Layers className="h-8 w-8 text-muted-foreground" />
-                        <span className="font-medium"><Trans>Product with options</Trans></span>
+                        <span className="font-medium">
+                            <Trans>Product with options</Trans>
+                        </span>
                         <span className="text-sm text-muted-foreground">
                             <Trans>Size, colour, etc.</Trans>
                         </span>
@@ -306,15 +312,17 @@ function ProductDetailPage() {
                 )}
                 {entity && entity.optionGroups.length > 0 && (
                     <PageBlock column="side" blockId="option-groups" title={<Trans>Product Options</Trans>}>
-                        <div className="flex flex-wrap gap-1.5 mb-3">
+                        <div className="space-y-3 mb-3">
                             {entity.optionGroups.map(g => (
-                                <ProductOptionGroupBadge
-                                    key={g.id}
-                                    id={g.id}
-                                    name={g.name}
-                                    productId={entity.id}
-                                    onRemoved={() => refreshEntity()}
-                                />
+                                <div key={g.id} className="space-y-2">
+                                    <ProductOptionGroupBadge
+                                        id={g.id}
+                                        name={g.name}
+                                        productId={entity.id}
+                                        onRemoved={() => refreshEntity()}
+                                    />
+                                    <SharedOptionGroupWarning productCount={g.productCount} />
+                                </div>
                             ))}
                         </div>
                         <AddOptionGroupDialog


### PR DESCRIPTION
# Description

Editing a shared option group or option affects every product using it, but the dashboard never rendered the existing `SharedOptionGroupWarning` component. Show that warning next to each group on product details and above the group/option editing forms. New options also show their parent group's warning.

Query `productCount` where it was missing. Reuse the existing translated message and its single-product suppression. The product sidebar keeps each group's name adjacent to its warning, so multiple groups can be distinguished.

Fixes #5348.

Validation:
- Added three scenarios to the existing product dashboard suite, using real API-created groups with zero, one, and two assigned products. They visit product details, group details, existing options, and new options, asserting both warning presence and absence.
- The shared-group scenario fails because the warning is absent when the three original page files are restored; it passes with the fix.
- Full product-page Playwright run: 18 checks pass, including authentication and existing product CRUD/detail tests. Production dashboard builds and `check-types` pass.
- Changed files pass Prettier and whitespace checks; commitlint passes.
- ESLint crashes with `services.getTypeAtLocation is not a function` in `@typescript-eslint/no-floating-promises`. The same crash was reproduced on the untouched test file, consistent with #5353. The lint-dependent commit hook was skipped after these checks; no dependency changes are included.
- Tested locally on Chromium using the repository's backend and production preview; other browsers and the full dashboard E2E suite were not run. A temporary config selected the locally installed Chromium channel and was removed afterward.

AI-assisted contribution; the implementation, regression behavior, and validation results were checked locally.

# Breaking changes

None. Shared option and duplication semantics are unchanged.

# Screenshots

Not included. Browser tests verify the warning on the affected routes and its absence for unused or single-product groups.

# Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
- [x] I have added or updated test cases
- [x] I have updated the README if needed (not needed for this dashboard warning)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791807890&installation_model_id=20193&pr_number=5364&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5364&signature=0aa1be3eb9f83525ca3dd298d384b7564708969e6f793600dd49daad2e6ff36c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->