### PR TITLE
fix(dashboard): restore display component precedence for additionalColumns

### DIFF
--- a/packages/dashboard/src/lib/components/data-table/use-generated-columns.spec.tsx
+++ b/packages/dashboard/src/lib/components/data-table/use-generated-columns.spec.tsx
@@ -39,13 +39,14 @@ const cellContext = {
  * `createElement` for any function cell, so a cell using hooks behaves here as it does in
  * a real table; calling `column.cell(context)` directly would not.
  */
-function renderColumnCell(pageId: string, columnId: string): string {
+function renderColumnCell(pageId: string, columnId: string, additionalColumns?: any): string {
     const captured: { columns?: Array<{ id?: string; cell?: any }> } = {};
 
     function Harness() {
         const { columns } = useGeneratedColumns({
             fields,
             customizeColumns,
+            additionalColumns,
             includeSelectionColumn: false,
             includeActionsColumn: false,
         });
@@ -133,5 +134,38 @@ describe('useGeneratedColumns display component precedence', () => {
         executeDashboardExtensionCallbacks();
 
         expect(renderColumnCell(pageId, 'price')).toBe('<span>via-extension-api</span>');
+    });
+});
+
+describe('useGeneratedColumns additional column display component precedence', () => {
+    const additionalColumns = {
+        inventoryStatus: { cell: () => <span>additional-column-cell</span> },
+    } as any;
+
+    it('gives precedence to a registered display component over an additional column cell', () => {
+        const pageId = 'test-page-additional-column-registered';
+
+        addDisplayComponent({
+            pageId,
+            blockId: BLOCK_ID,
+            field: 'inventoryStatus',
+            component: ({ value }) => (
+                <span>{`registered-additional-column-display-component:${value as number}`}</span>
+            ),
+        });
+
+        expect(renderColumnCell(pageId, 'inventoryStatus', additionalColumns)).toBe(
+            `<span>registered-additional-column-display-component:${PRICE}</span>`,
+        );
+    });
+
+    it('falls back to the additional column cell when no display component is registered', () => {
+        expect(
+            renderColumnCell(
+                'test-page-additional-column-unregistered',
+                'inventoryStatus',
+                additionalColumns,
+            ),
+        ).toBe('<span>additional-column-cell</span>');
     });
 });

--- a/packages/dashboard/src/lib/components/data-table/use-generated-columns.tsx
+++ b/packages/dashboard/src/lib/components/data-table/use-generated-columns.tsx
@@ -191,7 +191,31 @@ export function useGeneratedColumns<T extends TypedDocumentNode<any, any>>({
             if (!id) {
                 throw new Error('Column id is required');
             }
-            finalColumns.push(columnHelper.accessor(id as any, { enableColumnFilter: false, ...column, id }));
+            const displayComponentId =
+                pageId && pageBlock?.blockId
+                    ? generateDisplayComponentKey(pageId, pageBlock.blockId, id)
+                    : undefined;
+            const CustomDisplayComponent = displayComponentId
+                ? getDisplayComponent(displayComponentId)
+                : undefined;
+
+            finalColumns.push(
+                columnHelper.accessor(id as any, {
+                    enableColumnFilter: false,
+                    ...column,
+                    ...(CustomDisplayComponent
+                        ? {
+                              cell: (cellContext: CellContext<any, any>) => (
+                                  <CustomDisplayComponent
+                                      value={cellContext.cell.getValue()}
+                                      {...cellContext}
+                                  />
+                              ),
+                          }
+                        : {}),
+                    id,
+                }),
+            );
         }
 
         if (defaultColumnOrder) {


### PR DESCRIPTION
#5339 fixed display components registered via `addDisplayComponent()` being ignored for schema-derived columns in `useGeneratedColumns`, but that PR deliberately left `additionalColumns` alone since it's a completely separate loop. This issue is the natural follow-up: registering a display component for an `additionalColumns` entry currently does nothing at all, because that loop pushes the column through unchanged, whatever `cell` the extension itself supplied.

This applies the same precedence check to that loop: compute the same `generateDisplayComponentKey(pageId, blockId, id)` key, look it up via `getDisplayComponent`, and if something is registered, render that instead of the column's own cell. If nothing is registered, behavior is exactly as before.

Added two tests mirroring the existing precedence tests in this file - one where a registered component overrides an `additionalColumns` cell, one where an unregistered column still falls back to its own cell unchanged.

Closes #5347

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791856383&installation_model_id=20193&pr_number=5366&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5366&signature=6f1f61a06062ca8bb0a1354d35fff41c3c8e65a45992aa00a1a4bd58c16f5277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->