### PR TITLE
fix(dashboard): warn when an extension route collides with an existing route

### DIFF
--- a/packages/dashboard/src/lib/framework/page/use-extended-router.spec.tsx
+++ b/packages/dashboard/src/lib/framework/page/use-extended-router.spec.tsx
@@ -1,0 +1,80 @@
+import { AnyRoute, createRootRoute, createRoute, createRouter } from '@tanstack/react-router';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { extensionRoutes, registerRoute } from './page-api.js';
+import { useExtendedRouter } from './use-extended-router.js';
+
+vi.mock('../extension-api/use-dashboard-extensions.js', () => ({
+    useDashboardExtensions: () => ({ extensionsLoaded: true }),
+}));
+
+vi.mock('../../components/shared/error-page.js', () => ({
+    ErrorPage: () => null,
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('useExtendedRouter', () => {
+    let container: HTMLDivElement;
+    let root: ReturnType<typeof createRoot>;
+
+    beforeEach(() => {
+        extensionRoutes.clear();
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        root = createRoot(container);
+    });
+
+    afterEach(async () => {
+        await act(async () => {
+            root.unmount();
+        });
+        container.remove();
+        extensionRoutes.clear();
+        vi.restoreAllMocks();
+    });
+
+    // #5200 — extension route collisions should be visible during development
+    it.each([
+        { path: '/products', authenticated: true },
+        { path: '/login', authenticated: false },
+    ])('warns when $path collides with an existing route', async ({ path, authenticated }) => {
+        const rootRoute = createRootRoute();
+        const authenticatedRoute = createRoute({
+            getParentRoute: () => rootRoute,
+            id: '_authenticated',
+        });
+        const existingRoute = createRoute({
+            getParentRoute: () => (authenticated ? authenticatedRoute : rootRoute),
+            path,
+        });
+        const routeTree = rootRoute.addChildren([
+            authenticatedRoute.addChildren(authenticated ? [existingRoute] : []),
+            ...(authenticated ? [] : [existingRoute]),
+        ]);
+        createRouter({ routeTree });
+
+        registerRoute({
+            path,
+            authenticated,
+            component: () => null,
+        });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        function DashboardRouter() {
+            useExtendedRouter(routeTree as AnyRoute, {});
+            return null;
+        }
+
+        await act(async () => {
+            root.render(<DashboardRouter />);
+        });
+
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy).toHaveBeenCalledWith(
+            `[Dashboard] Extension route "${path}" conflicts with an existing route and will not be registered.`,
+        );
+    });
+});

--- a/packages/dashboard/src/lib/framework/page/use-extended-router.tsx
+++ b/packages/dashboard/src/lib/framework/page/use-extended-router.tsx
@@ -61,6 +61,11 @@ export const useExtendedRouter = (
                         (r: AnyRoute) => r.path === pathWithoutLeadingSlash,
                     ) > -1
                 ) {
+                    if (process.env.NODE_ENV !== 'production') {
+                        console.warn(
+                            `[Dashboard] Extension route "${path}" conflicts with an existing route and will not be registered.`,
+                        );
+                    }
                     // Skip if the route already exists
                     continue;
                 }
@@ -91,6 +96,11 @@ export const useExtendedRouter = (
                     );
 
                 if (routeExists) {
+                    if (process.env.NODE_ENV !== 'production') {
+                        console.warn(
+                            `[Dashboard] Extension route "${path}" conflicts with an existing route and will not be registered.`,
+                        );
+                    }
                     // Skip if the route already exists
                     continue;
                 }


### PR DESCRIPTION
`useExtendedRouter` silently skips registering an extension route whenever its path already matches a built-in route — there's no indication registration was even attempted, so a path collision is indistinguishable from a typo.

Added a dev-only `console.warn` at both skip points (the authenticated-route branch and the root-level branch) naming the exact conflicting path, matching the existing symmetric structure of the two checks.

Added a parameterized test covering both branches (an authenticated route colliding with an existing authenticated route, and a public route colliding with an existing public route), asserting the warning fires with the exact expected message.

Relates to #5200

I wasn't able to get a full `vitest` run working in the sandbox I used for this — this checkout's workspace linking for `@vendure/core`'s own dependencies (`@nestjs/graphql` etc.) never resolved correctly despite a clean `pnpm install`, which looks like an environment-specific issue unrelated to this change. I did verify the change against the rest of the toolchain: `prettier --check` passes, and `packages/dashboard/scripts/check-lib-imports.js` (this package's own import-convention check) passes on both touched files. The test is in a new spec file and asserts a `console.warn` spy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791856076&installation_model_id=20193&pr_number=5365&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5365&signature=4bbf62e27d80f22f966aa1d061c09c486ed4e778873235a50b9ea76ed436ab07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
